### PR TITLE
Make hovered primary buttons readable again

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -46,7 +46,11 @@ export function withAlpha(hex: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-export const darkBlack = "0x000000";
+// What contained primary buttons darken to on hover. MUI passes this straight into a CSS custom
+// property, so it has to be a real CSS color: an invalid one drops the background to transparent
+// and leaves the light contrastText label sitting unreadable on the page behind it. blue800 also
+// clears 4.5:1 against that label, so hovering is the more legible of the two states.
+export const primaryDarkColor = blue[800];
 export const disabledColor = grey[100];
 export const interactiveColor = blue[600];
 export const blackoutColor = red[800]; // darker than red[500] so the translucent band reads on white
@@ -62,7 +66,7 @@ export default createTheme({
     primary: {
       light: disabledColor,
       main: supplyColor,
-      dark: darkBlack,
+      dark: primaryDarkColor,
       contrastText: grey[100],
     },
     secondary: amber,

--- a/src/app.scss
+++ b/src/app.scss
@@ -490,10 +490,6 @@ $topbar_height: 56px;
   right: 0;
 }
 
-.MuiButton-containedPrimary:hover {
-  background-color: #1976d2; /* blue600->700 on hover */
-}
-
 // for text inputs that are close to bottom, give the screen space to scroll up
 .inputSpacer {
   margin-bottom: 100%;


### PR DESCRIPTION
Hovering the Play button on the main menu made it unreadable — the button lost its background and its light grey label was left on the white card. It affects every contained primary button, not just Play.

## Cause

`palette.primary.dark` was `"0x000000"`, which is not a CSS color. MUI 9 passes that value into a custom property and then reads it back:

```css
@media (hover: hover){ .css-…-MuiButton-root:hover{ --variant-containedBg:0x000000; … } }
.css-…-MuiButton-root{ background-color: var(--variant-containedBg); color: var(--variant-containedColor); }
```

An invalid custom property value makes `background-color` invalid at computed-value time, so it falls back to `transparent`, while `--variant-containedColor` (grey100) keeps painting the label.

## Fix

- `primary.dark` is now `blue[800]` — a real color, darker than the resting `blue600` so hover still reads as a state change, and 5.2:1 against the grey100 label.
- Removed the `.MuiButton-containedPrimary:hover` rule from `app.scss`. It was trying to patch the same problem, but MUI 9 no longer emits that class (buttons carry `MuiButton-contained` + `MuiButton-colorPrimary`), so it never applied.

## Verification

Checked against the running dev server: the emitted hover rule now reads `--variant-containedBg:#1565c0`, and `0x000000` no longer appears in any stylesheet the app ships.

One thing this PR does not change: the resting state, `grey[100]` on `blue[600]`, is 3.5:1 — below the 4.5:1 that button text wants. Fixing that means moving `primary.main` or `contrastText`, which recolors the whole app, so it seemed worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
