### PR TITLE
Migrate off deprecated ListItemSecondaryAction

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -382,8 +382,13 @@ $topbar_height: 56px;
   padding: 0 !important;
 }
 
+// Facility rows paint an .outputProgressBar behind their contents, so both the text and the
+// action buttons have to be lifted over it - and they have to be lifted by the same amount, or
+// the full-width text block would cover the left edge of the buttons and eat their clicks.
+// `.MuiListItem-secondaryAction` is the slot class ListItem's own `secondaryAction` prop emits;
+// it outlives the deprecated ListItemSecondaryAction component's own class.
 .MuiListItemText-root,
-.MuiListItemSecondaryAction-root {
+.MuiListItem-secondaryAction {
   z-index: 1;
 }
 

--- a/src/components/base/Navigation.tsx
+++ b/src/components/base/Navigation.tsx
@@ -26,21 +26,18 @@ export default function Navigation() {
       }
     >
       <BottomNavigationAction
-        classes={{ label: "navlabel" }}
         id="faciltiesNav"
         label="Facilities"
         value="FACILITIES"
         icon={<FlashOnIcon />}
       />
       <BottomNavigationAction
-        classes={{ label: "navlabel" }}
         id="financesNav"
         label="Finances"
         value="FINANCES"
         icon={<AttachMoneyIcon />}
       />
       <BottomNavigationAction
-        classes={{ label: "navlabel" }}
         id="forecastsNav"
         label="Forecasts"
         value="FORECASTS"

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -11,7 +11,6 @@ import {
   List,
   ListItem,
   ListItemAvatar,
-  ListItemSecondaryAction,
   ListItemText,
   Toolbar,
   Typography,
@@ -184,6 +183,56 @@ function FacilityListItem(props: FacilityListItemProps): JSX.Element {
                 ? { opacity: (theme) => theme.palette.action.disabledOpacity }
                 : undefined
             }
+            secondaryAction={
+              <>
+                {!underConstruction &&
+                  props.listLength > 1 &&
+                  !facility.paused && (
+                    <IconButton
+                      onClick={() => onPause(facility.id, facility.name)}
+                      aria-label={`Pause ${facility.name}`}
+                      edge="end"
+                      color="primary"
+                      size="large"
+                    >
+                      <PauseIcon />
+                    </IconButton>
+                  )}
+                {facility.paused && (
+                  <IconButton
+                    onClick={() => onTogglePause(facility.id)}
+                    aria-label={`Resume ${facility.name}`}
+                    edge="end"
+                    color="primary"
+                    size="large"
+                  >
+                    <PlayIcon />
+                  </IconButton>
+                )}
+                {!underConstruction && props.listLength > 1 && (
+                  <IconButton
+                    onClick={toggleDialog}
+                    aria-label={`Sell ${facility.name}`}
+                    edge="end"
+                    color="primary"
+                    size="large"
+                  >
+                    <DeleteForeverIcon />
+                  </IconButton>
+                )}
+                {underConstruction && (
+                  <IconButton
+                    onClick={toggleDialog}
+                    aria-label={`Cancel construction of ${facility.name}`}
+                    edge="end"
+                    color="primary"
+                    size="large"
+                  >
+                    <CancelIcon />
+                  </IconButton>
+                )}
+              </>
+            }
           >
             <DragIndicatorIcon
               className="draggable-indicator"
@@ -262,54 +311,6 @@ function FacilityListItem(props: FacilityListItemProps): JSX.Element {
                 </Button>
               </DialogActions>
             </Dialog>
-            <ListItemSecondaryAction>
-              {!underConstruction &&
-                props.listLength > 1 &&
-                !facility.paused && (
-                  <IconButton
-                    onClick={() => onPause(facility.id, facility.name)}
-                    aria-label={`Pause ${facility.name}`}
-                    edge="end"
-                    color="primary"
-                    size="large"
-                  >
-                    <PauseIcon />
-                  </IconButton>
-                )}
-              {facility.paused && (
-                <IconButton
-                  onClick={() => onTogglePause(facility.id)}
-                  aria-label={`Resume ${facility.name}`}
-                  edge="end"
-                  color="primary"
-                  size="large"
-                >
-                  <PlayIcon />
-                </IconButton>
-              )}
-              {!underConstruction && props.listLength > 1 && (
-                <IconButton
-                  onClick={toggleDialog}
-                  aria-label={`Sell ${facility.name}`}
-                  edge="end"
-                  color="primary"
-                  size="large"
-                >
-                  <DeleteForeverIcon />
-                </IconButton>
-              )}
-              {underConstruction && (
-                <IconButton
-                  onClick={toggleDialog}
-                  aria-label={`Cancel construction of ${facility.name}`}
-                  edge="end"
-                  color="primary"
-                  size="large"
-                >
-                  <CancelIcon />
-                </IconButton>
-              )}
-            </ListItemSecondaryAction>
           </ListItem>
         </div>
       )}


### PR DESCRIPTION
Closes #142.

`ListItemSecondaryAction` is deprecated and a removal candidate for MUI's next major. The one call site — the per-facility pause / resume / sell / cancel-construction buttons in `FacilityListItem` — now goes through `ListItem`'s `secondaryAction` prop instead.

## The stylesheet rule

`src/app.scss` lifted the row's text and controls above the `.outputProgressBar` fill that sits behind them:

```scss
.MuiListItemText-root,
.MuiListItemSecondaryAction-root {
  z-index: 1;
}
```

Both halves of the issue's question, checked against the running app:

**Does the class still appear?** Yes — `secondaryAction` still renders `ListItemSecondaryAction` internally in v9, so the DOM carries both `MuiListItemSecondaryAction-root` and the new `MuiListItem-secondaryAction`. But the deprecated component's class is precisely what goes away when the removal lands, so the selector moves to `.MuiListItem-secondaryAction`, the slot class the prop itself owns.

**Is the `z-index` still needed?** Yes, and dropping it is a live regression, not a no-op. I tried removing it first: the action element is absolutely positioned with `z-index: auto` (paint step 8), while `.MuiListItemText-root` is a flex item at `z-index: 1` (paint step 9). Under the old markup the two tied at 1 and DOM order put the action on top; with only the text raised, the full-width secondary-text block paints *over* the left edge of the button strip and swallows clicks there. Hit-testing at the pause button's left edge returned the `<p>`, not the `<button>`. Keeping both at 1 restores the tie.

## Verification

Ran the Carbon Fee scenario and hit-tested every row, for a running facility and one under construction:

| Row | Bar | Text hit | Button left edge | Button center |
|---|---|---|---|---|
| Natural Gas (building, opacity 0.38) | none | text span | `Cancel construction` button | its icon |
| Natural Gas (200/200MW) | 100% | text span | `Pause` / `Sell` buttons | their icons |
| Coal (250/300MW) | 83% | text span | `Pause` / `Sell` buttons | their icons |

The progress bar never wins a hit test, so it renders behind both the name and the buttons in both states. Clicking the pause button at its left edge — the strip that regressed without the fix — fires the action and raises the "Paused Coal" snackbar.

One incidental improvement: the `secondaryAction` prop makes MUI add its own `padding-right: 48px` to the row, so the name and the buttons now have a little breathing room they didn't before.

## Also

Dropped `classes={{ label: "navlabel" }}` from Navigation's three `BottomNavigationAction`s — `navlabel` has no styles anywhere in the project.

`npm run check` passes: typecheck, lint, prettier, and 100 tests across 10 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)