### PR TITLE
Fix walkthrough Back button leaving no tooltip across a card boundary

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -71,6 +71,12 @@ export type CardNameType =
   | "SETTINGS"
   | "CUSTOM_GAME";
 
+// What the card reducer's navigate action accepts, beyond a bare card name
+export interface NavigateActionType {
+  name: CardNameType;
+  dontRemember?: boolean;
+}
+
 export interface CardType {
   name: CardNameType;
   ts: number;
@@ -221,6 +227,13 @@ interface SharedShoppingType {
 
 export interface TutorialStepType {
   skipBeacon?: boolean;
+  // The card this step's target lives on. Every step change navigates here, in both
+  // directions, so stepping backwards over a step that navigated forwards still lands on
+  // the card holding the target instead of leaving Joyride with nothing to point at
+  card?: CardNameType | NavigateActionType;
+  // A one-way side effect of leaving this step forwards, such as starting the clock. It
+  // isn't replayed when stepping backwards, since nothing would undo it - navigation
+  // belongs in `card`, which works in both directions
   onNext?: () => Redux.Action;
   target: string;
   content: React.JSX.Element;

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -137,14 +137,20 @@ export interface StateProps {
   tutorialSteps?: TutorialStepType[];
 }
 
+// A walkthrough moving between two steps. Both ends are named because Back and Next need
+// telling apart: a step's onNext only applies to leaving it forwards
+export interface TutorialStepChangeType {
+  fromStep: number;
+  toStep: number;
+  tutorialSteps: TutorialStepType[] | undefined;
+  scenarioId: number;
+  currentCard: CardNameType;
+}
+
 export interface DispatchProps {
   closeDialog: () => void;
   closeSnackbar: () => void;
-  onTutorialStep: (
-    newStep: number,
-    tutorialSteps: TutorialStepType[] | undefined,
-    scenarioId: number,
-  ) => void;
+  onTutorialStep: (change: TutorialStepChangeType) => void;
   onTutorialEnd: (tutorialSteps: TutorialStepType[] | undefined) => void;
 }
 
@@ -223,11 +229,13 @@ export default class Compositor extends React.Component<Props, {}> {
       EVENTS.TARGET_NOT_FOUND,
     ];
     if (advancingEvents.includes(type)) {
-      this.props.onTutorialStep(
-        index + (action === ACTIONS.PREV ? -1 : 1),
-        this.props.tutorialSteps,
-        this.props.scenarioId,
-      );
+      this.props.onTutorialStep({
+        fromStep: index,
+        toStep: index + (action === ACTIONS.PREV ? -1 : 1),
+        tutorialSteps: this.props.tutorialSteps,
+        scenarioId: this.props.scenarioId,
+        currentCard: this.props.card.name,
+      });
     }
   };
 

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -1,0 +1,207 @@
+import * as React from "react";
+import { SCENARIOS } from "../data/Scenarios";
+import { CardNameType, TutorialStepType } from "../Types";
+import { mapDispatchToProps } from "./CompositorContainer";
+
+// Where `loaded` drops the player, and so where every walkthrough starts
+const STARTING_CARD: CardNameType = "FACILITIES";
+
+function walkthrough(name: string): TutorialStepType[] {
+  const scenario = SCENARIOS.find((s) => s.name === name);
+  if (!scenario || !scenario.tutorialSteps) {
+    throw new Error(`No walkthrough named ${name}`);
+  }
+  return scenario.tutorialSteps;
+}
+
+function cardOf(step: TutorialStepType): CardNameType | undefined {
+  if (!step.card) {
+    return undefined;
+  }
+  return typeof step.card === "string" ? step.card : step.card.name;
+}
+
+interface Move {
+  steps: TutorialStepType[];
+  fromStep: number;
+  toStep: number;
+  currentCard: CardNameType;
+}
+
+/**
+ * Runs one step change and collects what it dispatched. The actions are captured rather than
+ * reduced because the card reducer logs analytics and pushes browser history, neither of which
+ * this is about - all that matters is which card the walkthrough asks for.
+ */
+function step(move: Move): any[] {
+  const dispatched: any[] = [];
+  mapDispatchToProps((action: any) => {
+    dispatched.push(action);
+    return action;
+  }).onTutorialStep({
+    fromStep: move.fromStep,
+    toStep: move.toStep,
+    tutorialSteps: move.steps,
+    scenarioId: 1,
+    currentCard: move.currentCard,
+  });
+  return dispatched;
+}
+
+function navigatedTo(dispatched: any[]): CardNameType | undefined {
+  const navigations = dispatched.filter((a) => a.type === "card/navigate");
+  if (navigations.length > 1) {
+    throw new Error(
+      `One step change dispatched ${navigations.length} navigations`,
+    );
+  }
+  if (navigations.length === 0) {
+    return undefined;
+  }
+  const payload = navigations[0].payload;
+  return (typeof payload === "string" ? payload : payload.name) as CardNameType;
+}
+
+describe("onTutorialStep", () => {
+  const generators = walkthrough("102: Generators");
+
+  it("moves the walkthrough to the new step", () => {
+    const dispatched = step({
+      steps: generators,
+      fromStep: 0,
+      toStep: 1,
+      currentCard: STARTING_CARD,
+    });
+    expect(dispatched).toContainEqual(
+      expect.objectContaining({ payload: { tutorialStep: 1 } }),
+    );
+  });
+
+  it("navigates forwards onto the card holding the next step's target", () => {
+    const dispatched = step({
+      steps: generators,
+      fromStep: 0,
+      toStep: 1,
+      currentCard: STARTING_CARD,
+    });
+    expect(navigatedTo(dispatched)).toBe("BUILD_GENERATORS");
+  });
+
+  /**
+   * Regression test. Back used to dispatch the previous step's onNext, which only ever modelled
+   * moving forwards, so nothing undid the navigation the forward step performed: the player was
+   * left on the build screen while the step's target lived on Facilities, Joyride found no
+   * target, and the walkthrough appeared to die with no tooltip anywhere.
+   */
+  it("navigates back onto the card holding the previous step's target", () => {
+    const dispatched = step({
+      steps: generators,
+      fromStep: 1,
+      toStep: 0,
+      currentCard: "BUILD_GENERATORS",
+    });
+    expect(navigatedTo(dispatched)).toBe(STARTING_CARD);
+    expect(dispatched).toContainEqual(
+      expect.objectContaining({ payload: { tutorialStep: 0 } }),
+    );
+  });
+
+  // The mirror of the case above: the last step closes the build screen, so stepping back into
+  // it has to reopen it
+  it("navigates back into a screen a later step closed", () => {
+    const last = generators.length - 1;
+    expect(cardOf(generators[last])).toBe(STARTING_CARD);
+    const dispatched = step({
+      steps: generators,
+      fromStep: last,
+      toStep: last - 1,
+      currentCard: STARTING_CARD,
+    });
+    expect(navigatedTo(dispatched)).toBe("BUILD_GENERATORS");
+  });
+
+  it("doesn't navigate while stepping within a single card", () => {
+    expect(
+      navigatedTo(
+        step({
+          steps: generators,
+          fromStep: 1,
+          toStep: 2,
+          currentCard: "BUILD_GENERATORS",
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  describe("one-way side effects", () => {
+    const sideEffect = { type: "test/onNext" };
+    const steps: TutorialStepType[] = [
+      {
+        card: "FACILITIES",
+        target: "#first",
+        content: <span />,
+        onNext: () => sideEffect,
+      },
+      { card: "FINANCES", target: "#second", content: <span /> },
+    ];
+
+    it("fires onNext when leaving a step forwards", () => {
+      expect(
+        step({ steps, fromStep: 0, toStep: 1, currentCard: "FACILITIES" }),
+      ).toContainEqual(sideEffect);
+    });
+
+    it("doesn't replay onNext when stepping backwards", () => {
+      expect(
+        step({ steps, fromStep: 1, toStep: 0, currentCard: "FINANCES" }),
+      ).not.toContainEqual(sideEffect);
+    });
+  });
+});
+
+describe("walkthrough steps", () => {
+  const tutorials = SCENARIOS.filter((s) => s.tutorialSteps);
+
+  it("covers every walkthrough", () => {
+    expect(tutorials.length).toBeGreaterThan(0);
+  });
+
+  tutorials.forEach((scenario) => {
+    const steps = scenario.tutorialSteps as TutorialStepType[];
+
+    it(`${scenario.name} declares the card every step's target lives on`, () => {
+      steps.forEach((s, i) => {
+        expect([`step ${i}`, cardOf(s)]).not.toContainEqual(undefined);
+      });
+    });
+
+    // Walk the whole thing forwards and then all the way back, tracking the card the store
+    // would be showing. Any step whose target isn't on the current card would show no tooltip
+    it(`${scenario.name} shows each step's card in both directions`, () => {
+      let card: CardNameType = STARTING_CARD;
+      expect(cardOf(steps[0])).toBe(card);
+
+      const moves: Array<[number, number]> = [];
+      for (let i = 0; i < steps.length - 1; i++) {
+        moves.push([i, i + 1]);
+      }
+      for (let i = steps.length - 1; i > 0; i--) {
+        moves.push([i, i - 1]);
+      }
+
+      moves.forEach(([fromStep, toStep]) => {
+        const destination = navigatedTo(
+          step({ steps, fromStep, toStep, currentCard: card }),
+        );
+        if (destination) {
+          card = destination;
+        }
+        expect([scenario.name, toStep, card]).toEqual([
+          scenario.name,
+          toStep,
+          cardOf(steps[toStep]),
+        ]);
+      });
+    });
+  });
+});

--- a/src/components/CompositorContainer.tsx
+++ b/src/components/CompositorContainer.tsx
@@ -4,8 +4,14 @@ import { delta, quit } from "../reducers/Game";
 import { dialogClose, snackbarClose, snackbarOpen } from "../reducers/UI";
 import { recordScenarioPlayed } from "../LocalStorage";
 import { SCENARIOS } from "../data/Scenarios";
+import { navigate } from "../reducers/Card";
 import { AppStateType, TransitionClassType, TutorialStepType } from "../Types";
-import Compositor, { DispatchProps, isNavCard, StateProps } from "./Compositor";
+import Compositor, {
+  DispatchProps,
+  isNavCard,
+  StateProps,
+  TutorialStepChangeType,
+} from "./Compositor";
 
 const mapStateToProps = (state: AppStateType): StateProps => {
   let transition: TransitionClassType = "next";
@@ -46,19 +52,37 @@ export const mapDispatchToProps = (
     closeSnackbar(): void {
       dispatch(snackbarClose());
     },
-    onTutorialStep(
-      newStep: number,
-      tutorialSteps: TutorialStepType[] | undefined,
-      scenarioId: number,
-    ): void {
+    onTutorialStep({
+      fromStep,
+      toStep,
+      tutorialSteps,
+      scenarioId,
+      currentCard,
+    }: TutorialStepChangeType): void {
       const steps = tutorialSteps || [];
-      const prevStep = steps[newStep - 1];
-      if (prevStep && prevStep.onNext) {
-        dispatch(prevStep.onNext());
-      }
-      dispatch(delta({ tutorialStep: newStep }));
 
-      if (newStep < steps.length) {
+      // Only leaving a step forwards runs its one-way side effects - Back has no way to undo
+      // them, and replaying the previous step's would fire an effect nobody triggered
+      const leaving = toStep > fromStep ? steps[fromStep] : undefined;
+      if (leaving && leaving.onNext) {
+        dispatch(leaving.onNext());
+      }
+
+      // Steps declare the card their target lives on, and every step change navigates there
+      // regardless of direction. Otherwise Back leaves the player on whatever card the
+      // forward step navigated to, where Joyride can't find the target and shows no tooltip
+      const destination = steps[toStep] && steps[toStep].card;
+      if (destination) {
+        const name =
+          typeof destination === "string" ? destination : destination.name;
+        if (name !== currentCard) {
+          dispatch(navigate(destination));
+        }
+      }
+
+      dispatch(delta({ tutorialStep: toStep }));
+
+      if (toStep < steps.length) {
         return;
       }
 

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -1,7 +1,6 @@
 import { Typography } from "@mui/material";
 import * as React from "react";
 
-import { navigate } from "../reducers/Card";
 import { setSpeed } from "../reducers/Game";
 import { ScenarioType } from "../Types";
 
@@ -25,6 +24,7 @@ export const SCENARIOS = [
     tutorialSteps: [
       {
         skipBeacon: true, // causes tutorial to auto-start
+        card: "FACILITIES",
         target: "#topbar",
         content: (
           <Typography variant="body1">
@@ -37,6 +37,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FACILITIES",
         target: ".VictoryContainer",
         content: (
           <Typography variant="body1">
@@ -53,6 +54,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FACILITIES",
         target: ".VictoryContainer",
         content: (
           <Typography variant="body1">
@@ -66,6 +68,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FACILITIES",
         target: ".facility",
         content: (
           <Typography variant="body1">
@@ -79,6 +82,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FACILITIES",
         target: "#speedChangeButtons",
         onNext: () => setSpeed("SLOW"),
         content: (
@@ -107,9 +111,8 @@ export const SCENARIOS = [
     tutorialSteps: [
       {
         skipBeacon: true, // causes tutorial to auto-start
+        card: "FACILITIES",
         target: ".button-buildGenerator",
-        onNext: () =>
-          navigate({ name: "BUILD_GENERATORS", dontRemember: true }),
         content: (
           <Typography variant="body1">
             Build generators to produce additional electricity when you're
@@ -118,6 +121,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: { name: "BUILD_GENERATORS", dontRemember: true },
         target: "#peak-output",
         content: (
           <Typography variant="body1">
@@ -126,12 +130,14 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: { name: "BUILD_GENERATORS", dontRemember: true },
         target: "#sort",
         content: (
           <Typography variant="body1">Sort by different properties.</Typography>
         ),
       },
       {
+        card: { name: "BUILD_GENERATORS", dontRemember: true },
         target: ".action-seconday-text",
         content: (
           <Typography variant="body1">
@@ -142,6 +148,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: { name: "BUILD_GENERATORS", dontRemember: true },
         target: ".build-list-item",
         content: (
           <Typography variant="body1">
@@ -150,6 +157,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: { name: "BUILD_GENERATORS", dontRemember: true },
         target: ".buy-button",
         content: (
           <Typography variant="body1">
@@ -158,8 +166,8 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: { name: "BUILD_GENERATORS", dontRemember: true },
         target: "#close-button",
-        onNext: () => navigate("FACILITIES"),
         content: (
           <Typography variant="body1">
             Tap X to close the buy screen.
@@ -167,6 +175,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FACILITIES",
         target: "#speedChangeButtons",
         content: (
           <Typography variant="body1">
@@ -201,8 +210,8 @@ export const SCENARIOS = [
     tutorialSteps: [
       {
         skipBeacon: true, // causes tutorial to auto-start
+        card: "FACILITIES",
         target: ".button-buildStorage",
-        onNext: () => navigate({ name: "BUILD_STORAGE", dontRemember: true }),
         content: (
           <Typography variant="body1">
             When you're getting blackouts, generators aren't your only option.
@@ -214,6 +223,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: { name: "BUILD_STORAGE", dontRemember: true },
         target: ".build-list-item",
         content: (
           <Typography variant="body1">
@@ -222,8 +232,8 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: { name: "BUILD_STORAGE", dontRemember: true },
         target: "#close-button",
-        onNext: () => navigate("FACILITIES"),
         content: (
           <Typography variant="body1">
             Tap X to close the build screen.
@@ -231,6 +241,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FACILITIES",
         target: ".capacityProgressBar",
         content: (
           <Typography variant="body1">
@@ -244,6 +255,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FACILITIES",
         target: ".facility",
         content: (
           <Typography variant="body1">
@@ -256,6 +268,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FACILITIES",
         target: ".facility",
         onNext: () => setSpeed("SLOW"),
         content: (
@@ -287,8 +300,8 @@ export const SCENARIOS = [
     tutorialSteps: [
       {
         skipBeacon: true, // causes tutorial to auto-start
+        card: "FACILITIES",
         target: "#financesNav",
-        onNext: () => navigate("FINANCES"),
         content: (
           <Typography variant="body1">
             To run a profitable business, you'll need to understand the Finances
@@ -306,6 +319,7 @@ export const SCENARIOS = [
         },
       },
       {
+        card: "FINANCES",
         target: ".VictoryContainer",
         // Unqualified, this matches the Facilities pane's chart first once all three panes
         // are on screen
@@ -319,6 +333,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FINANCES",
         target: ".MuiTable-root",
         content: (
           <Typography variant="body1">
@@ -329,6 +344,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FINANCES",
         target: "#speedChangeButtons",
         onNext: () => setSpeed("SLOW"),
         content: (
@@ -360,8 +376,8 @@ export const SCENARIOS = [
     tutorialSteps: [
       {
         skipBeacon: true, // causes tutorial to auto-start
+        card: "FACILITIES",
         target: "#financesNav",
-        onNext: () => navigate("FINANCES"),
         content: (
           <Typography variant="body1">
             When you have spare capacity, you can use marketing to grow your
@@ -379,6 +395,7 @@ export const SCENARIOS = [
         },
       },
       {
+        card: "FINANCES",
         target: "#marketingSlider",
         content: (
           <Typography variant="body1">
@@ -388,6 +405,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FINANCES",
         target: "#plotMetric",
         content: (
           <Typography variant="body1">
@@ -400,6 +418,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FINANCES",
         target: "#speedChangeButtons",
         onNext: () => setSpeed("SLOW"),
         content: (
@@ -428,8 +447,8 @@ export const SCENARIOS = [
     tutorialSteps: [
       {
         skipBeacon: true, // causes tutorial to auto-start
+        card: "FACILITIES",
         target: "#forecastsNav",
-        onNext: () => navigate("FORECASTS"),
         content: (
           <Typography variant="body1">
             To truly succeed, you'll need to plan ahead - let's check out the
@@ -447,6 +466,7 @@ export const SCENARIOS = [
         },
       },
       {
+        card: "FORECASTS",
         target: "#chartForecastSupplyDemand",
         content: (
           <Typography variant="body1">
@@ -457,6 +477,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FORECASTS",
         target: "#chartForecastSupplyByFuel",
         content: (
           <Typography variant="body1">
@@ -467,6 +488,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FORECASTS",
         target: "#chartForecastFuelPrices",
         content: (
           <Typography variant="body1">
@@ -477,6 +499,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FORECASTS",
         target: "#chartForecastWeather",
         content: (
           <Typography variant="body1">
@@ -487,6 +510,7 @@ export const SCENARIOS = [
         ),
       },
       {
+        card: "FORECASTS",
         target: "#speedChangeButtons",
         onNext: () => setSpeed("FAST"),
         content: (

--- a/src/reducers/Card.tsx
+++ b/src/reducers/Card.tsx
@@ -1,14 +1,9 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { getHistoryApi, logEvent } from "../Globals";
 import { NAVIGATION_DEBOUNCE_MS } from "../Constants";
-import { CardNameType, CardType } from "../Types";
+import { CardNameType, CardType, NavigateActionType } from "../Types";
 import { start, loaded, quit } from "./GameActions";
 import type { RootState } from "../Store";
-
-interface NavigateAction {
-  name: CardNameType;
-  dontRemember?: boolean;
-}
 
 /**
  * ts: 0 solves an obscure bug (instead of Date.now()) where rapidly triggering navigations with undefined states
@@ -25,10 +20,10 @@ export const cardSlice = createSlice({
   name: "card",
   initialState: initialCard,
   reducers: {
-    navigate: (state, action: PayloadAction<string | NavigateAction>) => {
+    navigate: (state, action: PayloadAction<string | NavigateActionType>) => {
       let a = action.payload;
       if (typeof a === "string" || a == null) {
-        a = { name: a } as NavigateAction;
+        a = { name: a } as NavigateActionType;
       }
       if (
         a.name === state.name &&


### PR DESCRIPTION
## Problem

Start **102: Generators**, click NEXT on step 1 (the app navigates to the `BUILD_GENERATORS` card via the step's `onNext`), then click BACK. The app stays on `BUILD_GENERATORS`, but step 1's target (`.button-buildGenerator`) lives on Facilities, so Joyride finds no target and renders no tooltip. The tour appears to die.

`mapDispatchToProps.onTutorialStep` always dispatched `steps[newStep - 1].onNext()`, which only models forward movement. Moving backwards had no counterpart to undo the navigation the forward step performed — and worse, it re-fired the *earlier* step's `onNext`, an action nobody triggered.

The same bug hits the other end of that walkthrough: step 7 (`#close-button`, on the build screen) → step 8 (`#speedChangeButtons`, on Facilities) → BACK leaves the player on Facilities with the target on a hidden card.

Pre-existing behavior, not caused by any Joyride upgrade.

## Fix

Each tutorial step now declares the card its target lives on (`card?: CardNameType | NavigateActionType` on `TutorialStepType`), and every step change navigates there regardless of direction — the more robust of the options, since it also makes `TARGET_NOT_FOUND` less likely in general. The navigation-only `onNext` entries in `Scenarios.tsx` are replaced by `card` declarations; `Scenarios` no longer imports the card reducer at all.

`onNext` is left for genuinely one-way side effects (starting the clock at the end of a walkthrough) and now only fires when a step is left *forwards*.

`onTutorialStep` takes an object (`fromStep` / `toStep` / `currentCard` / …) so direction and the current card are explicit rather than inferred.

## Tests

New `src/components/CompositorContainer.test.tsx` (20 tests), including:

- regression tests for stepping backwards across a card boundary, in both directions
- no navigation dispatched while stepping within a single card
- `onNext` fires forwards, is not replayed backwards
- per-walkthrough: every step declares a card, and walking all the way forwards and then all the way back always leaves the player on the card holding the current step's target

Verified the new tests fail (8 of 20) with the old handler restored. Full suite: 120 passed. `eslint` and `prettier` clean.

> Note: `npm test` finds no tests when run from a git worktree under `.claude/` — jest's `testMatch` doesn't match the dot-directory in the path. Ran with `--testMatch "**/*.test.tsx"`; unaffected on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
