### PR TITLE
Fix broken images in prod by fetching Git LFS objects in CI

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+        with:
+          # Images and audio live in Git LFS (see .gitattributes). Without this
+          # the runner gets 130-byte pointer files, the build still succeeds, and
+          # every image and sound on the site ships as a stub.
+          lfs: true
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4.0.2

--- a/deploy.sh
+++ b/deploy.sh
@@ -54,6 +54,15 @@ deploy() {
   fi
 }
 
+# Git LFS pointer files build without error but publish 130-byte stubs in place
+# of every image and audio file, so check before anything reaches the bucket.
+assertNoLfsPointers() {
+  if grep -rql "https://git-lfs.github.com/spec/v1" build; then
+    echo "Build contains Git LFS pointers instead of real assets; aborting." >&2
+    echo "Run 'git lfs pull' and rebuild." >&2
+    exit 1
+  fi
+}
 prebuild() {
   # clear out old build files to prevent conflicts
   rm -rf build
@@ -67,6 +76,7 @@ betabuild() {
 
 beta() {
   betabuild
+  assertNoLfsPointers
   aws s3 cp build s3://beta.electrifygame.com --recursive --region us-east-2
 }
 
@@ -79,6 +89,7 @@ prodbuild() {
 
 prod() {
   prodbuild
+  assertNoLfsPointers
   # Deploy web app to prod with 1 day cache for most files, 6 month cache for art assets
   export AWS_DEFAULT_REGION='us-east-2'
   aws s3 cp build s3://electrifygame.com --recursive --exclude '*.mp3' --exclude '*.jpg' --exclude '*.png' --cache-control max-age=86400 --cache-control public


### PR DESCRIPTION
Every image and audio file on electrifygame.com is currently a 130-byte Git LFS pointer file rather than the real asset. That is why the logo renders broken.

```
$ curl -s https://electrifygame.com/images/logo.svg
version https://git-lfs.github.com/spec/v1
oid sha256:25c3d08b2fd22193fbeac295d859a32f90874f34306c532be1e9dbb159b34a4e
size 22485
```

### Root cause

`.gitattributes` routes `*.svg`, `*.png`, `*.jpg`, `*.mp3`, `*.ico`, `*.psd` and `*.ai` through Git LFS — 56 files, 27 MB — but `actions/checkout` defaults to `lfs: false`. The runner checked out pointer files, `react-scripts` copied them from `public/` into `build/` verbatim, and the deploy uploaded the pointers.

Nothing failed anywhere: the build succeeded, all 75 objects uploaded, and S3 serves the pointers with `Content-Type: image/svg+xml` and HTTP 200. Local deploys were never affected, because a normal clone smudges the real files into the working tree — this only appears once a CI runner does the build.

### Changes

- **`lfs: true`** on the checkout step, so LFS objects are actually fetched.
- **`assertNoLfsPointers()`** in `deploy.sh`, called after the build in both `beta()` and `prod()`. A pointer file in `build/` now aborts the deploy before anything reaches the bucket. This protects manual deploys too, and means the next variant of "the build succeeded but shipped stubs" fails loudly.

### Verification

With stubbed `npm`/`aws`: a build containing a pointer file aborts with exit 1 and makes zero `aws` calls; a build with real assets runs the full deploy sequence and exits 0. The workflow YAML parses and resolves to `{"lfs": true}` on the checkout step.

Merging triggers a redeploy, which is what restores the assets on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
