### PR TITLE
Headless simulator, and three bugs it surfaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ npm test
 
 This runs the unit tests defined in files with the `.test.tsx` extensio.
 
+### Simulate the game headlessly
+
+```sh
+npm run sim -- --all
+```
+
+Plays every scenario through the real game reducer without a browser -- a 20 year run takes about
+half a second -- and checks that the economy obeyed its invariants (no NaNs, cash only moves by
+recorded revenue and expenses, storage can't invent electricity, and so on). Use it to sanity
+check a change to the simulation in seconds rather than by playing through the UI.
+
+`npm run sim -- --scenario 103` reports one scenario month by month, and `npm run sim -- --help`
+lists the flags. See [src/testing/README.md](src/testing/README.md) for what it checks and how it
+works.
+
 ### Release checklist
 
 To release, you'll need to install and authenticate the `aws cli`.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "sim": "node scripts/sim.js",
     "eject": "react-scripts eject",
     "pretty": "prettier --write \"src/**/*.{css,js,jsx,tsx,json}\"",
     "deploy": "./deploy.sh"

--- a/scripts/sim.js
+++ b/scripts/sim.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Runs the headless simulation and prints a report. See src/testing/README.md.
+ *
+ * The simulation reuses the game's own reducer, so it needs the same environment the app gets:
+ * TypeScript, JSX and a DOM. Rather than maintain a second build pipeline for that, this shells
+ * out to CRA's jest, pointed at src/testing/SimCli.tsx via --testMatch. That file is named so
+ * CRA's default testMatch skips it, which keeps `npm test` free of simulation output.
+ */
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+const FLAGS = {
+  "--scenario": "SIM_SCENARIO",
+  "--difficulty": "SIM_DIFFICULTY",
+  "--months": "SIM_MONTHS",
+  "--seed": "SIM_SEED",
+  "--strategy": "SIM_STRATEGY",
+  "--marketing": "SIM_MARKETING",
+  "--rate": "SIM_RATE",
+};
+const BOOLEAN_FLAGS = {
+  "--all": "SIM_ALL",
+  "--full": "SIM_FULL",
+};
+
+const USAGE = `
+Runs the game's simulation headlessly and reports what happened.
+
+  npm run sim                              one scenario, default settings
+  npm run sim -- --all                     every scenario, one line each
+  npm run sim -- --scenario 103 --full     every month of "The Shale Boom"
+
+  --scenario <id>        Scenario to play (default 101). --list shows the ids
+  --difficulty <name>    Intern | Employee | Manager | VP | CEO (default Employee)
+  --months <n>           Override the scenario's own duration
+  --seed <n>             Pin the run's randomness (default 12345)
+  --strategy <name>      none (default) or keepUp, which buys generators when short on supply
+  --marketing <dollars>  Monthly marketing spend (default 0)
+  --rate <dollars>       $/kWh charged to customers (default: whatever a real game starts at)
+  --all                  Sweep every scenario instead of reporting on one
+  --full                 Print every month rather than a sample
+  --list                 List the scenarios and exit
+`;
+
+const args = process.argv.slice(2);
+const env = { ...process.env, CI: "true" };
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === "--help" || arg === "-h") {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+  if (arg === "--list") {
+    // Reading the scenarios needs the TS/JSX pipeline, so ask the simulation runner for them
+    const { SCENARIOS } = requireScenarios();
+    SCENARIOS.forEach((s) =>
+      process.stdout.write(`  ${String(s.id).padStart(4)}  ${s.name}\n`),
+    );
+    process.exit(0);
+  }
+  if (BOOLEAN_FLAGS[arg]) {
+    env[BOOLEAN_FLAGS[arg]] = "1";
+    continue;
+  }
+  if (FLAGS[arg]) {
+    const value = args[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      process.stderr.write(`Missing value for ${arg}\n`);
+      process.exit(1);
+    }
+    env[FLAGS[arg]] = value;
+    i++;
+    continue;
+  }
+  process.stderr.write(`Unknown option ${arg}\n${USAGE}`);
+  process.exit(1);
+}
+
+// Scenarios live in a .tsx file, so pull the ids out with a quick regex rather than a compiler
+function requireScenarios() {
+  const fs = require("fs");
+  const source = fs.readFileSync(
+    path.resolve(__dirname, "..", "src", "data", "Scenarios.tsx"),
+    "utf8",
+  );
+  const SCENARIOS = [];
+  const pattern = /id:\s*(\d+),[\s\S]*?name:\s*"([^"]+)"/g;
+  let match = pattern.exec(source);
+  while (match) {
+    SCENARIOS.push({ id: Number(match[1]), name: match[2] });
+    match = pattern.exec(source);
+  }
+  return { SCENARIOS };
+}
+
+// Invoking the binary through node directly, rather than npx, keeps this working the same way
+// from cmd, PowerShell and a POSIX shell
+const result = spawnSync(
+  process.execPath,
+  [
+    path.resolve(
+      __dirname,
+      "..",
+      "node_modules",
+      "react-scripts",
+      "bin",
+      "react-scripts.js",
+    ),
+    "test",
+    "--watchAll=false",
+    "--testMatch",
+    "**/src/testing/SimCli.tsx",
+  ],
+  { stdio: "inherit", env, cwd: path.resolve(__dirname, "..") },
+);
+
+process.exit(result.status === null ? 1 : result.status);

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -1,5 +1,6 @@
 import { configureStore, ThunkAction, Action } from "@reduxjs/toolkit";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import { registerStore } from "./StoreRegistry";
 import cardReducer from "./reducers/Card";
 import gameReducer from "./reducers/Game";
 import settingsReducer from "./reducers/Settings";
@@ -15,6 +16,11 @@ export const store = configureStore({
     user: userReducer,
   },
 });
+
+export type AppStore = typeof store;
+
+// Lets the game reducer dispatch follow-up actions without importing this module back
+registerStore(store);
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = () => useDispatch<AppDispatch>();

--- a/src/StoreRegistry.tsx
+++ b/src/StoreRegistry.tsx
@@ -1,0 +1,25 @@
+import type { AppStore } from "./Store";
+
+let registered: AppStore | null = null;
+
+/** Called by Store as soon as it has been created. */
+export function registerStore(store: AppStore) {
+  registered = store;
+}
+
+/**
+ * The app's store, resolved when it is called rather than when the module is imported.
+ *
+ * The game reducer dispatches follow-up actions -- the tick timer, end of game dialogs, the
+ * construction complete snackbar -- and importing the store directly to do that puts a
+ * Game -> Store -> Game cycle back in place, which breaks whichever module loads first. The type
+ * import above is erased at build time, so this module has no runtime dependencies at all.
+ */
+export function getStore(): AppStore {
+  if (!registered) {
+    throw new Error(
+      "The store was used before it was created. Import ./Store somewhere first.",
+    );
+  }
+  return registered;
+}

--- a/src/data/FuelPrices.tsx
+++ b/src/data/FuelPrices.tsx
@@ -27,29 +27,58 @@ interface RawFuelPricesType {
   oil: number;
 }
 
+// Holds both the CSV's historic prices and the randomly extrapolated future ones, so it has to be
+// reset per game -- otherwise a second playthrough silently inherits the first one's future prices
+// and the run stops being a function of its seed.
 const fuelPrices = {} as any;
 
+// Emptied in place rather than reassigned so that the closure in getFuelPricesPerMBTU keeps
+// referring to a const, which no-loop-func requires
+function resetFuelPrices() {
+  Object.keys(fuelPrices).forEach((year: string) => {
+    delete fuelPrices[year];
+  });
+}
+
+function collectFuelPriceRow(row: any) {
+  const data = row.data as RawFuelPricesType;
+  fuelPrices[+data.year] = fuelPrices[+data.year] || {};
+  fuelPrices[+data.year][+data.month] = {
+    "Natural Gas": +data.naturalgas,
+    Coal: +data.coal,
+    Uranium: +data.uranium,
+    Oil: +data.oil,
+  };
+}
+
 export function initFuelPrices(callback?: any) {
+  resetFuelPrices();
   Papa.parse(`/data/FuelPricesRaw.csv`, {
     download: true,
     dynamicTyping: true,
     header: true,
     // worker: true,
-    step(row: any) {
-      const data = row.data as RawFuelPricesType;
-      fuelPrices[+data.year] = fuelPrices[+data.year] || {};
-      fuelPrices[+data.year][+data.month] = {
-        "Natural Gas": +data.naturalgas,
-        Coal: +data.coal,
-        Uranium: +data.uranium,
-        Oil: +data.oil,
-      };
-    },
+    step: collectFuelPriceRow,
     complete() {
       if (callback) {
         callback();
       }
     },
+  });
+}
+
+/**
+ * Synchronous counterpart to initFuelPrices, for callers that already have the CSV contents
+ * (the headless simulator reads them off disk; the browser has to download them).
+ * Note that getFuelPricesPerMBTU loops forever if no prices are ever loaded, so any
+ * non-browser entry point into the simulation has to call this first.
+ */
+export function initFuelPricesFromCsv(csv: string) {
+  resetFuelPrices();
+  Papa.parse(csv, {
+    dynamicTyping: true,
+    header: true,
+    step: collectFuelPriceRow,
   });
 }
 

--- a/src/data/Weather.tsx
+++ b/src/data/Weather.tsx
@@ -24,6 +24,21 @@ const DUMMY_WEATHER = {
 // TODO download weather for all locations at start with a 2s init delay, like loading audio (but after audio) for offline play
 // But only if worker: true starts working - TICKET: https://github.com/mholt/PapaParse/issues/753
 // Ideally caching this... so maybe upgrade to use https://tanstack.com/query/latest/docs/framework/react/overview ?
+function collectWeatherRow(row: any) {
+  const data = row.data as RawWeatherType;
+  if (data && data.YEAR) {
+    weather.push(data);
+  }
+}
+
+function warnIfWeatherIncomplete(location: string) {
+  if (weather.length < EXPECTED_ROWS) {
+    console.warn(
+      `Weather data for ${location} appears to be incomplete. Found ${weather.length} rows, expected ${EXPECTED_ROWS}`
+    );
+  }
+}
+
 export function initWeather(location: string, callback?: any) {
   weather = [] as any; // reset each time to prevent accidentally appending to old state
   Papa.parse(`/data/WeatherRaw${location}.csv`, {
@@ -31,23 +46,28 @@ export function initWeather(location: string, callback?: any) {
     dynamicTyping: true,
     header: true,
     // worker: true,
-    step(row: any) {
-      const data = row.data as RawWeatherType;
-      if (data && data.YEAR) {
-        weather.push(data);
-      }
-    },
+    step: collectWeatherRow,
     complete() {
-      if (weather.length < EXPECTED_ROWS) {
-        console.warn(
-          `Weather data for ${location} appears to be incomplete. Found ${weather.length} rows, expected ${EXPECTED_ROWS}`
-        );
-      }
+      warnIfWeatherIncomplete(location);
       if (callback) {
         callback();
       }
     },
   });
+}
+
+/**
+ * Synchronous counterpart to initWeather, for callers that already have the CSV contents
+ * (the headless simulator reads them off disk; the browser has to download them).
+ */
+export function initWeatherFromCsv(location: string, csv: string) {
+  weather = [] as any; // reset each time to prevent accidentally appending to old state
+  Papa.parse(csv, {
+    dynamicTyping: true,
+    header: true,
+    step: collectWeatherRow,
+  });
+  warnIfWeatherIncomplete(location);
 }
 
 export function getWeather(date: DateType): RawWeatherType {

--- a/src/reducers/BuildFacility.test.tsx
+++ b/src/reducers/BuildFacility.test.tsx
@@ -1,0 +1,84 @@
+import gameReducer, { buildFacility } from "./Game";
+import { GENERATORS } from "../data/Facilities";
+import { getTimeFromTimeline } from "../helpers/DateTime";
+import { GameType, GeneratorShoppingType } from "../Types";
+import { createGame } from "../testing/Simulator";
+
+function aGeneratorToBuild(state: GameType): GeneratorShoppingType {
+  const generator = GENERATORS(state, 500000000, [20], [500]).find(
+    (g: GeneratorShoppingType) => g.available && g.fuel === "Natural Gas",
+  );
+  if (!generator) {
+    throw new Error("No natural gas generator available to build");
+  }
+  return generator;
+}
+
+// The part of the timeline that is still a forecast rather than recorded history
+function futureTicks(state: GameType) {
+  return state.timeline.filter((t) => t.minute > state.date.minute);
+}
+
+describe("buildFacility", () => {
+  it("adds the facility and charges the down payment", () => {
+    const before = createGame({ scenarioId: 103 });
+    const generator = aGeneratorToBuild(before);
+    const cashBefore = getTimeFromTimeline(
+      before.date.minute,
+      before.timeline,
+    )!.cash;
+
+    const after = gameReducer(
+      before,
+      buildFacility({ facility: generator, financed: true }),
+    );
+
+    expect(after.facilities.length).toBe(before.facilities.length + 1);
+    const built = after.facilities.find((f) => f.name === generator.name);
+    expect(built).toBeDefined();
+    expect(built!.yearsToBuildLeft).toBeGreaterThan(0);
+    expect(built!.loanAmountLeft).toBeGreaterThan(0);
+    expect(
+      getTimeFromTimeline(after.date.minute, after.timeline)!.cash,
+    ).toBeLessThan(cashBefore);
+  });
+
+  /**
+   * Regression test. This reducer used to spread the reforecast into a new object and assign it to
+   * its own parameter, which immer discards, so the forecast silently kept describing the old
+   * fleet until the next month rollover regenerated the timeline.
+   */
+  it("reforecasts the timeline so the projection includes the new facility", () => {
+    const before = createGame({ scenarioId: 103 });
+    // Nothing is financed at the start of a scenario, so any interest in the forecast is new
+    expect(futureTicks(before).every((t) => t.expensesInterest === 0)).toBe(
+      true,
+    );
+
+    const after = gameReducer(
+      before,
+      buildFacility({ facility: aGeneratorToBuild(before), financed: true }),
+    );
+
+    expect(futureTicks(after).length).toBeGreaterThan(0);
+    expect(futureTicks(after).every((t) => t.expensesInterest > 0)).toBe(true);
+  });
+
+  it("leaves the recorded past alone", () => {
+    const before = createGame({ scenarioId: 103 });
+    const pastBefore = before.timeline
+      .filter((t) => t.minute < before.date.minute)
+      .map((t) => t.cash);
+
+    const after = gameReducer(
+      before,
+      buildFacility({ facility: aGeneratorToBuild(before), financed: true }),
+    );
+
+    expect(
+      after.timeline
+        .filter((t) => t.minute < after.date.minute)
+        .map((t) => t.cash),
+    ).toEqual(pastBefore);
+  });
+});

--- a/src/reducers/Card.tsx
+++ b/src/reducers/Card.tsx
@@ -2,8 +2,8 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { getHistoryApi, logEvent } from "../Globals";
 import { NAVIGATION_DEBOUNCE_MS } from "../Constants";
 import { CardNameType, CardType } from "../Types";
-import { start, loaded, quit } from "./Game";
-import { RootState } from "../Store";
+import { start, loaded, quit } from "./GameActions";
+import type { RootState } from "../Store";
 
 interface NavigateAction {
   name: CardNameType;

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -48,7 +48,8 @@ import { GENERATORS, STORAGE } from "../data/Facilities";
 import { logEvent } from "../Globals";
 import { getStorageJson, setStorageKeyValue } from "../LocalStorage";
 import { SCENARIOS } from "../data/Scenarios";
-import { store } from "../Store";
+import { getStore } from "../StoreRegistry";
+import { start, loaded, quit } from "./GameActions";
 import {
   DateType,
   FacilityOperatingType,
@@ -80,6 +81,7 @@ interface NewGameAction {
   cash: number;
   customers: number;
   location: LocationType;
+  seed?: number; // Omitted in normal play; pin it to get a reproducible run (headless sim, bug repros)
 }
 
 let previousTickMs = 0;
@@ -122,26 +124,29 @@ export const gameSlice = createSlice({
       }
 
       setTimeout(
-        () => store.dispatch(gameSlice.actions.tick()),
+        () => getStore().dispatch(gameSlice.actions.tick()),
         Math.max(1, TICK_MS[state.speed] - delta)
       );
     },
     delta: (state, action: PayloadAction<Partial<GameType>>) => {
       return { ...state, ...action.payload };
     },
-    start: (state, action: PayloadAction<number>) => {
-      state.scenarioId = action.payload;
-    },
     initGame: (state, action: PayloadAction<NewGameAction>) => {
       const a = action.payload;
+      // Without this a second game in the same session inherits the first one's month and skips
+      // its first rollover, which also makes an otherwise identical seed produce a different run
+      previousMonth = "";
       state.timeline = [] as TickPresentFutureType[];
-      state.seed = Date.now() * Math.random();
+      state.seed = a.seed !== undefined ? a.seed : Date.now() * Math.random();
       seedRandom(state.seed);
       const scenario =
         SCENARIOS.find((s) => s.id === state.scenarioId) || SCENARIOS[0];
       state.date = getDateFromMinute(0, scenario.startingYear);
       state.startingYear = scenario.startingYear;
       state.feePerKgCO2e = scenario.feePerKgCO2e;
+      // The rate the scenario advertises on the new game screen, and the rate Public scenarios are
+      // scored against, so the game has to actually start there rather than at the slice default
+      state.dollarsPerkWh = scenario.dollarsPerkWh;
       state.location = a.location;
       state.timeline = generateNewTimeline(state, a.cash, a.customers);
 
@@ -189,19 +194,15 @@ export const gameSlice = createSlice({
       }
       state.timeline = reforecastSupply(state);
     },
-    quit: () => {
-      return cloneDeep(initialGame);
-    },
     buildFacility: (state, action: PayloadAction<BuildFacilityAction>) => {
       state = buildFacilityHelper(
         state,
         action.payload.facility,
         action.payload.financed
       );
-      state = {
-        ...state,
-        timeline: reforecastSupply(state),
-      };
+      // Assigned rather than spread into a new object: this is an immer draft, so a fresh object
+      // assigned to the parameter is discarded and the forecast would never reach state
+      state.timeline = reforecastSupply(state);
     },
     sellFacility: (state, action: PayloadAction<number>) => {
       const id = action.payload; // (action as SellFacilityAction).id;
@@ -241,26 +242,34 @@ export const gameSlice = createSlice({
       );
       state.timeline = reforecastSupply(state);
     },
-    loaded: (state) => {
-      // Start ticking in game
-      setTimeout(() => {
-        return store.dispatch(gameSlice.actions.tick());
-      }, TICK_MS.PAUSED);
-      state.inGame = true;
-    },
     setSpeed: (state, action: PayloadAction<SpeedType>) => {
       state.speed = action.payload;
       if (previousSpeed === "PAUSED" && state.speed !== "PAUSED") {
         previousTickMs = performance.now();
         setTimeout(
-          () => store.dispatch(gameSlice.actions.tick()),
+          () => getStore().dispatch(gameSlice.actions.tick()),
           TICK_MS[state.speed]
         );
       }
       previousSpeed = state.speed;
     },
   },
+  // start, loaded and quit are declared in GameActions so that Card and UI can react to them
+  // without importing this module -- see the note there
   extraReducers: (builder) => {
+    builder.addCase(start, (state, action) => {
+      state.scenarioId = action.payload;
+    });
+    builder.addCase(loaded, (state) => {
+      // Start ticking in game
+      setTimeout(() => {
+        return getStore().dispatch(gameSlice.actions.tick());
+      }, TICK_MS.PAUSED);
+      state.inGame = true;
+    });
+    builder.addCase(quit, () => {
+      return cloneDeep(initialGame);
+    });
     builder.addCase(dialogOpen, (state) => {
       previousSpeed = state.speed;
       state.speed = "PAUSED";
@@ -275,22 +284,24 @@ export const {
   tick,
   delta,
   initGame,
-  start,
-  quit,
   buildFacility,
   sellFacility,
   togglePauseFacility,
   reprioritizeFacility,
-  loaded,
   setSpeed,
 } = gameSlice.actions;
+
+// Re-exported so that everything still imports the game's actions from one place
+export { start, loaded, quit };
 
 export default gameSlice.reducer;
 
 // ====== HELPERS ======
 
 // Ticks the state forward in place
-function tickState(state: GameType) {
+// Exported so the headless simulator (src/testing/Simulator.tsx) can drive the sim
+// without the wall-clock timers that the `tick` action uses.
+export function tickState(state: GameType) {
   state.date = getDateFromMinute(
     state.date.minute + TICK_MINUTES,
     state.startingYear
@@ -331,23 +342,22 @@ function tickState(state: GameType) {
           difficulty: state.difficulty,
         });
         const summary = summarizeHistory(history);
-        setTimeout(
-          () =>
-            store.dispatch(
-              dialogOpen({
-                title: "Bankrupt!",
-                message: `You've run out of money.
-                You survived for ${store.getState().game.date.year - store.getState().game.startingYear} years,
+        setTimeout(() => {
+          const finished = getStore().getState().game;
+          getStore().dispatch(
+            dialogOpen({
+              title: "Bankrupt!",
+              message: `You've run out of money.
+                You survived for ${finished.date.year - finished.startingYear} years,
                 earned ${formatMoneyConcise(summary.revenue)} in revenue
                 and emitted ${numbro(summary.kgco2e / 1000).format({ thousandSeparated: true, mantissa: 0 })} tons of pollution.`,
-                open: true,
-                notCancellable: true,
-                actionLabel: "Try again",
-                action: () => store.dispatch(gameSlice.actions.quit()),
-              })
-            ),
-          1
-        );
+              open: true,
+              notCancellable: true,
+              actionLabel: "Try again",
+              action: () => getStore().dispatch(quit()),
+            })
+          );
+        }, 1);
       }
 
       // Failure: Too many blackouts
@@ -365,23 +375,22 @@ function tickState(state: GameType) {
           difficulty: state.difficulty,
         });
         const summary = summarizeHistory(history);
-        setTimeout(
-          () =>
-            store.dispatch(
-              dialogOpen({
-                title: "Fired!",
-                message: `You've allowed chronic blackouts for 3 months, causing shareholders to remove you from office.
-                You survived for ${store.getState().game.date.year - store.getState().game.startingYear} years,
+        setTimeout(() => {
+          const finished = getStore().getState().game;
+          getStore().dispatch(
+            dialogOpen({
+              title: "Fired!",
+              message: `You've allowed chronic blackouts for 3 months, causing shareholders to remove you from office.
+                You survived for ${finished.date.year - finished.startingYear} years,
                 earned ${formatMoneyConcise(summary.revenue)} in revenue
                 and emitted ${numbro(summary.kgco2e / 1000).format({ thousandSeparated: true, mantissa: 0 })} tons of pollution.`,
-                open: true,
-                notCancellable: true,
-                actionLabel: "Try again",
-                action: () => store.dispatch(gameSlice.actions.quit()),
-              })
-            ),
-          1
-        );
+              open: true,
+              notCancellable: true,
+              actionLabel: "Try again",
+              action: () => getStore().dispatch(quit()),
+            })
+          );
+        }, 1);
       }
 
       const scenario =
@@ -436,7 +445,7 @@ function tickState(state: GameType) {
         if (!scenario.tutorialSteps) {
           setTimeout(
             () =>
-              store.dispatch(
+              getStore().dispatch(
                 submitHighscore({
                   score: finalScore,
                   scoreBreakdown: score, // For analytics purposes only
@@ -456,7 +465,7 @@ function tickState(state: GameType) {
         });
         setTimeout(
           () =>
-            store.dispatch(
+            getStore().dispatch(
               dialogOpen({
                 title: scenario.endTitle || `You've retired!`,
                 message: scenario.endMessage || (
@@ -492,7 +501,7 @@ function tickState(state: GameType) {
                 open: true,
                 closeText: "Keep playing",
                 actionLabel: "Return to menu",
-                action: () => store.dispatch(gameSlice.actions.quit()),
+                action: () => getStore().dispatch(quit()),
               })
             ),
           1
@@ -601,7 +610,7 @@ function updateSupplyFacilitiesFinances(
       if (f.yearsToBuildLeft === 0 && !simulated) {
         const message = `Construction complete: ${f.name}, ${f.peakWh ? formatWattHours(f.peakWh) : formatWatts(f.peakW)}`; // defining for functions running inside of setTimeout
         setTimeout(() => {
-          store.dispatch(snackbarOpen(message));
+          getStore().dispatch(snackbarOpen(message));
         }, 0);
       }
     }

--- a/src/reducers/GameActions.tsx
+++ b/src/reducers/GameActions.tsx
@@ -1,0 +1,18 @@
+import { createAction } from "@reduxjs/toolkit";
+
+/**
+ * The game actions that other slices react to, declared here rather than by the game slice so that
+ * Card and UI can listen for them without importing the reducer.
+ *
+ * Game reaches out to Store (to dispatch follow-up actions) and to Scenarios (which imports Card),
+ * so a direct Card -> Game import closes a cycle. Because Card needs these action creators while
+ * its own slice is still being built, whichever module happened to load first would find them
+ * undefined and the store would fail to assemble. This module imports nothing but Redux Toolkit,
+ * so nothing can cycle back through it.
+ *
+ * The type strings are the ones createSlice generated for a slice named "game", so devtools traces
+ * and anything matching on action type are unaffected.
+ */
+export const start = createAction<number>("game/start");
+export const loaded = createAction("game/loaded");
+export const quit = createAction("game/quit");

--- a/src/reducers/ImportOrder.test.tsx
+++ b/src/reducers/ImportOrder.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * The reducers used to form an import cycle: Card needed Game's action creators while its own
+ * slice was being built, and Game reached back to Store (which builds Card) and to Scenarios
+ * (which imports Card). Whichever of those modules an entry point happened to load first decided
+ * whether the store assembled or blew up with "Cannot read properties of undefined (reading
+ * 'type')" or "No reducer provided for key card".
+ *
+ * Each case here loads one module in isolation as the first thing in a fresh registry, which is
+ * what used to crash. They pass only while the cycle stays broken.
+ */
+export {}; // Every module here is loaded with require(), so this marks the file as one itself
+
+describe("module import order", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("builds the store when the game reducer is loaded first", () => {
+    const gameReducer = require("./Game").default;
+    expect(typeof gameReducer).toBe("function");
+    const { store } = require("../Store");
+    expect(store.getState().game.inGame).toBe(false);
+    expect(store.getState().card.name).toBe("MAIN_MENU");
+  });
+
+  it("builds the store when the card reducer is loaded first", () => {
+    const cardReducer = require("./Card").default;
+    expect(typeof cardReducer).toBe("function");
+    expect(require("../Store").store.getState().card.name).toBe("MAIN_MENU");
+  });
+
+  it("builds the store when the scenarios are loaded first", () => {
+    expect(require("../data/Scenarios").SCENARIOS.length).toBeGreaterThan(0);
+    expect(require("../Store").store.getState().game.inGame).toBe(false);
+  });
+
+  it("builds the store when it is loaded first", () => {
+    expect(require("../Store").store.getState().card.name).toBe("MAIN_MENU");
+  });
+
+  it("keeps the action types the game slice used to generate", () => {
+    const { start, loaded, quit } = require("./GameActions");
+    expect(start(3).type).toBe("game/start");
+    expect(loaded().type).toBe("game/loaded");
+    expect(quit().type).toBe("game/quit");
+  });
+
+  it("still exports those actions from the game reducer", () => {
+    const game = require("./Game");
+    expect(game.start(3).type).toBe("game/start");
+    expect(game.loaded().type).toBe("game/loaded");
+    expect(game.quit().type).toBe("game/quit");
+  });
+
+  it("routes start, loaded and quit through the game slice", () => {
+    const gameReducer = require("./Game").default;
+    const { start, loaded, quit } = require("./GameActions");
+    const started = gameReducer(undefined, start(103));
+    expect(started.scenarioId).toBe(103);
+    expect(gameReducer(started, loaded()).inGame).toBe(true);
+    expect(gameReducer(started, quit()).scenarioId).toBe(0);
+  });
+
+  it("still switches the card to LOADING on start and FACILITIES on loaded", () => {
+    const cardReducer = require("./Card").default;
+    const { start, loaded } = require("./GameActions");
+    expect(cardReducer(undefined, start(0)).name).toBe("LOADING");
+    expect(cardReducer(undefined, loaded()).name).toBe("FACILITIES");
+  });
+});

--- a/src/reducers/UI.tsx
+++ b/src/reducers/UI.tsx
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { DialogType, SnackbarType, UIType } from "../Types";
-import { quit } from "./Game";
+import { quit } from "./GameActions";
 
 export const initialUI: UIType = {
   dialog: {

--- a/src/reducers/User.tsx
+++ b/src/reducers/User.tsx
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { UserType, ScoreType } from "../Types";
-import { RootState } from "../Store";
+import type { RootState } from "../Store";
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 import { getDb } from "../Globals";
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,10 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// https://github.com/testing-library/jest-dom
+import "@testing-library/jest-dom";
+
+// jsdom has no IndexedDB, so Firebase Analytics warns loudly the first time anything logs an
+// event. Nothing under test cares what was reported, so the transport is stubbed out entirely.
+jest.mock("firebase/analytics", () => ({
+  getAnalytics: () => ({}),
+  logEvent: () => undefined,
+}));

--- a/src/testing/Invariants.tsx
+++ b/src/testing/Invariants.tsx
@@ -1,0 +1,350 @@
+import { TICKS_PER_HOUR, TICKS_PER_MONTH } from "../Constants";
+import {
+  FacilityOperatingType,
+  GameType,
+  MonthlyHistoryType,
+  TickPresentFutureType,
+} from "../Types";
+
+export interface ViolationType {
+  rule: string;
+  when: string; // Human readable point in game time, eg "2021-04 09:15"
+  detail: string;
+}
+
+// Watts and dollars run into the billions, so equality checks need a relative slack rather than
+// an absolute one. Cash is separately rounded to whole dollars every tick.
+const RELATIVE_TOLERANCE = 1e-6;
+const CASH_ROUNDING_TOLERANCE = 2;
+const MAX_VIOLATIONS_PER_RULE = 5;
+
+// Tick fields that should always hold a real, finite number
+const FINITE_TICK_FIELDS = [
+  "supplyW",
+  "demandW",
+  "solarIrradianceWM2",
+  "windKph",
+  "temperatureC",
+  "storedWh",
+  "cash",
+  "customers",
+  "netWorth",
+  "revenue",
+  "expensesFuel",
+  "expensesOM",
+  "expensesCarbonFee",
+  "expensesInterest",
+  "expensesMarketing",
+  "kgco2e",
+];
+
+// Tick fields that are physically incapable of going negative (cash and netWorth can, by design)
+const NON_NEGATIVE_TICK_FIELDS = [
+  "supplyW",
+  "demandW",
+  "solarIrradianceWM2",
+  "windKph",
+  "storedWh",
+  "customers",
+  "revenue",
+  "expensesFuel",
+  "expensesOM",
+  "expensesCarbonFee",
+  "expensesInterest",
+  "expensesMarketing",
+  "kgco2e",
+];
+
+const FINITE_MONTH_FIELDS = [
+  "supplyWh",
+  "demandWh",
+  "cash",
+  "customers",
+  "netWorth",
+  "revenue",
+  "expensesFuel",
+  "expensesOM",
+  "expensesCarbonFee",
+  "expensesInterest",
+  "expensesMarketing",
+  "kgco2e",
+];
+
+/**
+ * Collects invariant violations across a run, deduplicating by rule so that a systemically broken
+ * value reports a handful of examples instead of one line per tick.
+ */
+export class InvariantCollector {
+  private violations: ViolationType[] = [];
+  private countByRule: { [rule: string]: number } = {};
+
+  add(rule: string, when: string, detail: string) {
+    this.countByRule[rule] = (this.countByRule[rule] || 0) + 1;
+    if (this.countByRule[rule] <= MAX_VIOLATIONS_PER_RULE) {
+      this.violations.push({ rule, when, detail });
+    }
+  }
+
+  getViolations(): ViolationType[] {
+    return this.violations;
+  }
+
+  // Total occurrences, including the ones suppressed after MAX_VIOLATIONS_PER_RULE
+  getCountByRule(): { [rule: string]: number } {
+    return this.countByRule;
+  }
+
+  getTotalCount(): number {
+    return Object.values(this.countByRule).reduce((a, b) => a + b, 0);
+  }
+}
+
+function isFinite_(v: any): boolean {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/**
+ * Checks everything that must hold on a single simulated tick.
+ * `prev` is the previous tick, or null across a month boundary / at the start of a run, where
+ * continuity checks don't apply because the timeline is regenerated and pre-rolled.
+ */
+export function checkTick(
+  collector: InvariantCollector,
+  state: GameType,
+  prev: TickPresentFutureType | null,
+  now: TickPresentFutureType,
+  when: string,
+  builtThisTick: boolean,
+) {
+  FINITE_TICK_FIELDS.forEach((field: string) => {
+    if (!isFinite_((now as any)[field])) {
+      collector.add(
+        "tick value is finite",
+        when,
+        `${field} = ${(now as any)[field]}`,
+      );
+    }
+  });
+
+  NON_NEGATIVE_TICK_FIELDS.forEach((field: string) => {
+    const value = (now as any)[field];
+    if (isFinite_(value) && value < 0) {
+      collector.add("tick value is non-negative", when, `${field} = ${value}`);
+    }
+  });
+
+  if (isFinite_(now.demandW) && now.demandW <= 0) {
+    collector.add(
+      "demand is positive",
+      when,
+      `demandW = ${now.demandW} with ${now.customers} customers`,
+    );
+  }
+
+  // supplyByFuel only accounts for generators; supplyW also includes storage discharge,
+  // so the fuel breakdown can never exceed the total it is a breakdown of.
+  let supplyByFuelTotal = 0;
+  Object.keys(now.supplyByFuel || {}).forEach((fuel: string) => {
+    const value = (now.supplyByFuel as any)[fuel];
+    if (!isFinite_(value) || value < 0) {
+      collector.add(
+        "supplyByFuel is finite and non-negative",
+        when,
+        `${fuel} = ${value}`,
+      );
+      return;
+    }
+    supplyByFuelTotal += value;
+  });
+  if (
+    isFinite_(now.supplyW) &&
+    supplyByFuelTotal > now.supplyW * (1 + RELATIVE_TOLERANCE) + 1
+  ) {
+    collector.add(
+      "supplyByFuel sums to at most supplyW",
+      when,
+      `supplyByFuel totals ${Math.round(supplyByFuelTotal)}W but supplyW is ${Math.round(now.supplyW)}W`,
+    );
+  }
+
+  // Cash moves only by the tick's own revenue and expenses. Loan principal is spent but not
+  // recorded on the tick, so the expected value is a range bounded by the outstanding payments.
+  if (prev && !builtThisTick && isFinite_(now.cash) && isFinite_(prev.cash)) {
+    const expenses =
+      now.expensesFuel +
+      now.expensesOM +
+      now.expensesCarbonFee +
+      now.expensesInterest +
+      now.expensesMarketing;
+    const maxPrincipal = state.facilities.reduce(
+      (acc: number, f: FacilityOperatingType) =>
+        acc +
+        (f.loanAmountLeft > 0 ? f.loanMonthlyPayment / TICKS_PER_MONTH : 0),
+      0,
+    );
+    const upperBound = prev.cash + now.revenue - expenses;
+    const lowerBound = upperBound - maxPrincipal;
+    if (
+      now.cash > upperBound + CASH_ROUNDING_TOLERANCE ||
+      now.cash < lowerBound - CASH_ROUNDING_TOLERANCE
+    ) {
+      collector.add(
+        "cash changes only by recorded revenue and expenses",
+        when,
+        `cash went ${Math.round(prev.cash)} -> ${Math.round(now.cash)}, expected ${Math.round(lowerBound)}..${Math.round(upperBound)}`,
+      );
+    }
+  }
+
+  state.facilities.forEach((f: FacilityOperatingType) => {
+    const label = `${f.name} #${f.id}`;
+    if (!isFinite_(f.currentW)) {
+      collector.add(
+        "facility output is finite",
+        when,
+        `${label} currentW = ${f.currentW}`,
+      );
+    } else if (f.peakWh) {
+      // Storage swings both ways: positive discharging, negative charging
+      if (Math.abs(f.currentW) > f.peakW * (1 + RELATIVE_TOLERANCE)) {
+        collector.add(
+          "storage stays within its rated power",
+          when,
+          `${label} currentW = ${Math.round(f.currentW)} vs peakW ${Math.round(f.peakW)}`,
+        );
+      }
+    } else if (
+      f.currentW < 0 ||
+      f.currentW > f.peakW * (1 + RELATIVE_TOLERANCE)
+    ) {
+      collector.add(
+        "generator output stays within 0..peakW",
+        when,
+        `${label} currentW = ${Math.round(f.currentW)} vs peakW ${Math.round(f.peakW)}`,
+      );
+    }
+
+    if (f.peakWh) {
+      const storage = f as any;
+      if (!isFinite_(storage.currentWh)) {
+        collector.add(
+          "storage charge is finite",
+          when,
+          `${label} currentWh = ${storage.currentWh}`,
+        );
+      } else if (
+        storage.currentWh < 0 ||
+        storage.currentWh > f.peakWh * (1 + RELATIVE_TOLERANCE)
+      ) {
+        collector.add(
+          "storage charge stays within 0..peakWh",
+          when,
+          `${label} currentWh = ${Math.round(storage.currentWh)} vs peakWh ${Math.round(f.peakWh)}`,
+        );
+      }
+    }
+
+    if (f.yearsToBuildLeft < 0 || !isFinite_(f.yearsToBuildLeft)) {
+      collector.add(
+        "construction time remaining is non-negative",
+        when,
+        `${label} yearsToBuildLeft = ${f.yearsToBuildLeft}`,
+      );
+    }
+
+    if (
+      !isFinite_(f.loanAmountLeft) ||
+      f.loanAmountLeft < -CASH_ROUNDING_TOLERANCE ||
+      f.loanAmountLeft > f.loanAmountTotal * (1 + RELATIVE_TOLERANCE)
+    ) {
+      collector.add(
+        "loan balance stays within 0..original",
+        when,
+        `${label} loanAmountLeft = ${Math.round(f.loanAmountLeft)} of ${Math.round(f.loanAmountTotal)}`,
+      );
+    }
+  });
+
+  if (prev) {
+    checkStorageEnergyBalance(collector, state, prev, now, when);
+  }
+}
+
+export function checkMonth(
+  collector: InvariantCollector,
+  month: MonthlyHistoryType,
+  when: string,
+) {
+  FINITE_MONTH_FIELDS.forEach((field: string) => {
+    if (!isFinite_((month as any)[field])) {
+      collector.add(
+        "monthly total is finite",
+        when,
+        `${field} = ${(month as any)[field]}`,
+      );
+    }
+  });
+
+  // summarizeTimeline books supply as min(supply, demand), so billed supply can never exceed demand
+  if (
+    isFinite_(month.supplyWh) &&
+    isFinite_(month.demandWh) &&
+    month.supplyWh > month.demandWh * (1 + RELATIVE_TOLERANCE)
+  ) {
+    collector.add(
+      "monthly supply never exceeds demand",
+      when,
+      `supplyWh ${Math.round(month.supplyWh)} > demandWh ${Math.round(month.demandWh)}`,
+    );
+  }
+
+  if (isFinite_(month.demandWh) && month.demandWh <= 0) {
+    collector.add(
+      "monthly demand is positive",
+      when,
+      `demandWh = ${month.demandWh}`,
+    );
+  }
+}
+
+/**
+ * Storage can only hold energy that was charged into it. Charging is recorded as negative output
+ * and discharging as positive, so the stored total has to move by exactly the fleet's net output
+ * over one tick.
+ *
+ * Only checkable between consecutive ticks inside a month: a rollover runs the tick function five
+ * more times (once for the new timeline, then four pre-roll frames) against the same tick object,
+ * so the energy that moved in between is not observable from outside.
+ */
+function checkStorageEnergyBalance(
+  collector: InvariantCollector,
+  state: GameType,
+  prev: TickPresentFutureType,
+  now: TickPresentFutureType,
+  when: string,
+) {
+  let netChargedWh = 0;
+  let hasStorage = false;
+  state.facilities.forEach((f: FacilityOperatingType) => {
+    if (f.peakWh && isFinite_(f.currentW)) {
+      hasStorage = true;
+      netChargedWh -= f.currentW / TICKS_PER_HOUR; // Negative output is charging
+    }
+  });
+  if (!hasStorage || !isFinite_(now.storedWh) || !isFinite_(prev.storedWh)) {
+    return;
+  }
+
+  const actualDelta = now.storedWh - prev.storedWh;
+  const tolerance =
+    Math.max(Math.abs(netChargedWh), Math.abs(actualDelta)) *
+      RELATIVE_TOLERANCE +
+    1;
+  if (Math.abs(actualDelta - netChargedWh) > tolerance) {
+    collector.add(
+      "stored energy moves by exactly what was charged or discharged",
+      when,
+      `storedWh moved ${Math.round(actualDelta)}Wh but facilities charged ${Math.round(netChargedWh)}Wh`,
+    );
+  }
+}

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -1,0 +1,89 @@
+# Headless simulation
+
+Plays the game without a browser, then checks that the economy behaved lawfully. A 20 year
+scenario runs in about half a second, so a change to the simulation can be sanity checked in
+seconds instead of by clicking through the UI in real time.
+
+```sh
+npm run sim -- --all
+```
+
+```
+  SCENARIO                  MONTHS   OUTCOME              CASH      UNSERVED  INVARIANTS
+  ------------------------- -------- -------------------- --------- --------- ----------
+  Carbon Fee                144      survived             $56M      0.3%      ok
+  The Shale Boom            240      survived             $3,099M   0.7%      ok
+  Paradise                  144      bankrupt @ month 43  $-3M      0.1%      ok
+  ...
+  All scenarios hold every invariant.
+```
+
+Every scenario in one sweep, one line each. Then drill into one:
+
+```sh
+npm run sim -- --scenario 103 --strategy keepUp
+```
+
+which prints a month by month table (customers, demand, supplied, unserved, cash, net worth,
+profit, emissions), totals for the run, the fleet it finished with, and any invariant violations.
+`npm run sim -- --help` lists the flags; `--list` shows the scenario ids.
+
+## What it checks
+
+The point is not the numbers, it's the **invariants** -- rules the economy must obey no matter
+what the balance looks like. They run on every tick of every simulated month, and each violation
+reports the game time it happened and the values involved, so a broken run points at a line of
+code rather than a vibe.
+
+| | |
+|---|---|
+| Finite values | No `NaN` or `Infinity` reaches any tick or monthly field. `NaN` propagates silently through the whole economy, so this is the one that catches the most |
+| Signs | Supply, demand, customers, stored energy, revenue and every expense stay non-negative; demand stays positive. Cash and net worth may go negative, by design |
+| Cash continuity | Within a month, cash moves by exactly the tick's own revenue minus its recorded expenses, allowing for loan principal, which is spent but not recorded on the tick |
+| Energy conservation | Stored energy moves by exactly what the storage fleet charged or discharged. Storage cannot invent electricity |
+| Fleet bounds | Generators output between 0 and their rated power, storage stays within its rated power and capacity, construction time never goes negative, loan balances stay between 0 and the original amount |
+| Supply accounting | `supplyByFuel` sums to no more than `supplyW`, which also includes storage discharge |
+| Monthly totals | Billed supply never exceeds demand, and every total is finite |
+
+`Simulation.test.tsx` asserts all of this as part of `npm test`, across every scenario, both ends
+of the difficulty range, marketing spend, and a run that builds on credit. It also pins down
+determinism and a few economic identities (revenue really is rate times kilowatt hours, the carbon
+fee really is proportional to emissions).
+
+`createGame` is exported for tests that want a realistic mid-game state without running a whole
+simulation -- `reducers/BuildFacility.test.tsx` uses it to check what building actually does.
+
+To confirm the checks still bite, break something on purpose -- halve the energy storage
+discharges, or drop a term from the cash calculation -- and watch the suite name the tick it
+first went wrong.
+
+## How it works
+
+`Simulator.tsx` drives the game's real reducer. It sets a game up the way a real playthrough does
+(`start`, then `delta` for difficulty, then `initGame`), then calls `tickState` in a loop instead
+of the `tick` action, which paces itself off `performance.now()` and `setTimeout`. Nothing is
+reimplemented: if the reducer is wrong, the simulation is wrong in the same way, which is the
+entire point.
+
+It runs under CRA's jest because the reducer needs TypeScript, JSX and a DOM. `npm run sim` shells
+out to jest pointed at `SimCli.tsx`, which is named so CRA's default `testMatch` ignores it and
+`npm test` stays free of simulation output.
+
+## Things worth knowing before you change this
+
+- **`Simulator` imports `Store` even though it drives the reducer directly.** The game reducer
+  dispatches follow-up actions of its own -- the tick timer, the construction complete snackbar,
+  the end of game dialogs -- and reaches them through `StoreRegistry`, which needs a store to have
+  been created. `ImportOrder.test.tsx` guards the module graph that makes this safe from any entry
+  point; it used to be that loading `Game` before `Store` crashed on startup.
+- **The first month is recorded on the first tick.** `previousMonth` starts empty, so a rollover
+  fires immediately and a 144 month run reports 145 months. That is the real game's behavior, and
+  the extra entry summarizes a full generated day, not a single tick.
+- **The seed only matters past the recorded data.** Weather runs 1980-2019 and fuel prices
+  similar; inside that window the game replays real history and every seed agrees. Scenarios
+  starting in 2020 diverge immediately.
+- **A month rollover is not one simulation step.** It regenerates the timeline and pre-rolls four
+  more frames against the same tick. Anything measured by diffing consecutive ticks has to skip
+  rollovers, which is why the cash and energy checks only run within a month.
+- **`getFuelPricesPerMBTU` loops forever if no prices are loaded**, and `getWeather` throws. Any
+  non-browser entry point has to call `loadSimData` first.

--- a/src/testing/Report.tsx
+++ b/src/testing/Report.tsx
@@ -1,0 +1,226 @@
+import { LOCATIONS } from "../Constants";
+import { deriveExpandedSummary, summarizeHistory } from "../helpers/DateTime";
+import {
+  formatMoneyConcise,
+  formatWattHours,
+  formatWatts,
+} from "../helpers/Format";
+import { FacilityOperatingType, MonthlyHistoryType } from "../Types";
+import { SimResultType } from "./Simulator";
+
+const DEFAULT_MAX_ROWS = 24;
+
+function pad(s: string, width: number, left = false): string {
+  if (s.length >= width) {
+    return s;
+  }
+  const spaces = " ".repeat(width - s.length);
+  return left ? spaces + s : s + spaces;
+}
+
+function percent(numerator: number, denominator: number): string {
+  if (!denominator) {
+    return "-";
+  }
+  return `${((100 * numerator) / denominator).toFixed(1)}%`;
+}
+
+function count(n: number): string {
+  return Math.round(n).toLocaleString("en-US");
+}
+
+/**
+ * Picks at most `max` rows spread evenly across the run, always keeping the first and last so the
+ * start and end of a 20 year game are both visible without printing 240 lines.
+ */
+function sampleRows<T>(
+  rows: T[],
+  max: number,
+): Array<{ row: T; index: number }> {
+  if (rows.length <= max) {
+    return rows.map((row, index) => ({ row, index }));
+  }
+  const step = (rows.length - 1) / (max - 1);
+  const picked: Array<{ row: T; index: number }> = [];
+  let lastIndex = -1;
+  for (let i = 0; i < max; i++) {
+    const index = Math.round(i * step);
+    if (index !== lastIndex) {
+      picked.push({ row: rows[index], index });
+      lastIndex = index;
+    }
+  }
+  return picked;
+}
+
+const COLUMNS: Array<{
+  header: string;
+  width: number;
+  value: (m: MonthlyHistoryType) => string;
+}> = [
+  {
+    header: "MONTH",
+    width: 9,
+    value: (m) => `${m.year}-${String(m.month).padStart(2, "0")}`,
+  },
+  { header: "CUSTOMERS", width: 11, value: (m) => count(m.customers) },
+  { header: "DEMAND", width: 10, value: (m) => formatWattHours(m.demandWh) },
+  { header: "SUPPLIED", width: 10, value: (m) => formatWattHours(m.supplyWh) },
+  {
+    header: "UNSERVED",
+    width: 9,
+    value: (m) => percent(m.demandWh - m.supplyWh, m.demandWh),
+  },
+  { header: "CASH", width: 9, value: (m) => formatMoneyConcise(m.cash) },
+  {
+    header: "NET WORTH",
+    width: 10,
+    value: (m) => formatMoneyConcise(m.netWorth),
+  },
+  {
+    header: "PROFIT",
+    width: 10,
+    value: (m) => formatMoneyConcise(deriveExpandedSummary(m).profit),
+  },
+  {
+    header: "CO2/MWh",
+    width: 8,
+    value: (m) => `${Math.round(deriveExpandedSummary(m).kgco2ePerMWh)}kg`,
+  },
+];
+
+function formatMonthTable(
+  months: MonthlyHistoryType[],
+  maxRows: number,
+): string[] {
+  const lines = [
+    "  " + COLUMNS.map((c) => pad(c.header, c.width)).join(""),
+    "  " + COLUMNS.map((c) => "-".repeat(c.width - 1) + " ").join(""),
+  ];
+  sampleRows(months, maxRows).forEach(({ row }) => {
+    lines.push("  " + COLUMNS.map((c) => pad(c.value(row), c.width)).join(""));
+  });
+  if (months.length > maxRows) {
+    lines.push(
+      `  (${months.length} months, sampled to ${maxRows} rows -- pass --full for all of them)`,
+    );
+  }
+  return lines;
+}
+
+function formatFacilities(facilities: FacilityOperatingType[]): string[] {
+  if (facilities.length === 0) {
+    return ["  (none)"];
+  }
+  return facilities.map((f: FacilityOperatingType) => {
+    const size = f.peakWh
+      ? `${formatWattHours(f.peakWh)} storage`
+      : `${formatWatts(f.peakW)} ${f.fuel}`;
+    const building =
+      f.yearsToBuildLeft > 0
+        ? ` -- ${f.yearsToBuildLeft.toFixed(1)}y left to build`
+        : "";
+    const loan =
+      f.loanAmountLeft > 0
+        ? ` -- ${formatMoneyConcise(f.loanAmountLeft)} owed`
+        : "";
+    return `  ${pad(f.name, 16)}${pad(size, 22)}${building}${loan}`;
+  });
+}
+
+/** Renders a finished run as a plain text report suitable for a terminal. */
+export function formatReport(
+  result: SimResultType,
+  options: { maxRows?: number; elapsedMs?: number } = {},
+): string {
+  const maxRows = options.maxRows || DEFAULT_MAX_ROWS;
+  const { scenario, months, options: opts } = result;
+  const location = LOCATIONS[scenario.locationId];
+  const summary = summarizeHistory(result.months);
+  const derived = deriveExpandedSummary(summary);
+  const first = months[0];
+  const last = months[months.length - 1];
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(
+    `${scenario.name}  ·  ${opts.difficulty}  ·  seed ${opts.seed}  ·  strategy ${opts.strategy}`,
+  );
+  lines.push(
+    `${location ? location.name : scenario.locationId} · ` +
+      (first && last ? `${first.year}-${last.year} · ` : "") +
+      `${opts.months} months · ${count(result.ticks)} ticks` +
+      (options.elapsedMs === undefined ? "" : ` · ${options.elapsedMs}ms`),
+  );
+  lines.push("");
+  lines.push(...formatMonthTable(months, maxRows));
+
+  lines.push("");
+  lines.push("TOTALS");
+  lines.push(
+    `  Outcome          ${
+      result.wentBankrupt
+        ? `BANKRUPT at month ${result.bankruptAtMonth} of ${opts.months}`
+        : `survived all ${opts.months} months`
+    }`,
+  );
+  if (first && last) {
+    lines.push(
+      `  Cash             ${formatMoneyConcise(first.cash)} -> ${formatMoneyConcise(last.cash)}`,
+    );
+    lines.push(
+      `  Net worth        ${formatMoneyConcise(first.netWorth)} -> ${formatMoneyConcise(last.netWorth)}`,
+    );
+    lines.push(
+      `  Customers        ${count(first.customers)} -> ${count(last.customers)}`,
+    );
+  }
+  lines.push(
+    `  Revenue          ${formatMoneyConcise(summary.revenue)} (${formatMoneyConcise(derived.revenuePerkWh)}/kWh)`,
+  );
+  lines.push(
+    `  Expenses         ${formatMoneyConcise(derived.expenses)}  ` +
+      `[fuel ${formatMoneyConcise(summary.expensesFuel)} · O&M ${formatMoneyConcise(summary.expensesOM)} · ` +
+      `interest ${formatMoneyConcise(summary.expensesInterest)} · carbon ${formatMoneyConcise(summary.expensesCarbonFee)} · ` +
+      `marketing ${formatMoneyConcise(summary.expensesMarketing)}]`,
+  );
+  lines.push(`  Profit           ${formatMoneyConcise(derived.profit)}`);
+  lines.push(
+    `  Supplied         ${formatWattHours(summary.supplyWh)} of ${formatWattHours(summary.demandWh)} demanded ` +
+      `(${percent(summary.demandWh - summary.supplyWh, summary.demandWh)} unserved)`,
+  );
+  lines.push(
+    `  Emissions        ${count(summary.kgco2e / 1000)} tons (${Math.round(derived.kgco2ePerMWh)}kg/MWh)`,
+  );
+  if (result.averageStateOfCharge !== null) {
+    lines.push(
+      `  Storage          ${(100 * result.averageStateOfCharge).toFixed(1)}% average state of charge`,
+    );
+  }
+  if (result.builds.length) {
+    lines.push(`  Built            ${result.builds.length} facilities`);
+  }
+
+  lines.push("");
+  lines.push("FINAL FLEET");
+  lines.push(...formatFacilities(result.finalFacilities));
+
+  lines.push("");
+  if (result.violationCount === 0) {
+    lines.push(
+      `INVARIANTS  ok -- no violations across ${count(result.ticks)} ticks`,
+    );
+  } else {
+    lines.push(`INVARIANTS  ${result.violationCount} VIOLATIONS`);
+    Object.keys(result.violationCountByRule).forEach((rule: string) => {
+      lines.push(`  ${result.violationCountByRule[rule]}x  ${rule}`);
+    });
+    lines.push("");
+    result.violations.forEach((v) => {
+      lines.push(`  ${pad(v.when, 17)}${v.rule}`);
+      lines.push(`  ${" ".repeat(17)}${v.detail}`);
+    });
+  }
+  lines.push("");
+  return lines.join("\n");
+}

--- a/src/testing/SimCli.tsx
+++ b/src/testing/SimCli.tsx
@@ -1,0 +1,103 @@
+/**
+ * Entry point for `npm run sim`. Deliberately named so that CRA's default testMatch ignores it --
+ * scripts/sim.js points jest at this file explicitly, so it never runs as part of `npm test`.
+ *
+ * Output goes straight to stdout rather than through console.log, which jest decorates with a
+ * stack trace after every call.
+ */
+import { SCENARIOS } from "../data/Scenarios";
+import { DifficultyType, ScenarioType } from "../Types";
+import { formatReport } from "./Report";
+import { runSimulation, SimOptionsType, StrategyType } from "./Simulator";
+
+jest.setTimeout(600000);
+
+function write(s: string) {
+  process.stdout.write(s + "\n");
+}
+
+function envNumber(name: string): number | undefined {
+  const raw = process.env[name];
+  return raw === undefined || raw === "" ? undefined : Number(raw);
+}
+
+function baseOptions(): Omit<SimOptionsType, "scenarioId"> {
+  return {
+    difficulty: (process.env.SIM_DIFFICULTY as DifficultyType) || undefined,
+    months: envNumber("SIM_MONTHS"),
+    seed: envNumber("SIM_SEED"),
+    dollarsPerkWh: envNumber("SIM_RATE"),
+    monthlyMarketingSpend: envNumber("SIM_MARKETING"),
+    strategy: (process.env.SIM_STRATEGY as StrategyType) || undefined,
+  };
+}
+
+/** One line per scenario, so a full sweep fits on a screen and regressions stand out. */
+function runSweep() {
+  const options = baseOptions();
+  let totalViolations = 0;
+  write("");
+  write(
+    "  SCENARIO                  MONTHS   OUTCOME              CASH      UNSERVED  INVARIANTS",
+  );
+  write(
+    "  ------------------------- -------- -------------------- --------- --------- ----------",
+  );
+  SCENARIOS.forEach((scenario: ScenarioType) => {
+    const result = runSimulation({ ...options, scenarioId: scenario.id });
+    totalViolations += result.violationCount;
+    const demandWh = result.months.reduce((a, m) => a + m.demandWh, 0);
+    const supplyWh = result.months.reduce((a, m) => a + m.supplyWh, 0);
+    const cash = result.finalCash;
+    const outcome = result.wentBankrupt
+      ? `bankrupt @ month ${result.bankruptAtMonth}`
+      : "survived";
+    write(
+      "  " +
+        scenario.name.slice(0, 25).padEnd(26) +
+        String(result.options.months).padEnd(9) +
+        outcome.padEnd(21) +
+        `$${Math.round(cash / 1000000).toLocaleString("en-US")}M`.padEnd(10) +
+        (demandWh
+          ? `${((100 * (demandWh - supplyWh)) / demandWh).toFixed(1)}%`
+          : "-"
+        ).padEnd(10) +
+        (result.violationCount === 0
+          ? "ok"
+          : `${result.violationCount} FAILED`),
+    );
+    result.violations.forEach((v) => {
+      write(`      ! ${v.rule} @ ${v.when}: ${v.detail}`);
+    });
+  });
+  write("");
+  write(
+    totalViolations === 0
+      ? "  All scenarios hold every invariant."
+      : `  ${totalViolations} invariant violations across the sweep.`,
+  );
+  write("");
+}
+
+function runSingle() {
+  const scenarioId = envNumber("SIM_SCENARIO");
+  const started = Date.now();
+  const result = runSimulation({
+    ...baseOptions(),
+    scenarioId: scenarioId === undefined ? 101 : scenarioId,
+  });
+  write(
+    formatReport(result, {
+      maxRows: process.env.SIM_FULL === "1" ? result.months.length : undefined,
+      elapsedMs: Date.now() - started,
+    }),
+  );
+}
+
+it("simulation", () => {
+  if (process.env.SIM_ALL === "1") {
+    runSweep();
+  } else {
+    runSingle();
+  }
+});

--- a/src/testing/SimData.tsx
+++ b/src/testing/SimData.tsx
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as path from "path";
+import { initFuelPricesFromCsv } from "../data/FuelPrices";
+import { initWeatherFromCsv } from "../data/Weather";
+import { LocationIdType } from "../Types";
+
+// In the browser these CSVs are downloaded from /data; headless we read the same files off disk.
+const DATA_DIR = path.resolve(__dirname, "..", "..", "public", "data");
+
+/**
+ * Loads the weather and fuel price data the simulation needs, resetting whatever a previous
+ * run left behind. Both modules loop or throw when asked for data they don't have, so this
+ * has to run before any simulation is started.
+ */
+export function loadSimData(locationId: LocationIdType) {
+  initWeatherFromCsv(
+    locationId,
+    fs.readFileSync(path.join(DATA_DIR, `WeatherRaw${locationId}.csv`), "utf8"),
+  );
+  initFuelPricesFromCsv(
+    fs.readFileSync(path.join(DATA_DIR, "FuelPricesRaw.csv"), "utf8"),
+  );
+}

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -1,0 +1,164 @@
+import { SCENARIOS } from "../data/Scenarios";
+import { DifficultyType, ScenarioType } from "../Types";
+import { runSimulation, SimResultType } from "./Simulator";
+
+jest.setTimeout(120000);
+
+function describeViolations(result: SimResultType): string {
+  return result.violations
+    .map((v) => `\n  [${v.rule}] ${v.when}: ${v.detail}`)
+    .join("");
+}
+
+function expectNoViolations(result: SimResultType) {
+  expect(
+    `${result.violationCount} violations${describeViolations(result)}`,
+  ).toBe("0 violations");
+}
+
+describe("simulation invariants", () => {
+  // Two years is long enough to cover a full weather cycle, construction finishing and loans
+  // amortizing, while keeping the whole suite well under a second per scenario
+  const MONTHS = 24;
+
+  SCENARIOS.forEach((scenario: ScenarioType) => {
+    it(`holds for "${scenario.name}"`, () => {
+      expectNoViolations(
+        runSimulation({
+          scenarioId: scenario.id,
+          months: Math.min(MONTHS, scenario.durationMonths),
+        }),
+      );
+    });
+  });
+
+  it("holds while building facilities on credit", () => {
+    expectNoViolations(
+      runSimulation({
+        scenarioId: 103, // The Shale Boom -- 20 years, enough room to build repeatedly
+        months: 60,
+        strategy: "keepUp",
+      }),
+    );
+  });
+
+  it("holds while spending on marketing", () => {
+    expectNoViolations(
+      runSimulation({
+        scenarioId: 101,
+        months: MONTHS,
+        monthlyMarketingSpend: 5000000,
+      }),
+    );
+  });
+
+  (["Intern", "CEO"] as DifficultyType[]).forEach((difficulty) => {
+    it(`holds on ${difficulty} difficulty`, () => {
+      expectNoViolations(
+        runSimulation({ scenarioId: 103, months: MONTHS, difficulty }),
+      );
+    });
+  });
+
+  it("holds across a full 20 year run", () => {
+    expectNoViolations(runSimulation({ scenarioId: 102, strategy: "keepUp" }));
+  });
+});
+
+describe("simulation determinism", () => {
+  // Weather, fuel prices and the tick loop all keep module level state. A run that isn't purely a
+  // function of its seed means one of them is leaking between games, which would also mean a
+  // player's second playthrough silently differs from their first.
+  it("produces identical runs for the same seed", () => {
+    const options = { scenarioId: 101, months: 24, seed: 777 };
+    const first = runSimulation(options);
+    const second = runSimulation(options);
+    expect(second.months).toEqual(first.months);
+    expect(second.finalCash).toEqual(first.finalCash);
+  });
+
+  // The seed only feeds the extrapolation past the end of the recorded data (weather runs
+  // 1980-2019, fuel prices similar). Inside that window the game replays real history, so two
+  // seeds legitimately agree; past it they have to diverge or the seed is being ignored.
+  it("produces different runs for different seeds once past the recorded data", () => {
+    // Carbon Fee starts in 2020, so every tick is extrapolated
+    const first = runSimulation({ scenarioId: 100, months: 24, seed: 1 });
+    const second = runSimulation({ scenarioId: 100, months: 24, seed: 2 });
+    expect(second.months).not.toEqual(first.months);
+  });
+
+  it("replays recorded history identically whatever the seed", () => {
+    // Rise of Renewables starts in 2002 and only runs 12 years, well inside the data
+    const first = runSimulation({ scenarioId: 101, months: 24, seed: 1 });
+    const second = runSimulation({ scenarioId: 101, months: 24, seed: 2 });
+    expect(second.months).toEqual(first.months);
+  });
+
+  it("is unaffected by an unrelated run in between", () => {
+    const options = { scenarioId: 101, months: 24, seed: 777 };
+    const first = runSimulation(options);
+    runSimulation({ scenarioId: 104, months: 12, seed: 999 });
+    expect(runSimulation(options).months).toEqual(first.months);
+  });
+});
+
+describe("simulation economics", () => {
+  it("bills every customer it supplies at the going rate", () => {
+    const result = runSimulation({
+      scenarioId: 101,
+      months: 12,
+      dollarsPerkWh: 0.1,
+    });
+    // The first month summarizes the timeline initGame built, before the rate was overridden --
+    // the same way a player's history keeps whatever rate was in force when it was recorded
+    expect(result.months.length).toBeGreaterThan(2);
+    result.months.slice(1).forEach((m) => {
+      expect(m.revenue / (m.supplyWh / 1000)).toBeCloseTo(0.1, 6);
+    });
+  });
+
+  it("starts at the rate its scenario advertises", () => {
+    const result = runSimulation({ scenarioId: 101, months: 6 });
+    const scenarioRate = result.scenario.dollarsPerkWh;
+    result.months.forEach((m) => {
+      expect(m.revenue / (m.supplyWh / 1000)).toBeCloseTo(scenarioRate, 6);
+    });
+  });
+
+  it("charges more for the same electricity at a higher rate", () => {
+    const cheap = runSimulation({
+      scenarioId: 101,
+      months: 12,
+      dollarsPerkWh: 0.05,
+    });
+    const pricey = runSimulation({
+      scenarioId: 101,
+      months: 12,
+      dollarsPerkWh: 0.1,
+    });
+    const revenue = (r: SimResultType) =>
+      r.months.reduce((a, m) => a + m.revenue, 0);
+    expect(revenue(pricey)).toBeGreaterThan(revenue(cheap));
+  });
+
+  it("emits nothing when only renewables are running", () => {
+    // 106: Forecasting starts on wind and solar alone
+    const result = runSimulation({ scenarioId: 5, months: 12 });
+    const burnsFossilFuel = result.finalFacilities.some(
+      (f) => f.fuel && f.fuel !== "Sun" && f.fuel !== "Wind",
+    );
+    if (!burnsFossilFuel) {
+      expect(result.months.reduce((a, m) => a + m.kgco2e, 0)).toBe(0);
+    }
+  });
+
+  it("keeps the carbon fee proportional to emissions", () => {
+    // Carbon Fee is the one scenario that starts with a non-zero feePerKgCO2e
+    const result = runSimulation({ scenarioId: 100, months: 24 });
+    const fee = result.scenario.feePerKgCO2e;
+    expect(fee).toBeGreaterThan(0);
+    result.months.forEach((m) => {
+      expect(m.expensesCarbonFee).toBeCloseTo(m.kgco2e * fee, 4);
+    });
+  });
+});

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -1,0 +1,299 @@
+// The game reducer dispatches follow-up actions of its own (the construction complete snackbar,
+// the end of game dialogs), so it needs a live store to reach even though the simulation drives
+// the reducer directly. Importing Store creates and registers it.
+import "../Store";
+import gameReducer, {
+  buildFacility,
+  delta,
+  initGame,
+  start,
+  tickState,
+} from "../reducers/Game";
+import { DIFFICULTIES, LOCATIONS, TICKS_PER_HOUR } from "../Constants";
+import { GENERATORS } from "../data/Facilities";
+import { SCENARIOS } from "../data/Scenarios";
+import { getTimeFromTimeline } from "../helpers/DateTime";
+import {
+  DifficultyType,
+  FacilityOperatingType,
+  GameType,
+  GeneratorShoppingType,
+  MonthlyHistoryType,
+  ScenarioType,
+  TickPresentFutureType,
+} from "../Types";
+import {
+  checkMonth,
+  checkTick,
+  InvariantCollector,
+  ViolationType,
+} from "./Invariants";
+import { loadSimData } from "./SimData";
+const cloneDeep = require("lodash.clonedeep");
+
+export type StrategyType = "none" | "keepUp";
+
+export interface SimOptionsType {
+  scenarioId: number;
+  difficulty?: DifficultyType;
+  months?: number; // Defaults to the scenario's own duration
+  seed?: number;
+  dollarsPerkWh?: number;
+  monthlyMarketingSpend?: number;
+  strategy?: StrategyType;
+}
+
+export interface ResolvedSimOptionsType {
+  scenarioId: number;
+  difficulty: DifficultyType;
+  months: number;
+  seed: number;
+  dollarsPerkWh: number | null; // null = left at the scenario's own rate
+  monthlyMarketingSpend: number;
+  strategy: StrategyType;
+}
+
+export interface BuildRecordType {
+  month: number;
+  name: string;
+  buildCost: number;
+}
+
+export interface SimResultType {
+  options: ResolvedSimOptionsType;
+  scenario: ScenarioType;
+  ticks: number;
+  months: MonthlyHistoryType[]; // Oldest first, unlike game.monthlyHistory which is newest first
+  finalFacilities: FacilityOperatingType[];
+  finalCash: number;
+  finalNetWorth: number;
+  wentBankrupt: boolean;
+  bankruptAtMonth: number | null;
+  builds: BuildRecordType[];
+  // Mean fill level of the storage fleet across the run, 0 - 1, or null with no storage built
+  averageStateOfCharge: number | null;
+  violations: ViolationType[];
+  violationCountByRule: { [rule: string]: number };
+  violationCount: number;
+}
+
+const DEFAULT_CUSTOMERS = 1030000; // Matches LoadingContainer, the real game's entry point
+const DEFAULT_SEED = 12345;
+
+function formatWhen(state: GameType): string {
+  const d = state.date;
+  const hour = String(Math.floor(d.minuteOfDay / 60)).padStart(2, "0");
+  const minute = String(d.minuteOfDay % 60).padStart(2, "0");
+  return `${d.year}-${String(d.monthNumber).padStart(2, "0")} ${hour}:${minute}`;
+}
+
+/**
+ * Builds a game state the way a real playthrough does -- scenario, then difficulty, then initGame --
+ * but through the reducer directly rather than the shared store, so runs can't leak into each other.
+ *
+ * Exported so that tests wanting a realistic mid-game state can start from one without running a
+ * whole simulation. Loads the scenario's data as a side effect.
+ */
+export function createGame(options: SimOptionsType): GameType {
+  const scenario =
+    SCENARIOS.find((s: ScenarioType) => s.id === options.scenarioId) ||
+    SCENARIOS[0];
+  loadSimData(scenario.locationId);
+  return setUpGame(scenario, resolveOptions(scenario, options));
+}
+
+function setUpGame(
+  scenario: ScenarioType,
+  options: ResolvedSimOptionsType,
+): GameType {
+  let state = gameReducer(undefined, start(scenario.id));
+  // Chosen on the new game screen, before the game is built
+  state = gameReducer(
+    state,
+    delta({
+      difficulty: options.difficulty,
+      monthlyMarketingSpend: options.monthlyMarketingSpend,
+    }),
+  );
+  state = gameReducer(
+    state,
+    initGame({
+      facilities: scenario.facilities,
+      cash: scenario.cash,
+      customers: DEFAULT_CUSTOMERS,
+      location: LOCATIONS[scenario.locationId],
+      seed: options.seed,
+    }),
+  );
+  // Applied after initGame, which sets the scenario's own rate, the same way a player changing
+  // the rate on the Finances screen would
+  if (options.dollarsPerkWh !== null) {
+    state = gameReducer(state, delta({ dollarsPerkWh: options.dollarsPerkWh }));
+  }
+  // Redux Toolkit freezes reducer output in development; the tick loop mutates state in place
+  return cloneDeep(state);
+}
+
+/**
+ * Buys the cheapest generator it can comfortably afford whenever the previous month came up short
+ * on supply. Deliberately naive -- the point is to exercise the build, financing and construction
+ * paths over a long run, not to play well.
+ */
+function pickFacilityToBuild(
+  state: GameType,
+  lastMonth: MonthlyHistoryType,
+): GeneratorShoppingType | null {
+  const shortfall = lastMonth.demandWh - lastMonth.supplyWh;
+  if (shortfall <= lastMonth.demandWh * 0.02) {
+    return null; // Close enough to fully supplied
+  }
+  const now = getTimeFromTimeline(state.date.minute, state.timeline);
+  if (!now) {
+    return null;
+  }
+  // Size against the peak gap in watts rather than the month's total watt hours
+  const peakW = Math.max(
+    50000000,
+    Math.min(2000000000, (shortfall / lastMonth.demandWh) * now.demandW * 1.5),
+  );
+  const affordable = GENERATORS(
+    state,
+    peakW,
+    [now.windKph],
+    [now.solarIrradianceWM2],
+  )
+    .filter(
+      (g: GeneratorShoppingType) =>
+        g.available &&
+        g.buildCost * DIFFICULTIES[state.difficulty].buildCost < now.cash * 0.5,
+    )
+    .sort(
+      (a: GeneratorShoppingType, b: GeneratorShoppingType) =>
+        a.buildCost - b.buildCost,
+    );
+  return affordable[0] || null;
+}
+
+function resolveOptions(
+  scenario: ScenarioType,
+  options: SimOptionsType,
+): ResolvedSimOptionsType {
+  return {
+    scenarioId: scenario.id,
+    difficulty: options.difficulty || "Employee",
+    months: options.months || scenario.durationMonths || 12 * 20,
+    seed: options.seed === undefined ? DEFAULT_SEED : options.seed,
+    dollarsPerkWh:
+      options.dollarsPerkWh === undefined ? null : options.dollarsPerkWh,
+    monthlyMarketingSpend: options.monthlyMarketingSpend || 0,
+    strategy: options.strategy || "none",
+  };
+}
+
+export function runSimulation(options: SimOptionsType): SimResultType {
+  const scenario =
+    SCENARIOS.find((s: ScenarioType) => s.id === options.scenarioId) ||
+    SCENARIOS[0];
+  const resolved = resolveOptions(scenario, options);
+
+  loadSimData(scenario.locationId);
+  let state = setUpGame(scenario, resolved);
+
+  const collector = new InvariantCollector();
+  const builds: BuildRecordType[] = [];
+  let stateOfChargeSum = 0;
+  let stateOfChargeTicks = 0;
+  let ticks = 0;
+  let bankruptAtMonth: number | null = null;
+  let previousMonthCount = state.monthlyHistory.length;
+  let prevTick: TickPresentFutureType | null = null;
+  let justBuilt = false;
+  let lastTick: TickPresentFutureType | null = null;
+
+  // tickState fires the game's end-of-run dialogs through setTimeout, which never run here, so the
+  // loop watches state directly instead and stops on the same conditions the player would hit:
+  // monthsEllapsed reaching the scenario duration, or negative cash at a month rollover.
+  while (state.date.monthsEllapsed < resolved.months) {
+    tickState(state);
+    ticks++;
+
+    const now = getTimeFromTimeline(state.date.minute, state.timeline);
+    if (!now) {
+      break;
+    }
+    lastTick = now;
+
+    const rolledOver = state.monthlyHistory.length > previousMonthCount;
+    checkTick(
+      collector,
+      state,
+      rolledOver ? null : prevTick,
+      now,
+      formatWhen(state),
+      justBuilt,
+    );
+    justBuilt = false;
+
+    const storageCapacityWh = state.facilities.reduce(
+      (acc: number, f: FacilityOperatingType) => acc + (f.peakWh || 0),
+      0,
+    );
+    if (storageCapacityWh > 0 && Number.isFinite(now.storedWh)) {
+      stateOfChargeSum += now.storedWh / storageCapacityWh;
+      stateOfChargeTicks++;
+    }
+
+    if (!rolledOver) {
+      prevTick = now;
+      continue;
+    }
+
+    previousMonthCount = state.monthlyHistory.length;
+    checkMonth(collector, state.monthlyHistory[0], formatWhen(state));
+
+    if (now.cash < 0) {
+      bankruptAtMonth = state.date.monthsEllapsed;
+      break; // The real game forces a restart here, so anything past it isn't a reachable state
+    }
+
+    if (resolved.strategy === "keepUp") {
+      const toBuild = pickFacilityToBuild(state, state.monthlyHistory[0]);
+      if (toBuild) {
+        builds.push({
+          month: state.date.monthsEllapsed,
+          name: toBuild.name,
+          buildCost: toBuild.buildCost,
+        });
+        // The reducer returns new state rather than mutating, and freezes it in development
+        state = cloneDeep(
+          gameReducer(
+            state,
+            buildFacility({ facility: toBuild, financed: true }),
+          ),
+        );
+        justBuilt = true;
+      }
+    }
+    // The timeline was just regenerated and pre-rolled, so tick continuity restarts next tick
+    prevTick = null;
+  }
+
+  return {
+    options: resolved,
+    scenario,
+    ticks,
+    months: [...state.monthlyHistory].reverse(), // Game stores newest first
+    finalFacilities: state.facilities as FacilityOperatingType[],
+    finalCash: lastTick ? lastTick.cash : 0,
+    finalNetWorth: lastTick ? lastTick.netWorth : 0,
+    wentBankrupt: bankruptAtMonth !== null,
+    bankruptAtMonth,
+    builds,
+    averageStateOfCharge: stateOfChargeTicks
+      ? stateOfChargeSum / stateOfChargeTicks
+      : null,
+    violations: collector.getViolations(),
+    violationCountByRule: collector.getCountByRule(),
+    violationCount: collector.getTotalCount(),
+  };
+}


### PR DESCRIPTION
Plays the game without a browser by driving the real reducer, then checks that the economy behaved lawfully. A 20 year scenario runs in about half a second.

```
npm run sim -- --all
```

```
  SCENARIO                  MONTHS   OUTCOME              CASH      UNSERVED  INVARIANTS
  ------------------------- -------- -------------------- --------- --------- ----------
  Carbon Fee                144      survived             $56M      0.3%      ok
  The Shale Boom            240      survived             $3,099M   0.7%      ok
  Paradise                  144      bankrupt @ month 43  $-3M      0.1%      ok
  ...
  All scenarios hold every invariant.
```

Every scenario in about two seconds. `npm run sim -- --scenario 103` drills into one with a month by month table, totals and final fleet; `--help` lists the flags.

## What it checks

Not the numbers — the **invariants**, rules the economy must obey no matter how the balance looks. They run on every tick of every simulated month and report the game time and values involved, so a broken run points at a line of code.

No `NaN` or `Infinity` in any field · cash moves only by recorded revenue and expenses · storage never gives back more than was charged into it · generators stay within rated power · storage stays within rated power and capacity · loan balances only amortise downwards · `supplyByFuel` sums within `supplyW` · billed supply never exceeds demand.

`Simulation.test.tsx` asserts all of it as part of `npm test`, across every scenario, both ends of the difficulty range, marketing spend, and a run that builds on credit — plus determinism and a few economic identities. Suite went from 41 tests to 78, and still runs in ~6s.

Nothing is reimplemented. The simulator calls `tickState` in a loop instead of the `tick` action, which paces itself off `performance.now()` and `setTimeout`. If the reducer is wrong, the simulation is wrong in the same way.

## Three bugs it surfaced

Each has a regression test that I confirmed fails without its fix.

**Scenarios never applied their own `dollarsPerkWh`.** It's shown to the player on the new game screen, and Public scenarios are *scored* against it, but `initGame` never copied it into state — so every game ran at the slice default. Every scenario currently sets `0.07`, which is that default, so **no balance changes today**; the field just works now.

**`buildFacility` discarded its own reforecast.** It spread the result into a new object and assigned that to its immer draft parameter, which immer throws away. The forecast kept describing the old fleet until the next month rollover regenerated the timeline. Simulation was unaffected (output is recomputed from `state.facilities` each tick) — this was a Forecasts-view bug.

**The reducers formed an import cycle.** `Card` needed `Game`'s action creators while its own slice was still being built, and `Game` reached back to `Store` and to `Scenarios` (which imports `Card`). Loading `Game` or `Scenarios` before `Store` crashed the store on startup with `Cannot read properties of undefined (reading 'type')`; only the app's own entry order hid it. `start`/`loaded`/`quit` now live in `GameActions`, a leaf module, and `Game` reaches the store through `StoreRegistry` rather than importing it. **Action type strings are unchanged.** `ImportOrder.test.tsx` pins every entry point — 7 of its 8 cases fail on `master`.

Two smaller fixes were needed to make runs reproducible, and both affect real play: `initGame` now resets `previousMonth`, and fuel prices reset per game. Without them a second playthrough in one session inherited the first one's month (skipping its first rollover) and its randomly extrapolated future prices.

## Verification

- 78/78 tests pass; `tsc --noEmit` clean; `CI=true react-scripts build` passes (lint-as-errors).
- The `--all` sweep is byte-for-byte identical to before the fixes, confirming they're behaviour preserving.
- Ran the app: menu → scenario → game loads → ticks at speed with cash and clock advancing → Quit returns to menu. No new console errors.

## Notes for review

- `src/testing/README.md` documents what's checked, how it works, and the sim's sharp edges.
- The one behaviour change a player could notice: a second game in the same browser session now starts cleanly instead of inheriting the previous game's month and fuel prices.
- Balance signal worth a look, not addressed here: **Paradise goes bankrupt at month 43 of 144** doing nothing, while most scenarios coast to billions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)