### PR TITLE
Auto-deploy to prod on pushes to master

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,45 @@
+name: Deploy to Prod
+run-name: Deploying ${{ github.sha }} to electrifygame.com 🚀
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# Never let two prod deploys run at once; queue them instead of cancelling,
+# so a half-finished S3 sync is never overwritten by a newer one mid-flight.
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 21.7.0
+          cache: npm
+
+      - run: npm ci
+
+      # Tests are not run here; workflow.yml already runs them on every push.
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Build and deploy to prod
+        env:
+          # Baked into the JS bundle at build time by create-react-app.
+          REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}
+        run: ./deploy.sh ci-prod

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,9 @@
 # Requires the aws cli for s3 deploys (make sure to set your bucket region!)
 # Requires that you run `aws configure set preview.cloudfront true` to enable cloudfront invalidation
 
-TARGETS="beta prod local-beta local-prod"
+set -e
+
+TARGETS="beta prod local-beta local-prod ci-prod"
 target="$1"
 
 getTarget() {
@@ -25,6 +27,14 @@ deploy() {
     betabuild
   elif [ "$target" = "local-prod" ]; then
     prodbuild
+  elif [ "$target" = "ci-prod" ]; then
+    # Non-interactive prod deploy, used by the GitHub Action on pushes to master.
+    # Fail loudly rather than shipping a prod bundle with a broken Firebase key.
+    if [ -z "$REACT_APP_FIREBASE_API_KEY" ]; then
+      echo "REACT_APP_FIREBASE_API_KEY is not set; refusing to deploy prod." >&2
+      exit 1
+    fi
+    prod
   elif [ "$target" = "prod" ]; then
     read -p "Did you test on beta? (y/N) " -n 1
     echo

--- a/src/Globals.tsx
+++ b/src/Globals.tsx
@@ -4,7 +4,10 @@ import { getAuth, GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseApp = initializeApp({
-  apiKey: "CONTACT-ADMIN-TO-GET-KEY",
+  // Set by CI from a repo secret; falls back to the placeholder for local dev
+  // (contact an admin for a key). Firebase web API keys are public by design --
+  // access is controlled by Firestore rules and API key restrictions, not secrecy.
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY || "CONTACT-ADMIN-TO-GET-KEY",
   authDomain: "electrify-game.firebaseapp.com",
   databaseURL: "https://electrify-game.firebaseio.com",
   projectId: "electrify-game",


### PR DESCRIPTION
Adds a GitHub Action that builds and deploys to electrifygame.com whenever master is updated, reusing `deploy.sh` rather than duplicating the deploy steps in YAML.

### Changes

- **New `ci-prod` target** in `deploy.sh` runs the existing `prod()` path without the interactive confirmations that would hang a CI runner.
- **`set -e`** so a failed `aws` command fails the job. Previously the script's exit code was just that of the final CloudFront invalidation, so a broken S3 upload could still report success.
- **Firebase key from the environment.** `apiKey` now reads `REACT_APP_FIREBASE_API_KEY`, falling back to the existing placeholder for local dev. Without this, a clean CI checkout would build and ship the literal `CONTACT-ADMIN-TO-GET-KEY` placeholder and silently break login and high scores in prod. `ci-prod` aborts if the variable is unset, so a missing secret fails loudly instead of publishing a broken site.

Tests are not repeated in this workflow since `workflow.yml` already runs them on every push. Note that the two workflows therefore run in parallel on master — a failing test will not block the deploy.

### Required setup before merging

Three repo secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `REACT_APP_FIREBASE_API_KEY`. The AWS pair should belong to a dedicated IAM user scoped to `s3:PutObject`/`s3:ListBucket` on the `electrifygame.com` bucket plus `cloudfront:CreateInvalidation` on distribution `E38D57AILAHD00`.

Merging this PR is itself a push to master, so it triggers the first prod deploy immediately.

### Verification

`ci-prod` was exercised locally with stubbed `npm`/`aws` binaries: unset key exits 1 before building; with the key set it runs the full build, both S3 copies, the `package.json` upload, and the CloudFront invalidation. `tsc --noEmit` passes and `npm ci` resolves cleanly against the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
