### PR TITLE
Fix accuracy and polish bugs found in playtesting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ res/
 config.json
 google-services.json
 GoogleService-Info.plist
+.env.local
 .idea

--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -48,7 +48,7 @@ export const LOCATIONS = {
   },
   SF: {
     id: "SF",
-    name: "San Fransisco, CA",
+    name: "San Francisco, CA",
     lat: 37.7749,
     long: -122.4194,
   },
@@ -60,7 +60,7 @@ export const LOCATIONS = {
   },
   SJU: {
     id: "SJU",
-    name: "San Juan, Puero Rico",
+    name: "San Juan, Puerto Rico",
     lat: 18.4671,
     long: -66.1185,
   },

--- a/src/app.scss
+++ b/src/app.scss
@@ -454,6 +454,48 @@ span.weak {
   margin-bottom: 100%;
 }
 
+// Completion state of each tutorial in the scenario list
+.tutorialIncomplete {
+  color: #bdbdbd; /* grey400 */
+}
+
+// Units appended to numbers in tables, de-emphasized so the number still reads first
+.unitSuffix {
+  opacity: 0.6;
+  font-size: 0.85em;
+}
+
+// Keyboard shortcut listings (Settings + Manual)
+.shortcuts {
+  margin: 8px auto;
+  border-collapse: collapse;
+  text-align: left;
+
+  td {
+    padding: 4px 8px;
+    vertical-align: middle;
+  }
+
+  td:first-child {
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  kbd {
+    display: inline-block;
+    min-width: 1.6em;
+    padding: 1px 5px;
+    border: 1px solid #bdbdbd; /* grey400 */
+    border-bottom-width: 2px;
+    border-radius: 3px;
+    background: #fafafa; /* grey50 */
+    font-family: monospace;
+    font-size: 0.85em;
+    line-height: 1.5;
+    text-align: center;
+  }
+}
+
 // For things that use size() / get recalulcated on larger displays
 @mixin styling() {
   .clickable-card {

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -36,12 +36,12 @@ import { navigate } from "../reducers/Card";
 import { setSpeed } from "../reducers/Game";
 import { store } from "../Store";
 
+// Keep in sync with the Keyboard Shortcuts entry in the Manual and Settings
 const keyMap = {
   PAUSED: ["`", "space", "0"],
   SLOW: "1",
   NORMAL: "2",
   FAST: "3",
-  LIGHTNING: "4",
   FACILITIES: "q",
   FINANCES: "w",
   FORECASTS: "e",

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -73,6 +73,11 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): JSX.Element {
     LOAN_MONTHS
   );
   const buildable = props.generator.peakW <= props.generator.maxPeakW;
+  // kg of CO2 equivalent released per MWh generated - 0 for carbon-free sources,
+  // whose fuel either isn't in FUELS at all (sun, wind) or is emission-free (uranium)
+  const kgCO2ePerMWh = Math.round(
+    1000000 * generator.btuPerWh * (fuel.kgCO2ePerBtu || 0)
+  );
   const secondaryText = buildable ? (
     generator.description
   ) : (
@@ -128,6 +133,10 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): JSX.Element {
               <br />
               {fuelPrices[generator.fuel] ? "~" : ""}
               {formatMoneyConcise(generator.lcWh * 1000000)}/MWh
+              <br />
+              {kgCO2ePerMWh > 0
+                ? `${kgCO2ePerMWh.toLocaleString()}kg CO2e/MWh`
+                : "No CO2e"}
             </Typography>
           </span>
         }
@@ -188,10 +197,10 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): JSX.Element {
                     </Typography>
                   </TableCell>
                   <TableCell align="right">
+                    {/* btuPerWh * 1M = BTU per MWh, and prices are per million BTU,
+                        so the two factors of a million cancel out */}
                     {formatMoneyConcise(
-                      1000000 *
-                        generator.btuPerWh *
-                        fuelPrices[generator.fuel] || 0
+                      generator.btuPerWh * fuelPrices[generator.fuel] || 0
                     )}
                     /MWh
                   </TableCell>
@@ -224,22 +233,17 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): JSX.Element {
                   </TableCell>
                 </TableRow>
               )}
-              {fuel.kgCO2ePerBtu > 0 && (
-                <TableRow>
-                  <TableCell>
-                    Air pollution
-                    <Typography variant="body2" color="textSecondary">
-                      (kg of CO2 equivalent)
-                    </Typography>
-                  </TableCell>
-                  <TableCell align="right">
-                    {Math.round(
-                      1000000 * generator.btuPerWh * fuel.kgCO2ePerBtu || 0
-                    )}
-                    kg/MWh
-                  </TableCell>
-                </TableRow>
-              )}
+              <TableRow>
+                <TableCell>
+                  Air pollution
+                  <Typography variant="body2" color="textSecondary">
+                    Greenhouse gas released per unit generated
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  {kgCO2ePerMWh.toLocaleString()}kg CO2e/MWh
+                </TableCell>
+              </TableRow>
             </TableBody>
           </Table>
         </TableContainer>

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -460,6 +460,12 @@ export default class Finances extends React.Component<Props, State> {
                       <TableCell>{k.label}</TableCell>
                       <TableCell align="right">
                         {format(summary[key as DerivedHistoryKeysType])}
+                        {k.suffix && (
+                          <span className="unitSuffix">
+                            {k.suffix.startsWith("/") ? "" : " "}
+                            {k.suffix}
+                          </span>
+                        )}
                       </TableCell>
                     </TableRow>
                   );

--- a/src/components/views/Manual.tsx
+++ b/src/components/views/Manual.tsx
@@ -229,7 +229,98 @@ const MANUAL_ENTRIES = [
   },
   {
     title: `Forecasts`,
-    entry: <p>TODO how to read the forecast</p>,
+    entry: (
+      <div>
+        <p>
+          The Forecasts tab projects your company forward, so you can spot
+          problems before they cost you customers. Use the dropdown at the top
+          right to look ahead 1, 5, 10 or 20 years - the further out you look,
+          the coarser (and less certain) the projection.
+        </p>
+        <p>
+          <strong>Supply &amp; Demand</strong> plots your projected output
+          against projected demand. Wherever demand rises above supply, the gap
+          is shaded as a blackout. If any are forecasted, the table underneath
+          breaks them down: total energy not served, the size of the single
+          worst event, the peak shortage (how much extra capacity you'd need to
+          cover it) and when it happens. That "when" is the most useful number
+          on the page - it tells you whether you need generation that can ramp
+          up for a few hours, or baseload for a whole season.
+        </p>
+        <p>
+          <strong>Supply by Fuel</strong> breaks that same supply down by fuel,
+          in dispatch order. This is where you can see your merit order at work:
+          cheap, always-on sources carry the base, and expensive or fast-ramping
+          ones fill the peaks. Re-ordering your facilities changes this chart.
+        </p>
+        <p>
+          <strong>Stored power</strong> (shown once you own storage) tracks the
+          energy in your batteries and reservoirs as they charge off surplus
+          and discharge into peaks.
+        </p>
+        <p>
+          <strong>Fuel Prices</strong> projects the cost of each fuel you can
+          burn, based on real historical price data. Fuel prices move suddenly
+          and by a lot, which can flip a profitable plant into a money-loser -
+          watch this chart before committing to a decades-long build.
+        </p>
+        <p>
+          <strong>Weather</strong> projects temperature and sunlight for your
+          region. It drives demand (heating and air conditioning) as well as the
+          output of your solar and wind generators.
+        </p>
+        <p>
+          Forecasts assume you make no further changes, so treat them as "what
+          happens if I do nothing" rather than a promise. Pausing a generator or
+          reordering your stack updates them immediately, which makes them a
+          cheap way to test a decision before you pay for it.
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: `Keyboard Shortcuts`,
+    entry: (
+      <div>
+        <p>
+          While a scenario is running, you can drive the game from the keyboard:
+        </p>
+        <table className="shortcuts">
+          <tbody>
+            <tr>
+              <td>
+                <kbd>`</kbd> <kbd>space</kbd> <kbd>0</kbd>
+              </td>
+              <td>Pause</td>
+            </tr>
+            <tr>
+              <td>
+                <kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd>
+              </td>
+              <td>Slow / normal / fast speed</td>
+            </tr>
+            <tr>
+              <td>
+                <kbd>Q</kbd>
+              </td>
+              <td>Facilities tab</td>
+            </tr>
+            <tr>
+              <td>
+                <kbd>W</kbd>
+              </td>
+              <td>Finances tab</td>
+            </tr>
+            <tr>
+              <td>
+                <kbd>E</kbd>
+              </td>
+              <td>Forecasts tab</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    ),
   },
   {
     // Credit to https://www.e-education.psu.edu/ebf200/node/151
@@ -258,7 +349,7 @@ const MANUAL_ENTRIES = [
           you'll receive a score for how well you did. Try to beat your score
           the next time you play!
         </p>
-        <p>Scores are calculated as follows:</p>
+        <p>Investor-owned scenarios are scored as follows:</p>
         <p>
           4 pts for each $100M of net worth at the end
           <br />
@@ -266,9 +357,20 @@ const MANUAL_ENTRIES = [
           <br />
           1 pt for each TWh supplied
           <br />
-          -2 pts for each kTon of pollution
+          -2 pts for each megaton (1M tons) of CO2e emitted
           <br />
           -8 pts for each TWh of blackouts
+        </p>
+        <p>Public-owned scenarios are scored as follows:</p>
+        <p>
+          +/-80 pts for each $0.01/kWh that your lifetime average rate lands
+          below/above the scenario's target rate
+          <br />
+          10 pts for each TWh supplied
+          <br />
+          -5 pts for each megaton (1M tons) of CO2e emitted
+          <br />
+          -10 pts for each TWh of blackouts
         </p>
       </div>
     ),

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -11,6 +11,8 @@ import {
 } from "@mui/material";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import { getStorageJson } from "../../LocalStorage";
 import { LOCATIONS } from "../../Constants";
 import { SCENARIOS } from "../../data/Scenarios";
@@ -39,7 +41,21 @@ function TutorialListItem(props: TutorialListItemProps): JSX.Element {
   return (
     <Card className="build-list-item">
       <CardHeader
-        style={{ opacity: completed ? 0.5 : 1 }}
+        style={{ opacity: completed ? 0.6 : 1 }}
+        avatar={
+          completed ? (
+            <CheckCircleIcon
+              className="tutorialComplete"
+              color="primary"
+              titleAccess={`${s.name} completed`}
+            />
+          ) : (
+            <RadioButtonUncheckedIcon
+              className="tutorialIncomplete"
+              titleAccess={`${s.name} not yet completed`}
+            />
+          )
+        }
         action={
           <Button
             size="small"
@@ -47,7 +63,7 @@ function TutorialListItem(props: TutorialListItemProps): JSX.Element {
             color="primary"
             onClick={(e: any) => onTutorial(s.id)}
           >
-            {completed ? "Done" : "Play"}
+            {completed ? "Replay" : "Play"}
           </Button>
         }
         title={s.name}

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -214,7 +214,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                 <p>+40 pts per $1B of net worth at the end</p>
                 <p>+2 pts per 100k customers at the end</p>
                 <p>+1 pt per TWh of electricity supplied</p>
-                <p>-2 pts per gigaton of greenhouse gas emissions</p>
+                <p>-2 pts per megaton (1M tons) of greenhouse gas emissions</p>
                 <p>-8 pts per TWh of blackouts</p>
               </div>
             )}
@@ -225,7 +225,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   {scenario.dollarsPerkWh}/kWh
                 </p>
                 <p>+10 pts per TWh of electricity supplied</p>
-                <p>-5 pts per gigaton of greenhouse gas emissions</p>
+                <p>-5 pts per megaton (1M tons) of greenhouse gas emissions</p>
                 <p>-10 pts per TWh of blackouts</p>
               </div>
             )}

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -35,8 +35,6 @@ export default function Settings(props: Props): JSX.Element {
   //   {(props.settings.experimental) ? 'Experimental features are currently enabled.' : 'Experimental features are currently disabled.'}
   // </Checkbox>
 
-  // Getting keyboard shortcut map: https://www.npmjs.com/package/react-hotkeys#displaying-a-list-of-available-hot-keys
-
   return (
     <div className="flexContainer" id="gameCard">
       <div id="topbar">
@@ -65,6 +63,44 @@ export default function Settings(props: Props): JSX.Element {
         {props.settings.audioEnabled
           ? "Music and sound effects enabled."
           : "Music and sound effects disabled."}
+        {/* Keep in sync with keyMap in Compositor.tsx and the Manual entry */}
+        <Typography variant="h6" style={{ marginTop: 24 }}>
+          Keyboard Shortcuts
+        </Typography>
+        <table className="shortcuts">
+          <tbody>
+            <tr>
+              <td>
+                <kbd>`</kbd> <kbd>space</kbd> <kbd>0</kbd>
+              </td>
+              <td>Pause</td>
+            </tr>
+            <tr>
+              <td>
+                <kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd>
+              </td>
+              <td>Slow / normal / fast speed</td>
+            </tr>
+            <tr>
+              <td>
+                <kbd>Q</kbd>
+              </td>
+              <td>Facilities tab</td>
+            </tr>
+            <tr>
+              <td>
+                <kbd>W</kbd>
+              </td>
+              <td>Finances tab</td>
+            </tr>
+            <tr>
+              <td>
+                <kbd>E</kbd>
+              </td>
+              <td>Forecasts tab</td>
+            </tr>
+          </tbody>
+        </table>
         <Typography className="version">
           Electrify App v{packageJson.version}
         </Typography>

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -135,8 +135,9 @@ export const SCENARIOS = [
         target: ".action-seconday-text",
         content: (
           <Typography variant="body1">
-            See how long it will take to build, and the total cost of
-            electricity across its lifetime.
+            See how long it will take to build, the total cost of electricity
+            across its lifetime, and how much greenhouse gas it releases per
+            unit generated.
           </Typography>
         ),
       },
@@ -276,7 +277,7 @@ export const SCENARIOS = [
     durationMonths: 1,
     endTitle: "Tutorial complete!",
     endMessage:
-      "You now know enough to run a company on VP difficulty - or, continue tutorials to build your skills",
+      "You now know enough to run a company on Manager difficulty - or, continue tutorials to build your skills",
     facilities: [
       { name: "Pumped Hydro", peakWh: 1000000000 },
       { fuel: "Coal", peakW: 600000000 },
@@ -337,7 +338,7 @@ export const SCENARIOS = [
     durationMonths: 12,
     endTitle: "Tutorial complete!",
     endMessage:
-      "You now know enough to run a company on Manager difficulty - or, continue tutorials to build your skills",
+      "You now know enough to run a company on VP difficulty - or, continue tutorials to build your skills",
     facilities: [
       { name: "Pumped Hydro", peakWh: 1000000000 },
       { fuel: "Coal", peakW: 600000000 },

--- a/src/reducers/Card.test.tsx
+++ b/src/reducers/Card.test.tsx
@@ -1,0 +1,16 @@
+import cardReducer from "./Card";
+import { quit } from "./GameActions";
+
+describe("card reducer", () => {
+  it("returns to the title screen on a plain quit", () => {
+    const state = cardReducer(undefined, quit());
+    expect(state.name).toBe("MAIN_MENU");
+  });
+
+  it("returns to the scenario list when a scenario ends", () => {
+    const state = cardReducer(undefined, quit({ toScenarioList: true }));
+    expect(state.name).toBe("NEW_GAME");
+    // Back from the scenario list should still reach the title screen
+    expect(state.history).toEqual(["NEW_GAME", "MAIN_MENU"]);
+  });
+});

--- a/src/reducers/Card.tsx
+++ b/src/reducers/Card.tsx
@@ -75,7 +75,15 @@ export const cardSlice = createSlice({
       };
       return state;
     });
-    builder.addCase(quit, (state) => {
+    builder.addCase(quit, (state, action) => {
+      if (action.payload && action.payload.toScenarioList) {
+        return {
+          name: "NEW_GAME" as CardNameType,
+          ts: Date.now(),
+          history: ["NEW_GAME", "MAIN_MENU"] as CardNameType[],
+          toPrevious: false,
+        };
+      }
       state = { ...initialCard };
       return state;
     });

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -354,7 +354,8 @@ export function tickState(state: GameType) {
               open: true,
               notCancellable: true,
               actionLabel: "Try again",
-              action: () => getStore().dispatch(quit()),
+              action: () =>
+                getStore().dispatch(quit({ toScenarioList: true })),
             })
           );
         }, 1);
@@ -387,7 +388,8 @@ export function tickState(state: GameType) {
               open: true,
               notCancellable: true,
               actionLabel: "Try again",
-              action: () => getStore().dispatch(quit()),
+              action: () =>
+                getStore().dispatch(quit({ toScenarioList: true })),
             })
           );
         }, 1);
@@ -500,8 +502,9 @@ export function tickState(state: GameType) {
                 ),
                 open: true,
                 closeText: "Keep playing",
-                actionLabel: "Return to menu",
-                action: () => getStore().dispatch(quit()),
+                actionLabel: "Return to scenarios",
+                action: () =>
+                  getStore().dispatch(quit({ toScenarioList: true })),
               })
             ),
           1

--- a/src/reducers/GameActions.tsx
+++ b/src/reducers/GameActions.tsx
@@ -15,4 +15,11 @@ import { createAction } from "@reduxjs/toolkit";
  */
 export const start = createAction<number>("game/start");
 export const loaded = createAction("game/loaded");
-export const quit = createAction("game/quit");
+/**
+ * Ends the scenario. Pass { toScenarioList: true } to land on the scenario list rather than the
+ * title screen - what you want after finishing (or failing) a scenario, since the next thing a
+ * player wants is another scenario.
+ */
+export const quit = createAction<{ toScenarioList?: boolean } | undefined>(
+  "game/quit"
+);


### PR DESCRIPTION
Fixes the "small accuracy/polish bugs" from a v0.2.0 playtest (tutorials 101–106 plus a full 12-year Carbon Fee run).

## The scoring unit error

The emissions scoring rule was documented in three different units, and two were wrong by 1000×. `Game.tsx` scores `-2 * kgco2e / 1e9`, and `kgco2e` is kilograms — so that's **-2 pts per megaton**. The Manual said "kTon" (1000× too harsh) and the victory-conditions tooltip said "gigaton" (1000× too lenient). Both now say megaton, which matches the playtester's 22,502,882 tons → −45 pts.

The Manual's Score entry also only documented investor-owned scoring, so public-owned scoring is now spelled out beside it.

## Everything else

| Fix | Before | After |
| --- | --- | --- |
| Finances table units | `CO2e emitted 22,502,882` | `CO2e emitted 22,502,882 tons` |
| Emissions factor | `581` | `581 kg/MWh` |
| Build screen CO2 | hidden for zero-emission plants | shown for every generator, next to the price |
| Build screen fuel cost | `$32.2M/MWh` for coal | `$32.2/MWh` |
| Manual → Forecasts | `TODO how to read the forecast` | a real entry covering all five charts |
| Location names | "San Fransisco", "Puero Rico" | "San Francisco", "Puerto Rico" |
| End of scenario | drops you at the title screen | returns to the scenario list |
| Tutorial list | no completion markers | checkmark + "Replay" on finished tutorials |
| Tutorials 104/105 | announce VP, then Manager | Manager, then VP (matching the difficulty ladder) |
| Hotkeys | mentioned only inside tutorial text | Manual entry + Options section |

Two things worth calling out because they weren't on the list but are the same class of bug, found while fixing the ones that were:

- **Fuel cost was off by 1,000,000× on the build screen.** It multiplied `btuPerWh` by a million to get BTU/MWh without dividing by the million in "price per *million* BTU". The sim itself does divide, so only the display was wrong.
- **`LIGHTNING: "4"`** was in the hotkey map with no handler and no matching `SpeedType`. Removed rather than documented.

The build-screen emissions change also required a copy tweak in tutorial 102, which points at that row and previously listed only build time and lifetime cost.

## Implementation note

Routing the end-of-scenario dialog to the scenario list is done with a payload on the existing `quit` action (`quit({ toScenarioList: true })`) rather than by dispatching a follow-up `navigate`. `Card` already reacts to `quit`, and the reducers deliberately avoid a `Card → Game` import — the comment block in `GameActions.tsx` explains the cycle that used to break the store — so a payload keeps that boundary intact. `src/reducers/Card.test.tsx` covers both destinations.

## Verification

- `npx tsc --noEmit` clean, `CI=true react-scripts test` 80/80 passing, `CI=true react-scripts build` compiles with no lint warnings.
- Walked the running app: Manual and Options render the shortcuts, the victory tooltip and Manual agree on megatons, the build screen shows `1,176kg CO2e/MWh` for coal and `No CO2e` for solar/wind/geothermal/nuclear, the Finances table reads `2,930 tons` / `1,103 kg/MWh`, and completing tutorial 101 lands on the scenario list with 101 checked off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
