### PR TITLE
Add new public-owned scenario type with different scoring

### DIFF
--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -53,8 +53,8 @@ export const LOCATIONS = [
 ] as LocationType[];
 
 export const TICK_MS = {
-  PAUSED: 150,
-  SLOW: 80,
+  PAUSED: 250,
+  SLOW: 100,
   NORMAL: 40,
   FAST: 1,
 };

--- a/src/Facilities.tsx
+++ b/src/Facilities.tsx
@@ -145,24 +145,6 @@ export function GENERATORS(state: GameType, peakW: number) {
     //   annualOperatingCost: 1000000, // about 0.005/kwh in 2018 - https://www.eia.gov/electricity/annual/html/epa_08_04.html
     //   yearsToBuild: 1,
     // },
-    // {
-    //   name: 'Oil', // Aka petroleum
-    //   fuel: 'Oil',
-    //   description: 'Dispatchable, but fuel prices swing',
-    //   buildCost: 200000000,
-      // 1,087 plants in 2018 - https://www.eia.gov/electricity/annual/html/epa_04_01.html
-      // 40 GW in 2019 ("fuel oil") - https://www.publicpower.org/system/files/documents/67-America%27s%20Electricity%20Generation%20Capacity%202019_final2.pdf
-    //   peakW,
-    //   btuPerW: 11,
-    //     // varies by ~1%/yr - https://www.eia.gov/electricity/annual/html/epa_08_01.html
-    //   spinMinutes: 10,
-    //   annualOperatingCost: 1000000, // TODO make variable
-    //     // about 0.005/kwh in 2018 - https://www.eia.gov/electricity/annual/html/epa_08_04.html
-    //   yearsToBuild: 2,
-      // https://www.eia.gov/outlooks/aeo/assumptions/pdf/table_8.2.pdf
-      // capacityFactor: 0.66,
-        // Max value from https://www.eia.gov/electricity/monthly/epm_table_grapher.php?t=epmt_6_07_a
-    // },
 
     // RENEWABLE
     {
@@ -298,6 +280,8 @@ export function GENERATORS(state: GameType, peakW: number) {
       // capacityFactor: 0.43,
       // https://en.wikipedia.org/wiki/Electricity_sector_of_the_United_States#Renewable_energy
     // },
+
+  // TODO biomass
   ] as GeneratorShoppingType[];
 
   // update with calculations that occur across all entries, like difficulty multipliers

--- a/src/Scenarios.tsx
+++ b/src/Scenarios.tsx
@@ -10,6 +10,7 @@ export const SCENARIOS = [
     id: 0, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
     name: '101: Electricity',
     locationId: 'SF',
+    ownership: 'Investor',
     startingYear: 2019,
     cash: 200000000,
     feePerKgCO2e: 0,
@@ -61,6 +62,7 @@ export const SCENARIOS = [
     id: 1, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
     name: '102: Generators',
     locationId: 'SF',
+    ownership: 'Investor',
     startingYear: 2019,
     cash: 200000000,
     feePerKgCO2e: 0,
@@ -127,6 +129,7 @@ export const SCENARIOS = [
     id: 2, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
     name: '103: Storage',
     locationId: 'SF',
+    ownership: 'Investor',
     startingYear: 2019,
     cash: 200000000,
     feePerKgCO2e: 0,
@@ -183,6 +186,7 @@ export const SCENARIOS = [
     id: 4, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
     name: '104: Finances',
     locationId: 'SF',
+    ownership: 'Investor',
     startingYear: 2019,
     cash: 200000000,
     feePerKgCO2e: 0,
@@ -224,6 +228,7 @@ export const SCENARIOS = [
     id: 3, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
     name: '105: Marketing',
     locationId: 'SF',
+    ownership: 'Investor',
     startingYear: 2019,
     cash: 200000000,
     feePerKgCO2e: 0,
@@ -267,6 +272,7 @@ export const SCENARIOS = [
     id: 5, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
     name: '106: Forecasting',
     locationId: 'SF',
+    ownership: 'Investor',
     startingYear: 2020,
     cash: 200000000,
     feePerKgCO2e: 0,
@@ -317,6 +323,7 @@ export const SCENARIOS = [
     icon: 'solar',
     locationId: 'SF',
     summary: `New limits have been placed on pollution - can you modernize the company?`,
+    ownership: 'Investor',
     startingYear: 2020,
     cash: 300000000,
     feePerKgCO2e: 50 / 1000,
@@ -329,6 +336,7 @@ export const SCENARIOS = [
     icon: 'natural gas',
     locationId: 'PIT',
     summary: `Cheap natural gas has been discovered nearby - are you ready for the boom?`,
+    ownership: 'Investor',
     startingYear: 2006,
     cash: 200000000,
     feePerKgCO2e: 0,
@@ -341,6 +349,7 @@ export const SCENARIOS = [
     icon: 'wind',
     locationId: 'HNL',
     summary: 'A beautiful island - with a complex grid.',
+    ownership: 'Investor',
     startingYear: 2004,
     cash: 250000000,
     feePerKgCO2e: 0,
@@ -353,6 +362,7 @@ export const SCENARIOS = [
     icon: 'geothermal',
     locationId: 'SF',
     summary: 'Technology is advancing rapidly - can you keep up?',
+    ownership: 'Investor',
     startingYear: 2002,
     cash: 200000000,
     feePerKgCO2e: 0,
@@ -365,6 +375,7 @@ export const SCENARIOS = [
     icon: 'wind',
     locationId: 'SJU',
     summary: 'A remote island, with expensive fuel and destructive weather.',
+    ownership: 'Public',
     startingYear: 2000,
     cash: 200000000,
     feePerKgCO2e: 0,
@@ -377,10 +388,12 @@ export const SCENARIOS = [
     icon: 'coal',
     locationId: 'PIT',
     summary: 'Your coal business faces new challenges - and opportunities.',
+    ownership: 'Investor',
     startingYear: 1980,
     cash: 180000000,
     feePerKgCO2e: 0,
     durationMonths: 12 * 20,
     facilities: [{fuel: 'Coal', peakW: 200000000}, {fuel: 'Coal', peakW: 300000000}],
   },
+  // TODO more public-ownership scenarios, such as in LA or Nebraska
 ] as ScenarioType[];

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -201,6 +201,7 @@ export interface ScenarioType {
   icon: string; // assumed to be images/<string>.svg
   locationId: LocationIdType;
   summary?: string;
+  ownership: 'Investor' | 'Public';
   tutorialSteps?: TutorialStepType[];
   startingYear: number;
   cash: number;

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -248,7 +248,7 @@ export default class Finances extends React.Component<Props, State> {
               <Typography color="primary" component="strong">{formatMoneyConcise(game.monthlyMarketingSpend)}</Typography>/mo&nbsp;
               (+{numbro(customersFromMarketingSpend(game.monthlyMarketingSpend)).format({average: true})} customers)
             </Typography>}
-            <Slider
+            {(scenario.ownership === 'Investor') && <Slider
               id="marketingSlider"
               value={getTickFromValue(game.monthlyMarketingSpend)}
               aria-labelledby="marketing monthly budget"
@@ -257,8 +257,8 @@ export default class Finances extends React.Component<Props, State> {
               step={1}
               max={getTickFromValue(Math.max(now.cash / 12, game.monthlyMarketingSpend))}
               onChange={(e: any, newTick: number|number[]) => onDelta({monthlyMarketingSpend: getValueFromTick(Array.isArray(newTick) ? newTick[0] : newTick)})}
-            />
-            <div className="flex-newline"></div>
+            />}
+            {(scenario.ownership === 'Investor') && <div className="flex-newline"></div>}
             <Typography variant="h6" style={{flexGrow: 0}}>Plotting </Typography>
             <Select id="plotMetric" defaultValue={chartKey} onChange={(e: any) => this.setChartKey(e.target.value)}>
               {Object.keys(CHART_KEYS).map((key: string) => {

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -11,6 +11,7 @@ import {generateNewTimeline} from '../../reducers/Game';
 import {DerivedHistoryKeysType, GameType, MonthlyHistoryType} from '../../Types';
 import ChartFinances from '../base/ChartFinances';
 import GameCard from '../base/GameCard';
+import { SCENARIOS } from '../../Scenarios';
 
 const numbro = require('numbro');
 
@@ -192,6 +193,7 @@ export default class Finances extends React.Component<Props, State> {
       return <span/>;
     }
 
+    const scenario = SCENARIOS.find((s) => s.id === game.scenarioId) || SCENARIOS[0];
     const years = []; // Go in reverse so that newest value (current year) is on top
     for (let i = date.year; i >= startingYear; i--) { years.push(i); }
 
@@ -241,11 +243,11 @@ export default class Finances extends React.Component<Props, State> {
         <div className="scrollable">
           <br/>
           <Toolbar>
-            <Typography className="flex-newline" variant="body2" color="textSecondary">
+            {(scenario.ownership === 'Investor') && <Typography className="flex-newline" variant="body2" color="textSecondary">
               Marketing:&nbsp;
               <Typography color="primary" component="strong">{formatMoneyConcise(game.monthlyMarketingSpend)}</Typography>/mo&nbsp;
               (+{numbro(customersFromMarketingSpend(game.monthlyMarketingSpend)).format({average: true})} customers)
-            </Typography>
+            </Typography>}
             <Slider
               id="marketingSlider"
               value={getTickFromValue(game.monthlyMarketingSpend)}


### PR DESCRIPTION
Part 1 of https://github.com/toddmedema/electrify/issues/79 - makes some scenarios public-owned (based on factually which of those utilities at that time/place were public-owned), and score them differently