### PR TITLE
Stop the forecast from mutating the live fleet

### DIFF
--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -826,8 +826,12 @@ function reforecastSupply(
   state: GameType,
   simulated?: boolean
 ): TickPresentFutureType[] {
-  // Make temporary deep copy so that it can be revised in place
-  const newState = { ...state };
+  // updateSupplyFacilitiesFinances ramps generators, charges batteries and pays down loans by
+  // mutating the facilities in place, so forecasting has to run against a copy of them. A shallow
+  // spread shares the same facility objects, which let a forecast leave the real fleet sitting at
+  // its end-of-horizon state -- resuming a paused nuclear plant snapped straight to full output
+  // instead of ramping, and every reforecast silently aged construction and loans by a whole day.
+  const newState = { ...state, facilities: cloneDeep(state.facilities) };
   let prev = newState.timeline[0];
   return newState.timeline.map((t: TickPresentFutureType) => {
     if (t.minute >= state.date.minute) {

--- a/src/reducers/TogglePauseFacility.test.tsx
+++ b/src/reducers/TogglePauseFacility.test.tsx
@@ -1,0 +1,77 @@
+import { PayloadAction } from "@reduxjs/toolkit";
+import gameReducer, { togglePauseFacility, tickState } from "./Game";
+import { TICK_MINUTES } from "../Constants";
+import { createGame } from "../testing/Simulator";
+import { FacilityOperatingType, GameType } from "../Types";
+const cloneDeep = require("lodash.clonedeep");
+
+// Redux Toolkit freezes reducer output in development, and tickState mutates state in place
+function dispatch(state: GameType, action: PayloadAction<number>): GameType {
+  return cloneDeep(gameReducer(state, action));
+}
+
+// Everything about a facility that only the passage of time is supposed to change
+function liveState(state: GameType) {
+  return state.facilities.map((f: FacilityOperatingType) => ({
+    id: f.id,
+    currentW: f.currentW,
+    currentWh: f.currentWh,
+    yearsToBuildLeft: f.yearsToBuildLeft,
+    loanAmountLeft: f.loanAmountLeft,
+  }));
+}
+
+describe("togglePauseFacility", () => {
+  it("pauses and resumes the facility", () => {
+    const before = createGame({ scenarioId: 103 });
+    const id = before.facilities[0].id;
+    expect(before.facilities[0].paused).toBeFalsy();
+
+    const paused = dispatch(before, togglePauseFacility(id));
+    expect(paused.facilities[0].paused).toBe(true);
+
+    const resumed = dispatch(paused, togglePauseFacility(id));
+    expect(resumed.facilities[0].paused).toBe(false);
+  });
+
+  /**
+   * Regression test for #117. reforecastSupply used to shallow copy the state, so the forecast ran
+   * updateSupplyFacilitiesFinances against the real facility objects and left them wherever the
+   * end of the forecast horizon put them -- ramped up, charged, a day further into construction
+   * and a day further through their loan.
+   */
+  it("does not move the live fleet forward while reforecasting", () => {
+    const before = createGame({ scenarioId: 103 });
+    const snapshot = liveState(before);
+
+    const after = dispatch(
+      before,
+      togglePauseFacility(before.facilities[0].id),
+    );
+
+    expect(liveState(after)).toEqual(snapshot);
+  });
+
+  it("ramps back up over time rather than snapping to full output", () => {
+    let state = createGame({ scenarioId: 103 });
+    const id = state.facilities[0].id;
+    const { peakW, spinMinutes } = state.facilities[0];
+    const rampPerTick = (peakW * TICK_MINUTES) / spinMinutes;
+
+    // Pause and let it wind all the way down
+    state = dispatch(state, togglePauseFacility(id));
+    for (let i = 0; i < Math.ceil(spinMinutes / TICK_MINUTES); i++) {
+      tickState(state);
+    }
+    expect(state.facilities[0].currentW).toBe(0);
+
+    // Resuming reforecasts, which must not touch the facility's current output
+    state = dispatch(state, togglePauseFacility(id));
+    expect(state.facilities[0].currentW).toBe(0);
+
+    // ... and the first tick back may only spin it up by one tick's worth of ramp
+    tickState(state);
+    expect(state.facilities[0].currentW).toBeGreaterThan(0);
+    expect(state.facilities[0].currentW).toBeCloseTo(rampPerTick, 5);
+  });
+});


### PR DESCRIPTION
Fixes #117

## Root cause

`reforecastSupply` claimed to make a "temporary deep copy" but actually did a shallow spread:

```js
const newState = { ...state };
```

A spread copies the *reference* to `state.facilities`, so `newState.facilities` **is** the live fleet. `updateSupplyFacilitiesFinances` mutates facilities in place — ramping `currentW`, charging/discharging `currentWh`, decrementing `yearsToBuildLeft` and `loanAmountLeft`. Running it across the ~96-tick forecast horizon left the real facilities parked at their end-of-horizon state.

So the forecast and the now moment weren't using different code, as the issue suspected — the forecast ran first and mutated the fleet on its way through. Un-pausing nuclear reforecast the real generator to full output, and the next tick started from there instead of ramping. The forecast array itself was computed tick-by-tick and was correct all along.

`generateNewTimeline` was immune because it `cloneDeep`s the whole state first, which is exactly why only the reducers that call `reforecastSupply` directly (`buildFacility`, `sellFacility`, `togglePauseFacility`, `reprioritizeFacility`) showed the bug.

Two quieter bugs came through the same hole, beyond the reported symptom: every reforecast aged construction by a full game day and paid down a day's worth of loan principal for free. Pausing/selling/reordering facilities repeatedly was a way to rush builds and retire debt.

## The fix

Clone the facilities into the forecast's state so it works on a throwaway fleet. The intentional in-place pre-rolls in `initGame` and `tickState` call `updateSupplyFacilitiesFinances` directly, so they keep mutating the real fleet as designed.

## Tests

New `src/reducers/TogglePauseFacility.test.tsx`:

- pause/resume flips the flag
- a reforecast leaves `currentW` / `currentWh` / `yearsToBuildLeft` / `loanAmountLeft` untouched across the whole fleet
- the issue's exact repro: pause a coal plant, tick it down to zero, resume, and assert the next tick spins it up by exactly one tick's worth of ramp rather than snapping to peak

Reverting the one-line fix fails two of the three (`Expected: 0, Received: 347416477.8`), so they do catch it.

Full suite: 83/83 passing, including the simulation invariants across every scenario. `tsc --noEmit` clean.

Not verified through the browser preview — reproducing by hand needs a multi-year playthrough to get a slow-ramp plant built, whereas the headless simulator drives the same reducer path the UI dispatches into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
