### PR TITLE
Fix weather interpolation bug, eliminate `any`, and enforce it with lint rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,20 @@ All code submissions should be formatted with prettier, configured in `.prettier
 `npm run format` before committing, or use VSCode with the Prettier extension
 (esbenp.prettier-vscode) set to format on save. CI fails on unformatted files.
 
+Lint rules live under `eslintConfig` in `package.json`, on top of the create-react-app
+defaults. `npm run lint` runs with `--max-warnings=0`, so anything it reports fails CI. The
+rules worth knowing about, and why they are on:
+
+- **`@typescript-eslint/no-explicit-any`** -- `any` switches off checking for everything
+  downstream of it, and the ones this codebase had were hiding real bugs. If you genuinely need
+  one, disable it on the line with a comment saying why.
+- **`no-console`**, allowing `warn` and `error` -- `console.log` is for debugging and should
+  not survive review. Warnings and errors are how the game reports real problems, so they stay.
+- **`@typescript-eslint/no-unused-vars`**, including caught errors -- an error that is caught
+  and never looked at is usually a swallowed bug. Prefix with `_` (`catch (_err)`) to say the
+  swallowing is deliberate.
+- **`eqeqeq`** (`null` exempt), **`no-var`**, **`prefer-const`**.
+
 ## Pulling and pushing remote branches
 
 Git can get a bit confusing when it comes to pushing and pulling other folks' branches, so here's a quick reference:

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@testing-library/user-event": "^14.6.6",
         "@types/async": "^3.2.25",
         "@types/jest": "^30.0.0",
+        "@types/lodash.clonedeep": "^4.5.9",
         "@types/node": "^26.2.0",
         "@types/papaparse": "^5.5.2",
         "@types/react": "^18.3.31",
@@ -50,7 +51,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">= 21 < 22"
+        "node": ">= 24 < 25"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5927,6 +5928,23 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+      "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash.clonedeep": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
+      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,39 @@
     "extends": [
       "react-app",
       "react-app/jest"
-    ]
+    ],
+    "rules": {
+      "@typescript-eslint/no-explicit-any": "error",
+      "no-console": [
+        "error",
+        {
+          "allow": [
+            "warn",
+            "error"
+          ]
+        }
+      ],
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          "args": "after-used",
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_",
+          "caughtErrors": "all",
+          "caughtErrorsIgnorePattern": "^_"
+        }
+      ],
+      "eqeqeq": [
+        "error",
+        "always",
+        {
+          "null": "ignore"
+        }
+      ],
+      "no-var": "error",
+      "prefer-const": "error"
+    }
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@testing-library/user-event": "^14.6.6",
     "@types/async": "^3.2.25",
     "@types/jest": "^30.0.0",
+    "@types/lodash.clonedeep": "^4.5.9",
     "@types/node": "^26.2.0",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^18.3.31",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ function setupStorage(document: Document) {
     if (!ret) {
       throw new Error("Cookies disabled");
     }
-  } catch (err) {
+  } catch (_err) {
     setTimeout(() => {
       store.dispatch(
         snackbarOpen("Please enable cookies for the app to function properly."),

--- a/src/Globals.tsx
+++ b/src/Globals.tsx
@@ -27,7 +27,7 @@ export function login() {
       // access token, and the console is readable by anything running on the page.
     })
     .catch((error) => {
-      console.log(
+      console.error(
         "Auth error: ",
         error,
         GoogleAuthProvider.credentialFromError(error),
@@ -129,8 +129,8 @@ export function getAudioContext(): AudioContext | null {
   }
   try {
     refs.audioContext = new window.AudioContext();
-  } catch (err) {
-    console.log("Web Audio API is not supported in this browser");
+  } catch (_err) {
+    console.warn("Web Audio API is not supported in this browser");
     refs.audioContext = null;
   }
   return refs.audioContext;
@@ -162,8 +162,8 @@ export function getLocalStorage(): Storage {
     if (!refs.localStorage) {
       refs.localStorage = {
         clear: () => null,
-        getItem: (s: string) => null,
-        key: (index: number | string) => null,
+        getItem: () => null,
+        key: () => null,
         length: 0,
         removeItem: () => null,
         setItem: () => null,

--- a/src/Globals.tsx
+++ b/src/Globals.tsx
@@ -1,7 +1,7 @@
 import { getAnalytics, logEvent as firebaseLogEvent } from "firebase/analytics";
 import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider, signInWithPopup } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
+import { Firestore, getFirestore } from "firebase/firestore";
 
 const firebaseApp = initializeApp({
   // Set by CI from a repo secret; falls back to the placeholder for local dev
@@ -35,28 +35,28 @@ export function login() {
     });
 }
 
-export interface ReactWindow extends Window {
-  platform?: string;
-  VERSION?: string;
-  AudioContext?: AudioContext;
-  test?: boolean;
+// The slice of the History API the game uses. Card navigation pushes a hash entry so the
+// browser back button steps back through cards; anything without a history object (tests,
+// non-browser hosts) gets a no-op.
+interface HistoryApi {
+  pushState: History["pushState"];
 }
 
 const refs = {
-  db: null as any,
+  db: null as Firestore | null,
   history:
     typeof window.history !== "undefined"
-      ? window.history
-      : { pushState: () => null },
+      ? (window.history as HistoryApi)
+      : { pushState: () => undefined },
   localStorage: null as Storage | null,
-  audioContext: null,
+  audioContext: null as AudioContext | null,
 };
 
 export function logEvent(eventName: string, args?: object): void {
   firebaseLogEvent(getAnalytics(firebaseApp), eventName, args);
 }
 
-export function getDb(): any {
+export function getDb(): Firestore {
   if (!refs.db) {
     refs.db = getFirestore(firebaseApp);
   }
@@ -119,7 +119,7 @@ export function isDesktopScreen(): boolean {
   return width >= 1300;
 }
 
-export function getHistoryApi(): any {
+export function getHistoryApi(): HistoryApi {
   return refs.history;
 }
 
@@ -128,7 +128,7 @@ export function getAudioContext(): AudioContext | null {
     return refs.audioContext;
   }
   try {
-    refs.audioContext = new (window.AudioContext as any)();
+    refs.audioContext = new window.AudioContext();
   } catch (err) {
     console.log("Web Audio API is not supported in this browser");
     refs.audioContext = null;
@@ -136,7 +136,7 @@ export function getAudioContext(): AudioContext | null {
   return refs.audioContext;
 }
 
-export function openWindow(url: string): any {
+export function openWindow(url: string): void {
   window.open(url, "_system");
 }
 

--- a/src/LocalStorage.tsx
+++ b/src/LocalStorage.tsx
@@ -12,13 +12,13 @@ export function getStorageBooleanOrUndefined(key: string): boolean | undefined {
   return val !== null ? val.toLowerCase() === "true" : undefined;
 }
 
-export function getStorageJson(key: string, fallback: object): object {
+export function getStorageJson<T extends object>(key: string, fallback: T): T {
   try {
     const item = getLocalStorage().getItem(key);
     if (item === null) {
       return fallback;
     }
-    const val = JSON.parse(item);
+    const val = JSON.parse(item) as T | null;
     return val !== null ? val : fallback;
   } catch (err) {
     return fallback;
@@ -41,7 +41,7 @@ export function getStorageString(key: string, fallback: string): string {
 // value has to land.
 export function setStorageKeyValue(
   key: string,
-  value: any,
+  value: unknown,
   ignoreErrors = true,
 ) {
   const serialized =
@@ -56,8 +56,9 @@ export function setStorageKeyValue(
 }
 
 function getPlays(): LocalStoragePlayedType[] {
-  return (getStorageJson("plays", { plays: [] }) as any)
-    .plays as LocalStoragePlayedType[];
+  return getStorageJson<{ plays: LocalStoragePlayedType[] }>("plays", {
+    plays: [],
+  }).plays;
 }
 
 // The scenarios (tutorials included) the player has finished, used for the completion
@@ -108,7 +109,7 @@ export function checkStorageFreeBytes(gls = getLocalStorage): number {
   }
 
   try {
-    ls.setItem("test", null as any);
+    ls.removeItem("test");
   } catch (e) {
     // Ignore errors
   }

--- a/src/LocalStorage.tsx
+++ b/src/LocalStorage.tsx
@@ -20,7 +20,7 @@ export function getStorageJson<T extends object>(key: string, fallback: T): T {
     }
     const val = JSON.parse(item) as T | null;
     return val !== null ? val : fallback;
-  } catch (err) {
+  } catch (_err) {
     return fallback;
   }
 }
@@ -101,7 +101,7 @@ export function checkStorageFreeBytes(gls = getLocalStorage): number {
       ls.setItem("test", n1000b.repeat(test));
       // If no exception, we're under the max. Raise min.
       min = test;
-    } catch (e) {
+    } catch (_e) {
       // If exception, we're over the max. Lower max.
       max = test;
     }
@@ -110,7 +110,7 @@ export function checkStorageFreeBytes(gls = getLocalStorage): number {
 
   try {
     ls.removeItem("test");
-  } catch (e) {
+  } catch (_e) {
     // Ignore errors
   }
   return min * 1000;

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -1,3 +1,4 @@
+import type { FieldValue, Timestamp } from "firebase/firestore";
 import type * as React from "react";
 import Redux from "redux";
 
@@ -84,12 +85,18 @@ export interface CardType {
   toPrevious?: boolean;
 }
 
+// The per-category points that sum to `score`. Investor and public-ownership scenarios are
+// scored on different categories (see reducers/Game), so the keys vary by scenario.
+export type ScoreBreakdownType = Record<string, number>;
+
 export interface ScoreType {
   scenarioId: number;
   score: number;
-  scoreBreakdown: any;
+  scoreBreakdown: ScoreBreakdownType;
   difficulty: string;
-  date: any; // serverTimestamp from Firestore
+  // A FieldValue on the way out (serverTimestamp() is resolved by Firestore, not by us) and a
+  // Timestamp on the way back in
+  date: Timestamp | FieldValue;
   uid: string;
 }
 
@@ -211,6 +218,9 @@ export interface GeneratorShoppingType extends SharedShoppingType {
 }
 
 interface SharedShoppingType {
+  // TODO remove: this defeats type checking on every shopping type, but the build and
+  // facilities views index these by string and treat the Storage/Generator union as
+  // interchangeable, so it cannot go until those are narrowed properly.
   [index: string]: any;
   name: string;
   description: string;
@@ -284,7 +294,6 @@ export interface GameType {
 }
 
 export interface SettingsType {
-  [index: string]: any;
   audioEnabled?: boolean;
 }
 

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -221,6 +221,7 @@ interface SharedShoppingType {
   // TODO remove: this defeats type checking on every shopping type, but the build and
   // facilities views index these by string and treat the Storage/Generator union as
   // interchangeable, so it cannot go until those are narrowed properly.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [index: string]: any;
   name: string;
   description: string;

--- a/src/audio/AudioNode.tsx
+++ b/src/audio/AudioNode.tsx
@@ -1,12 +1,22 @@
 import { MUSIC_FADE_SECONDS } from "../Constants";
 
-type GainNode = any;
-type SourceNode = any;
+/**
+ * Pre-standard Web Audio names this class still guards for. Browsers of the Safari 6 / Chrome 20
+ * era exposed noteOn/noteOff rather than start/stop, and reported playback through
+ * playbackState. None of them exist in a current browser, so every one of these is optional.
+ */
+interface LegacyBufferSource extends AudioBufferSourceNode {
+  noteOn?: AudioBufferSourceNode["start"];
+  noteOff?: AudioBufferSourceNode["stop"];
+  playbackState?: number;
+  PLAYING_STATE?: number;
+}
+
 export class AudioNode {
   private context: AudioContext;
   private buffer: AudioBuffer;
   private gain: GainNode | null;
-  private source: SourceNode | null;
+  private source: LegacyBufferSource | null;
 
   constructor(audioContext: AudioContext, buffer: AudioBuffer) {
     this.buffer = buffer;
@@ -22,14 +32,18 @@ export class AudioNode {
     if (fadeInVolume) {
       this.fadeIn(fadeInVolume);
     }
-    this.source = this.context.createBufferSource();
-    this.source.buffer = this.buffer;
-    this.source.connect(this.gain);
-    this.source.start = this.source.start || (this.source as SourceNode).noteOn; // polyfill for old browsers
-    this.source.start(0);
+    const source: LegacyBufferSource = this.context.createBufferSource();
+    this.source = source;
+    source.buffer = this.buffer;
+    source.connect(this.gain);
+    source.start = source.start || source.noteOn; // polyfill for old browsers
+    source.start(0);
   }
 
   public fadeIn(peak?: number, seconds?: number) {
+    if (!this.gain) {
+      return;
+    }
     this.gain.gain.linearRampToValueAtTime(
       peak || 1.0,
       this.context.currentTime + (seconds || MUSIC_FADE_SECONDS),
@@ -40,17 +54,19 @@ export class AudioNode {
     if (seconds === undefined) {
       seconds = MUSIC_FADE_SECONDS;
     }
-    this.gain.gain.linearRampToValueAtTime(
-      0,
-      this.context.currentTime + seconds,
-    );
-    if (stop) {
-      this.source.stop = this.source.stop || this.source.noteOff; // polyfill for old browsers
+    const gain = this.gain;
+    if (!gain) {
+      return;
+    }
+    gain.gain.linearRampToValueAtTime(0, this.context.currentTime + seconds);
+    if (stop && this.source) {
+      const source = this.source;
+      source.stop = source.stop || source.noteOff; // polyfill for old browsers
       try {
-        this.source.stop(this.context.currentTime + seconds);
-      } catch (err) {
+        source.stop(this.context.currentTime + seconds);
+      } catch (_err) {
         // polyfill for iOS
-        this.gain.disconnect();
+        gain.disconnect();
       }
     }
   }
@@ -62,6 +78,11 @@ export class AudioNode {
     return this.gain.gain.value;
   }
 
+  // NOTE: playbackState and PLAYING_STATE are both undefined in any browser released this
+  // decade, so this comparison holds whenever a source exists -- meaning the answer is really
+  // "has playOnce been called", and a node never reports itself as finished. Preserved as-is
+  // because the music fading in ThemeManager is tuned around the current behaviour; fixing it
+  // means tracking completion off the source's ended event.
   public isPlaying(): boolean {
     return Boolean(
       this.source && this.source.playbackState === this.source.PLAYING_STATE,

--- a/src/audio/ThemeManager.tsx
+++ b/src/audio/ThemeManager.tsx
@@ -144,7 +144,7 @@ export class ThemeManager {
     }
     const theme = this.theme;
     this.active = this.generateTracks();
-    theme.tracks.forEach((track: string, i: number) => {
+    theme.tracks.forEach((track: string) => {
       let file = this.getActiveInstrument(track);
       const active = this.intensity > 0 || Boolean(file);
       file = file || `${theme.directory}${track}`;

--- a/src/audio/ThemeManager.tsx
+++ b/src/audio/ThemeManager.tsx
@@ -34,7 +34,7 @@ export class ThemeManager {
   private intensity: number;
   private paused: boolean;
   private theme: MusicDefinition;
-  private timeout: any;
+  private timeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor(nodes: { [key: string]: AudioNode }, intensity: number = 0) {
     this.nodes = nodes;
@@ -89,9 +89,6 @@ export class ThemeManager {
   private startTheme(theme: MusicDefinition = this.theme) {
     this.fadeOut();
     this.theme = theme;
-    if (theme) {
-      console.log("starting " + theme.directory);
-    }
     this.loopTheme(true);
   }
 
@@ -143,7 +140,7 @@ export class ThemeManager {
   // Doesn't stop the current music nodes (lets them stop naturally for reverb)
   private loopTheme(newTheme: boolean = false) {
     if (this.paused) {
-      return console.log("Skipping music (paused)");
+      return;
     }
     const theme = this.theme;
     this.active = this.generateTracks();
@@ -159,7 +156,10 @@ export class ThemeManager {
 
       const node = this.nodes[file];
       if (!node) {
-        console.log(file + " not loaded");
+        // Every file a theme names is loaded up front, and a failure there is already reported
+        // by loadAudioFiles -- so reaching this means MUSIC_DEFINITIONS names a track that
+        // getAllMusicFiles never fetched, which is a content bug rather than a runtime hiccup.
+        console.warn(`No audio node for ${file}; skipping that track`);
         return;
       }
 
@@ -186,13 +186,10 @@ export class ThemeManager {
     if (delta > 0) {
       // Fade in one inaudible (but active) baseline track randomly
       // (don't touch peak instrument, don't duplicate instruments)
-      console.log("looking for node to fade in");
       for (const inst of theme.tracks) {
         const activeinst = this.getActiveInstrument(inst) || "";
-        console.log(activeinst);
         const a = this.nodes[activeinst];
         if (a && a.isPlaying() && (a.getVolume() || 0) < 1.0) {
-          console.log("fading in " + activeinst);
           a.fadeIn();
           break;
         }
@@ -202,10 +199,8 @@ export class ThemeManager {
       // (don't touch the peak instrument, don't go below 1 active instrument)
       for (const inst of [...theme.tracks].reverse()) {
         const activeinst = this.getActiveInstrument(inst) || "";
-        console.log(activeinst);
         const a = this.nodes[activeinst];
         if (a && a.isPlaying() && (a.getVolume() || 0) > 0.9) {
-          console.log("fading out " + activeinst);
           a.fadeOut();
           break;
         }

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
+import type { UnknownAction } from "redux";
+import type { AppDispatch } from "../Store";
 import { SCENARIOS } from "../data/Scenarios";
-import { CardNameType, TutorialStepType } from "../Types";
+import { CardNameType, NavigateActionType, TutorialStepType } from "../Types";
 import { mapDispatchToProps } from "./CompositorContainer";
 
 // Where `loaded` drops the player, and so where every walkthrough starts
@@ -33,12 +35,12 @@ interface Move {
  * reduced because the card reducer logs analytics and pushes browser history, neither of which
  * this is about - all that matters is which card the walkthrough asks for.
  */
-function step(move: Move): any[] {
-  const dispatched: any[] = [];
-  mapDispatchToProps((action: any) => {
+function step(move: Move): UnknownAction[] {
+  const dispatched: UnknownAction[] = [];
+  mapDispatchToProps(((action: UnknownAction) => {
     dispatched.push(action);
     return action;
-  }).onTutorialStep({
+  }) as AppDispatch).onTutorialStep({
     fromStep: move.fromStep,
     toStep: move.toStep,
     tutorialSteps: move.steps,
@@ -48,7 +50,7 @@ function step(move: Move): any[] {
   return dispatched;
 }
 
-function navigatedTo(dispatched: any[]): CardNameType | undefined {
+function navigatedTo(dispatched: UnknownAction[]): CardNameType | undefined {
   const navigations = dispatched.filter((a) => a.type === "card/navigate");
   if (navigations.length > 1) {
     throw new Error(
@@ -58,7 +60,8 @@ function navigatedTo(dispatched: any[]): CardNameType | undefined {
   if (navigations.length === 0) {
     return undefined;
   }
-  const payload = navigations[0].payload;
+  // card/navigate takes either a bare card name or a full navigation object
+  const payload = navigations[0].payload as string | NavigateActionType;
   return (typeof payload === "string" ? payload : payload.name) as CardNameType;
 }
 

--- a/src/components/CompositorContainer.tsx
+++ b/src/components/CompositorContainer.tsx
@@ -1,5 +1,5 @@
+import type { AppDispatch } from "../Store";
 import { connect } from "react-redux";
-import Redux from "redux";
 import { delta, quit } from "../reducers/Game";
 import { dialogClose, snackbarClose, snackbarOpen } from "../reducers/UI";
 import { recordScenarioPlayed } from "../LocalStorage";
@@ -42,9 +42,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-export const mapDispatchToProps = (
-  dispatch: Redux.Dispatch<any>,
-): DispatchProps => {
+export const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     closeDialog(): void {
       dispatch(dialogClose());

--- a/src/components/base/AudioContainer.tsx
+++ b/src/components/base/AudioContainer.tsx
@@ -1,5 +1,5 @@
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
-import Redux from "redux";
 import { change as changeSettings } from "../../reducers/Settings";
 import { snackbarOpen } from "../../reducers/UI";
 import { AppStateType } from "../../Types";
@@ -11,7 +11,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     disableAudio(): void {
       dispatch(snackbarOpen("Audio not supported on this device; disabling."));

--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -60,7 +60,8 @@ const ChartFinances = (props: Props): React.JSX.Element => {
         height={props.height || 300}
         containerComponent={chartTooltipContainer({
           ariaLabel: `Chart of ${props.title} over time`,
-          labels: ({ datum }: any) => props.format(datum.value).toString(),
+          labels: ({ datum }: { datum: ChartData }) =>
+            props.format(datum.value).toString(),
         })}
       >
         <VictoryAxis

--- a/src/components/base/ChartForecastFuelPrices.tsx
+++ b/src/components/base/ChartForecastFuelPrices.tsx
@@ -50,9 +50,11 @@ export default class ChartForecastFuelPrices extends React.PureComponent<
           height={height || 300}
           containerComponent={chartTooltipContainer({
             ariaLabel: "Chart of forecasted fuel prices",
-            labels: ({ datum }: any) =>
+            labels: ({ datum }: { datum: TickPresentFutureType }) =>
               PRICED_FUELS.map(
-                (f) => `${f}: ${formatMoneyStable(datum[f])}`,
+                // Every tick carries all four prices; the fallback is only here because the
+                // fuel prices are optional on the tick type
+                (f) => `${f}: ${formatMoneyStable(datum[f] ?? 0)}`,
               ).join("\n"),
             // Labels are rendered on EACH chart, so we only render on Coal, otherwise we get duplicate labels
             voronoiBlacklist: PRICED_FUELS.slice(1),

--- a/src/components/base/ChartForecastStorage.tsx
+++ b/src/components/base/ChartForecastStorage.tsx
@@ -42,7 +42,8 @@ export default class chartForecastStorage extends React.PureComponent<
           height={height || 300}
           containerComponent={chartTooltipContainer({
             ariaLabel: "Chart of forecasted stored power",
-            labels: ({ datum }: any) => formatWattHours(datum.storedWh),
+            labels: ({ datum }: { datum: TickPresentFutureType }) =>
+              formatWattHours(datum.storedWh),
           })}
         >
           <VictoryAxis

--- a/src/components/base/ChartForecastSupplyByFuel.tsx
+++ b/src/components/base/ChartForecastSupplyByFuel.tsx
@@ -27,6 +27,10 @@ export interface Props {
   fuels: FuelNameType[];
 }
 
+// One x of the stack: the minute, the demand, and every fuel's output at that minute. Keyed
+// loosely because which fuels are present depends on what the player has built.
+type SupplyByFuelPoint = { [index: string]: number };
+
 // This is a pureComponent because its props should change much less frequently than it renders
 export default class ChartForecastSupplyByFuel extends React.PureComponent<
   Props,
@@ -55,12 +59,12 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
     // the whole mix off whichever series the pointer landed on.
     // The sampled forecast repeats its first minute, and a stack lines its bands up by x, so a
     // duplicate x knocks every band after it out of alignment - drop repeats as we go.
-    const data: Array<{ [index: string]: number }> = [];
+    const data: SupplyByFuelPoint[] = [];
     timeline.forEach((t) => {
       if (data.length && data[data.length - 1].minute === t.minute) {
         return;
       }
-      const point: { [index: string]: number } = {
+      const point: SupplyByFuelPoint = {
         minute: t.minute,
         demandW: t.demandW,
       };
@@ -95,7 +99,7 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
           height={height || 300}
           containerComponent={chartTooltipContainer({
             ariaLabel: "Chart of forecasted electricity supply by fuel type",
-            labels: ({ datum }: any) =>
+            labels: ({ datum }: { datum: SupplyByFuelPoint }) =>
               [
                 ...[...fuels]
                   .reverse()

--- a/src/components/base/ChartForecastSupplyDemand.tsx
+++ b/src/components/base/ChartForecastSupplyDemand.tsx
@@ -55,7 +55,7 @@ export default class chartForecastSupplyDemand extends React.PureComponent<
           height={height || 300}
           containerComponent={chartTooltipContainer({
             ariaLabel: "Chart of forecasted electricity supply and demand",
-            labels: ({ datum }: any) =>
+            labels: ({ datum }: { datum: TickPresentFutureType }) =>
               `Supply: ${formatWatts(datum.supplyW)}\nDemand: ${formatWatts(datum.demandW)}`,
             // Labels are rendered on EACH chart, so we only render on supply, otherwise we get duplicate labels
             voronoiBlacklist: ["demand", "blackouts"],

--- a/src/components/base/ChartForecastWeather.tsx
+++ b/src/components/base/ChartForecastWeather.tsx
@@ -50,7 +50,7 @@ export default class ChartForecastWeather extends React.PureComponent<
           height={height || 300}
           containerComponent={chartTooltipContainer({
             ariaLabel: "Chart of forecasted temperature and wind",
-            labels: ({ datum }: any) =>
+            labels: ({ datum }: { datum: TickPresentFutureType }) =>
               `Temperature: ${Math.round(datum.temperatureC)}°C\nWind: ${Math.round(datum.windKph)} km/h`,
             // Labels are rendered on EACH chart, so we only render on temperature, otherwise we get duplicate labels
             voronoiBlacklist: ["wind"],

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -160,14 +160,16 @@ const ChartSupplyDemand = (props: Props): React.JSX.Element => {
     (d: ChartData) => d.minute >= currentMinute,
   );
 
-  const legendItems = [
+  // Annotated so the optional blackout entry below is not measured against a type inferred
+  // from the first two colours alone
+  const legendItems: Array<{ name: string; symbol: { fill: string } }> = [
     { name: "Supply", symbol: { fill: supplyColor } },
     { name: "Demand", symbol: { fill: demandColor } },
   ];
   if (blackoutCount > 0) {
     legendItems.push({
       name: "Blackout",
-      symbol: { fill: blackoutColor as any },
+      symbol: { fill: blackoutColor },
     });
   }
 
@@ -182,7 +184,7 @@ const ChartSupplyDemand = (props: Props): React.JSX.Element => {
         height={height || 300}
         containerComponent={chartTooltipContainer({
           ariaLabel: "Chart of electricity supply and demand over the day",
-          labels: ({ datum }: any) =>
+          labels: ({ datum }: { datum: ChartData }) =>
             `Supply: ${formatWatts(datum.supplyW)}\nDemand: ${formatWatts(datum.demandW)}`,
           // Labels are rendered on EACH chart, so we only render on demand, otherwise we get duplicate labels
           voronoiBlacklist: [

--- a/src/components/base/ChartTooltipContainer.tsx
+++ b/src/components/base/ChartTooltipContainer.tsx
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { createContainer, LineSegment, VictoryTooltip } from "victory";
+import {
+  createContainer,
+  LineSegment,
+  VictoryCursorContainerProps,
+  VictoryTooltip,
+  VictoryVoronoiContainerProps,
+} from "victory";
 import { cursorColor } from "../../Theme";
 
 // Voronoi puts one tooltip on screen covering every series at the hovered x; cursor draws the
@@ -8,14 +14,20 @@ import { cursorColor } from "../../Theme";
 // Cursor first, voronoi second: the combined container appends each behaviour's elements in
 // the order given, and SVG paints in document order, so this keeps the tooltip above the line
 // rather than letting the line strike through it.
-// createContainer's return type is too loose for TSX to accept as a component
+// createContainer's return type is too loose for TSX to accept as a component, so it is
+// asserted to one taking the union of the two behaviours' props -- which is what the combined
+// container actually accepts.
 const CursorVoronoiContainer = createContainer(
   "cursor",
   "voronoi",
-) as React.ComponentType<any>;
+) as React.ComponentType<
+  VictoryCursorContainerProps & VictoryVoronoiContainerProps
+>;
 
-interface Props {
-  labels: (point: any) => string;
+interface Props<Datum> {
+  // Victory hands the callback the whole point; every chart here only reads the datum, which
+  // is one entry of whatever array it passed as `data`.
+  labels: (point: { datum: Datum }) => string;
   // Series that shouldn't raise their own tooltip, because one tooltip already reports them all
   voronoiBlacklist?: string[];
   // What this chart shows, read by screen readers instead of the raw SVG path data
@@ -23,11 +35,11 @@ interface Props {
 }
 
 // Shared hover behaviour for every chart in the game
-export function chartTooltipContainer({
+export function chartTooltipContainer<Datum>({
   labels,
   voronoiBlacklist,
   ariaLabel,
-}: Props) {
+}: Props<Datum>) {
   return (
     <CursorVoronoiContainer
       role="img"

--- a/src/components/base/GameCard.tsx
+++ b/src/components/base/GameCard.tsx
@@ -1,6 +1,6 @@
+import type { AppDispatch } from "../../Store";
 import * as React from "react";
 import { connect } from "react-redux";
-import Redux from "redux";
 import { IconButton, Menu, MenuItem, Toolbar, Typography } from "@mui/material";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import FastForwardIcon from "@mui/icons-material/FastForward";
@@ -258,7 +258,7 @@ const mapStateToProps = (
   ...ownProps,
 });
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onManual: () => {
       dispatch(navigate("MANUAL"));

--- a/src/components/base/GameCard.tsx
+++ b/src/components/base/GameCard.tsx
@@ -15,7 +15,7 @@ import { quit, setSpeed } from "../../reducers/Game";
 import { AppStateType, GameType, SpeedType } from "../../Types";
 import NavigationContainer from "./NavigationContainer";
 
-export interface GameCardProps extends React.ComponentPropsWithoutRef<any> {
+export interface GameCardProps extends React.ComponentPropsWithoutRef<"div"> {
   children?: React.JSX.Element | React.JSX.Element[] | undefined;
   className?: string | undefined;
   game: GameType;

--- a/src/components/base/NavigationContainer.tsx
+++ b/src/components/base/NavigationContainer.tsx
@@ -1,11 +1,8 @@
 import { connect } from "react-redux";
 import { AppStateType } from "../../Types";
-import Navigation, { Props, StateProps } from "./Navigation";
+import Navigation, { StateProps } from "./Navigation";
 
-const mapStateToProps = (
-  state: AppStateType,
-  ownProps: Partial<Props>,
-): StateProps => {
+const mapStateToProps = (state: AppStateType): StateProps => {
   return {
     card: state.card,
   };

--- a/src/components/views/BuildGeneratorsContainer.tsx
+++ b/src/components/views/BuildGeneratorsContainer.tsx
@@ -1,5 +1,5 @@
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
-import Redux from "redux";
 import { navigate } from "../../reducers/Card";
 import { setSpeed, buildFacility } from "../../reducers/Game";
 import { AppStateType, GeneratorShoppingType, SpeedType } from "../../Types";
@@ -11,7 +11,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onBack: () => {
       dispatch(navigate("FACILITIES"));

--- a/src/components/views/BuildStorageContainer.tsx
+++ b/src/components/views/BuildStorageContainer.tsx
@@ -1,5 +1,5 @@
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
-import Redux from "redux";
 import { navigate } from "../../reducers/Card";
 import { setSpeed } from "../../reducers/Game";
 import { buildFacility } from "../../reducers/Game";
@@ -12,7 +12,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onBack: () => {
       dispatch(navigate("FACILITIES"));

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -403,7 +403,7 @@ export default class Facilities extends React.Component<Props, {}> {
           </Toolbar>
           <DragDropContext onDragEnd={this.onDragEnd}>
             <Droppable droppableId="droppable">
-              {(provided, snapshot) => (
+              {(provided) => (
                 <div {...provided.droppableProps} ref={provided.innerRef}>
                   {game.facilities.map(
                     (g: FacilityOperatingType, i: number) => (

--- a/src/components/views/FacilitiesContainer.tsx
+++ b/src/components/views/FacilitiesContainer.tsx
@@ -1,4 +1,4 @@
-import Redux from "redux";
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigate } from "../../reducers/Card";
 import {
@@ -16,7 +16,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onGeneratorBuild: () => {
       dispatch(navigate({ name: "BUILD_GENERATORS", dontRemember: true }));

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -204,7 +204,7 @@ export default class Finances extends React.Component<Props, State> {
     };
   }
 
-  public shouldComponentUpdate(nextProps: Props, nextState: State) {
+  public shouldComponentUpdate(nextProps: Props) {
     // In fast modes, skip rendering alternating frames so that CPU can focus on simulation
     switch (nextProps.game.speed) {
       case "FAST":

--- a/src/components/views/FinancesContainer.tsx
+++ b/src/components/views/FinancesContainer.tsx
@@ -1,4 +1,4 @@
-import Redux from "redux";
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { delta } from "../../reducers/Game";
 import { AppStateType, GameType } from "../../Types";
@@ -10,7 +10,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onDelta: (d: Partial<GameType>) => {
       dispatch(delta(d));

--- a/src/components/views/ForecastsContainer.tsx
+++ b/src/components/views/ForecastsContainer.tsx
@@ -1,7 +1,6 @@
-import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { AppStateType } from "../../Types";
-import Forecasts, { DispatchProps, StateProps } from "./Forecasts";
+import Forecasts, { StateProps } from "./Forecasts";
 
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
@@ -9,13 +8,6 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
-  return {};
-};
-
-const ForecastsContainer = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(Forecasts);
+const ForecastsContainer = connect(mapStateToProps)(Forecasts);
 
 export default ForecastsContainer;

--- a/src/components/views/ForecastsContainer.tsx
+++ b/src/components/views/ForecastsContainer.tsx
@@ -1,4 +1,4 @@
-import Redux from "redux";
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { AppStateType } from "../../Types";
 import Forecasts, { DispatchProps, StateProps } from "./Forecasts";
@@ -9,7 +9,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {};
 };
 

--- a/src/components/views/LoadingContainer.tsx
+++ b/src/components/views/LoadingContainer.tsx
@@ -1,4 +1,4 @@
-import Redux from "redux";
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { logEvent } from "../../Globals";
 import { initFuelPrices } from "../../data/FuelPrices";
@@ -18,7 +18,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
 let lastLoad = performance.now();
 const LOADING_DEBOUNCE_MS = 1000;
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     load: (game: GameType) => {
       if (performance.now() - lastLoad < LOADING_DEBOUNCE_MS) {

--- a/src/components/views/MainMenuContainer.tsx
+++ b/src/components/views/MainMenuContainer.tsx
@@ -1,4 +1,4 @@
-import Redux from "redux";
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { AppStateType } from "../../Types";
 import { navigate } from "../../reducers/Card";
@@ -12,7 +12,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onAudioChange: (v: boolean) => {
       dispatch(changeSettings({ audioEnabled: v }));

--- a/src/components/views/ManualContainer.tsx
+++ b/src/components/views/ManualContainer.tsx
@@ -1,4 +1,4 @@
-import Redux from "redux";
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigateBack } from "../../reducers/Card";
 import { AppStateType } from "../../Types";
@@ -8,7 +8,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   return {};
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onBack: () => {
       dispatch(navigateBack());

--- a/src/components/views/ManualContainer.tsx
+++ b/src/components/views/ManualContainer.tsx
@@ -1,10 +1,9 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigateBack } from "../../reducers/Card";
-import { AppStateType } from "../../Types";
 import Manual, { DispatchProps, StateProps } from "./Manual";
 
-const mapStateToProps = (state: AppStateType): StateProps => {
+const mapStateToProps = (): StateProps => {
   return {};
 };
 

--- a/src/components/views/NewGameContainer.tsx
+++ b/src/components/views/NewGameContainer.tsx
@@ -1,4 +1,4 @@
-import Redux from "redux";
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { delta, start, quit } from "../../reducers/Game";
 import { navigate } from "../../reducers/Card";
@@ -11,7 +11,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onBack: () => {
       dispatch(quit());

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -80,7 +80,8 @@ export default class NewGameDetails extends React.Component<Props, State> {
   private async loadScores(uid: string) {
     if (this.state.scenario && uid) {
       const db = getDb();
-      let scores = [] as any; // tracking here synchronously because React state updates are async
+      // Tracked synchronously here because React state updates are async
+      let scores: ScoreType[] = [];
 
       let q = query(
         collection(db, "scores"),
@@ -89,8 +90,8 @@ export default class NewGameDetails extends React.Component<Props, State> {
         limit(50),
       );
       let querySnapshot = await getDocs(q);
-      querySnapshot.forEach((doc: any) => {
-        scores = [...(scores || []), doc.data()];
+      querySnapshot.forEach((doc) => {
+        scores = [...scores, doc.data() as ScoreType];
         this.setState({ scores });
       });
 
@@ -102,8 +103,8 @@ export default class NewGameDetails extends React.Component<Props, State> {
         limit(1),
       );
       querySnapshot = await getDocs(q);
-      querySnapshot.forEach((doc: any) => {
-        this.setState({ myTopScore: doc.data() });
+      querySnapshot.forEach((doc) => {
+        this.setState({ myTopScore: doc.data() as ScoreType });
       });
     }
   }

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -109,7 +109,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
     }
   }
 
-  public shouldComponentUpdate(nextProps: Props, nextState: State) {
+  public shouldComponentUpdate(nextProps: Props) {
     if (!this.props.uid && nextProps.uid) {
       this.loadScores(nextProps.uid);
     }

--- a/src/components/views/NewGameDetailsContainer.tsx
+++ b/src/components/views/NewGameDetailsContainer.tsx
@@ -1,4 +1,4 @@
-import Redux from "redux";
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigateBack } from "../../reducers/Card";
 import { start, delta } from "../../reducers/Game";
@@ -12,7 +12,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onBack: () => {
       dispatch(navigateBack());

--- a/src/components/views/SettingsContainer.tsx
+++ b/src/components/views/SettingsContainer.tsx
@@ -1,4 +1,4 @@
-import Redux from "redux";
+import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigate } from "../../reducers/Card";
 import { change as changeSettings } from "../../reducers/Settings";
@@ -11,7 +11,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Redux.Dispatch<any>): DispatchProps => {
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onAudioChange: (v: boolean) => {
       dispatch(changeSettings({ audioEnabled: v }));

--- a/src/data/FuelPrices.tsx
+++ b/src/data/FuelPrices.tsx
@@ -1,3 +1,4 @@
+import Papa from "papaparse";
 import { INFLATION } from "../Constants";
 import { DateType, FuelPricesType } from "../Types";
 import { getRandomRange } from "../helpers/Math";
@@ -16,8 +17,6 @@ import { getRandomRange } from "../helpers/Math";
 
 // Oil: imported crude oil prices https://www.eia.gov/outlooks/steo/realprices/
 
-const Papa = require("papaparse");
-
 // The first year in FuelPricesRaw.csv. Asking for a year before this means the CSV was never
 // loaded, rather than that the game is being played in the 1970s.
 const EARLIEST_DATA_YEAR = 1975;
@@ -34,18 +33,19 @@ interface RawFuelPricesType {
 // Holds both the CSV's historic prices and the randomly extrapolated future ones, so it has to be
 // reset per game -- otherwise a second playthrough silently inherits the first one's future prices
 // and the run stops being a function of its seed.
-const fuelPrices = {} as any;
+// year -> month (1-12) -> price per MBTU by fuel
+const fuelPrices: Record<number, Record<number, FuelPricesType>> = {};
 
 // Emptied in place rather than reassigned so that the closure in getFuelPricesPerMBTU keeps
 // referring to a const, which no-loop-func requires
 function resetFuelPrices() {
   Object.keys(fuelPrices).forEach((year: string) => {
-    delete fuelPrices[year];
+    delete fuelPrices[+year];
   });
 }
 
-function collectFuelPriceRow(row: any) {
-  const data = row.data as RawFuelPricesType;
+function collectFuelPriceRow(row: Papa.ParseStepResult<RawFuelPricesType>) {
+  const data = row.data;
   fuelPrices[+data.year] = fuelPrices[+data.year] || {};
   fuelPrices[+data.year][+data.month] = {
     "Natural Gas": +data.naturalgas,
@@ -55,9 +55,9 @@ function collectFuelPriceRow(row: any) {
   };
 }
 
-export function initFuelPrices(callback?: any) {
+export function initFuelPrices(callback?: () => void) {
   resetFuelPrices();
-  Papa.parse(`/data/FuelPricesRaw.csv`, {
+  Papa.parse<RawFuelPricesType>(`/data/FuelPricesRaw.csv`, {
     download: true,
     dynamicTyping: true,
     header: true,
@@ -79,7 +79,7 @@ export function initFuelPrices(callback?: any) {
  */
 export function initFuelPricesFromCsv(csv: string) {
   resetFuelPrices();
-  Papa.parse(csv, {
+  Papa.parse<RawFuelPricesType>(csv, {
     dynamicTyping: true,
     header: true,
     step: collectFuelPriceRow,

--- a/src/data/Weather.test.tsx
+++ b/src/data/Weather.test.tsx
@@ -1,0 +1,111 @@
+import { getWeather, initWeatherFromCsv } from "./Weather";
+import { getDateFromMinute } from "../helpers/DateTime";
+import { seedRandom } from "../helpers/Math";
+
+// Weather rows are looked up by position, one row per hour, with DAYS_PER_MONTH = 1 -- so a
+// single year of data is 12 months x 24 hours. The fixture starts at 1980, the first year the
+// real CSVs cover.
+const FIXTURE_STARTING_YEAR = 1980;
+const HOURS_PER_MONTH = 24;
+const MONTHS_PER_YEAR = 12;
+
+function fixtureCsv(): string {
+  const rows = ["YEAR,MONTH,TEMP_C,CLOUD_PCT,WIND_KPH"];
+  for (let month = 1; month <= MONTHS_PER_YEAR; month++) {
+    for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
+      // Values chosen so every row is distinguishable from its neighbours, which is what makes
+      // "did it pick the right row" and "did it blend in the right direction" observable.
+      rows.push(
+        [FIXTURE_STARTING_YEAR, month, month * 100 + hour, hour, hour * 2].join(
+          ",",
+        ),
+      );
+    }
+  }
+  return rows.join("\n");
+}
+
+function dateAt(month: number, hourOfDay: number, minuteOfHour = 0) {
+  const minute = (month - 1) * 1440 + hourOfDay * 60 + minuteOfHour;
+  return getDateFromMinute(minute, FIXTURE_STARTING_YEAR);
+}
+
+describe("getWeather", () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    // The fixture is deliberately one year rather than the forty the real data has, and the
+    // loader warns about that. Silence it so a passing run has a clean log.
+    warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    seedRandom(1);
+    initWeatherFromCsv("PIT", fixtureCsv());
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("returns the current hour's reading exactly, on the hour", () => {
+    expect(getWeather(dateAt(3, 10))).toEqual({
+      YEAR: 1980,
+      MONTH: 3,
+      TEMP_C: 310,
+      CLOUD_PCT: 10,
+      WIND_KPH: 20,
+    });
+  });
+
+  it("blends towards the next hour as the minutes tick over", () => {
+    // A quarter past is three parts this hour, one part the next.
+    expect(getWeather(dateAt(3, 10, 15)).TEMP_C).toBeCloseTo(
+      0.75 * 310 + 0.25 * 311,
+    );
+    expect(getWeather(dateAt(3, 10, 45)).TEMP_C).toBeCloseTo(
+      0.25 * 310 + 0.75 * 311,
+    );
+  });
+
+  it("moves monotonically from one hour's reading to the next", () => {
+    const readings = [0, 15, 30, 45].map(
+      (minuteOfHour) => getWeather(dateAt(5, 6, minuteOfHour)).TEMP_C,
+    );
+    for (let i = 1; i < readings.length; i++) {
+      expect(readings[i]).toBeGreaterThan(readings[i - 1]);
+    }
+    expect(readings[0]).toEqual(506);
+    expect(readings[readings.length - 1]).toBeLessThan(507);
+  });
+
+  it("stamps a blended reading with the hour it started in", () => {
+    const blended = getWeather(dateAt(7, 12, 30));
+    expect(blended.YEAR).toEqual(1980);
+    expect(blended.MONTH).toEqual(7);
+  });
+
+  it("forecasts past the end of the data rather than returning holes", () => {
+    // The fixture stops at the end of 1980, so this is a year past anything loaded.
+    const forecast = getWeather(dateAt(MONTHS_PER_YEAR + 2, 8));
+    expect(Number.isFinite(forecast.TEMP_C)).toBe(true);
+    expect(Number.isFinite(forecast.CLOUD_PCT)).toBe(true);
+    expect(Number.isFinite(forecast.WIND_KPH)).toBe(true);
+    expect(Number.isFinite(forecast.YEAR)).toBe(true);
+    expect(Number.isFinite(forecast.MONTH)).toBe(true);
+  });
+
+  it("keeps forecast values inside their physical bounds", () => {
+    for (
+      let month = MONTHS_PER_YEAR + 1;
+      month <= MONTHS_PER_YEAR + 6;
+      month++
+    ) {
+      for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
+        const forecast = getWeather(dateAt(month, hour));
+        expect(forecast.TEMP_C).toBeGreaterThanOrEqual(-20);
+        expect(forecast.TEMP_C).toBeLessThanOrEqual(45);
+        expect(forecast.CLOUD_PCT).toBeGreaterThanOrEqual(0);
+        expect(forecast.CLOUD_PCT).toBeLessThanOrEqual(100);
+        expect(forecast.WIND_KPH).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+});

--- a/src/data/Weather.tsx
+++ b/src/data/Weather.tsx
@@ -2,8 +2,7 @@ import { DAYS_PER_MONTH, DAYS_PER_YEAR, EQUATOR_RADIANCE } from "../Constants";
 import { DateType, RawWeatherType } from "../Types";
 import { getRandomRange } from "../helpers/Math";
 import { getSunriseSunset } from "../helpers/DateTime";
-
-const Papa = require("papaparse");
+import Papa from "papaparse";
 
 const STARTING_YEAR = 1980; // for weather data, Jan 1st, assumed to be the same for all locations
 const ENDING_YEAR = 2019; // for weather data, Dec 31st, assumed to be the same for all locations
@@ -11,8 +10,8 @@ const ROWS_PER_DAY = 24;
 const ROWS_PER_YEAR = DAYS_PER_YEAR * ROWS_PER_DAY;
 const EXPECTED_ROWS = (ENDING_YEAR - STARTING_YEAR + 1) * ROWS_PER_YEAR;
 
-let weather = [] as any;
-// Ordred oldest first
+// Ordered oldest first
+let weather: RawWeatherType[] = [];
 const DUMMY_WEATHER = {
   YEAR: 0,
   MONTH: 0,
@@ -24,8 +23,8 @@ const DUMMY_WEATHER = {
 // TODO download weather for all locations at start with a 2s init delay, like loading audio (but after audio) for offline play
 // But only if worker: true starts working - TICKET: https://github.com/mholt/PapaParse/issues/753
 // Ideally caching this... so maybe upgrade to use https://tanstack.com/query/latest/docs/framework/react/overview ?
-function collectWeatherRow(row: any) {
-  const data = row.data as RawWeatherType;
+function collectWeatherRow(row: Papa.ParseStepResult<RawWeatherType>) {
+  const data = row.data;
   if (data && data.YEAR) {
     weather.push(data);
   }
@@ -39,9 +38,9 @@ function warnIfWeatherIncomplete(location: string) {
   }
 }
 
-export function initWeather(location: string, callback?: any) {
-  weather = [] as any; // reset each time to prevent accidentally appending to old state
-  Papa.parse(`/data/WeatherRaw${location}.csv`, {
+export function initWeather(location: string, callback?: () => void) {
+  weather = []; // reset each time to prevent accidentally appending to old state
+  Papa.parse<RawWeatherType>(`/data/WeatherRaw${location}.csv`, {
     download: true,
     dynamicTyping: true,
     header: true,
@@ -61,8 +60,8 @@ export function initWeather(location: string, callback?: any) {
  * (the headless simulator reads them off disk; the browser has to download them).
  */
 export function initWeatherFromCsv(location: string, csv: string) {
-  weather = [] as any; // reset each time to prevent accidentally appending to old state
-  Papa.parse(csv, {
+  weather = []; // reset each time to prevent accidentally appending to old state
+  Papa.parse<RawWeatherType>(csv, {
     dynamicTyping: true,
     header: true,
     step: collectWeatherRow,
@@ -85,14 +84,17 @@ export function getWeather(date: DateType): RawWeatherType {
     return weather[row] || DUMMY_WEATHER;
   }
 
-  // Otherwise, blend hours for smoother weather
+  // Otherwise, blend hours for smoother weather.
+  // The weights run with the clock: on the hour the reading is entirely the hour we are in,
+  // and it slides to the next hour's reading as the minutes tick over.
   const prev = weather[row];
   const next = weather[nextRow];
-  const prevPerc = minuteOfHour / 60;
-  const nextPerc = 1 - prevPerc;
+  const nextPerc = minuteOfHour / 60;
+  const prevPerc = 1 - nextPerc;
   return {
-    YEAR: next.year,
-    MONTH: next.month,
+    // The blended reading is stamped with the hour it starts in, not the one it is heading towards
+    YEAR: prev.YEAR,
+    MONTH: prev.MONTH,
     TEMP_C: prev.TEMP_C * prevPerc + next.TEMP_C * nextPerc,
     CLOUD_PCT: prev.CLOUD_PCT * prevPerc + next.CLOUD_PCT * nextPerc,
     WIND_KPH: prev.WIND_KPH * prevPerc + next.WIND_KPH * nextPerc,
@@ -151,6 +153,9 @@ function forecastNextDay() {
   for (let row = 0; row < ROWS_PER_DAY; row++) {
     const prev = weather[length - ROWS_PER_YEAR + row];
     weather.push({
+      // Forecast rows are last year's same hour nudged, so they belong to the following year
+      YEAR: prev.YEAR + 1,
+      MONTH: prev.MONTH,
       TEMP_C: Math.min(45, Math.max(-20, prev.TEMP_C + temperatureModifier)),
       CLOUD_PCT: Math.min(100, Math.max(0, prev.CLOUD_PCT + cloudModifier)),
       WIND_KPH: Math.max(0, prev.WIND_KPH + windModifier),

--- a/src/helpers/Energy.test.tsx
+++ b/src/helpers/Energy.test.tsx
@@ -52,7 +52,7 @@ describe("getSolarOutputFactor", () => {
 
 describe("getWindCapacityFactor", () => {
   it("should correctly handle empty case", () => {
-    const windSpeedsKph = [] as any;
+    const windSpeedsKph: number[] = [];
     const result = getWindCapacityFactor(windSpeedsKph);
     expect(result).toBeGreaterThanOrEqual(0);
     expect(result).toBeLessThanOrEqual(1);
@@ -67,7 +67,7 @@ describe("getWindCapacityFactor", () => {
 
 describe("getSolarCapacityFactor", () => {
   it("should correctly handle empty case", () => {
-    const irradiancesWM2 = [] as any;
+    const irradiancesWM2: number[] = [];
     const result = getSolarCapacityFactor(irradiancesWM2);
     expect(result).toBeGreaterThanOrEqual(0);
     expect(result).toBeLessThanOrEqual(1);

--- a/src/helpers/Math.tsx
+++ b/src/helpers/Math.tsx
@@ -35,23 +35,30 @@ function splitmix32(a: number) {
   };
 }
 
-let prng = null as any;
+type Prng = () => number;
 
-export function seedRandom(seed: number) {
+let prng: Prng | null = null;
+
+export function seedRandom(seed: number): Prng {
   prng = splitmix32(seed);
+  return prng;
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
 export function getRandomRange(min: number, max: number) {
-  if (!prng) {
-    console.log("prng not seeded, generating now");
-    seedRandom(Date.now() * Math.random());
-  }
-  return prng() * (max - min) + min;
+  // A run is meant to be reproducible from its seed, so callers are expected to have seeded
+  // first. Self-seeding here keeps an unseeded caller working rather than throwing at them,
+  // at the cost of that one run not being replayable.
+  const random = prng ?? seedRandom(Date.now() * Math.random());
+  return random() * (max - min) + min;
 }
 
 // https://stackoverflow.com/questions/5306680/move-an-array-element-from-one-array-position-to-another
-export function arrayMove(arr: any[], oldIndex: number, newIndex: number) {
+export function arrayMove<T>(
+  arr: Array<T | undefined>,
+  oldIndex: number,
+  newIndex: number,
+) {
   if (newIndex >= arr.length) {
     let k = newIndex - arr.length + 1;
     while (k--) {

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1,3 +1,4 @@
+import cloneDeep from "lodash.clonedeep";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import numbro from "numbro";
 import { submitHighscore } from "./User";
@@ -64,7 +65,6 @@ import {
   TickPresentFutureType,
   FuelProductionType,
 } from "../Types";
-const cloneDeep = require("lodash.clonedeep");
 
 interface BuildFacilityAction {
   facility: FacilityShoppingType;
@@ -888,7 +888,16 @@ export function generateNewTimeline(
       expensesInterest: 0,
       expensesMarketing: 0,
       kgco2e: 0,
-    };
+      // reforecastWeatherAndPrices sets both of these on the next line, for every tick from
+      // the current minute onwards -- which is all of them, since the timeline starts there.
+      // Initialised anyway so a tick is a complete TickPresentFutureType the moment it exists,
+      // rather than one that happens to be patched up before anything reads it.
+      storedWh: 0,
+      supplyByFuel: {} as FuelProductionType,
+      // Asserted because FuelPricesType carries a `[index: string]: number` index signature,
+      // which a fresh object literal with a non-number field cannot satisfy. Same reason
+      // reforecastWeatherAndPrices asserts its own tick literal.
+    } as TickPresentFutureType;
   }
   state.timeline = reforecastWeatherAndPrices(state);
   state.timeline = reforecastDemand(state);

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -614,7 +614,7 @@ function reforecastWeatherAndPrices(state: GameType): TickPresentFutureType[] {
 
 function reforecastDemand(state: GameType): TickPresentFutureType[] {
   let prev = state.timeline[0];
-  return state.timeline.map((t: TickPresentFutureType, i: number) => {
+  return state.timeline.map((t: TickPresentFutureType) => {
     if (t.minute >= state.date.minute) {
       const date = getDateFromMinute(t.minute, state.startingYear);
       t.demandW = getDemandW(date, state, prev, t);
@@ -669,7 +669,7 @@ function updateSupplyFacilitiesFinances(
 
   // Update supply and facility outputs
   let supply = 0;
-  let supplyByFuel = {} as FuelProductionType;
+  const supplyByFuel = {} as FuelProductionType;
   let charge = 0;
   let storedWh = 0;
   facilities.forEach((g: FacilityOperatingType, i: number) => {

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -58,6 +58,7 @@ import {
   GameType,
   GeneratorOperatingType,
   MonthlyHistoryType,
+  ScoreBreakdownType,
   SpeedType,
   StorageOperatingType,
   TickPresentFutureType,
@@ -448,7 +449,7 @@ export function tickState(state: GameType) {
         const blackoutsTWh =
           Math.max(0, summary.demandWh - summary.supplyWh) / 1000000000000;
         // Scoring algorithm should also be updated in Game.tsx
-        const score =
+        const score: ScoreBreakdownType =
           scenario.ownership === "Investor"
             ? {
                 supply: Math.round(summary.supplyWh / 1000000000000),
@@ -469,9 +470,7 @@ export function tickState(state: GameType) {
                 blackouts: Math.round(-10 * blackoutsTWh),
               };
 
-        const finalScore = Object.values(score).reduce(
-          (a: number, b: number) => a + b,
-        );
+        const finalScore = Object.values(score).reduce((a, b) => a + b);
         const difficulty = state.difficulty; // pulling out of state for functions running inside of setTimeout
 
         if (!scenario.tutorialSteps) {

--- a/src/reducers/Settings.tsx
+++ b/src/reducers/Settings.tsx
@@ -16,9 +16,10 @@ export const settingsSlice = createSlice({
   reducers: {
     change: (state, action: PayloadAction<Partial<SettingsType>>) => {
       const changes = action.payload || {};
-      // Update values in local storage
-      Object.keys(changes).forEach((key: string) => {
-        setStorageKeyValue(key, changes[key]);
+      // Update values in local storage. Object.entries rather than keys + lookup so the value
+      // stays tied to its key's type instead of needing a string index into SettingsType.
+      Object.entries(changes).forEach(([key, value]) => {
+        setStorageKeyValue(key, value);
       });
       return { ...state, ...changes };
     },

--- a/src/reducers/Settings.tsx
+++ b/src/reducers/Settings.tsx
@@ -23,7 +23,7 @@ export const settingsSlice = createSlice({
       });
       return { ...state, ...changes };
     },
-    pauseAudio: (state) => {
+    pauseAudio: () => {
       pause();
     },
     resumeAudio: (state) => {

--- a/src/reducers/TogglePauseFacility.test.tsx
+++ b/src/reducers/TogglePauseFacility.test.tsx
@@ -1,9 +1,9 @@
+import cloneDeep from "lodash.clonedeep";
 import { PayloadAction } from "@reduxjs/toolkit";
 import gameReducer, { togglePauseFacility, tickState } from "./Game";
 import { TICK_MINUTES } from "../Constants";
 import { createGame } from "../testing/Simulator";
 import { FacilityOperatingType, GameType } from "../Types";
-const cloneDeep = require("lodash.clonedeep");
 
 // Redux Toolkit freezes reducer output in development, and tickState mutates state in place
 function dispatch(state: GameType, action: PayloadAction<number>): GameType {

--- a/src/testing/Invariants.tsx
+++ b/src/testing/Invariants.tsx
@@ -3,8 +3,12 @@ import {
   FacilityOperatingType,
   GameType,
   MonthlyHistoryType,
+  StorageOperatingType,
   TickPresentFutureType,
 } from "../Types";
+
+type TickFieldType = keyof TickPresentFutureType;
+type MonthFieldType = keyof MonthlyHistoryType;
 
 export interface ViolationType {
   rule: string;
@@ -19,7 +23,7 @@ const CASH_ROUNDING_TOLERANCE = 2;
 const MAX_VIOLATIONS_PER_RULE = 5;
 
 // Tick fields that should always hold a real, finite number
-const FINITE_TICK_FIELDS = [
+const FINITE_TICK_FIELDS: TickFieldType[] = [
   "supplyW",
   "demandW",
   "solarIrradianceWM2",
@@ -39,7 +43,7 @@ const FINITE_TICK_FIELDS = [
 ];
 
 // Tick fields that are physically incapable of going negative (cash and netWorth can, by design)
-const NON_NEGATIVE_TICK_FIELDS = [
+const NON_NEGATIVE_TICK_FIELDS: TickFieldType[] = [
   "supplyW",
   "demandW",
   "solarIrradianceWM2",
@@ -55,7 +59,7 @@ const NON_NEGATIVE_TICK_FIELDS = [
   "kgco2e",
 ];
 
-const FINITE_MONTH_FIELDS = [
+const FINITE_MONTH_FIELDS: MonthFieldType[] = [
   "supplyWh",
   "demandWh",
   "cash",
@@ -99,7 +103,9 @@ export class InvariantCollector {
   }
 }
 
-function isFinite_(v: any): boolean {
+// A type predicate, so a value that passes is narrowed to number for the comparisons that
+// follow rather than needing a cast at each one
+function isFinite_(v: unknown): v is number {
   return typeof v === "number" && Number.isFinite(v);
 }
 
@@ -116,18 +122,14 @@ export function checkTick(
   when: string,
   builtThisTick: boolean,
 ) {
-  FINITE_TICK_FIELDS.forEach((field: string) => {
-    if (!isFinite_((now as any)[field])) {
-      collector.add(
-        "tick value is finite",
-        when,
-        `${field} = ${(now as any)[field]}`,
-      );
+  FINITE_TICK_FIELDS.forEach((field) => {
+    if (!isFinite_(now[field])) {
+      collector.add("tick value is finite", when, `${field} = ${now[field]}`);
     }
   });
 
-  NON_NEGATIVE_TICK_FIELDS.forEach((field: string) => {
-    const value = (now as any)[field];
+  NON_NEGATIVE_TICK_FIELDS.forEach((field) => {
+    const value = now[field];
     if (isFinite_(value) && value < 0) {
       collector.add("tick value is non-negative", when, `${field} = ${value}`);
     }
@@ -145,7 +147,7 @@ export function checkTick(
   // so the fuel breakdown can never exceed the total it is a breakdown of.
   let supplyByFuelTotal = 0;
   Object.keys(now.supplyByFuel || {}).forEach((fuel: string) => {
-    const value = (now.supplyByFuel as any)[fuel];
+    const value = now.supplyByFuel[fuel];
     if (!isFinite_(value) || value < 0) {
       collector.add(
         "supplyByFuel is finite and non-negative",
@@ -225,7 +227,9 @@ export function checkTick(
     }
 
     if (f.peakWh) {
-      const storage = f as any;
+      // peakWh is only on storage; the union is indexable, so this is the narrowing the
+      // check above has already established
+      const storage = f as StorageOperatingType;
       if (!isFinite_(storage.currentWh)) {
         collector.add(
           "storage charge is finite",
@@ -275,12 +279,12 @@ export function checkMonth(
   month: MonthlyHistoryType,
   when: string,
 ) {
-  FINITE_MONTH_FIELDS.forEach((field: string) => {
-    if (!isFinite_((month as any)[field])) {
+  FINITE_MONTH_FIELDS.forEach((field) => {
+    if (!isFinite_(month[field])) {
       collector.add(
         "monthly total is finite",
         when,
-        `${field} = ${(month as any)[field]}`,
+        `${field} = ${month[field]}`,
       );
     }
   });

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -1,6 +1,7 @@
 // The game reducer dispatches follow-up actions of its own (the construction complete snackbar,
 // the end of game dialogs), so it needs a live store to reach even though the simulation drives
 // the reducer directly. Importing Store creates and registers it.
+import cloneDeep from "lodash.clonedeep";
 import "../Store";
 import gameReducer, {
   buildFacility,
@@ -29,7 +30,6 @@ import {
   ViolationType,
 } from "./Invariants";
 import { loadSimData } from "./SimData";
-const cloneDeep = require("lodash.clonedeep");
 
 export type StrategyType = "none" | "keepUp";
 


### PR DESCRIPTION
`npm run check` was already green when I started, so this is not a backlog of failing checks — it is the issues the checks were not configured to notice. Nothing was set up to object to `any` or to `console.log`, so both had accumulated, and typing the `any`s away turned up two real bugs.

## Bugs fixed

**Hourly weather blending ran backwards.** `getWeather` interpolates between the current hour's reading and the next, but the weights were swapped: at `:00` it returned entirely the *next* hour's values, at `:59` entirely the current hour's. Every temperature, wind speed and cloud reading the simulation saw was up to an hour ahead of the clock, and jumped backwards each time an hour rolled over. The same return read `next.year` / `next.month` off a row whose fields are `YEAR` / `MONTH`, so both came back `undefined` from fields typed `number`.

Six tests cover this — I confirmed they fail against the old code before keeping them.

**Storage probe left its scratch key behind.** `getLocalStorageSize` cleaned up with `setItem("test", null as any)`, writing the string `"null"` into the key it meant to free. Now `removeItem`.

## Type safety

Every `any` in `src/` is gone except one, which is marked with a TODO and an eslint-disable explaining why.

The ones worth calling out:

- **`Redux.Dispatch<any>`** in all 14 containers → `AppDispatch`, imported with `import type` so the module graph `ImportOrder.test.tsx` guards is unchanged.
- **`type GainNode = any`** in `AudioNode` — shadowing the DOM type of the same name — was papering over pre-standard Web Audio APIs (`noteOn`/`noteOff`, `playbackState`). Those are declared properly now, which exposed `fadeIn`/`fadeOut` dereferencing a gain node that is null until `playOnce` runs.
- **`require("papaparse")` / `require("lodash.clonedeep")`** → typed imports. The latter caught `generateNewTimeline` building ticks missing two required fields.
- **Chart tooltips**: `chartTooltipContainer` is generic over its datum, so each chart declares what its tooltip reads instead of destructuring `any`. That caught `formatMoneyStable` being handed an optional fuel price.
- **Invariants**: field lists typed as keys of the record they index (removes six casts), and `isFinite_` is a type predicate.

## Debug output

`ThemeManager` logged on every theme start, every loop skipped while paused, and once per instrument on every intensity change — a steady stream in the deployed game's console. Removed. The one message reporting a real problem is kept as `console.warn`. `helpers/Math` logged `"prng not seeded"` on every test run; that is a comment now.

## Making it stick

New lint rules — `no-explicit-any`, `no-console` (warn/error allowed), `no-unused-vars` including caught errors, `eqeqeq`, `no-var`, `prefer-const` — plus the fixes they surfaced: 8 unused arguments, 3 unused caught errors, 1 unused import, 1 needless `let`. `CONTRIBUTING.md` documents each rule and why, since `package.json` cannot carry comments.

Verified against a production build, which is what the deploy runs and which lints with these rules too.

## Deliberately not done

- **`SharedShoppingType`'s `[index: string]: any`.** Removing it produces 271 type errors across the build and facilities views, which treat the Storage and Generator unions as interchangeable. That is a refactor of its own, in the least-tested code in the repo.
- **`FuelPricesType`'s index signature.** Asking it for the price of Sun or Wind returns `undefined` from a field typed `number`. Every call site already guards with `|| 0`, so nothing is broken today.
- **`AudioNode.isPlaying()`** compares two properties no browser released this decade defines, so it really answers "has `playOnce` been called" and a node never reports itself finished. Left as-is with a comment — the fade logic in `ThemeManager` is tuned around the current behaviour, and fixing it means tracking the source's `ended` event.
- **`npm audit`'s 28 dev-only advisories.** All from `react-scripts`' `webpack-dev-server` chain. `npm audit --omit=dev` is clean; nothing ships. Not fixable without replacing CRA.

## Verification

`npm run check` passes, coverage thresholds hold, and `react-scripts build` compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
