### PR TITLE
Run tests on pull requests only, not after merge

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,11 @@
 name: Test Code
 run-name: Running tests on behalf of ${{ github.actor }} 🚀
-on: [push]
+# Runs on pull requests only. Tests gate the merge (required status check on
+# master), so re-running them on the post-merge commit would only duplicate a
+# result we already have -- and slow down the prod deploy.
+on:
+  pull_request:
+  workflow_dispatch:
 jobs:
   npm-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pairs with a `npm-test` required status check on the `Protect master` ruleset, so tests run **before** merge and **block** it.

### Changes

`on: [push]` becomes `on: pull_request` (plus `workflow_dispatch` for manual runs).

- **Before merge, blocking.** The required status check on master means a PR cannot merge until `npm-test` passes. Since every path to master goes through a PR, the deploy that fires on the merge commit is transitively gated too — no `workflow_run` plumbing needed.
- **Not after merge.** The post-merge commit no longer re-runs a suite that already passed on the same tree, and the prod deploy doesn't queue behind it.
- **Fork PRs now covered.** A `push` event fires in whichever repo received the push, so an outside contributor's PR never reported a check here. `pull_request` runs in this repo's context. This matters more once the check is required: a required check that never reports would block fork PRs permanently.

One consequence worth naming: pushes to a branch with no PR open no longer run tests. That's the intent — the gate is the PR — but it does mean `git push` on a WIP branch is no longer a free CI run. `workflow_dispatch` covers that case on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
