### PR TITLE
Improve music enablement ux

### DIFF
--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -28,13 +28,10 @@ const MainMenu = (props: Props): JSX.Element => {
       </div>
       <div id="centeredMenu">
         <Button size="large" variant='contained' color="primary" onClick={props.onStart} autoFocus={true}>Play</Button>
-        {props.audioEnabled !== undefined && <Button variant="outlined" color="primary" onClick={props.onManual}>Manual</Button>}
-        {props.audioEnabled !== undefined && <Button variant="outlined" color="primary" onClick={props.onSettings}>Options</Button>}
-        {props.audioEnabled !== undefined && !props.uid && <Button variant="outlined" color="primary" onClick={login}>Log in</Button>}
-        {props.audioEnabled === undefined && <div>Enable music?<br/>
-          <Button variant="contained" color="primary" onClick={(e: any) => props.onAudioChange(true)} style={{display: 'inline', marginRight: '12px', marginTop: '4px'}}>Yes</Button>
-          <Button variant="outlined" color="primary" onClick={(e: any) => props.onAudioChange(false)} style={{display: 'inline', marginTop: '4px'}}>No</Button>
-        </div>}
+        <Button variant="outlined" color="primary" onClick={props.onManual}>Manual</Button>
+        <Button variant="outlined" color="primary" onClick={props.onSettings}>Options</Button>
+        {!props.uid && <Button variant="outlined" color="primary" onClick={login}>Log in</Button>}
+        {props.audioEnabled === undefined && <Button variant="outlined" color="primary" onClick={() => props.onAudioChange(true)} style={{display: 'inline', marginRight: '12px', marginTop: '4px'}}>Enable music</Button>}
       </div>
       <div style={{position: 'absolute', bottom: 0, left: 0, right: 0, opacity: 0.7}}>
         <IconButton


### PR DESCRIPTION
Switch bulky and confusing "Enable music?" "yes" / "no" to a more subtle single "Enable music" button that doesn't hide other buttons
<img width="640" alt="Screenshot 2024-04-05 at 10 27 46 PM" src="https://github.com/toddmedema/electrify/assets/775657/c49f43e8-29e6-41be-b910-350c07e5328c">
Closes #90 