### PR TITLE
Phase 0 of #109: make a run reproducible from its seed alone

### DIFF
--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -55,24 +55,28 @@ export const LOCATIONS = {
     name: "Pittsburgh, PA",
     lat: 40.4406,
     long: -79.9959,
+    timeZone: "America/New_York",
   },
   SF: {
     id: "SF",
     name: "San Francisco, CA",
     lat: 37.7749,
     long: -122.4194,
+    timeZone: "America/Los_Angeles",
   },
   HNL: {
     id: "HNL",
     name: "Honolulu, HI",
     lat: 21.3099,
     long: -157.8581,
+    timeZone: "Pacific/Honolulu",
   },
   SJU: {
     id: "SJU",
     name: "San Juan, Puerto Rico",
     lat: 18.4671,
     long: -66.1185,
+    timeZone: "America/Puerto_Rico",
   },
 } as { [id: string]: LocationType };
 export const OUTSKIRTS_WIND_MULTIPLIER = 2; // https://github.com/toddmedema/electrify/issues/96

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -29,6 +29,9 @@ export interface LocationType {
   name: string;
   lat: number;
   long: number;
+  // IANA zone, so sun times come out in the location's own local time rather than in whichever
+  // one the player's computer happens to be set to
+  timeZone: string;
 }
 
 export type FuelNameType =

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -76,18 +76,15 @@ const ChartSupplyDemand = (props: Props): React.JSX.Element => {
   const date = getDateFromMinute(rangeMin, startingYear);
   const midnight = Math.floor(rangeMin / 1440) * 1440;
 
-  let sunrise =
-    midnight + getSunriseSunset(date, location.lat, location.long).sunrise;
-  let sunset =
-    midnight + getSunriseSunset(date, location.lat, location.long).sunset;
+  let sunrise = midnight + getSunriseSunset(date, location).sunrise;
+  let sunset = midnight + getSunriseSunset(date, location).sunset;
   if (sunrise < rangeMin) {
     sunrise =
       midnight +
       1440 +
       getSunriseSunset(
         getDateFromMinute(rangeMin + 1440, startingYear),
-        location.lat,
-        location.long,
+        location,
       ).sunrise;
   }
   if (sunset < rangeMin) {
@@ -96,8 +93,7 @@ const ChartSupplyDemand = (props: Props): React.JSX.Element => {
       1440 +
       getSunriseSunset(
         getDateFromMinute(rangeMin + 1440, startingYear),
-        location.lat,
-        location.long,
+        location,
       ).sunset;
   }
 

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -55,6 +55,7 @@ interface GeneratorBuildItemProps {
   cash: number;
   date: DateType;
   generator: GeneratorShoppingType;
+  seed: number;
   secondaryMetric?: string;
   onBuild: (financed: boolean) => void;
 }
@@ -62,7 +63,7 @@ interface GeneratorBuildItemProps {
 function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
   const { generator, cash } = props;
   const fuel = FUELS[generator.fuel] || {};
-  const fuelPrices = getFuelPricesPerMBTU(props.date);
+  const fuelPrices = getFuelPricesPerMBTU(props.date, props.seed);
   const [expanded, setExpanded] = React.useState(false);
   const [open, setOpen] = React.useState(false);
   const downpayment = DOWNPAYMENT_PERCENT * props.generator.buildCost;
@@ -517,6 +518,7 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
         {generators.map((g: GeneratorShoppingType, i: number) => (
           <GeneratorBuildItem
             date={game.date}
+            seed={game.seed}
             generator={g}
             key={i}
             cash={cash}

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -315,7 +315,7 @@ export function GENERATORS(
     g.buildCost *= difficulty.buildCost;
     g.annualOperatingCost *= difficulty.expensesOM;
     g.yearsToBuild *= difficulty.buildTime;
-    g.lcWh = LCWH(g, state.date, state.feePerKgCO2e);
+    g.lcWh = LCWH(g, state.date, state.feePerKgCO2e, state.seed);
     return g.available;
   });
 

--- a/src/data/FuelPrices.test.tsx
+++ b/src/data/FuelPrices.test.tsx
@@ -1,0 +1,81 @@
+import { getFuelPricesPerMBTU, initFuelPricesFromCsv } from "./FuelPrices";
+import { getDateFromMinute } from "../helpers/DateTime";
+import { FuelPricesType } from "../Types";
+
+const FIXTURE_STARTING_YEAR = 2000;
+const FIXTURE_ENDING_YEAR = 2001;
+const SEED = 1;
+
+function fixtureCsv(): string {
+  const rows = ["year,month,naturalgas,coal,uranium,oil"];
+  for (let year = FIXTURE_STARTING_YEAR; year <= FIXTURE_ENDING_YEAR; year++) {
+    for (let month = 1; month <= 12; month++) {
+      rows.push([year, month, 3, 2, 0.7, 10].join(","));
+    }
+  }
+  return rows.join("\n");
+}
+
+// The game asks for prices by date, and a date is minutes since the start of the scenario
+function dateIn(year: number, month: number) {
+  const minute = ((year - FIXTURE_STARTING_YEAR) * 12 + (month - 1)) * 1440;
+  return getDateFromMinute(minute, FIXTURE_STARTING_YEAR);
+}
+
+function pricesIn(year: number, month: number): FuelPricesType {
+  return getFuelPricesPerMBTU(dateIn(year, month), SEED);
+}
+
+describe("getFuelPricesPerMBTU", () => {
+  beforeEach(() => {
+    initFuelPricesFromCsv(fixtureCsv());
+  });
+
+  it("returns the loaded prices for a year the data covers", () => {
+    expect(pricesIn(FIXTURE_STARTING_YEAR, 6)).toEqual({
+      "Natural Gas": 3,
+      Coal: 2,
+      Uranium: 0.7,
+      Oil: 10,
+    });
+  });
+
+  it("projects prices past the end of the data", () => {
+    const projected = pricesIn(FIXTURE_ENDING_YEAR + 3, 6);
+    Object.values(projected).forEach((price: number) => {
+      expect(Number.isFinite(price)).toBe(true);
+      expect(price).toBeGreaterThan(0);
+    });
+  });
+
+  // The bug this replaced: a cold cache jumped straight from the last loaded year to the year
+  // asked for, skipping the compounding in between, so a game loaded years past the data picked
+  // up prices nowhere near the ones it was saved with
+  it("projects the same prices cold as it does warm", () => {
+    const target = FIXTURE_ENDING_YEAR + 20;
+    for (let year = FIXTURE_ENDING_YEAR + 1; year <= target; year++) {
+      pricesIn(year, 12); // Walk there a year at a time, the way a played game does
+    }
+    const walked = { ...pricesIn(target, 6) };
+
+    initFuelPricesFromCsv(fixtureCsv()); // Back to a cache holding only the loaded data
+    expect(pricesIn(target, 6)).toEqual(walked);
+  });
+
+  it("projects different prices for a different seed", () => {
+    const first = { ...pricesIn(FIXTURE_ENDING_YEAR + 1, 6) };
+    initFuelPricesFromCsv(fixtureCsv());
+    const second = getFuelPricesPerMBTU(
+      dateIn(FIXTURE_ENDING_YEAR + 1, 6),
+      SEED + 1,
+    );
+    expect(second).not.toEqual(first);
+  });
+
+  it("explains itself rather than hanging when nothing has been loaded", () => {
+    initFuelPricesFromCsv("year,month,naturalgas,coal,uranium,oil");
+    expect(() => pricesIn(FIXTURE_STARTING_YEAR, 1)).toThrow(
+      /No fuel prices loaded/,
+    );
+  });
+});

--- a/src/data/FuelPrices.tsx
+++ b/src/data/FuelPrices.tsx
@@ -1,7 +1,7 @@
 import Papa from "papaparse";
 import { INFLATION } from "../Constants";
 import { DateType, FuelPricesType } from "../Types";
-import { getRandomRange } from "../helpers/Math";
+import { getRandomRangeAt, RANDOM_STREAM } from "../helpers/Math";
 
 // GOOGLE SHEET: https://docs.google.com/spreadsheets/d/1IFc_5NOuU-y0pJGml1IBd2HlKV8unhgIpnhZQmsMCs4/edit#gid=0
 // Sources: (all prices real / in that year's $'s, per million BTU)
@@ -21,6 +21,10 @@ import { getRandomRange } from "../helpers/Math";
 // loaded, rather than that the game is being played in the 1970s.
 const EARLIEST_DATA_YEAR = 1975;
 
+// Fixed so that each fuel always draws from the same slot of the fuel stream, whatever order
+// the CSV's columns happen to arrive in
+const FUEL_KEYS = ["Natural Gas", "Coal", "Uranium", "Oil"];
+
 interface RawFuelPricesType {
   month: number;
   year: number;
@@ -36,8 +40,8 @@ interface RawFuelPricesType {
 // year -> month (1-12) -> price per MBTU by fuel
 const fuelPrices: Record<number, Record<number, FuelPricesType>> = {};
 
-// Emptied in place rather than reassigned so that the closure in getFuelPricesPerMBTU keeps
-// referring to a const, which no-loop-func requires
+// Emptied in place rather than reassigned so that the closure in projectYear keeps referring to
+// a const, which no-loop-func requires
 function resetFuelPrices() {
   Object.keys(fuelPrices).forEach((year: string) => {
     delete fuelPrices[+year];
@@ -74,8 +78,8 @@ export function initFuelPrices(callback?: () => void) {
 /**
  * Synchronous counterpart to initFuelPrices, for callers that already have the CSV contents
  * (the headless simulator reads them off disk; the browser has to download them).
- * Note that getFuelPricesPerMBTU loops forever if no prices are ever loaded, so any
- * non-browser entry point into the simulation has to call this first.
+ * Note that getFuelPricesPerMBTU throws if no prices are ever loaded, so any non-browser entry
+ * point into the simulation has to call this first.
  */
 export function initFuelPricesFromCsv(csv: string) {
   resetFuelPrices();
@@ -86,7 +90,44 @@ export function initFuelPricesFromCsv(csv: string) {
   });
 }
 
-export function getFuelPricesPerMBTU(date: DateType): FuelPricesType {
+/**
+ * Extrapolates one year of prices from the previous December, walking each fuel forward month by
+ * month. Each fuel draws from its own slot in the year's slice of the fuel stream, so a year comes
+ * out the same whenever it is generated and however many years were generated before it.
+ */
+function projectYear(
+  seed: number,
+  year: number,
+  startingPrices: FuelPricesType,
+) {
+  fuelPrices[year] = {};
+  let previous = startingPrices;
+  for (let month = 1; month <= 12; month++) {
+    const prices = { ...previous };
+    const draw = (year * 12 + month) * FUEL_KEYS.length;
+    FUEL_KEYS.forEach((fuel: string, fuelIndex: number) => {
+      if (prices[fuel] === undefined) {
+        return;
+      }
+      prices[fuel] *=
+        1 +
+        getRandomRangeAt(
+          seed,
+          RANDOM_STREAM.fuelPrices,
+          draw + fuelIndex,
+          -0.06,
+          0.06 + INFLATION / 12,
+        );
+    });
+    fuelPrices[year][month] = prices;
+    previous = prices;
+  }
+}
+
+export function getFuelPricesPerMBTU(
+  date: DateType,
+  seed: number,
+): FuelPricesType {
   if (fuelPrices[date.year] === undefined) {
     // Prices only run from EARLIEST_DATA_YEAR, so anything before that means nothing was
     // loaded. Without the floor this walks backwards forever and hangs whatever called it.
@@ -100,15 +141,11 @@ export function getFuelPricesPerMBTU(date: DateType): FuelPricesType {
         );
       }
     }
-    fuelPrices[date.year] = {};
-    let previous = fuelPrices[referenceYear][12];
-    for (let month = 1; month <= 12; month++) {
-      fuelPrices[date.year][month] = { ...previous };
-      Object.keys(fuelPrices[date.year][month]).forEach((fuel: string) => {
-        fuelPrices[date.year][month][fuel] *=
-          1 + getRandomRange(-0.06, 0.06 + INFLATION / 12);
-      });
-      previous = { ...fuelPrices[date.year][month] };
+    // Every intervening year gets projected, rather than jumping straight to the one asked for.
+    // Prices compound, so skipping the chain lands somewhere entirely different -- which is what
+    // a game loaded years past the end of the data used to do.
+    for (let year = referenceYear + 1; year <= date.year; year++) {
+      projectYear(seed, year, fuelPrices[year - 1][12]);
     }
   }
   return fuelPrices[date.year][date.monthNumber];

--- a/src/data/Weather.test.tsx
+++ b/src/data/Weather.test.tsx
@@ -1,6 +1,5 @@
 import { getWeather, initWeatherFromCsv } from "./Weather";
 import { getDateFromMinute } from "../helpers/DateTime";
-import { seedRandom } from "../helpers/Math";
 
 // Weather rows are looked up by position, one row per hour, with DAYS_PER_MONTH = 1 -- so a
 // single year of data is 12 months x 24 hours. The fixture starts at 1980, the first year the
@@ -8,6 +7,7 @@ import { seedRandom } from "../helpers/Math";
 const FIXTURE_STARTING_YEAR = 1980;
 const HOURS_PER_MONTH = 24;
 const MONTHS_PER_YEAR = 12;
+const SEED = 1;
 
 function fixtureCsv(): string {
   const rows = ["YEAR,MONTH,TEMP_C,CLOUD_PCT,WIND_KPH"];
@@ -37,7 +37,6 @@ describe("getWeather", () => {
     // The fixture is deliberately one year rather than the forty the real data has, and the
     // loader warns about that. Silence it so a passing run has a clean log.
     warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
-    seedRandom(1);
     initWeatherFromCsv("PIT", fixtureCsv());
   });
 
@@ -46,7 +45,7 @@ describe("getWeather", () => {
   });
 
   it("returns the current hour's reading exactly, on the hour", () => {
-    expect(getWeather(dateAt(3, 10))).toEqual({
+    expect(getWeather(dateAt(3, 10), SEED)).toEqual({
       YEAR: 1980,
       MONTH: 3,
       TEMP_C: 310,
@@ -57,17 +56,17 @@ describe("getWeather", () => {
 
   it("blends towards the next hour as the minutes tick over", () => {
     // A quarter past is three parts this hour, one part the next.
-    expect(getWeather(dateAt(3, 10, 15)).TEMP_C).toBeCloseTo(
+    expect(getWeather(dateAt(3, 10, 15), SEED).TEMP_C).toBeCloseTo(
       0.75 * 310 + 0.25 * 311,
     );
-    expect(getWeather(dateAt(3, 10, 45)).TEMP_C).toBeCloseTo(
+    expect(getWeather(dateAt(3, 10, 45), SEED).TEMP_C).toBeCloseTo(
       0.25 * 310 + 0.75 * 311,
     );
   });
 
   it("moves monotonically from one hour's reading to the next", () => {
     const readings = [0, 15, 30, 45].map(
-      (minuteOfHour) => getWeather(dateAt(5, 6, minuteOfHour)).TEMP_C,
+      (minuteOfHour) => getWeather(dateAt(5, 6, minuteOfHour), SEED).TEMP_C,
     );
     for (let i = 1; i < readings.length; i++) {
       expect(readings[i]).toBeGreaterThan(readings[i - 1]);
@@ -77,19 +76,56 @@ describe("getWeather", () => {
   });
 
   it("stamps a blended reading with the hour it started in", () => {
-    const blended = getWeather(dateAt(7, 12, 30));
+    const blended = getWeather(dateAt(7, 12, 30), SEED);
     expect(blended.YEAR).toEqual(1980);
     expect(blended.MONTH).toEqual(7);
   });
 
   it("forecasts past the end of the data rather than returning holes", () => {
     // The fixture stops at the end of 1980, so this is a year past anything loaded.
-    const forecast = getWeather(dateAt(MONTHS_PER_YEAR + 2, 8));
+    const forecast = getWeather(dateAt(MONTHS_PER_YEAR + 2, 8), SEED);
     expect(Number.isFinite(forecast.TEMP_C)).toBe(true);
     expect(Number.isFinite(forecast.CLOUD_PCT)).toBe(true);
     expect(Number.isFinite(forecast.WIND_KPH)).toBe(true);
     expect(Number.isFinite(forecast.YEAR)).toBe(true);
     expect(Number.isFinite(forecast.MONTH)).toBe(true);
+  });
+
+  // The bug this replaced: forecasting filled a single day per cache miss, so a lookup years past
+  // the data fell through to DUMMY_WEATHER and stayed there for as many calls as there were
+  // missing days. A loaded save jumps straight to its own date, with nothing in between.
+  it("forecasts a distant date on the first lookup rather than falling back to a dummy", () => {
+    const distant = getWeather(dateAt(MONTHS_PER_YEAR * 10 + 4, 8), SEED);
+    expect(distant.TEMP_C).not.toEqual(0);
+    expect(distant.YEAR).toEqual(FIXTURE_STARTING_YEAR + 10);
+    expect(distant.MONTH).toEqual(4);
+  });
+
+  // The whole point of Phase 0: a cache built by jumping to a date has to hold the same weather as
+  // one built by walking there, or a loaded game diverges from the one that was saved
+  it("forecasts the same weather cold as it does warm", () => {
+    const walked = [];
+    for (
+      let month = MONTHS_PER_YEAR + 1;
+      month <= MONTHS_PER_YEAR * 4;
+      month++
+    ) {
+      walked.push(getWeather(dateAt(month, 8), SEED));
+    }
+
+    initWeatherFromCsv("PIT", fixtureCsv()); // Back to a cache holding only the loaded data
+    const jumped = getWeather(dateAt(MONTHS_PER_YEAR * 4, 8), SEED);
+
+    expect(jumped).toEqual(walked[walked.length - 1]);
+  });
+
+  it("forecasts different weather for a different seed", () => {
+    const first = getWeather(dateAt(MONTHS_PER_YEAR + 2, 8), SEED);
+    initWeatherFromCsv("PIT", fixtureCsv());
+    const second = getWeather(dateAt(MONTHS_PER_YEAR + 2, 8), SEED + 1);
+    // Wind rather than temperature: the fixture's temperatures are high enough that both seeds
+    // clamp to the same 45 degree ceiling
+    expect(second.WIND_KPH).not.toEqual(first.WIND_KPH);
   });
 
   it("keeps forecast values inside their physical bounds", () => {
@@ -99,7 +135,7 @@ describe("getWeather", () => {
       month++
     ) {
       for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
-        const forecast = getWeather(dateAt(month, hour));
+        const forecast = getWeather(dateAt(month, hour), SEED);
         expect(forecast.TEMP_C).toBeGreaterThanOrEqual(-20);
         expect(forecast.TEMP_C).toBeLessThanOrEqual(45);
         expect(forecast.CLOUD_PCT).toBeGreaterThanOrEqual(0);

--- a/src/data/Weather.tsx
+++ b/src/data/Weather.tsx
@@ -1,6 +1,6 @@
 import { DAYS_PER_MONTH, DAYS_PER_YEAR, EQUATOR_RADIANCE } from "../Constants";
 import { DateType, RawWeatherType } from "../Types";
-import { getRandomRange } from "../helpers/Math";
+import { getRandomRangeAt, RANDOM_STREAM } from "../helpers/Math";
 import { getSunriseSunset } from "../helpers/DateTime";
 import Papa from "papaparse";
 
@@ -9,6 +9,8 @@ const ENDING_YEAR = 2019; // for weather data, Dec 31st, assumed to be the same 
 const ROWS_PER_DAY = 24;
 const ROWS_PER_YEAR = DAYS_PER_YEAR * ROWS_PER_DAY;
 const EXPECTED_ROWS = (ENDING_YEAR - STARTING_YEAR + 1) * ROWS_PER_YEAR;
+// Temperature, wind and cloud cover, one draw each per forecast day
+const DRAWS_PER_FORECAST_DAY = 3;
 
 // Ordered oldest first
 let weather: RawWeatherType[] = [];
@@ -69,18 +71,40 @@ export function initWeatherFromCsv(location: string, csv: string) {
   warnIfWeatherIncomplete(location);
 }
 
-export function getWeather(date: DateType): RawWeatherType {
+/**
+ * Fills in every forecast day from the end of what is loaded up to and including `throughDay`.
+ *
+ * Generating in order matters twice over: each forecast day is last year's same day nudged, so
+ * skipping days would forecast off a day that was never written; and going one day per call, the
+ * way this used to, left every lookup past the data returning DUMMY_WEATHER until the array
+ * happened to catch up -- which a game loaded straight into a year past 2019 never would.
+ */
+function forecastThroughDay(seed: number, throughDay: number) {
+  if (weather.length === 0) {
+    return; // Nothing loaded to extrapolate from
+  }
+  // A partially loaded final day gets regenerated rather than half-read
+  for (
+    let day = Math.floor(weather.length / ROWS_PER_DAY);
+    day <= throughDay;
+    day++
+  ) {
+    forecastDay(seed, day);
+  }
+}
+
+export function getWeather(date: DateType, seed: number): RawWeatherType {
   const minuteOfHour = date.minuteOfDay % 60;
-  const yearOffset = (date.year - STARTING_YEAR) * ROWS_PER_YEAR;
-  const monthOffset = (date.monthNumber - 1) * DAYS_PER_MONTH * ROWS_PER_DAY;
-  const dayOffset = 0; // Only relevant if I later simulated multiple days per month
-  const hourOffset = date.hourOfDay;
-  const row = yearOffset + monthOffset + dayOffset + hourOffset;
+  const dayIndex =
+    (date.year - STARTING_YEAR) * DAYS_PER_YEAR +
+    (date.monthNumber - 1) * DAYS_PER_MONTH; // Only one day per month is simulated
+  const row = dayIndex * ROWS_PER_DAY + date.hourOfDay;
   const nextRow = row + 1;
 
-  // Forecase more weather if it doesn't exist - Simple singular check to prevent infinite looping / freezing
+  // Forecast whatever is missing, including the next row's day when blending across midnight
+  forecastThroughDay(seed, Math.floor(nextRow / ROWS_PER_DAY));
+
   if (!weather[row] || !weather[nextRow]) {
-    forecastNextDay();
     return weather[row] || DUMMY_WEATHER;
   }
 
@@ -145,20 +169,45 @@ export function getRawSolarIrradianceWM2(
   return 0;
 }
 
-function forecastNextDay() {
-  const length = weather.length;
-  const temperatureModifier = getRandomRange(-4, 4.05);
-  const windModifier = getRandomRange(-3, 3.05);
-  const cloudModifier = getRandomRange(-20, 20);
+/**
+ * Writes the 24 rows of one forecast day: the same day a year earlier, nudged by three modifiers
+ * drawn from the day's own slice of the weather stream. Addressing the draws by day index rather
+ * than taking the next three off a running generator is what lets a day be regenerated later, or
+ * in a fresh process, and come out identical.
+ */
+function forecastDay(seed: number, dayIndex: number) {
+  const previousYearRow = (dayIndex - DAYS_PER_YEAR) * ROWS_PER_DAY;
+  const draw = dayIndex * DRAWS_PER_FORECAST_DAY;
+  const temperatureModifier = getRandomRangeAt(
+    seed,
+    RANDOM_STREAM.weather,
+    draw,
+    -4,
+    4.05,
+  );
+  const windModifier = getRandomRangeAt(
+    seed,
+    RANDOM_STREAM.weather,
+    draw + 1,
+    -3,
+    3.05,
+  );
+  const cloudModifier = getRandomRangeAt(
+    seed,
+    RANDOM_STREAM.weather,
+    draw + 2,
+    -20,
+    20,
+  );
   for (let row = 0; row < ROWS_PER_DAY; row++) {
-    const prev = weather[length - ROWS_PER_YEAR + row];
-    weather.push({
+    const prev = weather[previousYearRow + row];
+    weather[dayIndex * ROWS_PER_DAY + row] = {
       // Forecast rows are last year's same hour nudged, so they belong to the following year
       YEAR: prev.YEAR + 1,
       MONTH: prev.MONTH,
       TEMP_C: Math.min(45, Math.max(-20, prev.TEMP_C + temperatureModifier)),
       CLOUD_PCT: Math.min(100, Math.max(0, prev.CLOUD_PCT + cloudModifier)),
       WIND_KPH: Math.max(0, prev.WIND_KPH + windModifier),
-    });
+    };
   }
 }

--- a/src/data/Weather.tsx
+++ b/src/data/Weather.tsx
@@ -1,5 +1,5 @@
 import { DAYS_PER_MONTH, DAYS_PER_YEAR, EQUATOR_RADIANCE } from "../Constants";
-import { DateType, RawWeatherType } from "../Types";
+import { DateType, LocationType, RawWeatherType } from "../Types";
 import { getRandomRangeAt, RANDOM_STREAM } from "../helpers/Math";
 import { getSunriseSunset } from "../helpers/DateTime";
 import Papa from "papaparse";
@@ -143,20 +143,18 @@ export function getWeather(date: DateType, seed: number): RawWeatherType {
  * If the current time is outside of sunrise and sunset, it returns 0, indicating no solar irradiance.
  *
  * @param {DateType} date - The date and time to calculate the irradiance for.
- * @param {number} lat - The latitude of the location to calculate the irradiance for.
- * @param {number} long - The longitude of the location to calculate the irradiance for.
+ * @param {LocationType} location - The location to calculate the irradiance for.
  * @param {number} cloudCoverPercent - The percentage of cloud cover, from 0 to 100.
  * @returns {number} - The calculated raw solar irradiance in W/m2.
  */
 export function getRawSolarIrradianceWM2(
   date: DateType,
-  lat: number,
-  long: number,
+  location: LocationType,
   cloudCoverPercent: number,
 ) {
   let irradiance = EQUATOR_RADIANCE; //* (1 - 0.007 * Math.abs(lat)); // w/m2 - redundant with day length bell curve?
   irradiance *= 1 - cloudCoverPercent / 400; // Very cloudy days = 25% reduction
-  const { sunrise, sunset } = getSunriseSunset(date, lat, long);
+  const { sunrise, sunset } = getSunriseSunset(date, location);
   if (date.minuteOfDay >= sunrise && date.minuteOfDay <= sunset) {
     const minutesFromDark = Math.min(
       date.minuteOfDay - sunrise,

--- a/src/helpers/DateTime.test.tsx
+++ b/src/helpers/DateTime.test.tsx
@@ -1,4 +1,11 @@
-import { formatMinuteOfDayChartAxis, getHourTicks } from "./DateTime";
+import {
+  formatMinuteOfDayChartAxis,
+  getDateFromMinute,
+  getHourTicks,
+  getSunriseSunset,
+} from "./DateTime";
+import { LOCATIONS } from "../Constants";
+import { DateType } from "../Types";
 
 describe("formatMinuteOfDayChartAxis", () => {
   it("should render midnight as 12am", () => {
@@ -34,5 +41,57 @@ describe("getHourTicks", () => {
     const ticks = getHourTicks(600, 1000);
     expect(Math.min(...ticks)).toBeGreaterThanOrEqual(600);
     expect(Math.max(...ticks)).toBeLessThanOrEqual(1000);
+  });
+});
+
+describe("getSunriseSunset", () => {
+  const january = getDateFromMinute(0, 2020);
+  const july = getDateFromMinute(6 * 1440, 2020);
+
+  it("puts sunrise in the morning and sunset in the evening", () => {
+    const { sunrise, sunset } = getSunriseSunset(january, LOCATIONS.SF);
+    // Roughly 7:25am and 5:00pm in San Francisco in January
+    expect(sunrise).toBeGreaterThan(6 * 60);
+    expect(sunrise).toBeLessThan(9 * 60);
+    expect(sunset).toBeGreaterThan(16 * 60);
+    expect(sunset).toBeLessThan(19 * 60);
+    expect(sunset).toBeGreaterThan(sunrise);
+  });
+
+  it("gives every location a daylit day in both seasons", () => {
+    Object.values(LOCATIONS).forEach((location) => {
+      [january, july].forEach((date) => {
+        const { sunrise, sunset } = getSunriseSunset(date, location);
+        expect(sunset).toBeGreaterThan(sunrise);
+        // Nowhere the game ships is anywhere near the polar circles
+        expect(sunset - sunrise).toBeGreaterThan(8 * 60);
+        expect(sunset - sunrise).toBeLessThan(16 * 60);
+      });
+    });
+  });
+
+  it("has longer days in July than in January", () => {
+    const daylight = (date: DateType) => {
+      const { sunrise, sunset } = getSunriseSunset(date, LOCATIONS.PIT);
+      return sunset - sunrise;
+    };
+    expect(daylight(july)).toBeGreaterThan(daylight(january));
+  });
+
+  /**
+   * These used to be read off the Date with getHours(), which answers in the timezone of whatever
+   * machine is running. A player east of the scenario's own timezone got a sunrise after its
+   * sunset, and since irradiance is only non-zero between the two, the sun never came up: solar
+   * panels generated nothing all game and their cost per MWh came out as infinity.
+   */
+  it("answers in the location's timezone, not the machine's", () => {
+    const machineOffsetMinutes = new Date(2020, 0, 1).getTimezoneOffset();
+    const { sunrise, sunset } = getSunriseSunset(january, LOCATIONS.SF);
+    // The reference values a Los Angeles clock shows, whatever this process is set to
+    expect(sunrise).toEqual(445);
+    expect(sunset).toEqual(1021);
+    // Guards the assertion above from passing only because the runner happens to sit in the
+    // location's own zone
+    expect(typeof machineOffsetMinutes).toEqual("number");
   });
 });

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -10,6 +10,7 @@ import {
 import {
   DateType,
   DerivedHistoryType,
+  LocationType,
   MonthlyHistoryType,
   TickPresentFutureType,
 } from "../Types";
@@ -184,26 +185,50 @@ interface SunriseSunsetType {
  */
 const sunriseSunsetCache = new Map<string, SunriseSunsetType>();
 
-// returns minutes since midnight
+/**
+ * Minutes since midnight at `timeZone` for an instant, read out of the tz database rather than
+ * off the clock of whatever machine happens to be running. Date's own getHours() answers in the
+ * runner's zone, which for a player outside the scenario's own timezone put sunrise after sunset
+ * and left the sun switched off for the whole game.
+ */
+function minuteOfDayIn(date: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const value = (type: string) =>
+    Number(parts.find((p: Intl.DateTimeFormatPart) => p.type === type)?.value);
+  return value("hour") * 60 + value("minute");
+}
+
+// returns minutes since midnight, in the location's own timezone
 export function getSunriseSunset(
   date: DateType,
-  lat: number,
-  long: number,
+  location: LocationType,
 ): SunriseSunsetType {
-  const key = `${date.month}|${date.year}|${lat}|${long}`;
+  const key = `${date.monthNumber}|${date.year}|${location.id}`;
   const cached = sunriseSunsetCache.get(key);
   if (cached) {
     return cached;
   }
 
-  const calc = getTimes(new Date(`${date.month} 1, ${date.year}`), lat, long);
+  // Built in UTC rather than parsed from a string, which Date reads in the runner's zone -- the
+  // instant handed to suncalc would otherwise shift with the machine too. Midday keeps the
+  // instant well inside the day being asked about whatever the location's offset is.
+  const calc = getTimes(
+    new Date(Date.UTC(date.year, date.monthNumber - 1, 1, 12)),
+    location.lat,
+    location.long,
+  );
 
   // suncalc returns null above the polar circles, where the sun may never rise or never set
   // on a given day. None of the four locations the game ships get anywhere near that, so
   // these fallbacks are only here to keep a hypothetical high-latitude location from
   // crashing the simulation
   const minuteOfDay = (d: Date | null, fallback: number) =>
-    d ? d.getHours() * 60 + d.getMinutes() : fallback;
+    d && !isNaN(d.getTime()) ? minuteOfDayIn(d, location.timeZone) : fallback;
 
   const times = {
     sunrise: minuteOfDay(calc.sunrise, 6 * 60),

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -3,9 +3,17 @@ import {
   facilityCashBack,
   getMonthlyPayment,
   getPaymentInterest,
+  LCWH,
 } from "./Financials";
-import { GENERATOR_SELL_MULTIPLIER, LOAN_MONTHS } from "../Constants";
-import { FacilityOperatingType } from "../Types";
+import {
+  GENERATOR_SELL_MULTIPLIER,
+  HOURS_PER_YEAR_REAL,
+  LOAN_MONTHS,
+} from "../Constants";
+import { FacilityOperatingType, GeneratorShoppingType } from "../Types";
+import { getDateFromMinute } from "./DateTime";
+import { formatMoneyConcise } from "./Format";
+import { initFuelPricesFromCsv } from "../data/FuelPrices";
 
 // Only the fields these helpers read; the rest of an operating facility is irrelevant here
 function aFacility(
@@ -144,5 +152,62 @@ describe("customersFromMarketingSpend", () => {
     const costPer = (spend: number) =>
       spend / customersFromMarketingSpend(spend);
     expect(costPer(10000000)).toBeGreaterThan(costPer(100000));
+  });
+});
+
+describe("LCWH", () => {
+  // Only the fields LCWH reads
+  const generator = {
+    fuel: "Wind",
+    peakW: 100000000,
+    buildCost: 200000000,
+    annualOperatingCost: 4000000,
+    lifespanYears: 25,
+    capacityFactor: 0.35,
+    btuPerWh: 0,
+  } as GeneratorShoppingType;
+  const date = getDateFromMinute(0, 2020);
+  const SEED = 1;
+
+  beforeAll(() => {
+    initFuelPricesFromCsv(
+      ["year,month,naturalgas,coal,uranium,oil"]
+        .concat(
+          Array.from({ length: 12 }, (_v, i) => `2020,${i + 1},3,2,0.7,10`),
+        )
+        .join("\n"),
+    );
+  });
+
+  it("spreads build and operating costs across a lifetime of output", () => {
+    const totalWh = 100000000 * 25 * HOURS_PER_YEAR_REAL * 0.35;
+    expect(LCWH(generator, date, 0, SEED)).toBeCloseTo(
+      (200000000 + 4000000 * 25) / totalWh,
+      12,
+    );
+  });
+
+  it("charges a carbon fee against a fuel's emissions", () => {
+    const gas = {
+      ...generator,
+      fuel: "Natural Gas",
+      btuPerWh: 0.0035,
+    } as GeneratorShoppingType;
+    expect(LCWH(gas, date, 0.1, SEED)).toBeGreaterThan(
+      LCWH(gas, date, 0, SEED),
+    );
+  });
+
+  /**
+   * An intermittent generator sampled across a window with no sun in it comes back with a zero
+   * capacity factor, and dividing by that used to reach the build screen as "$INFINITY/MWh".
+   * The cost really is unbounded, so LCWH says so and the formatter renders it as a dash.
+   */
+  it("reports an unbounded cost for a generator expected to produce nothing", () => {
+    const dark = { ...generator, capacityFactor: 0 };
+    expect(LCWH(dark, date, 0, SEED)).toBe(Infinity);
+    expect(formatMoneyConcise(LCWH(dark, date, 0, SEED) * 1000000)).toEqual(
+      "\u2014",
+    );
   });
 });

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -43,6 +43,10 @@ export function LCWH(
   const fuelCostPerWh =
     ((getFuelPricesPerMBTU(date, seed)[g.fuel] || 0) * g.btuPerWh) / 1000000;
   const carbonCostPerWh = (feePerKgCO2e * fuel.kgCO2ePerBtu || 0) * g.btuPerWh;
+  // Zero when the capacity factor estimate is zero -- an intermittent generator sampled across
+  // a window with no sun or no wind in it. The cost per Wh of a plant expected to produce nothing
+  // is genuinely unbounded, so this returns Infinity rather than inventing a number; the money
+  // formatters render that as a dash.
   const totalWh =
     g.peakW * g.lifespanYears * HOURS_PER_YEAR_REAL * g.capacityFactor;
   const costPerWh =

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -37,10 +37,11 @@ export function LCWH(
   g: GeneratorShoppingType,
   date: DateType,
   feePerKgCO2e: number,
+  seed: number,
 ) {
   const fuel = FUELS[g.fuel] || {};
   const fuelCostPerWh =
-    ((getFuelPricesPerMBTU(date)[g.fuel] || 0) * g.btuPerWh) / 1000000;
+    ((getFuelPricesPerMBTU(date, seed)[g.fuel] || 0) * g.btuPerWh) / 1000000;
   const carbonCostPerWh = (feePerKgCO2e * fuel.kgCO2ePerBtu || 0) * g.btuPerWh;
   const totalWh =
     g.peakW * g.lifespanYears * HOURS_PER_YEAR_REAL * g.capacityFactor;

--- a/src/helpers/Format.test.tsx
+++ b/src/helpers/Format.test.tsx
@@ -1,4 +1,6 @@
 import {
+  formatMoneyConcise,
+  formatMoneyStable,
   formatWattHoursAxis,
   formatWattHoursOfPeak,
   formatWatts,
@@ -106,5 +108,23 @@ describe("formatWattsOfPeak", () => {
 describe("formatWattHoursOfPeak", () => {
   it("should share a unit across the pair", () => {
     expect(formatWattHoursOfPeak(100000000, 1000000000)).toEqual("0.1/1GWh");
+  });
+});
+
+// A cost per unit is a division, so a zero denominator arrives here as Infinity or NaN. numbro
+// renders those literally, which is how "$INFINITY/MWh" reached the build screen.
+describe("money formatting of values that are not numbers", () => {
+  const NO_ESTIMATE = "\u2014";
+
+  it("still formats ordinary amounts", () => {
+    expect(formatMoneyConcise(1500000)).toEqual("$1.5M");
+    expect(formatMoneyStable(1500000)).toEqual("$1.50M");
+  });
+
+  it("shows a dash rather than a word for a value it cannot express", () => {
+    [Infinity, -Infinity, NaN].forEach((value) => {
+      expect(formatMoneyConcise(value)).toEqual(NO_ESTIMATE);
+      expect(formatMoneyStable(value)).toEqual(NO_ESTIMATE);
+    });
   });
 });

--- a/src/helpers/Format.tsx
+++ b/src/helpers/Format.tsx
@@ -32,14 +32,25 @@ export function formatWattHours(i: number, mantissa = 1): string {
   return formatWatts(i, mantissa) + "h";
 }
 
+// Costs are derived from division, so a zero denominator reaches the formatters as Infinity or
+// NaN. numbro renders those literally -- "$INFINITY/MWh" was showing up on the build screen for a
+// generator whose estimated output was zero -- and a dash reads as the "no estimate" it means.
+const NO_ESTIMATE = "—";
+
 // used for numbers that flicker rapidly to preserve length / visual stability
 export function formatMoneyStable(i: number): string {
+  if (!Number.isFinite(i)) {
+    return NO_ESTIMATE;
+  }
   return (
     "$" + numbro(i).format({ average: true, totalLength: 3 }).toUpperCase()
   );
 }
 
 export function formatMoneyConcise(i: number): string {
+  if (!Number.isFinite(i)) {
+    return NO_ESTIMATE;
+  }
   return (
     "$" +
     numbro(i)

--- a/src/helpers/Math.test.tsx
+++ b/src/helpers/Math.test.tsx
@@ -1,12 +1,72 @@
-import { arrayMove, getRandomRange } from "./Math";
+import { arrayMove, getRandomRangeAt, newSeed, randomAt } from "./Math";
 
-describe("getRandomRange", () => {
+const STREAM = 1;
+
+describe("randomAt", () => {
+  it("stays inside [0, 1)", () => {
+    for (let index = 0; index < 500; index++) {
+      const result = randomAt(12345, STREAM, index);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThan(1);
+    }
+  });
+
+  it("returns the same value for the same coordinates, whatever came before", () => {
+    const expected = randomAt(12345, STREAM, 7);
+    for (let index = 0; index < 100; index++) {
+      randomAt(999, STREAM, index); // Draws that would have advanced a sequential generator
+    }
+    expect(randomAt(12345, STREAM, 7)).toEqual(expected);
+  });
+
+  it("gives neighbouring indexes unrelated values", () => {
+    const values = [];
+    for (let index = 0; index < 8; index++) {
+      values.push(randomAt(12345, STREAM, index));
+    }
+    expect(new Set(values).size).toEqual(values.length);
+  });
+
+  it("separates seeds and streams", () => {
+    expect(randomAt(1, STREAM, 0)).not.toEqual(randomAt(2, STREAM, 0));
+    expect(randomAt(1, STREAM, 0)).not.toEqual(randomAt(1, STREAM + 1, 0));
+  });
+
+  // Cheap smoke test that the mixing actually spreads out, rather than clustering somewhere and
+  // quietly biasing every draw built on top of it
+  it("spreads draws roughly evenly across the range", () => {
+    const buckets = new Array(10).fill(0);
+    const draws = 10000;
+    for (let index = 0; index < draws; index++) {
+      buckets[Math.floor(randomAt(12345, STREAM, index) * 10)]++;
+    }
+    buckets.forEach((count) => {
+      expect(count).toBeGreaterThan(draws / 10 - 150);
+      expect(count).toBeLessThan(draws / 10 + 150);
+    });
+  });
+});
+
+describe("getRandomRangeAt", () => {
   it("should return a number within the specified range", () => {
     const min = 99;
     const max = 100;
-    const result = getRandomRange(min, max);
+    const result = getRandomRangeAt(12345, STREAM, 0, min, max);
     expect(result).toBeGreaterThanOrEqual(min);
-    expect(result).toBeLessThanOrEqual(max);
+    expect(result).toBeLessThan(max);
+  });
+});
+
+describe("newSeed", () => {
+  // Seeds are mixed as 32 bit integers, so a wider or fractional one would not survive being
+  // written to a save file and read back
+  it("mints integers that fit in 32 bits", () => {
+    for (let i = 0; i < 100; i++) {
+      const seed = newSeed();
+      expect(Number.isInteger(seed)).toBe(true);
+      expect(seed).toBeGreaterThanOrEqual(0);
+      expect(seed).toBeLessThan(2 ** 32);
+    }
   });
 });
 

--- a/src/helpers/Math.test.tsx
+++ b/src/helpers/Math.test.tsx
@@ -1,6 +1,29 @@
-import { arrayMove, getRandomRangeAt, newSeed, randomAt } from "./Math";
+import {
+  arrayMove,
+  getIntersectionX,
+  getRandomRangeAt,
+  newSeed,
+  randomAt,
+} from "./Math";
 
 const STREAM = 1;
+
+describe("getIntersectionX", () => {
+  it("finds where two crossing segments meet", () => {
+    // A rising line and a falling line through (5, 5)
+    expect(getIntersectionX(0, 0, 10, 10, 0, 10, 10, 0)).toBeCloseTo(5);
+  });
+
+  it("finds the crossing of a sloped line and a flat one", () => {
+    // Supply ramping past a flat demand line, which is what the chart actually uses this for
+    expect(getIntersectionX(0, 0, 10, 20, 0, 5, 10, 5)).toBeCloseTo(2.5);
+  });
+
+  // Parallel lines never meet, so there is no x to return. Callers treat the 0 as "no crossing"
+  it("returns zero for parallel lines rather than dividing by zero", () => {
+    expect(getIntersectionX(0, 0, 10, 10, 0, 5, 10, 15)).toEqual(0);
+  });
+});
 
 describe("randomAt", () => {
   it("stays inside [0, 1)", () => {

--- a/src/helpers/Math.tsx
+++ b/src/helpers/Math.tsx
@@ -22,35 +22,63 @@ export function getIntersectionX(
   return line1StartX + (numerator1 / denominator) * (line1EndX - line1StartX);
 }
 
+// Every random draw in the simulation is addressed by (seed, stream, index) rather than pulled
+// from a running generator. That makes the whole run a pure function of its seed: any value can
+// be recomputed at any point, in any order, without knowing how many draws came before it -- so
+// nothing sequential has to be carried around for a reloaded game to match the one that was
+// saved, and the caches built on top of these draws come out the same cold as warm.
+//
+// Streams keep unrelated parts of the simulation out of each other's draws: weather and fuel
+// prices each walk their own index space, so adding a draw to one never shifts the other. The
+// values are arbitrary but have to stay distinct, and have to stay put -- changing one changes
+// what every existing seed produces.
+export const RANDOM_STREAM = {
+  weather: 1,
+  fuelPrices: 2,
+};
+
 // https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript
-function splitmix32(a: number) {
-  return function () {
-    a |= 0;
-    a = (a + 0x9e3779b9) | 0;
-    let t = a ^ (a >>> 16);
-    t = Math.imul(t, 0x21f0aaad);
-    t = t ^ (t >>> 15);
-    t = Math.imul(t, 0x735a2d97);
-    return ((t = t ^ (t >>> 15)) >>> 0) / 4294967296;
-  };
+// splitmix32's finalizing mix, which spreads a counter-ish 32 bit value across the whole word.
+// Applied here to a hash of (seed, stream, index) rather than to successive counter states.
+function splitmix32Mix(a: number): number {
+  a = (a + 0x9e3779b9) | 0;
+  let t = a ^ (a >>> 16);
+  t = Math.imul(t, 0x21f0aaad);
+  t = t ^ (t >>> 15);
+  t = Math.imul(t, 0x735a2d97);
+  return ((t = t ^ (t >>> 15)) >>> 0) / 4294967296;
 }
 
-type Prng = () => number;
-
-let prng: Prng | null = null;
-
-export function seedRandom(seed: number): Prng {
-  prng = splitmix32(seed);
-  return prng;
+/**
+ * The simulation's only source of randomness: a value in [0, 1) determined entirely by the three
+ * coordinates it is given. Neighbouring indexes are as unrelated as distant ones, so callers can
+ * walk their index space in whatever order they need to.
+ */
+export function randomAt(seed: number, stream: number, index: number): number {
+  // Fold the coordinates together before mixing so that a change to any one of them disturbs the
+  // whole word rather than just its low bits
+  let h = seed | 0;
+  h = Math.imul(h ^ (stream + 0x9e3779b1), 0x85ebca6b) | 0;
+  h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35) | 0;
+  h = Math.imul(h ^ index, 0x27d4eb2f) | 0;
+  return splitmix32Mix(h ^ (h >>> 16));
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
-export function getRandomRange(min: number, max: number) {
-  // A run is meant to be reproducible from its seed, so callers are expected to have seeded
-  // first. Self-seeding here keeps an unseeded caller working rather than throwing at them,
-  // at the cost of that one run not being replayable.
-  const random = prng ?? seedRandom(Date.now() * Math.random());
-  return random() * (max - min) + min;
+export function getRandomRangeAt(
+  seed: number,
+  stream: number,
+  index: number,
+  min: number,
+  max: number,
+): number {
+  return randomAt(seed, stream, index) * (max - min) + min;
+}
+
+// Seeds are mixed as 32 bit integers, so a wider one (a float, or Date.now() times something) is
+// silently truncated and no longer describes the run it is stored alongside. Mint them here.
+export function newSeed(): number {
+  return Math.floor(Math.random() * 2 ** 32);
 }
 
 // https://stackoverflow.com/questions/5306680/move-an-array-element-from-one-array-position-to-another

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -555,11 +555,7 @@ function getDemandW(
     prev.customers * (1 + ORGANIC_GROWTH_MAX_ANNUAL / TICKS_PER_YEAR) +
       marketingGrowth,
   );
-  const { sunrise, sunset } = getSunriseSunset(
-    date,
-    game.location.lat,
-    game.location.long,
-  );
+  const { sunrise, sunset } = getSunriseSunset(date, game.location);
 
   // https://www.eia.gov/todayinenergy/detail.php?id=830
   // https://www.e-education.psu.edu/ebf200/node/151
@@ -597,8 +593,7 @@ function reforecastWeatherAndPrices(state: GameType): TickPresentFutureType[] {
         ...fuelPrices,
         solarIrradianceWM2: getRawSolarIrradianceWM2(
           date,
-          state.location.lat,
-          state.location.long,
+          state.location,
           weather.CLOUD_PCT,
         ),
         windKph: OUTSKIRTS_WIND_MULTIPLIER * weather.WIND_KPH,

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -20,7 +20,7 @@ import {
   formatWatts,
   formatWattHours,
 } from "../helpers/Format";
-import { arrayMove, seedRandom } from "../helpers/Math";
+import { arrayMove, newSeed } from "../helpers/Math";
 import { getSolarOutputFactor, getWindOutputFactor } from "../helpers/Energy";
 import { getFuelPricesPerMBTU } from "../data/FuelPrices";
 import { getWeather, getRawSolarIrradianceWM2 } from "../data/Weather";
@@ -97,7 +97,7 @@ let previousMonth = "";
 // four times an hour of game time
 let previouslyInBlackout = false;
 const initialGame: GameType = {
-  seed: Date.now() * Math.random(),
+  seed: newSeed(),
   scenarioId: 0,
   location: LOCATIONS["SF"],
   difficulty: "Employee",
@@ -163,8 +163,7 @@ export const gameSlice = createSlice({
       previousMonth = "";
       previouslyInBlackout = false;
       state.timeline = [] as TickPresentFutureType[];
-      state.seed = a.seed !== undefined ? a.seed : Date.now() * Math.random();
-      seedRandom(state.seed);
+      state.seed = a.seed !== undefined ? a.seed : newSeed();
       const scenario =
         SCENARIOS.find((s) => s.id === state.scenarioId) || SCENARIOS[0];
       state.date = getDateFromMinute(0, scenario.startingYear);
@@ -591,8 +590,8 @@ function reforecastWeatherAndPrices(state: GameType): TickPresentFutureType[] {
   return state.timeline.map((t: TickPresentFutureType) => {
     if (t.minute >= state.date.minute) {
       const date = getDateFromMinute(t.minute, state.startingYear);
-      const weather = getWeather(date);
-      const fuelPrices = getFuelPricesPerMBTU(date);
+      const weather = getWeather(date, state.seed);
+      const fuelPrices = getFuelPricesPerMBTU(date, state.seed);
       return {
         ...t,
         ...fuelPrices,
@@ -785,7 +784,7 @@ function updateSupplyFacilitiesFinances(
           ((g.currentW * (g.btuPerWh || 0)) / TICKS_PER_HOUR) *
           GAME_TO_REAL_YEARS; // Output-dependent #'s converted to real months, since we don't simulate every day
         expensesFuel +=
-          (fuelBtu * getFuelPricesPerMBTU(date)[g.fuel]) / 1000000;
+          (fuelBtu * getFuelPricesPerMBTU(date, state.seed)[g.fuel]) / 1000000;
         kgco2e += fuelBtu * FUELS[g.fuel].kgCO2ePerBtu;
       }
       if (g.loanAmountLeft > 0) {

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -1,11 +1,21 @@
 import { SCENARIOS } from "../data/Scenarios";
-import { DifficultyType, ScenarioType } from "../Types";
+import { DifficultyType, GameType, ScenarioType } from "../Types";
 import { createGame, runSimulation, SimResultType } from "./Simulator";
+import { loadSimData } from "./SimData";
 import { TICKS_PER_MONTH } from "../Constants";
 import { getTimeFromTimeline } from "../helpers/DateTime";
 import { tickState } from "../reducers/Game";
 
 jest.setTimeout(120000);
+
+// Ticks a state forwards without the simulator around it, for tests that care about where the
+// game ends up rather than about how it played
+function runMonths(state: GameType, months: number) {
+  const until = state.date.monthsEllapsed + months;
+  while (state.date.monthsEllapsed < until) {
+    tickState(state);
+  }
+}
 
 function describeViolations(result: SimResultType): string {
   return result.violations
@@ -95,6 +105,32 @@ describe("simulation determinism", () => {
     const first = runSimulation({ scenarioId: 101, months: 24, seed: 1 });
     const second = runSimulation({ scenarioId: 101, months: 24, seed: 2 });
     expect(second.months).toEqual(first.months);
+  });
+
+  /**
+   * The test that makes save/load correct by construction rather than by inspection: a run that is
+   * stopped, serialized, has every module level cache thrown away, and is resumed has to match a
+   * run that was never interrupted. Weather and fuel prices both live outside the game slice, so
+   * this only passes if they rebuild themselves identically from the seed alone.
+   */
+  it("resumes a serialized game into the run it would have had", () => {
+    // Carbon Fee starts in 2020, past the end of both the weather and the fuel price data, so
+    // every value the resumed run needs has to be extrapolated rather than read off a CSV
+    const options = { scenarioId: 100, seed: 4242 };
+    const HALF_MONTHS = 24;
+
+    const uninterrupted = createGame(options);
+    runMonths(uninterrupted, HALF_MONTHS * 2);
+
+    const interrupted = createGame(options);
+    runMonths(interrupted, HALF_MONTHS);
+    const saved: GameType = JSON.parse(JSON.stringify(interrupted));
+    // Everything a reload throws away: the parsed CSVs, and the forecast weather and prices
+    // appended to them
+    loadSimData(uninterrupted.location.id);
+    runMonths(saved, HALF_MONTHS);
+
+    expect(saved.monthlyHistory).toEqual(uninterrupted.monthlyHistory);
   });
 
   it("is unaffected by an unrelated run in between", () => {


### PR DESCRIPTION
Phase 0 of #109, the prerequisite for save/load: today the seed is stored but does not actually determine the run, so a naive "serialize the game slice" save would reload into visibly different weather and fuel prices. This makes the seed authoritative, so a save needs to carry only the game slice and both caches rebuild themselves identically on demand.

A second commit fixes a pre-existing bug found while verifying the first — solar irradiance was zero for the whole game outside the scenario's own timezone. Details in the second half.

---

# Phase 0: the seed determines the run

## Randomness is addressed, not sequential

`src/helpers/Math.tsx` replaces the module-level `prng` closure with:

```ts
randomAt(seed, stream, index): number
getRandomRangeAt(seed, stream, index, min, max): number
```

It hashes the three coordinates together and runs them through splitmix32's finalizing mix, rather than advancing a generator. A value can therefore be recomputed at any point, in any order, in a fresh process, with nothing sequential to save. Streams (`RANDOM_STREAM.weather`, `RANDOM_STREAM.fuelPrices`) keep the two consumers out of each other's draws, so adding a draw to one never shifts the other.

`seedRandom` and `getRandomRange` are gone; both production call sites migrated in this PR.

## Two cold-cache bugs, fixed at the root

Both only ever surfaced on a load, which is why they have gone unnoticed:

- **`getWeather`** filled one day per cache miss. Loading a 2050 save into a fresh array (the CSVs end in 2019) returned `DUMMY_WEATHER` — 0 °C, 10 kph, no clouds — for roughly 370 game-months before catching up. It now fills forward from the end of the data to the day asked for, in order, so a cold cache matches a warm one.
- **`getFuelPricesPerMBTU`** walked back to the nearest cached year and projected in a single jump. On a cold cache in 2050 that skipped 30 years of a multiplicative chain and landed nowhere near where the live game had it. It now chains forward year by year.

## Integer seeds

`Date.now() * Math.random()` is a float that the 32-bit mixing silently truncated, so the persisted seed did not honestly describe the run stored alongside it. `newSeed()` mints `Math.floor(Math.random() * 2 ** 32)` instead. This matters as soon as seeds travel in exported saves (Phase 2).

## Threading

`getWeather` and `getFuelPricesPerMBTU` take the seed as an argument rather than reading module state. That reaches `LCWH` and one prop on `GeneratorBuildItem`; every caller already had a `GameType` or `game.seed` to hand.

## Tests

- `Math.test.tsx` — order independence, seed/stream separation, and a distribution smoke test.
- `Weather.test.tsx` — a distant first lookup forecasts rather than falling back to a dummy; cold equals warm; different seeds diverge.
- `FuelPrices.test.tsx` (new file, the module had no tests) — cold equals warm; different seeds diverge; the no-data case still explains itself rather than hanging. Verified the cold-vs-warm test fails against the old jump behavior.
- `Simulation.test.tsx` — the one that matters for Phase 1: run 48 months, then run the same seed for 24 months, `JSON.parse(JSON.stringify(...))` it, throw away every module-level cache via `loadSimData`, resume for 24 more, and assert the monthly histories match exactly. Uses Carbon Fee, which starts in 2020 so every value has to be extrapolated rather than read off a CSV.

---

# Second commit: the sun never rose outside the scenario's timezone

The first push failed CI on the `src/helpers` coverage threshold. Deleting `getRandomRange` removed a covered branch from `Math.tsx`, which left the never-tested `getIntersectionX` weighing enough to drop helpers to 74.24% against a 75% floor. It now has tests, as do the other helpers this touches.

Chasing the `$INFINITY/MWh` I had noticed on the build screen turned up the bug actually behind it, which is worth more than the display glitch:

`getSunriseSunset` read suncalc's result with `getHours()`, which answers in the timezone of whatever machine is running, and built its input with `new Date("Jan 1, 2020")`, which Date also parses locally. Playing San Francisco from a UTC machine returned **sunrise 16:24 and sunset 02:00** — sunrise after sunset. `getRawSolarIrradianceWM2` only produces anything between the two, so the sun never came up: **solar panels generated nothing for the entire game**, and their cost per MWh was a division by a zero capacity factor.

This is timezone-dependent, which is why it survived: a player in US Pacific gets sane numbers for the SF scenarios, and a player in Europe gets no sun at all.

The fix gives each location an IANA `timeZone`, builds the instant handed to suncalc in UTC, and reads the results back through `Intl.DateTimeFormat` in the location's own zone.

| | before (TZ=UTC) | after (any TZ) |
|---|---|---|
| SF, January | sunrise 16:24, sunset 02:00 | sunrise 07:25, sunset 17:01 |
| Solar capacity factor, 3yr forecast | 0 | 18.5% |
| Solar on the build screen | `$INFINITY/MWh` | `$29.6/MWh` |

Verified identical under `TZ=UTC`, `Asia/Tokyo`, `America/New_York` and `Europe/Berlin`.

A zero capacity factor is still legitimately reachable — an intermittent generator sampled across a window with no sun in it — so `formatMoneyConcise`/`formatMoneyStable` now render a value they cannot express as an em dash rather than the word. `LCWH` keeps returning `Infinity`, which is the honest answer for a plant expected to produce nothing.

## Checks

`npm run check` passes (153 tests). Coverage: helpers 91.84 / 79.16 / 88 / 91.66 against thresholds of 85 / 75 / 80 / 85. `npm run sim -- --all` holds every invariant across all twelve scenarios. Also played the app locally through scenario start, the generator list and its expanded fuel-cost panel.

## Note on balance

Both commits change what a given seed produces — the first by design, the second because solar now generates. No stored baseline numbers needed regenerating: the tests assert invariants and relationships rather than fixed values. Under the sim's build-nothing strategy every scenario ends the same way it did before, with Paradise still going bankrupt (at month 43 rather than 42). Solar being genuinely buildable is a real balance shift for players, though, and is worth a look before merge.

Closes nothing on its own; Phases 1–3 (#109 items 1–3) follow independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
