### PR TITLE
Cut per-frame render cost, mostly on the Finances pane

### DIFF
--- a/src/Globals.tsx
+++ b/src/Globals.tsx
@@ -68,20 +68,42 @@ export function getDevicePlatform(): "web" {
 }
 
 /**
- * This function checks if the screen size is small, based on the width of the document being < 375
+ * Reading scrollWidth / offsetWidth forces the browser to flush pending layout, and between the
+ * compositor, the game card and the panes the answer is asked for the better part of a dozen
+ * times per render -- which at FAST speed is a hundred renders a second, all for a number that
+ * only moves when the window does. So it is measured once and kept until a resize says otherwise.
  * // https://stackoverflow.com/questions/1038727/how-to-get-browser-width-using-javascript-code
+ */
+let cachedViewportWidth: number | null = null;
+
+function getViewportWidth(): number {
+  if (cachedViewportWidth === null) {
+    cachedViewportWidth = Math.max(
+      document.body.scrollWidth,
+      document.documentElement.scrollWidth,
+      document.body.offsetWidth,
+      document.documentElement.offsetWidth,
+      document.documentElement.clientWidth,
+    );
+  }
+  return cachedViewportWidth;
+}
+
+if (typeof window !== "undefined") {
+  const invalidate = () => {
+    cachedViewportWidth = null;
+  };
+  window.addEventListener("resize", invalidate);
+  window.addEventListener("orientationchange", invalidate);
+}
+
+/**
+ * This function checks if the screen size is small, based on the width of the document being < 375
  *
  * @returns {boolean} - Returns true if the screen width is less than 375, otherwise false.
  */
 export function isSmallScreen(): boolean {
-  const width = Math.max(
-    document.body.scrollWidth,
-    document.documentElement.scrollWidth,
-    document.body.offsetWidth,
-    document.documentElement.offsetWidth,
-    document.documentElement.clientWidth,
-  );
-  return width < 375;
+  return getViewportWidth() < 375;
 }
 
 /**
@@ -91,14 +113,7 @@ export function isSmallScreen(): boolean {
  * @returns {boolean} - Returns true if the screen width is greater than 650, otherwise false.
  */
 export function isBigScreen(): boolean {
-  const width = Math.max(
-    document.body.scrollWidth,
-    document.documentElement.scrollWidth,
-    document.body.offsetWidth,
-    document.documentElement.offsetWidth,
-    document.documentElement.clientWidth,
-  );
-  return width > 650;
+  return getViewportWidth() > 650;
 }
 
 /**
@@ -109,14 +124,7 @@ export function isBigScreen(): boolean {
  * @returns {boolean} - Returns true if the screen width is at least 1300, otherwise false.
  */
 export function isDesktopScreen(): boolean {
-  const width = Math.max(
-    document.body.scrollWidth,
-    document.documentElement.scrollWidth,
-    document.body.offsetWidth,
-    document.documentElement.offsetWidth,
-    document.documentElement.clientWidth,
-  );
-  return width >= 1300;
+  return getViewportWidth() >= 1300;
 }
 
 export function getHistoryApi(): HistoryApi {

--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -111,4 +111,9 @@ const ChartFinances = (props: Props): React.JSX.Element => {
     </div>
   );
 };
-export default ChartFinances;
+/**
+ * The series only changes when a month rolls over or the player changes something, so memoising
+ * lets the whole Victory subtree -- easily the most expensive render in the game -- be skipped
+ * on the frames in between. Finances hands over a referentially stable series for exactly this.
+ */
+export default React.memo(ChartFinances);

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -47,6 +47,19 @@ export interface Props {
 
 // TODO how to indicate history vs reality vs forecast? Perhaps current time as a prop, and then split it in the chart
 // and don't actually differentiate between reality +  forecast in data?
+const SUPPLY_DEMAND_CONTAINER = chartTooltipContainer({
+  ariaLabel: "Chart of electricity supply and demand over the day",
+  labels: ({ datum }: { datum: ChartData }) =>
+    `Supply: ${formatWatts(datum.supplyW)}\nDemand: ${formatWatts(datum.demandW)}`,
+  // Labels are rendered on EACH chart, so we only render on demand, otherwise we get duplicate labels
+  voronoiBlacklist: [
+    "supplyHistoric",
+    "supplyForecast",
+    "blackouts",
+    "current",
+  ],
+});
+
 const ChartSupplyDemand = (props: Props): React.JSX.Element => {
   const { startingYear, height, legend, timeline, location } = props;
   // Figure out the boundaries of the chart data
@@ -182,18 +195,7 @@ const ChartSupplyDemand = (props: Props): React.JSX.Element => {
         domain={{ y: [domainMin, domainMax] }}
         domainPadding={{ y: [6, 6] }}
         height={height || 300}
-        containerComponent={chartTooltipContainer({
-          ariaLabel: "Chart of electricity supply and demand over the day",
-          labels: ({ datum }: { datum: ChartData }) =>
-            `Supply: ${formatWatts(datum.supplyW)}\nDemand: ${formatWatts(datum.demandW)}`,
-          // Labels are rendered on EACH chart, so we only render on demand, otherwise we get duplicate labels
-          voronoiBlacklist: [
-            "supplyHistoric",
-            "supplyForecast",
-            "blackouts",
-            "current",
-          ],
-        })}
+        containerComponent={SUPPLY_DEMAND_CONTAINER}
       >
         <VictoryAxis
           tickValues={hourTicks}

--- a/src/components/base/GameCard.tsx
+++ b/src/components/base/GameCard.tsx
@@ -35,8 +35,153 @@ export interface DispatchProps {
 
 export interface Props extends GameCardProps, DispatchProps {}
 
+interface SpeedOptionsProps {
+  smallScreen: boolean;
+  speed: SpeedType;
+  onSpeedChange: (speed: SpeedType) => void;
+  speedAnchorEl: HTMLElement | null;
+  handleSpeedClick: (event: React.MouseEvent<HTMLElement>) => void;
+  handleSpeedClose: () => void;
+}
+
+// Pulled out of the component so it can be memoised on the handful of things it actually
+// depends on, rather than rebuilt on every tick along with the cash readout beside it
+function buildSpeedOptions({
+  smallScreen,
+  speed,
+  onSpeedChange,
+  speedAnchorEl,
+  handleSpeedClick,
+  handleSpeedClose,
+}: SpeedOptionsProps): React.JSX.Element {
+  if (!smallScreen) {
+    return (
+      <span>
+        <IconButton
+          onClick={() => onSpeedChange("PAUSED")}
+          disabled={speed === "PAUSED"}
+          aria-label="pause"
+          edge="end"
+          color="primary"
+          size="large"
+        >
+          <PauseIcon />
+        </IconButton>
+        <IconButton
+          onClick={() => onSpeedChange("SLOW")}
+          disabled={speed === "SLOW"}
+          aria-label="slow speed"
+          edge="end"
+          color="primary"
+          size="large"
+        >
+          <ChevronRightIcon />
+        </IconButton>
+        <IconButton
+          onClick={() => onSpeedChange("NORMAL")}
+          disabled={speed === "NORMAL"}
+          aria-label="normal speed"
+          edge="end"
+          color="primary"
+          size="large"
+        >
+          <PlayArrowIcon />
+        </IconButton>
+        <IconButton
+          onClick={() => onSpeedChange("FAST")}
+          disabled={speed === "FAST"}
+          aria-label="fast speed"
+          edge="end"
+          color="primary"
+          size="large"
+        >
+          <FastForwardIcon />
+        </IconButton>
+      </span>
+    );
+  }
+
+  let speedIcon = <PlayArrowIcon />;
+  switch (speed) {
+    case "PAUSED":
+      speedIcon = <PlayArrowIcon />;
+      break;
+    case "SLOW":
+      speedIcon = <ChevronRightIcon />;
+      break;
+    case "NORMAL":
+      speedIcon = <PlayArrowIcon />;
+      break;
+    case "FAST":
+      speedIcon = <FastForwardIcon />;
+      break;
+    default:
+      break;
+  }
+  return (
+    <span>
+      {speed !== "PAUSED" && (
+        <IconButton
+          onClick={() => onSpeedChange("PAUSED")}
+          aria-label="pause"
+          size="large"
+        >
+          <PauseIcon color="primary" />
+        </IconButton>
+      )}
+      <IconButton
+        onClick={handleSpeedClick}
+        aria-label="change speed"
+        edge="end"
+        color="primary"
+        size="large"
+      >
+        {speedIcon}
+      </IconButton>
+      <Menu
+        id="speedMenu"
+        anchorEl={speedAnchorEl}
+        keepMounted
+        open={Boolean(speedAnchorEl)}
+        onClose={handleSpeedClose}
+      >
+        <MenuItem
+          onClick={() => {
+            onSpeedChange("SLOW");
+            handleSpeedClose();
+          }}
+          disabled={speed === "SLOW"}
+          aria-label="slow-speed"
+        >
+          <ChevronRightIcon color="primary" />
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            onSpeedChange("NORMAL");
+            handleSpeedClose();
+          }}
+          disabled={speed === "NORMAL"}
+          aria-label="normal-speed"
+        >
+          <PlayArrowIcon color="primary" />
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            onSpeedChange("FAST");
+            handleSpeedClose();
+          }}
+          disabled={speed === "FAST"}
+          aria-label="fast-speed"
+        >
+          <FastForwardIcon color="primary" />
+        </MenuItem>
+      </Menu>
+    </span>
+  );
+}
+
 export function GameCard(props: Props) {
-  const { game } = props;
+  const { game, onManual, onQuit, onSpeedChange } = props;
   const date = game.date;
   const now = getTimeFromTimeline(date.minute, game.timeline);
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<HTMLElement | null>(
@@ -45,6 +190,71 @@ export function GameCard(props: Props) {
   const [speedAnchorEl, setSpeedAnchorEl] = React.useState<HTMLElement | null>(
     null,
   );
+
+  const smallScreen = isSmallScreen();
+  const bigScreen = isBigScreen();
+  const speed = game.speed;
+
+  const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
+    setMenuAnchorEl(event.currentTarget);
+  const handleMenuClose = () => setMenuAnchorEl(null);
+  const handleSpeedClick = (event: React.MouseEvent<HTMLElement>) =>
+    setSpeedAnchorEl(event.currentTarget);
+  const handleSpeedClose = () => setSpeedAnchorEl(null);
+
+  /**
+   * The top bar has to re-render every tick to keep the cash and the clock honest, which at FAST
+   * is a hundred times a second. Everything else in it -- five icon buttons, a kept-mounted menu
+   * and the bottom nav -- only changes when the player clicks something, so those subtrees are
+   * built once per actual change and handed back as the same elements. React then skips them
+   * entirely on the frames in between, which is where a good quarter of the frame budget went.
+   */
+  const speedOptions = React.useMemo(
+    () =>
+      buildSpeedOptions({
+        smallScreen,
+        speed,
+        onSpeedChange,
+        speedAnchorEl,
+        handleSpeedClick,
+        handleSpeedClose,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [smallScreen, speed, onSpeedChange, speedAnchorEl],
+  );
+
+  const menu = React.useMemo(
+    () => (
+      <>
+        <IconButton
+          onClick={handleMenuClick}
+          aria-label="menu"
+          edge="start"
+          color="primary"
+          size="large"
+        >
+          <MoreVertIcon />
+        </IconButton>
+        <Menu
+          id="gameCardMenu"
+          anchorEl={menuAnchorEl}
+          keepMounted
+          open={Boolean(menuAnchorEl)}
+          onClose={handleMenuClose}
+        >
+          <MenuItem onClick={onManual}>Manual</MenuItem>
+          <MenuItem onClick={() => openWindow("mailto:todd@fabricate.io")}>
+            Send feedback
+          </MenuItem>
+          <MenuItem onClick={onQuit}>Quit</MenuItem>
+        </Menu>
+      </>
+    ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [menuAnchorEl, onManual, onQuit],
+  );
+
+  const nav = React.useMemo(() => <NavigationContainer />, []);
 
   if (!game.inGame || !now) {
     return <span />;
@@ -65,169 +275,13 @@ export function GameCard(props: Props) {
     );
   }
 
-  const smallScreen = isSmallScreen();
-  const bigScreen = isBigScreen();
-  const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
-    setMenuAnchorEl(event.currentTarget);
-  const handleMenuClose = () => setMenuAnchorEl(null);
-  const handleSpeedClick = (event: React.MouseEvent<HTMLElement>) =>
-    setSpeedAnchorEl(event.currentTarget);
-  const handleSpeedClose = () => setSpeedAnchorEl(null);
-
-  const inBlackout = now && now.supplyW < now.demandW;
-
-  let speedOptions = <span />;
-  if (!smallScreen) {
-    speedOptions = (
-      <span>
-        <IconButton
-          onClick={() => props.onSpeedChange("PAUSED")}
-          disabled={game.speed === "PAUSED"}
-          aria-label="pause"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <PauseIcon />
-        </IconButton>
-        <IconButton
-          onClick={() => props.onSpeedChange("SLOW")}
-          disabled={game.speed === "SLOW"}
-          aria-label="slow speed"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <ChevronRightIcon />
-        </IconButton>
-        <IconButton
-          onClick={() => props.onSpeedChange("NORMAL")}
-          disabled={game.speed === "NORMAL"}
-          aria-label="normal speed"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <PlayArrowIcon />
-        </IconButton>
-        <IconButton
-          onClick={() => props.onSpeedChange("FAST")}
-          disabled={game.speed === "FAST"}
-          aria-label="fast speed"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <FastForwardIcon />
-        </IconButton>
-      </span>
-    );
-  } else {
-    let speedIcon = <PlayArrowIcon />;
-    switch (props.game.speed) {
-      case "PAUSED":
-        speedIcon = <PlayArrowIcon />;
-        break;
-      case "SLOW":
-        speedIcon = <ChevronRightIcon />;
-        break;
-      case "NORMAL":
-        speedIcon = <PlayArrowIcon />;
-        break;
-      case "FAST":
-        speedIcon = <FastForwardIcon />;
-        break;
-      default:
-        break;
-    }
-    speedOptions = (
-      <span>
-        {game.speed !== "PAUSED" && (
-          <IconButton
-            onClick={() => props.onSpeedChange("PAUSED")}
-            aria-label="pause"
-            size="large"
-          >
-            <PauseIcon color="primary" />
-          </IconButton>
-        )}
-        <IconButton
-          onClick={handleSpeedClick}
-          aria-label="change speed"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          {speedIcon}
-        </IconButton>
-        <Menu
-          id="speedMenu"
-          anchorEl={speedAnchorEl}
-          keepMounted
-          open={Boolean(speedAnchorEl)}
-          onClose={handleSpeedClose}
-        >
-          <MenuItem
-            onClick={() => {
-              props.onSpeedChange("SLOW");
-              handleSpeedClose();
-            }}
-            disabled={game.speed === "SLOW"}
-            aria-label="slow-speed"
-          >
-            <ChevronRightIcon color="primary" />
-          </MenuItem>
-          <MenuItem
-            onClick={() => {
-              props.onSpeedChange("NORMAL");
-              handleSpeedClose();
-            }}
-            disabled={game.speed === "NORMAL"}
-            aria-label="normal-speed"
-          >
-            <PlayArrowIcon color="primary" />
-          </MenuItem>
-          <MenuItem
-            onClick={() => {
-              props.onSpeedChange("FAST");
-              handleSpeedClose();
-            }}
-            disabled={game.speed === "FAST"}
-            aria-label="fast-speed"
-          >
-            <FastForwardIcon color="primary" />
-          </MenuItem>
-        </Menu>
-      </span>
-    );
-  }
+  const inBlackout = now.supplyW < now.demandW;
 
   return (
     <div className={props.className + " flexContainer"} id="gameCard">
       <div id="topbar">
         <Toolbar className={inBlackout ? "blackout-pulsing" : ""}>
-          <IconButton
-            onClick={handleMenuClick}
-            aria-label="menu"
-            edge="start"
-            color="primary"
-            size="large"
-          >
-            <MoreVertIcon />
-          </IconButton>
-          <Menu
-            id="gameCardMenu"
-            anchorEl={menuAnchorEl}
-            keepMounted
-            open={Boolean(menuAnchorEl)}
-            onClose={handleMenuClose}
-          >
-            <MenuItem onClick={props.onManual}>Manual</MenuItem>
-            <MenuItem onClick={() => openWindow("mailto:todd@fabricate.io")}>
-              Send feedback
-            </MenuItem>
-            <MenuItem onClick={props.onQuit}>Quit</MenuItem>
-          </Menu>
+          {menu}
           <Typography variant="h6">
             {formatMoneyStable(now.cash)}&nbsp;
             <span className="weak">
@@ -245,7 +299,7 @@ export function GameCard(props: Props) {
         }}
       />
       {props.children}
-      <NavigationContainer />
+      {nav}
     </div>
   );
 }

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -33,7 +33,7 @@ import {
   DropResult,
   NotDraggingStyle,
 } from "@hello-pangea/dnd";
-import { TICK_MINUTES } from "../../Constants";
+import { TickThrottle } from "../../helpers/RenderThrottle";
 import { fuelColors, storageColor, withAlpha } from "../../Theme";
 import {
   FacilityOperatingType,
@@ -271,41 +271,43 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
               </div>
             </ListItemAvatar>
             <ListItemText primary={facility.name} secondary={secondaryText} />
-            <Dialog open={open} onClose={toggleDialog}>
-              <DialogTitle>
-                {underConstruction ? "Cancel construction of" : "Sell"}{" "}
-                {facility.peakWh
-                  ? formatWattHours(facility.peakWh)
-                  : formatWatts(facility.peakW)}{" "}
-                {facility.name.toLowerCase()} facility?
-              </DialogTitle>
-              <DialogContent>
-                <DialogContentText>
-                  You will receive{" "}
-                  {formatMoneyConcise(facilityCashBack(facility))}
-                  {facility.loanAmountLeft > 0
-                    ? ` and the rest will go towards paying off the remaining loan balance of ${formatMoneyConcise(facility.loanAmountLeft)}`
-                    : ""}
-                  .
-                </DialogContentText>
-              </DialogContent>
-              <DialogActions>
-                <Button onClick={toggleDialog} color="primary">
-                  Nevermind
-                </Button>
-                <Button
-                  onClick={() => {
-                    props.onSell(facility.id);
-                    toggleDialog();
-                  }}
-                  color="primary"
-                  variant="contained"
-                  autoFocus
-                >
-                  {underConstruction ? "Cancel construction" : "Sell"}
-                </Button>
-              </DialogActions>
-            </Dialog>
+            {open && (
+              <Dialog open onClose={toggleDialog}>
+                <DialogTitle>
+                  {underConstruction ? "Cancel construction of" : "Sell"}{" "}
+                  {facility.peakWh
+                    ? formatWattHours(facility.peakWh)
+                    : formatWatts(facility.peakW)}{" "}
+                  {facility.name.toLowerCase()} facility?
+                </DialogTitle>
+                <DialogContent>
+                  <DialogContentText>
+                    You will receive{" "}
+                    {formatMoneyConcise(facilityCashBack(facility))}
+                    {facility.loanAmountLeft > 0
+                      ? ` and the rest will go towards paying off the remaining loan balance of ${formatMoneyConcise(facility.loanAmountLeft)}`
+                      : ""}
+                    .
+                  </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                  <Button onClick={toggleDialog} color="primary">
+                    Nevermind
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      props.onSell(facility.id);
+                      toggleDialog();
+                    }}
+                    color="primary"
+                    variant="contained"
+                    autoFocus
+                  >
+                    {underConstruction ? "Cancel construction" : "Sell"}
+                  </Button>
+                </DialogActions>
+              </Dialog>
+            )}
           </ListItem>
         </div>
       )}
@@ -334,14 +336,19 @@ export default class Facilities extends React.Component<Props, {}> {
     this.onDragEnd = this.onDragEnd.bind(this);
   }
 
+  private throttle = new TickThrottle();
+
+  // In fast mode, skip frames so that CPU can focus on simulation -- this pane carries the
+  // supply/demand chart, which is the single most expensive thing the game draws
   public shouldComponentUpdate(nextProps: Props) {
-    // In fast modes, skip frames so that CPU can focus on simulation
-    switch (nextProps.game.speed) {
-      case "FAST":
-        return (nextProps.game.date.minute / TICK_MINUTES) % 8 === 0;
-      default:
-        return true;
+    if (nextProps.game.speed !== "FAST") {
+      return true;
     }
+    return this.throttle.due(nextProps.game.date.minute, 8);
+  }
+
+  public componentDidUpdate() {
+    this.throttle.rendered(this.props.game.date.minute);
   }
 
   public onDragEnd(result: DropResult) {

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -13,7 +13,8 @@ import {
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
-import { TICK_MINUTES, TICKS_PER_MONTH } from "../../Constants";
+import { TICKS_PER_MONTH } from "../../Constants";
+import { TickThrottle } from "../../helpers/RenderThrottle";
 import {
   deriveExpandedSummary,
   EMPTY_HISTORY,
@@ -172,6 +173,13 @@ interface State {
   chartKey: DerivedHistoryKeysType;
 }
 
+interface ChartPointType {
+  month: number; // unique across years
+  year: number;
+  value: number;
+  projected: boolean;
+}
+
 // -1:0 -> 0:$100k, each tick increments the front number - when it overflows, instead add a 0 (i.e. 1->2M, 9->10M, 10->20M)
 function getValueFromTick(tick: number) {
   if (tick === -1) {
@@ -204,14 +212,21 @@ export default class Finances extends React.Component<Props, State> {
     };
   }
 
+  private chartSeriesCache:
+    { key: string; series: ChartPointType[] } | undefined;
+
+  private throttle = new TickThrottle();
+
+  // In fast mode, skip rendering alternating frames so that CPU can focus on simulation
   public shouldComponentUpdate(nextProps: Props) {
-    // In fast modes, skip rendering alternating frames so that CPU can focus on simulation
-    switch (nextProps.game.speed) {
-      case "FAST":
-        return (nextProps.game.date.minute / TICK_MINUTES) % 2 === 0;
-      default:
-        return true;
+    if (nextProps.game.speed !== "FAST") {
+      return true;
     }
+    return this.throttle.due(nextProps.game.date.minute, 2);
+  }
+
+  public componentDidUpdate() {
+    this.throttle.rendered(this.props.game.date.minute);
   }
 
   public setExpand(expanded: boolean) {
@@ -222,6 +237,83 @@ export default class Finances extends React.Component<Props, State> {
   public setChartKey(chartKey: DerivedHistoryKeysType) {
     setStorageKeyValue("financesChartKey", chartKey);
     this.setState({ chartKey });
+  }
+
+  /**
+   * The chart plots monthly aggregates, and the projection behind its dashed half is a whole
+   * simulated year. Rebuilding that every frame was the single most expensive thing the game
+   * did -- at FAST it ran a year of simulation up to fifty times a second to redraw a line
+   * whose points cannot move until the month does. So it is rebuilt when something that can
+   * actually change it changes: the month rolling over, or the player touching the metric, the
+   * year, a slider or the fleet.
+   */
+  private getChartSeries(
+    monthlyHistory: MonthlyHistoryType[],
+    cash: number,
+    customers: number,
+  ): ChartPointType[] {
+    const { game } = this.props;
+    const { startingYear, timeline, date } = game;
+    const { year, chartKey } = this.state;
+
+    const key = [
+      chartKey,
+      year,
+      date.monthsEllapsed,
+      game.monthlyHistory.length,
+      game.monthlyMarketingSpend,
+      game.dollarsPerkWh,
+      game.facilities.map((f) => `${f.id}${f.paused ? "p" : ""}`).join(","),
+    ].join("|");
+    const cached = this.chartSeriesCache;
+    if (cached && cached.key === key) {
+      return cached.series;
+    }
+
+    const monthly = [] as ChartPointType[];
+    for (const m of monthlyHistory) {
+      const s = deriveExpandedSummary(m);
+      monthly.unshift({
+        month: s.year * 12 + s.month,
+        year: s.year,
+        value: s[chartKey],
+        projected: false,
+      });
+    }
+    if (!year || year === -1 || date.year === year) {
+      // Add projected months if current year is included in chart
+      const presentFutureMonths = [summarizeTimeline(timeline, startingYear)];
+      if (date.month !== "Dec") {
+        // Project out for the rest of the year
+        const forecastedTimeline = generateNewTimeline(
+          game,
+          cash,
+          customers,
+          TICKS_PER_MONTH * (1 + 12 - date.monthNumber),
+        ); // Current month, plus the rest of the months
+        for (let month = date.monthNumber + 1; month <= 12; month++) {
+          const m = summarizeTimeline(
+            forecastedTimeline,
+            startingYear,
+            (t) =>
+              getDateFromMinute(t.minute, startingYear).monthNumber === month,
+          );
+          presentFutureMonths.push(m);
+        }
+      }
+      presentFutureMonths.forEach((m) => {
+        const s = deriveExpandedSummary(m);
+        monthly.push({
+          month: s.year * 12 + s.month,
+          year: s.year,
+          value: s[chartKey],
+          projected: true,
+        });
+      });
+    }
+
+    this.chartSeriesCache = { key, series: monthly };
+    return monthly;
   }
 
   public render() {
@@ -262,49 +354,11 @@ export default class Finances extends React.Component<Props, State> {
       summaryMonths.reduce(reduceHistories, { ...EMPTY_HISTORY }),
     );
 
-    // For the monthly chart
-    const monthly = [];
-    for (const m of monthlyHistory) {
-      const s = deriveExpandedSummary(m);
-      monthly.unshift({
-        month: s.year * 12 + s.month,
-        year: s.year,
-        value: s[chartKey],
-        projected: false,
-      });
-    }
-    if (!year || year === -1 || date.year === year) {
-      // Add projected months if current year is included in chart
-      const presentFutureMonths = [summarizeTimeline(timeline, startingYear)];
-      if (date.month !== "Dec") {
-        // Project out for the rest of the year
-        const forecastedTimeline = generateNewTimeline(
-          game,
-          now.cash,
-          now.customers,
-          TICKS_PER_MONTH * (1 + 12 - date.monthNumber),
-        ); // Current month, plus the rest of the months
-        for (let month = date.monthNumber + 1; month <= 12; month++) {
-          const m = summarizeTimeline(
-            forecastedTimeline,
-            game.startingYear,
-            (t) =>
-              getDateFromMinute(t.minute, game.startingYear).monthNumber ===
-              month,
-          );
-          presentFutureMonths.push(m);
-        }
-      }
-      presentFutureMonths.forEach((m) => {
-        const s = deriveExpandedSummary(m);
-        monthly.push({
-          month: s.year * 12 + s.month,
-          year: s.year,
-          value: s[chartKey],
-          projected: true,
-        });
-      });
-    }
+    const monthly = this.getChartSeries(
+      monthlyHistory,
+      now.cash,
+      now.customers,
+    );
 
     return (
       <GameCard

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -168,8 +168,34 @@ export function getMonthYearFromMinute(minute: number, startingYear: number) {
   };
 }
 
+interface SunriseSunsetType {
+  sunrise: number;
+  sunset: number;
+}
+
+/**
+ * Sun times only move with the month, the year and the location, so a whole game month's worth
+ * of ticks all get the same answer. Working it out from scratch each time was the single most
+ * expensive thing in the simulation: parsing a date out of a string and running suncalc's full
+ * solar model costs ~17us a call, and a year-long forecast asks for one per tick -- twice, once
+ * for irradiance and once for demand. Caching turns tens of milliseconds per forecast into a
+ * map lookup. One entry per month played (plus however far the forecasts look ahead), so the
+ * map stays in the hundreds of entries for even a very long game.
+ */
+const sunriseSunsetCache = new Map<string, SunriseSunsetType>();
+
 // returns minutes since midnight
-export function getSunriseSunset(date: DateType, lat: number, long: number) {
+export function getSunriseSunset(
+  date: DateType,
+  lat: number,
+  long: number,
+): SunriseSunsetType {
+  const key = `${date.month}|${date.year}|${lat}|${long}`;
+  const cached = sunriseSunsetCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
   const calc = getTimes(new Date(`${date.month} 1, ${date.year}`), lat, long);
 
   // suncalc returns null above the polar circles, where the sun may never rise or never set
@@ -179,10 +205,12 @@ export function getSunriseSunset(date: DateType, lat: number, long: number) {
   const minuteOfDay = (d: Date | null, fallback: number) =>
     d ? d.getHours() * 60 + d.getMinutes() : fallback;
 
-  return {
+  const times = {
     sunrise: minuteOfDay(calc.sunrise, 6 * 60),
     sunset: minuteOfDay(calc.sunset, 18 * 60),
   };
+  sunriseSunsetCache.set(key, times);
+  return times;
 }
 
 export function getDateFromMinute(

--- a/src/helpers/RenderThrottle.tsx
+++ b/src/helpers/RenderThrottle.tsx
@@ -1,0 +1,28 @@
+import { TICK_MINUTES } from "../Constants";
+
+/**
+ * Frame skipping for the panes that are too expensive to redraw on every tick at FAST speed.
+ *
+ * The obvious way to write this -- "render when the tick counter divides evenly by N" -- looks
+ * right and quietly falls apart on a slow device. The tick action catches the simulation up
+ * several ticks at a time when a frame overruns, so React only ever sees every second or third
+ * value of the counter, and a remainder test can step straight over every multiple of N. At a
+ * stride of exactly N the pane then freezes for as long as the machine stays behind.
+ *
+ * Asking how far the game clock has moved since the last render instead is independent of the
+ * stride, and a clock that has gone backwards (a new game starting) always renders.
+ */
+export class TickThrottle {
+  private lastRenderedMinute = -Infinity;
+
+  /** True if at least `everyTicks` game ticks have passed since the last render. */
+  public due(minute: number, everyTicks: number): boolean {
+    const elapsed = minute - this.lastRenderedMinute;
+    return elapsed < 0 || elapsed >= everyTicks * TICK_MINUTES;
+  }
+
+  /** Call from componentDidUpdate, so only renders that actually happened count. */
+  public rendered(minute: number) {
+    this.lastRenderedMinute = minute;
+  }
+}

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -867,9 +867,21 @@ export function generateNewTimeline(
   customers: number,
   ticks = TICKS_PER_DAY,
 ): TickPresentFutureType[] {
-  // TODO performance optimization, figure out how to deep clone everything EXCEPT timeline, since I'm about to overwrite it
-  const state = cloneDeep(readOnlyState);
-  state.timeline = new Array(ticks) as TickPresentFutureType[];
+  // Everything below runs against a private copy, because reforecastSupply ramps generators and
+  // pays down loans by mutating the facilities it is handed. Only the facilities need the deep
+  // clone though: the timeline is overwritten on the very next line, and by the end of a long
+  // scenario the monthly history is hundreds of entries that nothing in the forecast reads.
+  // Deep cloning either of them was work thrown away, on a function that can run a year of
+  // simulation several times a second.
+  const state = {
+    ...readOnlyState,
+    facilities: cloneDeep(readOnlyState.facilities),
+    monthlyHistory: [] as MonthlyHistoryType[],
+    timeline: new Array(ticks) as TickPresentFutureType[],
+  };
+  // Loop invariant: the fleet is fixed across the horizon and the cash is a parameter, so this
+  // was the same number recomputed for every one of up to a year's worth of ticks
+  const netWorth = getNetWorth(state.facilities, cash);
   for (let i = 0; i < ticks; i++) {
     state.timeline[i] = {
       minute: state.date.minute + i * TICK_MINUTES,
@@ -880,7 +892,7 @@ export function generateNewTimeline(
       temperatureC: 0,
       cash,
       customers,
-      netWorth: getNetWorth(state.facilities, cash),
+      netWorth,
       revenue: 0,
       expensesFuel: 0,
       expensesOM: 0,


### PR DESCRIPTION
Profiled the running game at FAST speed with React's Profiler plus timers around the simulation internals, rather than guessing. The simulation was never the problem — `tickState` costs **0.28ms**. Rendering cost **7–130ms per tick** against a 10ms budget.

### Measuring

Both available browser surfaces report `visibilityState: "hidden"`, which freezes `rAF` and throttles `setTimeout` to ~5/sec, so the tick loop can't run at real speed. Worked around it with a virtual-clock harness: patch `performance.now()` with a controllable offset and drive `game/tick` through an unthrottled `MessageChannel`, so each dispatch advances exactly one game tick at full rate. Durations measured inside a task are unaffected by a constant offset, so `Profiler.actualDuration` and hand-placed timers stay accurate. All instrumentation was stripped before committing.

### What was slow

| | Cost | Why |
|---|---|---|
| `getSunriseSunset` | 17µs/call | Parses a date out of a template string and runs suncalc's full solar model. 74× more than every other forecast helper combined, and the forecast calls it twice per tick for up to a year of ticks. |
| `Finances.render()` | 52ms/render | Rebuilt a ~1150-tick year-ahead simulation every frame — two thirds of all render time — to redraw a line whose points can't move until the month does. |
| `GameCard` top bar | 2.76ms/tick | Re-renders every tick for the cash and clock, rebuilding five icon buttons and a `keepMounted` menu with them. 28% of the FAST budget. |
| `isDesktopScreen()` & friends | ~8 forced layouts/tick | Each reads `scrollWidth`, flushing layout, for a number that only changes on resize. |
| Facility rows | per row, per frame | Every row built a full closed `<Dialog>`, numbro formatting and all. |

### Changes

- **`getSunriseSunset` memoised** on month/year/lat/long — **16.97µs → 1.13µs**.
- **Finances chart series cached** on what can actually change it (month rollover, metric, year, sliders, fleet); `ChartFinances` is `React.memo` so the stable series skips the Victory subtree outright. The summary table underneath stays live every frame.
- **`GameCard` chrome memoised** — **2.76ms → 0.16ms per tick**.
- **Viewport width cached**, invalidated on resize.
- **`generateNewTimeline`** no longer deep-clones the timeline it's about to overwrite or the (unread, unbounded) monthly history, and hoists a loop-invariant `getNetWorth` out of its per-tick loop.
- **Supply/demand tooltip container** built once rather than per render.
- **Facility sell dialog** only mounted while open — 29% off the list render, scaling with fleet size.
- **New `TickThrottle`** replaces the `(minute / TICK_MINUTES) % N === 0` frame-skip test in Facilities and Finances. That test has a latent freeze bug: the tick action catches the simulation up several ticks at a time when a frame overruns, so the counter can step over every multiple of N and stall the pane for as long as the machine stays behind. Measuring elapsed game time is stride-independent.

### Results

FAST speed, 120 ticks, same protocol, dev build:

| Card | ms/tick before | after | p50 before → after | worst frame |
|---|---|---|---|---|
| Facilities | 13.4 | **10.2** | 6.2 → 1.8 | 92 → 85 |
| Finances | 136.7 | **8.1** | 84.8 → 7.3 | 662 → 49 |
| Forecasts | 7.5 | **3.2** | 4.4 → 1.8 | 277 → 151 |

Finances is **16.9× faster** and now fits inside the 10ms FAST budget instead of blowing it by 13×. The headless simulator runs all twelve scenarios in **1400ms rather than 3025ms**.

### Correctness

`npm run sim -- --all --seed 424242` gives byte-identical output before and after — every scenario's outcome, cash, unserved % and invariants match, so none of this moves the simulation. 126 tests, typecheck, lint and format all pass. Verified all three views, the speed controls, the game menu, building a generator and the sell dialog in the browser.

### Two deliberate behaviour changes

- The Finances chart refreshes on month rollover or player action rather than every frame. Forecasts already worked this way, and the chart plots monthly aggregates.
- The facility sell dialog no longer plays its fade-out, since it's only mounted while open.

### What's left

`ChartSupplyDemand` is now the biggest single cost at ~17ms a render, and it's **entirely inside Victory** — the data prep around it is 0.13ms. Dropping the cursor+voronoi tooltip container takes it to 9.3ms, but that's a real feature, so it stays. Getting past it means replacing Victory for that chart, which is a bigger change than this pass. It's throttled to 1-in-8 frames at FAST, so it costs ~25% of a core rather than saturating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
