### PR TITLE
Make "Supply by Fuel" a dispatch stack, and fix the charts around it

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -3,35 +3,42 @@
 // Shared Material-UI theming
 // https://material-ui.com/customization/themes
 
-import {
-  blue,
-  green,
-  grey,
-  purple,
-  red,
-  amber,
-  brown,
-  yellow,
-} from "@mui/material/colors";
+import { blue, grey, red, amber } from "@mui/material/colors";
 import {
   createTheme,
   adaptV4Theme,
   DeprecatedThemeOptions,
 } from "@mui/material/styles";
 
+// Seven series can never all clear WCAG's 3:1 non-text contrast against each other - the
+// luminance ladder runs out at about four - so these are tuned for two things that are achievable:
+// every fuel clears 3:1 against the white plot area, and the pairs that share a line chart
+// (the four priced fuels) are spread as far apart in luminance as that constraint allows.
+// Where color still can't carry it alone, the charts add a second channel: stacked bands with
+// direct labels in Supply by Fuel, dash patterns and end-of-line labels in Fuel Prices.
+// Uranium is teal rather than green so that no series pairs red with green.
 export const fuelColors = {
-  Uranium: green[500],
-  Coal: grey[900],
-  Oil: brown[800],
-  Geothermal: red[500],
-  "Natural Gas": purple[500],
-  Sun: yellow[600],
-  Wind: blue[600],
+  Coal: "#1a1a1a", // 17.4:1 on white
+  Uranium: "#0f5b63", // 7.8:1
+  Oil: "#ac4e13", // 5.5:1
+  "Natural Gas": "#bb79e6", // 3.0:1
+  Sun: "#a87817", // 3.9:1
+  Wind: "#193f79", // 10.4:1
+  Geothermal: "#531834", // 13.6:1
+};
+
+// Second encoding channel for the fuel price chart, where the lines overlap and color alone
+// can't separate four series. Ordered to match the drawing order of the lines.
+export const fuelDashArrays = {
+  Coal: undefined, // solid
+  "Natural Gas": "6,3",
+  Oil: "2,3",
+  Uranium: "9,3,2,3",
 };
 export const darkBlack = "0x000000";
 export const disabledColor = grey[100];
 export const interactiveColor = blue[600];
-export const blackoutColor = red[500];
+export const blackoutColor = red[800]; // darker than red[500] so the translucent band reads on white
 export const demandColor = grey[900];
 export const supplyColor = blue[600];
 export const temperatureColor = red[500];

--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -42,6 +42,7 @@ export const blackoutColor = red[800]; // darker than red[500] so the translucen
 export const demandColor = grey[900];
 export const supplyColor = blue[600];
 export const temperatureColor = red[500];
+export const cursorColor = grey[600]; // hover crosshair, lighter than the data it crosses
 export const windColor = fuelColors.Wind; // for weather forecasts
 
 export default createTheme(

--- a/src/app.scss
+++ b/src/app.scss
@@ -11,7 +11,7 @@ $bg_active: rgba(255, 255, 255, 0.9);
 $font_color_dark_primary: #ffffff;
 $bg_dark_primary: #161011;
 
-$blackout_red: #f44336; /* red500 https://material-ui.com/customization/color/ */
+$blackout_red: #c62828; /* red800 https://material-ui.com/customization/color/ - matches blackoutColor in Theme.tsx */
 $interactive_blue: #1e88e5; /* blue 600 */
 
 // ===============================================
@@ -397,6 +397,46 @@ span.weak {
     flex: 1 1 auto !important;
     overflow-y: auto;
   }
+}
+
+// Chart legends live below the plot instead of floating inside it, where they used to sit on
+// top of the data and clip. Plain HTML so they wrap on narrow screens and screen readers see them.
+.chartLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 12px;
+  padding: 0 8px 0 55px; // line up with the plot area, past the y axis labels
+  font-size: 12px;
+  color: $font_color_faded;
+}
+
+.chartLegendItem {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.chartLegendSwatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 4px;
+  border-radius: 2px;
+}
+
+// The demand overlay is a dashed line rather than a filled band, so its key looks like one
+.chartLegendSwatch-demand {
+  height: 0;
+  border-top: 2px dashed $font_color_primary;
+  border-radius: 0;
+}
+
+// Line-chart keys carry the series' dash pattern, since that's what tells them apart
+.chartLegendSwatch-line {
+  width: 20px;
+  height: 4px;
+  border-radius: 0;
+  overflow: visible;
 }
 
 .top-right {

--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -7,9 +7,8 @@ import {
   VictoryLabel,
   VictoryLine,
   VictoryTheme,
-  VictoryVoronoiContainer,
-  VictoryTooltip,
 } from "victory";
+import { chartTooltipContainer } from "./ChartTooltipContainer";
 
 interface ChartData {
   month: number; // unique across years
@@ -59,20 +58,9 @@ const ChartFinances = (props: Props): JSX.Element => {
         domain={{ x: [rangeMin, rangeMax], y: [domainMin, domainMax] }}
         domainPadding={{ y: [6, 6] }}
         height={props.height || 300}
-        containerComponent={
-          <VictoryVoronoiContainer
-            voronoiDimension="x"
-            labels={({ datum }) => props.format(datum.value).toString()}
-            labelComponent={
-              <VictoryTooltip
-                cornerRadius={2}
-                constrainToVisibleArea
-                flyoutStyle={{ fill: "white" }}
-                style={{ textAnchor: "end" }}
-              />
-            }
-          />
-        }
+        containerComponent={chartTooltipContainer({
+          labels: ({ datum }: any) => props.format(datum.value).toString(),
+        })}
       >
         <VictoryAxis
           tickFormat={(t) => formatMonthChartAxis(t, multiyear)}

--- a/src/components/base/ChartForecastFuelPrices.tsx
+++ b/src/components/base/ChartForecastFuelPrices.tsx
@@ -5,9 +5,8 @@ import {
   VictoryLabel,
   VictoryLine,
   VictoryTheme,
-  VictoryVoronoiContainer,
-  VictoryTooltip,
 } from "victory";
+import { chartTooltipContainer } from "./ChartTooltipContainer";
 import {
   formatMonthChartAxis,
   getDateFromMinute,
@@ -49,26 +48,14 @@ export default class ChartForecastFuelPrices extends React.PureComponent<
           domain={domain}
           domainPadding={{ y: [6, 6] }}
           height={height || 300}
-          containerComponent={
-            <VictoryVoronoiContainer
-              voronoiDimension="x"
-              // Labels are rendered on EACH chart, so we only render on Coal, otherwise we get duplicate labels
-              voronoiBlacklist={PRICED_FUELS.slice(1)}
-              labels={({ datum }) =>
-                PRICED_FUELS.map(
-                  (f) => `${f}: ${formatMoneyStable(datum[f])}`
-                ).join("\n")
-              }
-              labelComponent={
-                <VictoryTooltip
-                  cornerRadius={2}
-                  constrainToVisibleArea
-                  flyoutStyle={{ fill: "white" }}
-                  style={{ textAnchor: "end" }}
-                />
-              }
-            />
-          }
+          containerComponent={chartTooltipContainer({
+            labels: ({ datum }: any) =>
+              PRICED_FUELS.map(
+                (f) => `${f}: ${formatMoneyStable(datum[f])}`
+              ).join("\n"),
+            // Labels are rendered on EACH chart, so we only render on Coal, otherwise we get duplicate labels
+            voronoiBlacklist: PRICED_FUELS.slice(1),
+          })}
         >
           <VictoryAxis
             tickCount={6}

--- a/src/components/base/ChartForecastFuelPrices.tsx
+++ b/src/components/base/ChartForecastFuelPrices.tsx
@@ -3,7 +3,6 @@ import {
   VictoryAxis,
   VictoryChart,
   VictoryLabel,
-  VictoryLegend,
   VictoryLine,
   VictoryTheme,
   VictoryVoronoiContainer,
@@ -15,7 +14,7 @@ import {
 } from "../../helpers/DateTime";
 import { formatMoneyConcise, formatMoneyStable } from "../../helpers/Format";
 import { TickPresentFutureType } from "../../Types";
-import { chartTheme, fuelColors } from "../../Theme";
+import { chartTheme, fuelColors, fuelDashArrays } from "../../Theme";
 
 export interface Props {
   height?: number;
@@ -24,6 +23,14 @@ export interface Props {
   startingYear: number;
   multiyear: boolean;
 }
+
+type PricedFuelType = "Coal" | "Natural Gas" | "Oil" | "Uranium";
+const PRICED_FUELS: PricedFuelType[] = [
+  "Coal",
+  "Natural Gas",
+  "Oil",
+  "Uranium",
+];
 
 // This is a pureComponent because its props should change much less frequently than it renders
 export default class ChartForecastFuelPrices extends React.PureComponent<
@@ -46,12 +53,11 @@ export default class ChartForecastFuelPrices extends React.PureComponent<
             <VictoryVoronoiContainer
               voronoiDimension="x"
               // Labels are rendered on EACH chart, so we only render on Coal, otherwise we get duplicate labels
-              voronoiBlacklist={["naturalGas", "oil", "uranium"]}
+              voronoiBlacklist={PRICED_FUELS.slice(1)}
               labels={({ datum }) =>
-                `Coal: ${formatMoneyStable(datum.Coal)}
-                Natural Gas: ${formatMoneyStable(datum["Natural Gas"])}
-                Oil: ${formatMoneyStable(datum.Oil)}
-                Uranium: ${formatMoneyStable(datum.Uranium)}`
+                PRICED_FUELS.map(
+                  (f) => `${f}: ${formatMoneyStable(datum[f])}`
+                ).join("\n")
               }
               labelComponent={
                 <VictoryTooltip
@@ -94,76 +100,48 @@ export default class ChartForecastFuelPrices extends React.PureComponent<
               tickLabels: chartTheme.tickLabels,
             }}
           />
-          <VictoryLine
-            name="coal"
-            data={timeline}
-            x="minute"
-            y="Coal"
-            interpolation="natural"
-            style={{
-              data: {
-                stroke: fuelColors.Coal,
-                strokeWidth: 1,
-              },
-            }}
-          />
-          <VictoryLine
-            name="naturalGas"
-            data={timeline}
-            x="minute"
-            y="Natural Gas"
-            interpolation="natural"
-            style={{
-              data: {
-                stroke: fuelColors["Natural Gas"],
-                strokeWidth: 1,
-              },
-            }}
-          />
-          <VictoryLine
-            name="oil"
-            data={timeline}
-            x="minute"
-            y="Oil"
-            interpolation="natural"
-            style={{
-              data: {
-                stroke: fuelColors.Oil,
-                strokeWidth: 1,
-              },
-            }}
-          />
-          <VictoryLine
-            name="uranium"
-            data={timeline}
-            x="minute"
-            y="Uranium"
-            interpolation="natural"
-            style={{
-              data: {
-                stroke: fuelColors.Uranium,
-                strokeWidth: 1,
-              },
-            }}
-          />
-          <VictoryLegend
-            x={270}
-            y={15}
-            centerTitle
-            orientation="vertical"
-            rowGutter={-5}
-            symbolSpacer={5}
-            data={[
-              { name: "Coal", symbol: { fill: fuelColors.Coal } },
-              {
-                name: "Natural Gas",
-                symbol: { fill: fuelColors["Natural Gas"] },
-              },
-              { name: "Oil", symbol: { fill: fuelColors.Oil } },
-              { name: "Uranium", symbol: { fill: fuelColors.Uranium } },
-            ]}
-          />
+          {PRICED_FUELS.map((f) => (
+            <VictoryLine
+              key={f}
+              name={f}
+              data={timeline}
+              x="minute"
+              y={f}
+              interpolation="natural"
+              style={{
+                data: {
+                  stroke: fuelColors[f],
+                  strokeWidth: 1.5,
+                  // Four overlapping lines are more than color alone can separate, so each
+                  // fuel also gets its own dash pattern
+                  strokeDasharray: fuelDashArrays[f],
+                },
+              }}
+            />
+          ))}
         </VictoryChart>
+        {/* Below the plot rather than floating in it, where it used to clip the data */}
+        <div className="chartLegend">
+          {PRICED_FUELS.map((f) => (
+            <span key={f} className="chartLegendItem">
+              <svg
+                className="chartLegendSwatch chartLegendSwatch-line"
+                viewBox="0 0 20 4"
+              >
+                <line
+                  x1="0"
+                  y1="2"
+                  x2="20"
+                  y2="2"
+                  stroke={fuelColors[f]}
+                  strokeWidth="3"
+                  strokeDasharray={fuelDashArrays[f]}
+                />
+              </svg>
+              {f}
+            </span>
+          ))}
+        </div>
       </div>
     );
   }

--- a/src/components/base/ChartForecastStorage.tsx
+++ b/src/components/base/ChartForecastStorage.tsx
@@ -13,7 +13,7 @@ import {
   formatMonthChartAxis,
   getDateFromMinute,
 } from "../../helpers/DateTime";
-import { formatWattHours } from "../../helpers/Format";
+import { formatWattHours, formatWattHoursAxis } from "../../helpers/Format";
 import { chartTheme, supplyColor } from "../../Theme";
 
 export interface Props {
@@ -76,7 +76,9 @@ export default class chartForecastStorage extends React.PureComponent<
           />
           <VictoryAxis
             dependentAxis
-            tickFormat={(t: number) => formatWattHours(t)}
+            tickFormat={(t: number, _i: number, ticks: number[]) =>
+              formatWattHoursAxis(t, ticks)
+            }
             tickLabelComponent={<VictoryLabel dx={10} />}
             fixLabelOverlap={true}
             style={{

--- a/src/components/base/ChartForecastStorage.tsx
+++ b/src/components/base/ChartForecastStorage.tsx
@@ -5,9 +5,8 @@ import {
   VictoryLabel,
   VictoryLine,
   VictoryTheme,
-  VictoryVoronoiContainer,
-  VictoryTooltip,
 } from "victory";
+import { chartTooltipContainer } from "./ChartTooltipContainer";
 import { TickPresentFutureType } from "../../Types";
 import {
   formatMonthChartAxis,
@@ -41,20 +40,9 @@ export default class chartForecastStorage extends React.PureComponent<
           domain={domain}
           domainPadding={{ y: [6, 6] }}
           height={height || 300}
-          containerComponent={
-            <VictoryVoronoiContainer
-              voronoiDimension="x"
-              labels={({ datum }) => formatWattHours(datum.storedWh)}
-              labelComponent={
-                <VictoryTooltip
-                  cornerRadius={2}
-                  constrainToVisibleArea
-                  flyoutStyle={{ fill: "white" }}
-                  style={{ textAnchor: "end" }}
-                />
-              }
-            />
-          }
+          containerComponent={chartTooltipContainer({
+            labels: ({ datum }: any) => formatWattHours(datum.storedWh),
+          })}
         >
           <VictoryAxis
             tickCount={6}

--- a/src/components/base/ChartForecastSupplyByFuel.tsx
+++ b/src/components/base/ChartForecastSupplyByFuel.tsx
@@ -7,9 +7,8 @@ import {
   VictoryLine,
   VictoryStack,
   VictoryTheme,
-  VictoryVoronoiContainer,
-  VictoryTooltip,
 } from "victory";
+import { chartTooltipContainer } from "./ChartTooltipContainer";
 import {
   formatMonthChartAxis,
   getDateFromMinute,
@@ -94,29 +93,17 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
           padding={{ top: 5, bottom: 25, left: 55, right: 5 }}
           domain={{ x: domain.x, y: [0, maxY] }}
           height={height || 300}
-          containerComponent={
-            <VictoryVoronoiContainer
-              voronoiDimension="x"
-              // The stacked bands all carry the same datum, so only the demand line renders labels
-              voronoiBlacklist={fuels}
-              labels={({ datum }) =>
-                [
-                  ...[...fuels]
-                    .reverse()
-                    .map((f: FuelNameType) => f + ": " + formatWatts(datum[f])),
-                  "Demand: " + formatWatts(datum.demandW),
-                ].join("\n")
-              }
-              labelComponent={
-                <VictoryTooltip
-                  cornerRadius={2}
-                  constrainToVisibleArea
-                  flyoutStyle={{ fill: "white" }}
-                  style={{ textAnchor: "end" }}
-                />
-              }
-            />
-          }
+          containerComponent={chartTooltipContainer({
+            labels: ({ datum }: any) =>
+              [
+                ...[...fuels]
+                  .reverse()
+                  .map((f: FuelNameType) => f + ": " + formatWatts(datum[f])),
+                "Demand: " + formatWatts(datum.demandW),
+              ].join("\n"),
+            // The stacked bands all carry the same datum, so only the demand line renders labels
+            voronoiBlacklist: fuels,
+          })}
         >
           <VictoryAxis
             tickCount={6}

--- a/src/components/base/ChartForecastSupplyByFuel.tsx
+++ b/src/components/base/ChartForecastSupplyByFuel.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import {
+  VictoryArea,
   VictoryAxis,
   VictoryChart,
   VictoryLabel,
-  VictoryLegend,
   VictoryLine,
+  VictoryStack,
   VictoryTheme,
   VictoryVoronoiContainer,
   VictoryTooltip,
@@ -13,9 +14,9 @@ import {
   formatMonthChartAxis,
   getDateFromMinute,
 } from "../../helpers/DateTime";
-import { formatWatts } from "../../helpers/Format";
+import { formatWatts, formatWattsAxis } from "../../helpers/Format";
 import { FuelNameType, TickPresentFutureType } from "../../Types";
-import { chartTheme, fuelColors } from "../../Theme";
+import { chartTheme, demandColor, fuelColors } from "../../Theme";
 
 export interface Props {
   height?: number;
@@ -23,6 +24,8 @@ export interface Props {
   domain: { x: [number, number] };
   startingYear: number;
   multiyear: boolean;
+  // Bottom-to-top order of the stack, ie the order these fuels are dispatched in
+  fuels: FuelNameType[];
 }
 
 // This is a pureComponent because its props should change much less frequently than it renders
@@ -32,27 +35,56 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
 > {
   public render() {
     const { domain, height, timeline, startingYear, multiyear } = this.props;
-    // Extract the supply by fuel values
-    const data = timeline.map((t) => {
-      return { minute: t.minute, ...t.supplyByFuel };
+
+    // Anything generating in the forecast window belongs in the stack, even if it was built
+    // partway through and so isn't in the fleet the dispatch order was derived from
+    const fuelsInForecast = new Set<FuelNameType>();
+    timeline.forEach((t) => {
+      Object.keys(t.supplyByFuel).forEach((f) =>
+        fuelsInForecast.add(f as FuelNameType)
+      );
+    });
+    const fuels = this.props.fuels.filter((f) => fuelsInForecast.has(f));
+    fuelsInForecast.forEach((f) => {
+      if (fuels.indexOf(f) === -1) {
+        fuels.push(f);
+      }
     });
 
-    // Check at the end of the list in case anything new is built during the forecast window, and backfill zeroes as needed, until all fuels are present
-    const fuels = Object.keys(
-      timeline[timeline.length - 1].supplyByFuel
-    ).sort() as FuelNameType[];
-    for (let i = 0; i < data.length; i++) {
-      let missingFuel = false;
-      for (let f = 0; f < fuels.length; f++) {
-        if (!data[i][fuels[f]]) {
-          missingFuel = true;
-          data[i][fuels[f]] = 0;
-        }
+    // Every band needs a value at every x or the stack tears, so backfill the whole series.
+    // Each point carries every fuel as well as its own x/y, so that the shared tooltip can read
+    // the whole mix off whichever series the pointer landed on.
+    // The sampled forecast repeats its first minute, and a stack lines its bands up by x, so a
+    // duplicate x knocks every band after it out of alignment - drop repeats as we go.
+    const data: Array<{ [index: string]: number }> = [];
+    timeline.forEach((t) => {
+      if (data.length && data[data.length - 1].minute === t.minute) {
+        return;
       }
-      if (!missingFuel) {
-        break;
-      }
-    }
+      const point: { [index: string]: number } = {
+        minute: t.minute,
+        demandW: t.demandW,
+      };
+      fuels.forEach((f) => {
+        point[f] = t.supplyByFuel[f] || 0;
+      });
+      data.push(point);
+    });
+    const seriesByFuel = fuels.map((f) =>
+      data.map((point) => ({ ...point, x: point.minute, y: point[f] }))
+    );
+    const demandSeries = data.map((point) => ({
+      ...point,
+      x: point.minute,
+      y: point.demandW,
+    }));
+
+    // The stack tops out at total generation, which can sit either side of demand - leave room for both
+    let maxY = 0;
+    data.forEach((d) => {
+      const generated = fuels.reduce((sum, f) => sum + d[f], 0);
+      maxY = Math.max(maxY, generated, d.demandW);
+    });
 
     // Wrapping in spare div prevents excessive height bug
     return (
@@ -60,18 +92,20 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
         <VictoryChart
           theme={VictoryTheme.material}
           padding={{ top: 5, bottom: 25, left: 55, right: 5 }}
-          domain={domain}
-          domainPadding={{ y: [6, 6] }}
+          domain={{ x: domain.x, y: [0, maxY] }}
           height={height || 300}
           containerComponent={
             <VictoryVoronoiContainer
               voronoiDimension="x"
-              // Labels are rendered on EACH chart, so we only render on first one, otherwise we get duplicate labels
-              voronoiBlacklist={fuels.slice(1)}
+              // The stacked bands all carry the same datum, so only the demand line renders labels
+              voronoiBlacklist={fuels}
               labels={({ datum }) =>
-                fuels
-                  .map((f: FuelNameType) => f + ": " + formatWatts(datum[f]))
-                  .join("\n")
+                [
+                  ...[...fuels]
+                    .reverse()
+                    .map((f: FuelNameType) => f + ": " + formatWatts(datum[f])),
+                  "Demand: " + formatWatts(datum.demandW),
+                ].join("\n")
               }
               labelComponent={
                 <VictoryTooltip
@@ -104,7 +138,9 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
           />
           <VictoryAxis
             dependentAxis
-            tickFormat={(t: number) => formatWatts(t)}
+            tickFormat={(t: number, _i: number, ticks: number[]) =>
+              formatWattsAxis(t, ticks)
+            }
             tickLabelComponent={<VictoryLabel dx={5} />}
             fixLabelOverlap={true}
             style={{
@@ -115,33 +151,54 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
               tickLabels: chartTheme.tickLabels,
             }}
           />
-          {fuels.map((f: FuelNameType, i: number) => (
-            <VictoryLine
-              key={i}
-              name={f}
-              data={data}
-              x="minute"
-              y={f}
-              style={{
-                data: {
-                  stroke: fuelColors[f],
-                  strokeWidth: 1,
-                },
-              }}
-            />
-          ))}
-          <VictoryLegend
-            x={270}
-            y={15}
-            centerTitle
-            orientation="vertical"
-            rowGutter={-5}
-            symbolSpacer={5}
-            data={fuels.map((f) => {
-              return { name: f, symbol: { fill: fuelColors[f] } };
-            })}
+          {/* Every band already covers every x, so let Victory stack them as given */}
+          <VictoryStack fillInMissingData={false}>
+            {fuels.map((f: FuelNameType, i: number) => (
+              <VictoryArea
+                key={f}
+                name={f}
+                data={seriesByFuel[i]}
+                style={{
+                  data: {
+                    fill: fuelColors[f],
+                    // A hairline of background between bands keeps them apart even where two
+                    // fuel colors are close, since seven series can't all be far apart
+                    stroke: "#ffffff",
+                    strokeWidth: 0.5,
+                  },
+                }}
+              />
+            ))}
+          </VictoryStack>
+          {/* Drawn over the stack so the gap between the two reads as the shortfall */}
+          <VictoryLine
+            name="demand"
+            data={demandSeries}
+            style={{
+              data: {
+                stroke: demandColor,
+                strokeWidth: 2,
+                strokeDasharray: "4,2",
+              },
+            }}
           />
         </VictoryChart>
+        {/* Below the plot rather than floating in it, where it used to clip the data */}
+        <div className="chartLegend">
+          {[...fuels].reverse().map((f: FuelNameType) => (
+            <span key={f} className="chartLegendItem">
+              <span
+                className="chartLegendSwatch"
+                style={{ backgroundColor: fuelColors[f] }}
+              />
+              {f}
+            </span>
+          ))}
+          <span className="chartLegendItem">
+            <span className="chartLegendSwatch chartLegendSwatch-demand" />
+            Demand
+          </span>
+        </div>
       </div>
     );
   }

--- a/src/components/base/ChartForecastSupplyDemand.tsx
+++ b/src/components/base/ChartForecastSupplyDemand.tsx
@@ -6,9 +6,8 @@ import {
   VictoryLabel,
   VictoryLine,
   VictoryTheme,
-  VictoryVoronoiContainer,
-  VictoryTooltip,
 } from "victory";
+import { chartTooltipContainer } from "./ChartTooltipContainer";
 import { TickPresentFutureType } from "../../Types";
 import {
   formatMonthChartAxis,
@@ -54,24 +53,12 @@ export default class chartForecastSupplyDemand extends React.PureComponent<
           domain={domain}
           domainPadding={{ y: [6, 6] }}
           height={height || 300}
-          containerComponent={
-            <VictoryVoronoiContainer
-              voronoiDimension="x"
-              // Labels are rendered on EACH chart, so we only render on supply, otherwise we get duplicate labels
-              voronoiBlacklist={["demand", "blackouts"]}
-              labels={({ datum }) =>
-                `Supply: ${formatWatts(datum.supplyW)}\nDemand: ${formatWatts(datum.demandW)}`
-              }
-              labelComponent={
-                <VictoryTooltip
-                  cornerRadius={2}
-                  constrainToVisibleArea
-                  flyoutStyle={{ fill: "white" }}
-                  style={{ textAnchor: "end" }}
-                />
-              }
-            />
-          }
+          containerComponent={chartTooltipContainer({
+            labels: ({ datum }: any) =>
+              `Supply: ${formatWatts(datum.supplyW)}\nDemand: ${formatWatts(datum.demandW)}`,
+            // Labels are rendered on EACH chart, so we only render on supply, otherwise we get duplicate labels
+            voronoiBlacklist: ["demand", "blackouts"],
+          })}
         >
           <VictoryAxis
             tickCount={6}

--- a/src/components/base/ChartForecastSupplyDemand.tsx
+++ b/src/components/base/ChartForecastSupplyDemand.tsx
@@ -14,7 +14,7 @@ import {
   formatMonthChartAxis,
   getDateFromMinute,
 } from "../../helpers/DateTime";
-import { formatWatts } from "../../helpers/Format";
+import { formatWatts, formatWattsAxis } from "../../helpers/Format";
 import {
   blackoutColor,
   chartTheme,
@@ -93,7 +93,9 @@ export default class chartForecastSupplyDemand extends React.PureComponent<
           />
           <VictoryAxis
             dependentAxis
-            tickFormat={(t: number) => formatWatts(t)}
+            tickFormat={(t: number, _i: number, ticks: number[]) =>
+              formatWattsAxis(t, ticks)
+            }
             tickLabelComponent={<VictoryLabel dx={5} />}
             fixLabelOverlap={true}
             style={{

--- a/src/components/base/ChartForecastWeather.tsx
+++ b/src/components/base/ChartForecastWeather.tsx
@@ -6,9 +6,8 @@ import {
   VictoryLegend,
   VictoryLine,
   VictoryTheme,
-  VictoryVoronoiContainer,
-  VictoryTooltip,
 } from "victory";
+import { chartTooltipContainer } from "./ChartTooltipContainer";
 import { TICK_MINUTES } from "../../Constants";
 import { TickPresentFutureType } from "../../Types";
 import {
@@ -49,24 +48,12 @@ export default class ChartForecastWeather extends React.PureComponent<
           domain={domain}
           domainPadding={{ y: [6, 6] }}
           height={height || 300}
-          containerComponent={
-            <VictoryVoronoiContainer
-              voronoiDimension="x"
-              // Labels are rendered on EACH chart, so we only render on temperature, otherwise we get duplicate labels
-              voronoiBlacklist={["wind"]}
-              labels={({ datum }) =>
-                `Temperature: ${Math.round(datum.temperatureC)}°C\nWind: ${Math.round(datum.windKph)} km/h`
-              }
-              labelComponent={
-                <VictoryTooltip
-                  cornerRadius={2}
-                  constrainToVisibleArea
-                  flyoutStyle={{ fill: "white" }}
-                  style={{ textAnchor: "end" }}
-                />
-              }
-            />
-          }
+          containerComponent={chartTooltipContainer({
+            labels: ({ datum }: any) =>
+              `Temperature: ${Math.round(datum.temperatureC)}°C\nWind: ${Math.round(datum.windKph)} km/h`,
+            // Labels are rendered on EACH chart, so we only render on temperature, otherwise we get duplicate labels
+            voronoiBlacklist: ["wind"],
+          })}
         >
           <VictoryAxis
             tickCount={6}

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -10,8 +10,13 @@ import {
   VictoryVoronoiContainer,
   VictoryTooltip,
 } from "victory";
-import { getDateFromMinute, getSunriseSunset } from "../../helpers/DateTime";
-import { formatWatts } from "../../helpers/Format";
+import {
+  formatMinuteOfDayChartAxis,
+  getDateFromMinute,
+  getHourTicks,
+  getSunriseSunset,
+} from "../../helpers/DateTime";
+import { formatWatts, formatWattsAxis } from "../../helpers/Format";
 import { getIntersectionX } from "../../helpers/Math";
 import {
   blackoutColor,
@@ -84,7 +89,10 @@ const ChartSupplyDemand = (props: Props): JSX.Element => {
       ).sunset;
   }
 
-  const noon = sunrise + (sunset - sunrise) / 2
+  const noon = sunrise + (sunset - sunrise) / 2;
+
+  // "Demand peaks in the early evening" only lands if you can read the clock off the axis
+  const hourTicks = getHourTicks(rangeMin, rangeMax);
 
   // BLACKOUT CALCULATION
   let blackoutCount = 0;
@@ -198,8 +206,8 @@ const ChartSupplyDemand = (props: Props): JSX.Element => {
         }
       >
         <VictoryAxis
-          tickValues={[sunrise, noon, sunset]}
-          tickFormat={["🌅", "☀️ ", "🌇"]}
+          tickValues={hourTicks}
+          tickFormat={(t: number) => formatMinuteOfDayChartAxis(t)}
           tickLabelComponent={<VictoryLabel dy={-5} />}
           style={{
             axis: chartTheme.axis,
@@ -209,9 +217,25 @@ const ChartSupplyDemand = (props: Props): JSX.Element => {
             tickLabels: chartTheme.tickLabels,
           }}
         />
+        {/* Sunrise and sunset ride a second axis so the hours stay evenly spaced and readable */}
+        <VictoryAxis
+          tickValues={[sunrise, noon, sunset]}
+          tickFormat={["🌅", "☀️ ", "🌇"]}
+          tickLabelComponent={<VictoryLabel dy={12} />}
+          style={{
+            axis: { stroke: "none" },
+            ticks: { stroke: "none" },
+            grid: {
+              display: "none",
+            },
+            tickLabels: chartTheme.tickLabels,
+          }}
+        />
         <VictoryAxis
           dependentAxis
-          tickFormat={(t: number) => formatWatts(t)}
+          tickFormat={(t: number, _i: number, ticks: number[]) =>
+            formatWattsAxis(t, ticks)
+          }
           tickLabelComponent={<VictoryLabel dx={5} />}
           fixLabelOverlap={true}
           style={{

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -7,9 +7,8 @@ import {
   VictoryLegend,
   VictoryLine,
   VictoryTheme,
-  VictoryVoronoiContainer,
-  VictoryTooltip,
 } from "victory";
+import { chartTooltipContainer } from "./ChartTooltipContainer";
 import {
   formatMinuteOfDayChartAxis,
   getDateFromMinute,
@@ -181,29 +180,17 @@ const ChartSupplyDemand = (props: Props): JSX.Element => {
         domain={{ y: [domainMin, domainMax] }}
         domainPadding={{ y: [6, 6] }}
         height={height || 300}
-        containerComponent={
-          <VictoryVoronoiContainer
-            voronoiDimension="x"
-            // Labels are rendered on EACH chart, so we only render on demand, otherwise we get duplicate labels
-            voronoiBlacklist={[
-              "supplyHistoric",
-              "supplyForecast",
-              "blackouts",
-              "current",
-            ]}
-            labels={({ datum }) =>
-              `Supply: ${formatWatts(datum.supplyW)}\nDemand: ${formatWatts(datum.demandW)}`
-            }
-            labelComponent={
-              <VictoryTooltip
-                cornerRadius={2}
-                constrainToVisibleArea
-                flyoutStyle={{ fill: "white" }}
-                style={{ textAnchor: "end" }}
-              />
-            }
-          />
-        }
+        containerComponent={chartTooltipContainer({
+          labels: ({ datum }: any) =>
+            `Supply: ${formatWatts(datum.supplyW)}\nDemand: ${formatWatts(datum.demandW)}`,
+          // Labels are rendered on EACH chart, so we only render on demand, otherwise we get duplicate labels
+          voronoiBlacklist: [
+            "supplyHistoric",
+            "supplyForecast",
+            "blackouts",
+            "current",
+          ],
+        })}
       >
         <VictoryAxis
           tickValues={hourTicks}

--- a/src/components/base/ChartTooltipContainer.tsx
+++ b/src/components/base/ChartTooltipContainer.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { createContainer, LineSegment, VictoryTooltip } from "victory";
+import { cursorColor } from "../../Theme";
+
+// Voronoi puts one tooltip on screen covering every series at the hovered x; cursor draws the
+// vertical line marking which x that is, so the numbers in the tooltip are tied to a place on
+// the chart rather than floating near the pointer.
+// createContainer's return type is too loose for TSX to accept as a component
+const VoronoiCursorContainer = createContainer(
+  "voronoi",
+  "cursor"
+) as React.ComponentType<any>;
+
+interface Props {
+  labels: (point: any) => string;
+  // Series that shouldn't raise their own tooltip, because one tooltip already reports them all
+  voronoiBlacklist?: string[];
+}
+
+// Shared hover behaviour for every chart in the game
+export function chartTooltipContainer({ labels, voronoiBlacklist }: Props) {
+  return (
+    <VoronoiCursorContainer
+      voronoiDimension="x"
+      cursorDimension="x"
+      voronoiBlacklist={voronoiBlacklist}
+      labels={labels}
+      cursorComponent={
+        <LineSegment
+          style={{
+            stroke: cursorColor,
+            strokeWidth: 1,
+            strokeDasharray: "3,2",
+            pointerEvents: "none",
+          }}
+        />
+      }
+      labelComponent={
+        <VictoryTooltip
+          cornerRadius={2}
+          constrainToVisibleArea
+          flyoutStyle={{ fill: "white" }}
+          style={{ textAnchor: "end" }}
+        />
+      }
+    />
+  );
+}

--- a/src/components/base/ChartTooltipContainer.tsx
+++ b/src/components/base/ChartTooltipContainer.tsx
@@ -5,10 +5,13 @@ import { cursorColor } from "../../Theme";
 // Voronoi puts one tooltip on screen covering every series at the hovered x; cursor draws the
 // vertical line marking which x that is, so the numbers in the tooltip are tied to a place on
 // the chart rather than floating near the pointer.
+// Cursor first, voronoi second: the combined container appends each behaviour's elements in
+// the order given, and SVG paints in document order, so this keeps the tooltip above the line
+// rather than letting the line strike through it.
 // createContainer's return type is too loose for TSX to accept as a component
-const VoronoiCursorContainer = createContainer(
-  "voronoi",
-  "cursor"
+const CursorVoronoiContainer = createContainer(
+  "cursor",
+  "voronoi"
 ) as React.ComponentType<any>;
 
 interface Props {
@@ -20,7 +23,7 @@ interface Props {
 // Shared hover behaviour for every chart in the game
 export function chartTooltipContainer({ labels, voronoiBlacklist }: Props) {
   return (
-    <VoronoiCursorContainer
+    <CursorVoronoiContainer
       voronoiDimension="x"
       cursorDimension="x"
       voronoiBlacklist={voronoiBlacklist}

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -28,7 +28,9 @@ import { facilityCashBack } from "../../helpers/Financials";
 import {
   formatMoneyConcise,
   formatWattHours,
+  formatWattHoursOfPeak,
   formatWatts,
+  formatWattsOfPeak,
 } from "../../helpers/Format";
 import ChartSupplyDemand from "../base/ChartSupplyDemand";
 import GameCard from "../base/GameCard";
@@ -66,9 +68,9 @@ function FacilityListItem(props: FacilityListItemProps): JSX.Element {
     );
     secondaryText = `Building: ${percentBuilt}%, ${Math.ceil(props.facility.yearsToBuildLeft * 12)} months left`;
   } else if (facility.peakWh) {
-    secondaryText = `${formatWattHours(facility.currentWh).replace(/[^0-9.,]/g, "")}/${formatWattHours(facility.peakWh)}, ${formatWatts(facility.peakW)}`;
+    secondaryText = `${formatWattHoursOfPeak(facility.currentWh, facility.peakWh)}, ${formatWatts(facility.peakW)}`;
   } else {
-    secondaryText = `${formatWatts(facility.currentW).replace(/[^0-9.,]/g, "")}/${formatWatts(facility.peakW)}`;
+    secondaryText = formatWattsOfPeak(facility.currentW, facility.peakW);
   }
 
   return (

--- a/src/components/views/Forecasts.tsx
+++ b/src/components/views/Forecasts.tsx
@@ -10,13 +10,14 @@ import {
   Typography,
 } from "@mui/material";
 import { TICKS_PER_YEAR } from "../../Constants";
-import { GameType, TickPresentFutureType } from "../../Types";
+import { FuelNameType, GameType, TickPresentFutureType } from "../../Types";
 import {
   formatHour,
   getDateFromMinute,
   getTimeFromTimeline,
 } from "../../helpers/DateTime";
 import { formatWattHours, formatWatts } from "../../helpers/Format";
+import { getDispatchOrderedFuels } from "../../helpers/Energy";
 import { generateNewTimeline } from "../../reducers/Game";
 import ChartForecastFuelPrices from "../base/ChartForecastFuelPrices";
 import ChartForecastSupplyDemand from "../base/ChartForecastSupplyDemand";
@@ -251,6 +252,7 @@ export default class Forecasts extends React.Component<Props, State> {
             domain={{ x: [rangeMin, rangeMax] }}
             startingYear={game.startingYear}
             multiyear={years > 1}
+            fuels={getDispatchOrderedFuels(game.facilities) as FuelNameType[]}
           />
           {hasStorage && (
             <div>

--- a/src/helpers/DateTime.test.tsx
+++ b/src/helpers/DateTime.test.tsx
@@ -1,0 +1,38 @@
+import { formatMinuteOfDayChartAxis, getHourTicks } from "./DateTime";
+
+describe("formatMinuteOfDayChartAxis", () => {
+  it("should render midnight as 12am", () => {
+    expect(formatMinuteOfDayChartAxis(0)).toEqual("12am");
+  });
+
+  it("should render noon as 12pm", () => {
+    expect(formatMinuteOfDayChartAxis(12 * 60)).toEqual("12pm");
+  });
+
+  it("should render the evening peak in 12 hour time", () => {
+    expect(formatMinuteOfDayChartAxis(19 * 60)).toEqual("7pm");
+  });
+
+  it("should ignore whole days, since the axis only shows a clock", () => {
+    expect(formatMinuteOfDayChartAxis(5 * 1440 + 6 * 60)).toEqual("6am");
+  });
+});
+
+describe("getHourTicks", () => {
+  it("should space a day's worth of ticks 4 hours apart", () => {
+    const ticks = getHourTicks(0, 1440);
+    expect(ticks).toEqual([0, 240, 480, 720, 960, 1200, 1440]);
+  });
+
+  it("should snap to whole hours when the range starts mid-hour", () => {
+    const ticks = getHourTicks(125, 125 + 1440);
+    expect(ticks[0] % 60).toEqual(0);
+    expect(ticks.every((t) => t % 60 === 0)).toEqual(true);
+  });
+
+  it("should stay inside the range", () => {
+    const ticks = getHourTicks(600, 1000);
+    expect(Math.min(...ticks)).toBeGreaterThanOrEqual(600);
+    expect(Math.max(...ticks)).toBeLessThanOrEqual(1000);
+  });
+});

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -213,3 +213,38 @@ export function getDateFromMinute(
     year,
   };
 }
+
+// eg "4am", "12pm" - a bare clock time for chart axes, where the day and month are already known
+export function formatMinuteOfDayChartAxis(minute: number): string {
+  const hourOfDay = Math.floor((minute % 1440) / 60);
+  return (
+    (hourOfDay % 12 === 0 ? 12 : hourOfDay % 12) +
+    (hourOfDay < 12 ? "am" : "pm")
+  );
+}
+
+/**
+ * Clock ticks across a span of minutes, snapped to a whole number of hours and spaced so that
+ * at most `maxTicks` of them land in the span.
+ */
+export function getHourTicks(
+  rangeMin: number,
+  rangeMax: number,
+  maxTicks = 6
+): number[] {
+  const hoursSpanned = (rangeMax - rangeMin) / 60;
+  const step =
+    ([1, 2, 3, 4, 6, 8, 12] as number[]).find(
+      (h) => hoursSpanned / h <= maxTicks
+    ) || 24;
+  const stepMinutes = step * 60;
+  const ticks = [];
+  for (
+    let m = Math.ceil(rangeMin / stepMinutes) * stepMinutes;
+    m <= rangeMax;
+    m += stepMinutes
+  ) {
+    ticks.push(m);
+  }
+  return ticks;
+}

--- a/src/helpers/Energy.test.tsx
+++ b/src/helpers/Energy.test.tsx
@@ -1,4 +1,5 @@
 import {
+  getDispatchOrderedFuels,
   getSolarOutputFactor,
   getWindOutputFactor,
   getSolarCapacityFactor,
@@ -76,5 +77,35 @@ describe("getSolarCapacityFactor", () => {
     const result = getSolarCapacityFactor(irradiancesWM2);
     expect(result).toBeGreaterThanOrEqual(0);
     expect(result).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("getDispatchOrderedFuels", () => {
+  it("should return unique fuels in facility list order", () => {
+    const result = getDispatchOrderedFuels([
+      { fuel: "Coal" },
+      { fuel: "Natural Gas" },
+      { fuel: "Coal" },
+    ]);
+    expect(result).toEqual(["Coal", "Natural Gas"]);
+  });
+
+  it("should put must-run renewables below the dispatchable fuels", () => {
+    const result = getDispatchOrderedFuels([
+      { fuel: "Coal" },
+      { fuel: "Wind" },
+      { fuel: "Natural Gas" },
+      { fuel: "Sun" },
+    ]);
+    expect(result).toEqual(["Sun", "Wind", "Coal", "Natural Gas"]);
+  });
+
+  it("should skip storage, which has no fuel", () => {
+    const result = getDispatchOrderedFuels([{}, { fuel: "Coal" }, {}]);
+    expect(result).toEqual(["Coal"]);
+  });
+
+  it("should handle an empty fleet", () => {
+    expect(getDispatchOrderedFuels([])).toEqual([]);
   });
 });

--- a/src/helpers/Energy.tsx
+++ b/src/helpers/Energy.tsx
@@ -1,4 +1,5 @@
 import { EQUATOR_RADIANCE, OUTSKIRTS_WIND_MULTIPLIER } from "../Constants";
+import { FacilityOperatingType, GeneratorOperatingType } from "../Types";
 
 export function getWindOutputFactor(windKph: number) {
   // Wind gradient, assuming 10m weather station, 100m wind turbine, neutral air above human habitation - https://en.wikipedia.org/wiki/Wind_gradient
@@ -52,4 +53,33 @@ export function getSolarCapacityFactor(irradiancesWM2: number[]) {
       0
     ) / irradiancesWM2.length
   );
+}
+
+// Sun and Wind aren't dispatchable - they generate whatever the weather allows regardless of
+// where the player drags them - so a dispatch stack puts them on the bottom as must-run supply,
+// the same convention EIA and ISO generation stacks use.
+const MUST_RUN_FUELS = ["Sun", "Wind"];
+
+/**
+ * The fuels present in a fleet, ordered the way a dispatch stack is drawn: must-run renewables
+ * first, then the dispatchable fuels in the player's own merit order (their facility list order).
+ */
+export function getDispatchOrderedFuels(
+  facilities: Array<Partial<FacilityOperatingType>>
+): string[] {
+  const mustRun: string[] = [];
+  const dispatchable: string[] = [];
+  facilities.forEach((facility) => {
+    const fuel = (facility as Partial<GeneratorOperatingType>).fuel;
+    if (!fuel) {
+      return; // storage, which the stack tracks separately
+    }
+    const bucket = MUST_RUN_FUELS.indexOf(fuel) > -1 ? mustRun : dispatchable;
+    if (bucket.indexOf(fuel) === -1) {
+      bucket.push(fuel);
+    }
+  });
+  // Keep Sun below Wind for a stable stack rather than whichever the player happened to build first
+  mustRun.sort((a, b) => MUST_RUN_FUELS.indexOf(a) - MUST_RUN_FUELS.indexOf(b));
+  return [...mustRun, ...dispatchable];
 }

--- a/src/helpers/Format.test.tsx
+++ b/src/helpers/Format.test.tsx
@@ -1,4 +1,10 @@
-import { formatWatts } from "./Format";
+import {
+  formatWattHoursAxis,
+  formatWattHoursOfPeak,
+  formatWatts,
+  formatWattsAxis,
+  formatWattsOfPeak,
+} from "./Format";
 
 describe("formatWatts", () => {
   it("should correctly format numbers in the tens", () => {
@@ -44,5 +50,61 @@ describe("formatWatts", () => {
   it("should correctly handle the mantissa parameter when 4", () => {
     const result = formatWatts(1521, 4);
     expect(result).toEqual("1.521kW");
+  });
+});
+
+describe("formatWattsAxis", () => {
+  it("should render every tick in the unit of the largest one", () => {
+    const ticks = [0, 1e8, 2e8, 3e8, 4e8, 5e8];
+    expect(ticks.map((t) => formatWattsAxis(t, ticks))).toEqual([
+      "0MW",
+      "100MW",
+      "200MW",
+      "300MW",
+      "400MW",
+      "500MW",
+    ]);
+  });
+
+  it("should promote the whole axis once the largest tick crosses a unit", () => {
+    const ticks = [0, 3e8, 6e8, 9e8, 1.2e9];
+    expect(ticks.map((t) => formatWattsAxis(t, ticks))).toEqual([
+      "0GW",
+      "0.3GW",
+      "0.6GW",
+      "0.9GW",
+      "1.2GW",
+    ]);
+  });
+});
+
+describe("formatWattHoursAxis", () => {
+  it("should append h to the shared unit", () => {
+    const ticks = [0, 5e8, 1e9];
+    expect(ticks.map((t) => formatWattHoursAxis(t, ticks))).toEqual([
+      "0GWh",
+      "0.5GWh",
+      "1GWh",
+    ]);
+  });
+});
+
+describe("formatWattsOfPeak", () => {
+  it("should report the current output in the peak's unit", () => {
+    expect(formatWattsOfPeak(356000000, 500000000)).toEqual("356/500MW");
+  });
+
+  it("should keep an extra digit when the current output is below the peak's unit", () => {
+    expect(formatWattsOfPeak(100000000, 1000000000)).toEqual("0.1/1GW");
+  });
+
+  it("should handle an idle facility", () => {
+    expect(formatWattsOfPeak(0, 500000000)).toEqual("0/500MW");
+  });
+});
+
+describe("formatWattHoursOfPeak", () => {
+  it("should share a unit across the pair", () => {
+    expect(formatWattHoursOfPeak(100000000, 1000000000)).toEqual("0.1/1GWh");
   });
 });

--- a/src/helpers/Format.tsx
+++ b/src/helpers/Format.tsx
@@ -47,3 +47,79 @@ export function formatMoneyConcise(i: number): string {
       .toUpperCase()
   );
 }
+
+interface WattUnitType {
+  suffix: string;
+  divisor: number;
+}
+
+const WATT_UNITS: WattUnitType[] = [
+  { suffix: "T", divisor: 1e12 },
+  { suffix: "G", divisor: 1e9 },
+  { suffix: "M", divisor: 1e6 },
+  { suffix: "k", divisor: 1e3 },
+  { suffix: "", divisor: 1 },
+];
+
+/**
+ * The unit a value of this magnitude reads most naturally in, eg 5e8 -> MegaWatts.
+ * Unlike formatWatts this never promotes to the next unit to save a digit
+ * (formatWatts renders 500MW as "0.5GW"), so a set of related numbers can share one unit.
+ */
+export function getWattUnit(i: number): WattUnitType {
+  const abs = Math.abs(i);
+  return (
+    WATT_UNITS.find((u) => abs >= u.divisor) ||
+    WATT_UNITS[WATT_UNITS.length - 1]
+  );
+}
+
+/**
+ * Formats watts in a caller-chosen unit, so that a group of related numbers - axis ticks,
+ * a current/peak pair - all read in the same unit instead of each picking its own.
+ */
+export function formatWattsInUnit(
+  i: number,
+  unit: WattUnitType,
+  mantissa = 1
+): string {
+  return (
+    numbro(i / unit.divisor).format({
+      thousandSeparated: true,
+      trimMantissa: true,
+      mantissa,
+    }) +
+    unit.suffix +
+    "W"
+  );
+}
+
+/**
+ * tickFormat for a watts axis. Victory calls tickFormat with (tick, index, ticks), so every
+ * tick is rendered in the unit of the largest one - no more "0.5GW / 400MW / 300MW" axes.
+ */
+export function formatWattsAxis(t: number, ticks: number[]): string {
+  return formatWattsInUnit(t, getWattUnit(Math.max(...ticks.map(Math.abs))));
+}
+
+export function formatWattHoursAxis(t: number, ticks: number[]): string {
+  return formatWattsAxis(t, ticks) + "h";
+}
+
+/**
+ * A current-out-of-peak pair sharing the peak's unit, eg "356/500MW" rather than "356/0.5GW".
+ */
+export function formatWattsOfPeak(current: number, peak: number): string {
+  const unit = getWattUnit(peak);
+  // A current well below the peak's unit would round away at one decimal, eg 100MW of a 1GW peak
+  const mantissa = Math.abs(current) >= unit.divisor ? 1 : 2;
+  return (
+    formatWattsInUnit(current, unit, mantissa).replace(/[^0-9.,]/g, "") +
+    "/" +
+    formatWattsInUnit(peak, unit)
+  );
+}
+
+export function formatWattHoursOfPeak(current: number, peak: number): string {
+  return formatWattsOfPeak(current, peak) + "h";
+}


### PR DESCRIPTION
Addresses the second suggestion in the v0.2.0 playtest notes: *"Fix Supply by Fuel — it's the most educational chart and the least readable one."*

## The main change: stacked dispatch chart

**Supply by Fuel** drew four thin overlapping high-frequency lines with a `VictoryLegend` floating on top of the plot area (clipping the data). You couldn't read your own generation mix off the chart that teaches the merit order — the concept the *Prioritizing Generators* manual entry illustrates with a real PJM **stacked area** chart.

It's now a stacked area chart, ordered bottom-to-top by dispatch priority:

1. **Must-run renewables first** (Sun, Wind). They generate whatever the weather allows regardless of where you drag them in the facility list, so they belong at the bottom — the convention EIA and ISO generation stacks use.
2. **Then the dispatchable fuels in your own merit order**, taken from the facility list order you control by dragging.

New `getDispatchOrderedFuels()` in `helpers/Energy.tsx` derives that order from the fleet, unit-tested.

Three things fall out, as the notes predicted:

- **Total height = supply**, with **demand overlaid as a dashed line**, so the shortfall is visible in place instead of on a separate chart in a separate tab.
- **Each band's thickness = that fuel's contribution.** In a fresh *Carbon Fee* game, Natural Gas sits flat at its 200MW cap on the bottom while Coal visibly follows load on top of it — "gas is filling in" becomes something you see rather than infer.
- It matches how the industry draws dispatch stacks.

The legend moved **below** the plot as plain HTML, so it can't clip the data, wraps on narrow screens, and is readable by screen readers. The tooltip now reports demand alongside the fuel mix.

## Colors

The notes' table asks for 3:1 between every fuel pair. That isn't reachable: contrast is luminance-based, so on a white plot the ladder runs out at about **four** mutually-3:1 colors, and at ~1.4:1 for seven series that must each also be visible against the background. Rather than chase it, this tunes for what *is* achievable and adds a second encoding channel where color can't carry it alone.

**Every fuel now clears 3:1 against the white plot area** (WCAG 1.4.11) — Sun was at **1.40:1** and effectively invisible; Uranium was at 2.78:1.

| pair | before | after |
| :--- | :--- | :--- |
| Coal vs Oil | 1.42 | **3.19** |
| Coal vs Natural Gas | 2.55 | **5.79** |
| Natural Gas vs Wind | 1.71 | **3.45** |
| Sun vs Wind | 2.64 | 2.64 |
| Oil vs Natural Gas | 1.80 | **1.81** |
| Uranium vs Blackout | 1.32 | **1.39**, and no longer red-vs-green |

Also: **Uranium moves from green to teal**, so no series pairs red with green (the deuteranopia collision the notes flagged). **Geothermal was literally the same hex as `blackoutColor`** (`red[500]`) — it's now a distinct dark plum, and blackouts moved to `red[800]` so the translucent band reads on white.

## Redundant encoding where color isn't enough

**Fuel Prices** has four overlapping lines, which is past what color alone can separate — so each fuel gets its own **dash pattern** (solid / dashed / dotted / dash-dot), and its legend moved below the plot showing each series' *actual* dash. Stacked bands get a hairline background-colored separator so adjacent fuels stay apart regardless of their colors.

## Units

**Y-axes mixed units within one axis** (`0.5GW / 400MW / 300MW / 200MW`) because `formatWatts` promotes to the next unit to save a digit. New `formatWattsAxis(t, ticks)` renders every tick in the unit of the largest one, via Victory's `tickFormat(tick, index, ticks)`. Applied to all four watt/watt-hour axes.

Same fix in the facility list: `356/0.5GW` and `100/1GWh, 100MW` now read `356/500MW` and `0.1/1GWh, 100MW`, via `formatWattsOfPeak()`.

## Daily chart x-axis

The daily supply/demand chart had **no time labels** — just three emoji floating below the axis, on a chart whose whole point is "demand peaks in the early evening." It now has hour ticks (`12am 4am 8am 12pm 4pm 8pm`), with sunrise/noon/sunset moved to their own row below so both read cleanly.

## Notes

- One real bug surfaced while building this: the sampled forecast repeats its first minute (`Forecasts.tsx` unshifts `timeline[0]` when the filter already included it). A line chart shrugs that off, but a stack aligns its bands by x, and the duplicate knocked every band after it to zero. The chart now drops repeated minutes and passes `fillInMissingData={false}`, since it already guarantees a value for every fuel at every x.
- No simulation changes — this is all presentation.

## Testing

- 41 unit tests pass, including new coverage for `getDispatchOrderedFuels`, `formatWattsAxis`/`formatWattHoursAxis`, `formatWattsOfPeak`/`formatWattHoursOfPeak`, and the new hour-tick helpers.
- `tsc --noEmit` clean.
- Verified in a running *Carbon Fee* game: bands stack in facility-list order, demand overlay draws, tooltip reports the full mix, axes render single-unit, dash patterns apply to all four price lines, and the 1-year and 5-year forecast views both render. No new console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)