### PR TITLE
Keep the music's place across tab switches

### DIFF
--- a/src/audio/AudioNode.tsx
+++ b/src/audio/AudioNode.tsx
@@ -25,10 +25,28 @@ export class AudioNode {
     this.source = null;
   }
 
-  public playOnce(initialVolume: number = 1, fadeInVolume: number = 0) {
+  /**
+   * Buffer sources are single-use: stopping one throws it away, so picking a track back up means
+   * building a new source and seeking into the buffer. offsetSeconds is where in the track to
+   * start, and startAt is when on the context clock to start it -- ThemeManager passes one shared
+   * startAt for every track in a theme so the stems stay aligned with each other.
+   */
+  public playOnce(
+    initialVolume: number = 1,
+    fadeInVolume: number = 0,
+    offsetSeconds: number = 0,
+    startAt?: number,
+  ) {
+    const when = startAt === undefined ? this.context.currentTime : startAt;
+    // Starting past the end of a buffer plays nothing at all, so treat an out-of-range seek as
+    // the top of the track: restarting is a worse outcome than resuming, silence is worse still.
+    const offset =
+      offsetSeconds > 0 && offsetSeconds < this.buffer.duration
+        ? offsetSeconds
+        : 0;
     this.gain = this.context.createGain();
     this.gain.connect(this.context.destination);
-    this.gain.gain.setValueAtTime(initialVolume, this.context.currentTime);
+    this.gain.gain.setValueAtTime(initialVolume, when);
     if (fadeInVolume) {
       this.fadeIn(fadeInVolume);
     }
@@ -37,7 +55,7 @@ export class AudioNode {
     source.buffer = this.buffer;
     source.connect(this.gain);
     source.start = source.start || source.noteOn; // polyfill for old browsers
-    source.start(0);
+    source.start(when, offset);
   }
 
   public fadeIn(peak?: number, seconds?: number) {

--- a/src/audio/ThemeManager.test.tsx
+++ b/src/audio/ThemeManager.test.tsx
@@ -1,0 +1,161 @@
+import { MUSIC_DEFINITIONS } from "../Constants";
+import { AudioNode } from "./AudioNode";
+import { ThemeManager } from "./ThemeManager";
+
+const BASIC = MUSIC_DEFINITIONS.basic;
+const BASIC_DURATION_SECONDS = BASIC.durationMs / 1000;
+
+interface FakeSource {
+  start: jest.Mock;
+  stop: jest.Mock;
+  connect: jest.Mock;
+  buffer: AudioBuffer | null;
+}
+
+/**
+ * jsdom has no Web Audio, and none of these tests care about anything audible -- what they check
+ * is the pair of arguments handed to source.start(): when on the context clock a track begins,
+ * and how far into its buffer it starts. tickPerSource advances the clock as sources are built,
+ * to stand in for real time passing while a theme's tracks are kicked off one after another.
+ */
+function fakeContext(tickPerSource: number = 0) {
+  const sources: FakeSource[] = [];
+  const context = {
+    currentTime: 0,
+    destination: {},
+    createGain: () => {
+      return {
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+        gain: {
+          value: 1,
+          setValueAtTime: jest.fn(),
+          linearRampToValueAtTime: jest.fn(),
+        },
+      };
+    },
+    createBufferSource: () => {
+      const source: FakeSource = {
+        start: jest.fn(),
+        stop: jest.fn(),
+        connect: jest.fn(),
+        buffer: null,
+      };
+      sources.push(source);
+      context.currentTime += tickPerSource;
+      return source;
+    },
+  };
+  return { context, sources };
+}
+
+// A manager already playing the basic theme, which is the long one (6+ minutes) where restarting
+// from the top on every tab switch is most obvious.
+function playingBasicTheme(tickPerSource: number = 0) {
+  const { context, sources } = fakeContext(tickPerSource);
+  // Music files are deliberately longer than their listed duration, to leave room for reverb
+  const buffer = { duration: BASIC_DURATION_SECONDS + 10 } as AudioBuffer;
+  const nodes: { [key: string]: AudioNode } = {};
+  for (const track of BASIC.tracks) {
+    nodes[`${BASIC.directory}${track}`] = new AudioNode(
+      context as unknown as AudioContext,
+      buffer,
+    );
+  }
+  const themeManager = new ThemeManager(
+    context as unknown as AudioContext,
+    nodes,
+  );
+  themeManager.setIntensity(2); // starts the basic theme from silence
+  return { themeManager, context, sources };
+}
+
+describe("ThemeManager pause / resume", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("picks the theme back up where it was paused", () => {
+    const { themeManager, context, sources } = playingBasicTheme();
+    expect(sources).toHaveLength(BASIC.tracks.length);
+
+    context.currentTime = 40;
+    themeManager.pause();
+    context.currentTime = 95; // 55 seconds spent on another tab
+    themeManager.resume();
+
+    // Buffer sources are single-use, so resuming builds a fresh one per track -- each seeking to
+    // where the pause happened rather than to the top of the file
+    const resumed = sources.slice(BASIC.tracks.length);
+    expect(resumed).toHaveLength(BASIC.tracks.length);
+    for (const source of resumed) {
+      expect(source.start).toHaveBeenCalledWith(95, 40);
+    }
+  });
+
+  it("starts every track of a resumed theme together", () => {
+    // The stems are written to play on top of each other, so a per-track clock reading would let
+    // them drift apart by however long the theme takes to start
+    const { themeManager, context, sources } = playingBasicTheme(0.01);
+    context.currentTime = 40;
+    themeManager.pause();
+    themeManager.resume();
+
+    const resumed = sources.slice(BASIC.tracks.length);
+    const startArgs = resumed.map((source) => source.start.mock.calls[0]);
+    for (const args of startArgs) {
+      expect(args).toEqual(startArgs[0]);
+    }
+  });
+
+  it("wraps a resumed theme after what is left of it, not its full length", () => {
+    const { themeManager, context, sources } = playingBasicTheme();
+    context.currentTime = 40;
+    themeManager.pause();
+    themeManager.resume();
+    const beforeWrap = sources.length;
+
+    jest.advanceTimersByTime(BASIC.durationMs - 40000 - 1);
+    expect(sources).toHaveLength(beforeWrap);
+
+    // Arming the loop with the full duration instead would push this 40 seconds later, and drift
+    // further on every pause / resume
+    jest.advanceTimersByTime(1);
+    expect(sources).toHaveLength(beforeWrap + BASIC.tracks.length);
+  });
+
+  it("restarts the theme when the pause lands past its end", () => {
+    const { themeManager, context, sources } = playingBasicTheme();
+    // The loop timer can run long when a background tab throttles timers
+    context.currentTime = BASIC_DURATION_SECONDS + 5;
+    themeManager.pause();
+    themeManager.resume();
+
+    const resumed = sources.slice(BASIC.tracks.length);
+    for (const source of resumed) {
+      expect(source.start).toHaveBeenCalledWith(expect.any(Number), 0);
+    }
+  });
+
+  it("ignores a resume that was not preceded by a pause", () => {
+    const { themeManager, sources } = playingBasicTheme();
+    themeManager.resume();
+    expect(sources).toHaveLength(BASIC.tracks.length);
+  });
+});
+
+describe("AudioNode seeking", () => {
+  it("falls back to the top of the track when the seek is past the buffer", () => {
+    const { context, sources } = fakeContext();
+    const buffer = { duration: 30 } as AudioBuffer;
+    const node = new AudioNode(context as unknown as AudioContext, buffer);
+
+    // Silence would be the alternative -- a source started past the end of its buffer never plays
+    node.playOnce(1, 0, 45, 10);
+    expect(sources[0].start).toHaveBeenCalledWith(10, 0);
+  });
+});

--- a/src/audio/ThemeManager.tsx
+++ b/src/audio/ThemeManager.tsx
@@ -21,11 +21,15 @@ import { AudioNode } from "./AudioNode";
     but, if you turn on audio later in the session, it'll download them at that time
 - audio.paused may change at any time (such as minimizing / returning to the tab),
   so it behaves like pause / resume
+- pause / resume keeps its place in the theme rather than starting it over. Buffer sources are
+  single-use, so resuming rebuilds them and seeks in; the position is tracked here at the theme
+  level rather than per node, since the stems have to stay aligned with each other.
 */
 
 const MUSIC_FADE_LONG_SECONDS = 3.5; // for fade outs, such as the end of combat
 
 export class ThemeManager {
+  private context: AudioContext;
   private nodes: {
     [key: string]: AudioNode;
   };
@@ -35,8 +39,18 @@ export class ThemeManager {
   private paused: boolean;
   private theme: MusicDefinition;
   private timeout: ReturnType<typeof setTimeout> | null = null;
+  // Context time at which the current theme would have started playing from its first sample, or
+  // null when nothing is playing. Backdated when a theme starts part-way through, so that the
+  // elapsed position is always currentTime - themeStartedAt.
+  private themeStartedAt: number | null = null;
+  private resumeOffsetSeconds: number = 0;
 
-  constructor(nodes: { [key: string]: AudioNode }, intensity: number = 0) {
+  constructor(
+    context: AudioContext,
+    nodes: { [key: string]: AudioNode },
+    intensity: number = 0,
+  ) {
+    this.context = context;
     this.nodes = nodes;
     this.active = [];
     for (const k of Object.keys(this.nodes)) {
@@ -54,13 +68,36 @@ export class ThemeManager {
       return;
     }
     this.paused = true;
+    // Stamp our place in the theme before fadeOut() tears the sources down. Taken at the moment
+    // pause is requested, so the fade-out tail -- which keeps sounding for up to
+    // MUSIC_FADE_LONG_SECONDS after this -- gets replayed under the fade-in on the way back.
+    // That rewind is a couple of seconds at most and sits under a fade, so it reads as natural.
+    this.resumeOffsetSeconds = this.elapsedInTheme();
     this.fadeOut();
   }
+
+  // How far into the current theme we are, in seconds. Zero when nothing is playing, or when the
+  // loop timer ran long enough that we are past the end of the theme and starting it over is the
+  // only sensible position.
+  private elapsedInTheme(): number {
+    if (this.themeStartedAt === null) {
+      return 0;
+    }
+    const elapsed = this.context.currentTime - this.themeStartedAt;
+    if (elapsed <= 0 || elapsed >= this.theme.durationMs / 1000) {
+      return 0;
+    }
+    return elapsed;
+  }
+
   private fadeOut() {
     if (this.timeout) {
       clearTimeout(this.timeout);
       this.timeout = null;
     }
+    // Every caller of this is ending the current playback, so there is no longer a position to
+    // measure against -- loopTheme sets it again when it starts the next one.
+    this.themeStartedAt = null;
     for (const i of this.active) {
       if (this.nodes[i] && this.nodes[i].isPlaying()) {
         this.nodes[i].fadeOut(
@@ -84,12 +121,16 @@ export class ThemeManager {
     }
   }
 
-  // Starts the music from scratch with a new theme, fading out any existing music
+  // Starts the music with a new theme, fading out any existing music
   // If no theme specified, uses existing music (for example, resuming from a pause)
-  private startTheme(theme: MusicDefinition = this.theme) {
+  // offsetSeconds seeks into the theme, so that a resume picks up where the pause left off
+  private startTheme(
+    theme: MusicDefinition = this.theme,
+    offsetSeconds: number = 0,
+  ) {
     this.fadeOut();
     this.theme = theme;
-    this.loopTheme(true);
+    this.loopTheme(true, offsetSeconds);
   }
 
   public resume() {
@@ -97,7 +138,9 @@ export class ThemeManager {
       return;
     }
     this.paused = false;
-    this.startTheme();
+    const offsetSeconds = this.resumeOffsetSeconds;
+    this.resumeOffsetSeconds = 0;
+    this.startTheme(this.theme, offsetSeconds);
   }
 
   private playAtIntensity(newIntensity: number) {
@@ -138,12 +181,18 @@ export class ThemeManager {
 
   // Kick off a copy of the existing music theme
   // Doesn't stop the current music nodes (lets them stop naturally for reverb)
-  private loopTheme(newTheme: boolean = false) {
+  // offsetSeconds starts every track that far in, for resuming a theme part-way through
+  private loopTheme(newTheme: boolean = false, offsetSeconds: number = 0) {
     if (this.paused) {
       return;
     }
     const theme = this.theme;
     this.active = this.generateTracks();
+    // One clock reading shared by every track in the theme: the stems are written to play on top
+    // of each other, so reading the clock per track would let them drift apart by however long
+    // the loop below takes to run.
+    const startAt = this.context.currentTime;
+    this.themeStartedAt = startAt - offsetSeconds;
     theme.tracks.forEach((track: string) => {
       let file = this.getActiveInstrument(track);
       const active = this.intensity > 0 || Boolean(file);
@@ -166,17 +215,23 @@ export class ThemeManager {
       // Determine initial & target volume
       const initialVolume = newTheme || !active ? 0 : 1;
       const targetVolume = active ? 1 : 0;
-      node.playOnce(initialVolume, targetVolume);
+      node.playOnce(initialVolume, targetVolume, offsetSeconds, startAt);
     });
 
-    this.timeout = setTimeout(() => {
-      if (this.intensity === 1) {
-        this.intensity = 2;
-        this.startTheme(MUSIC_DEFINITIONS.basic);
-      } else {
-        this.loopTheme();
-      }
-    }, theme.durationMs);
+    // Wrap the theme when it actually ends. A theme resumed part-way through has that much less
+    // left to play, so arming this with the full duration would push the loop boundary later on
+    // every pause / resume.
+    this.timeout = setTimeout(
+      () => {
+        if (this.intensity === 1) {
+          this.intensity = 2;
+          this.startTheme(MUSIC_DEFINITIONS.basic);
+        } else {
+          this.loopTheme();
+        }
+      },
+      theme.durationMs - offsetSeconds * 1000,
+    );
   }
 
   // Fade in / out tracks on the current theme for a smoother + more immediate change in intensity

--- a/src/data/Audio.tsx
+++ b/src/data/Audio.tsx
@@ -96,7 +96,7 @@ export function loadAudioFiles() {
         state.loaded = "ERROR";
         return;
       }
-      state.themeManager = new ThemeManager(audioNodes);
+      state.themeManager = new ThemeManager(ac, audioNodes);
       state.loaded = "LOADED";
       state.themeManager.setIntensity(1);
     },


### PR DESCRIPTION
Fixes #66.

## The bug

`visibilitychange` → `pauseAudio` → `ThemeManager.pause()` stopped every buffer source. Coming back, `resumeAudio` → `resume()` → `startTheme()` → `loopTheme(true)` built fresh sources and called `source.start(0)`. Web Audio buffer sources are single-use, and nothing recorded how far into the theme playback had got — so there was no position to resume to, and the theme began again from its first sample. `basic` runs 6.5 minutes, so a brief glance at another tab threw away most of it.

## The fix

`ThemeManager` now tracks elapsed position and seeks back to it:

- `pause()` stamps `elapsedInTheme()` before `fadeOut()` tears the sources down; `resume()` passes it through `startTheme` → `loopTheme` → `AudioNode.playOnce`, which seeks with `source.start(when, offset)`.
- Position is tracked **at the theme level**, not per node. The stems are written to play on top of each other, so `loopTheme` takes one clock reading and hands the same `when` and `offset` to every track — per-track readings would let them drift apart by however long the loop takes to run.
- The loop timer is re-armed with `durationMs - offset`, not the full duration. Arming it with the full length would push the loop boundary later on every pause/resume.
- Out-of-range seeks fall back to the top of the track, in `elapsedInTheme` (past the theme's end, if a background tab throttled the loop timer long enough) and defensively in `playOnce` (past the end of the buffer, where a source plays nothing at all).

Position is stamped when the pause is *requested* rather than when the fade-out finishes, so up to `MUSIC_FADE_LONG_SECONDS` gets replayed under the fade-in on the way back. That rewind sits under a fade and reads as natural — worth it to keep this synchronous and simple.

### Why not `audioContext.suspend()`

It would preserve position for free, but it hard-cuts instead of fading, so the same pause would fade on a settings toggle and cut on a tab switch. It also wouldn't save much: the loop timer is a `setTimeout`, unaffected by suspending the context, so the theme-level timing work is needed either way — and `suspend()`/`resume()` are promise-based, so rapid tab flips would need guarding against a resume landing before its suspend settles.

## Testing

New `src/audio/ThemeManager.test.tsx` covers resuming at the pause position, all tracks of a resumed theme starting together, the loop wrapping after the remaining duration, restarting when the pause lands past the theme's end, and the out-of-range seek fallback. Full suite passes (159 tests), along with typecheck, lint, and format.

Also verified in the running app: with audio enabled, patching `AudioBufferSourceNode.prototype.start` and dispatching a hide/show cycle ~25s into the intro theme recorded `start(when: 32.35, offset: 24.84)` — previously `start(0)`. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
