### PR TITLE
Phase 1 of #109: save and load games to localStorage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import { pauseAudio, resumeAudio } from "./reducers/Settings";
 import { snackbarOpen } from "./reducers/UI";
 import { firebaseAppAuth, getDevicePlatform } from "./Globals";
 import { delta } from "./reducers/User";
+import { SCENARIOS } from "./data/Scenarios";
+import { startAutosave } from "./SaveGame";
 import { store } from "./Store";
 import theme from "./Theme";
 
@@ -79,6 +81,16 @@ export default function App() {
     };
     document.addEventListener("visibilitychange", onVisibilityChange, false);
 
+    // Registered here rather than next to the store because the tutorial lookup needs the
+    // scenarios, and reducers/Game already reaches back into SaveGame -- App sits above both, so
+    // nothing can cycle. Tutorials are excluded: they're short, restoring a mid-walkthrough step
+    // isn't worth the complexity, and it means starting one can't clobber a real save.
+    const stopAutosave = startAutosave(
+      store,
+      (scenarioId: number) =>
+        !SCENARIOS.find((s) => s.id === scenarioId)?.tutorialSteps,
+    );
+
     // Returns its own unsubscribe, which was previously dropped on the floor
     const unsubscribeAuth = firebaseAppAuth.onAuthStateChanged(
       (user: User | null) => {
@@ -101,6 +113,7 @@ export default function App() {
         onVisibilityChange,
         false,
       );
+      stopAutosave();
       unsubscribeAuth();
       document.removeEventListener("deviceready", onDeviceReady, false);
       teardownDevice?.();

--- a/src/LocalStorage.tsx
+++ b/src/LocalStorage.tsx
@@ -55,6 +55,15 @@ export function setStorageKeyValue(
   }
 }
 
+// Best effort for the same reason as setStorageKeyValue: nothing useful to do if it throws
+export function removeStorageKey(key: string) {
+  try {
+    getLocalStorage().removeItem(key);
+  } catch (_err) {
+    // Ignore errors
+  }
+}
+
 function getPlays(): LocalStoragePlayedType[] {
   return getStorageJson<{ plays: LocalStoragePlayedType[] }>("plays", {
     plays: [],

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -136,77 +136,93 @@ describe("SaveGame", () => {
       return self;
     }
 
-    function atMonth(base: GameType, monthsEllapsed: number): GameType {
-      return { ...base, date: { ...base.date, monthsEllapsed } };
+    // A game running at a given point in a given year
+    function playing(base: GameType, year: number, minute: number): GameType {
+      return { ...base, inGame: true, date: { ...base.date, year, minute } };
     }
 
-    function playing(base: GameType): GameType {
-      return { ...base, inGame: true };
-    }
+    // What quit leaves behind
+    const quit = { ...game, inGame: false };
 
-    it("writes the first month of a game immediately", () => {
-      const store = fakeStore({ ...game, inGame: false });
+    it("writes as soon as a game starts", () => {
+      const store = fakeStore(quit);
       const stop = startAutosave(store as never, () => true);
 
-      store.set(playing(atMonth(game, 0)));
-      expect(readSave()!.game.date.monthsEllapsed).toBe(0);
+      store.set(playing(game, 2020, 0));
+      expect(readSave()!.game.date.year).toBe(2020);
+
+      stop();
+    });
+
+    it("writes once a year, at the turn of the year", () => {
+      const store = fakeStore(quit);
+      const stop = startAutosave(store as never, () => true);
+
+      store.set(playing(game, 2020, 0));
+      // Mid-year progress isn't written on its own
+      store.set(playing(game, 2020, 100));
+      store.set(playing(game, 2020, 200));
+      expect(readSave()!.game.date.minute).toBe(0);
+
+      // ...until the year turns, which is never skipped, throttled or collapsed
+      store.set(playing(game, 2021, 300));
+      expect(readSave()!.game.date.minute).toBe(300);
+      store.set(playing(game, 2022, 400));
+      expect(readSave()!.game.date.minute).toBe(400);
 
       stop();
     });
 
     /**
      * The bug this guards: quitting from the in-game menu fires none of the page lifecycle events,
-     * and quit resets the slice before the subscriber sees it, so a player who quit mid-throttle
-     * came back a few months behind where they left off.
+     * and quit resets the slice before the subscriber sees it, so a player who quit partway
+     * through a year came back to the start of it.
      */
-    it("flushes what the throttle skipped when the player quits to the menu", () => {
-      const store = fakeStore({ ...game, inGame: false });
+    it("flushes the part-year when the player quits to the menu", () => {
+      const store = fakeStore(quit);
       const stop = startAutosave(store as never, () => true);
 
-      store.set(playing(atMonth(game, 0)));
-      // Inside the throttle window, so these don't reach storage on their own
-      store.set(playing(atMonth(game, 1)));
-      store.set(playing(atMonth(game, 2)));
-      expect(readSave()!.game.date.monthsEllapsed).toBe(0);
+      store.set(playing(game, 2020, 0));
+      store.set(playing(game, 2020, 5000));
+      expect(readSave()!.game.date.minute).toBe(0);
 
-      // What quit leaves behind
-      store.set({ ...game, inGame: false });
-      expect(readSave()!.game.date.monthsEllapsed).toBe(2);
+      store.set(quit);
+      expect(readSave()!.game.date.minute).toBe(5000);
 
       stop();
     });
 
     // Bankrupt and fired clear the save and then quit, and the flush must not undo that
     it("doesn't resurrect a save the scenario ending cleared", () => {
-      const store = fakeStore({ ...game, inGame: false });
+      const store = fakeStore(quit);
       const stop = startAutosave(store as never, () => true);
 
-      store.set(playing(atMonth(game, 0)));
-      store.set(playing(atMonth(game, 1)));
+      store.set(playing(game, 2020, 0));
+      store.set(playing(game, 2020, 5000));
       clearSave();
 
-      store.set({ ...game, inGame: false });
+      store.set(quit);
       expect(readSave()).toBeNull();
 
       stop();
     });
 
     it("leaves tutorials alone", () => {
-      const store = fakeStore({ ...game, inGame: false });
+      const store = fakeStore(quit);
       const stop = startAutosave(store as never, () => false);
 
-      store.set(playing(atMonth(game, 0)));
-      store.set({ ...game, inGame: false });
+      store.set(playing(game, 2020, 0));
+      store.set(quit);
       expect(readSave()).toBeNull();
 
       stop();
     });
 
     it("stops writing once torn down", () => {
-      const store = fakeStore({ ...game, inGame: false });
+      const store = fakeStore(quit);
       startAutosave(store as never, () => true)();
 
-      store.set(playing(atMonth(game, 0)));
+      store.set(playing(game, 2020, 0));
       expect(readSave()).toBeNull();
     });
   });

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -1,0 +1,120 @@
+import { getTimeFromTimeline } from "./helpers/DateTime";
+import {
+  clearSave,
+  clearSaveFor,
+  isResumedGame,
+  parseSave,
+  readSave,
+  SAVE_KEY,
+  SAVE_VERSION,
+  serializeSave,
+  writeSave,
+} from "./SaveGame";
+import { createGame } from "./testing/Simulator";
+import { GameType } from "./Types";
+
+jest.setTimeout(60000);
+
+// Rise of Renewables, entirely inside the recorded data so setup stays quick
+const OPTIONS = { scenarioId: 101, seed: 31337 };
+
+function cash(game: GameType): number {
+  return getTimeFromTimeline(game.date.minute, game.timeline)!.cash;
+}
+
+describe("SaveGame", () => {
+  let game: GameType;
+
+  beforeAll(() => {
+    game = createGame(OPTIONS);
+  });
+
+  beforeEach(() => {
+    clearSave();
+  });
+
+  it("round trips a game through local storage", () => {
+    expect(writeSave(game)).toBe(true);
+
+    const save = readSave();
+    expect(save).not.toBeNull();
+    expect(save!.version).toBe(SAVE_VERSION);
+    expect(save!.game.seed).toBe(game.seed);
+    expect(save!.game.scenarioId).toBe(game.scenarioId);
+    expect(save!.game.facilities).toEqual(game.facilities);
+    expect(save!.game.monthlyHistory).toEqual(game.monthlyHistory);
+    expect(cash(save!.game)).toBe(cash(game));
+  });
+
+  // The memo must never alias the live game slice, or a Continue button would describe a game
+  // that has kept playing since it was saved
+  it("reads back through storage rather than handing back the live object", () => {
+    writeSave(game);
+
+    const save = readSave();
+    expect(save!.game).not.toBe(game);
+    expect(save!.game).toEqual(JSON.parse(JSON.stringify(game)));
+  });
+
+  it("reports no save when nothing has been written", () => {
+    expect(readSave()).toBeNull();
+  });
+
+  it("forgets the save it just cleared", () => {
+    writeSave(game);
+    expect(readSave()).not.toBeNull();
+    clearSave();
+    expect(readSave()).toBeNull();
+  });
+
+  it("ignores a save from a different schema version", () => {
+    expect(
+      parseSave({ ...serializeSave(game), version: SAVE_VERSION + 1 }),
+    ).toBeNull();
+  });
+
+  it("ignores corrupt JSON", () => {
+    window.localStorage.setItem(SAVE_KEY, "{not json");
+    expect(readSave()).toBeNull();
+  });
+
+  it("ignores blobs that aren't saves", () => {
+    expect(parseSave(null)).toBeNull();
+    expect(parseSave("nope")).toBeNull();
+    expect(parseSave({})).toBeNull();
+    expect(parseSave({ version: SAVE_VERSION })).toBeNull();
+  });
+
+  // An imported file is untrusted input, and a malformed facility would otherwise only surface as
+  // a crash mid-tick
+  it("ignores a save whose game is the wrong shape", () => {
+    const save = serializeSave(game);
+    expect(
+      parseSave({ ...save, game: { ...save.game, facilities: 3 } }),
+    ).toBeNull();
+    expect(
+      parseSave({ ...save, game: { ...save.game, scenarioId: "101" } }),
+    ).toBeNull();
+    expect(
+      parseSave({ ...save, game: { ...save.game, date: undefined } }),
+    ).toBeNull();
+    expect(
+      parseSave({ ...save, game: { ...save.game, monthlyHistory: null } }),
+    ).toBeNull();
+  });
+
+  // Tutorials run a single month and hit the win trigger on the way past. Clearing on any
+  // scenario ending would throw away a real game the player still wanted.
+  it("only clears the save belonging to the scenario that ended", () => {
+    writeSave(game);
+    clearSaveFor(game.scenarioId + 1);
+    expect(readSave()).not.toBeNull();
+    clearSaveFor(game.scenarioId);
+    expect(readSave()).toBeNull();
+  });
+
+  it("recognizes a restored slice by its timeline", () => {
+    expect(isResumedGame(game)).toBe(true);
+    expect(isResumedGame({ ...game, timeline: [] })).toBe(false);
+  });
+});

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -8,6 +8,7 @@ import {
   SAVE_KEY,
   SAVE_VERSION,
   serializeSave,
+  startAutosave,
   writeSave,
 } from "./SaveGame";
 import { createGame } from "./testing/Simulator";
@@ -111,6 +112,103 @@ describe("SaveGame", () => {
     expect(readSave()).not.toBeNull();
     clearSaveFor(game.scenarioId);
     expect(readSave()).toBeNull();
+  });
+
+  describe("autosave", () => {
+    // Enough of a store for the subscriber: state it can read, and a way to notify
+    function fakeStore(initial: GameType) {
+      const listeners: Array<() => void> = [];
+      const self = {
+        state: initial,
+        dispatched: [] as unknown[],
+        getState: () => ({ game: self.state }),
+        subscribe: (fn: () => void) => {
+          listeners.push(fn);
+          return () => listeners.splice(listeners.indexOf(fn), 1);
+        },
+        dispatch: (a: unknown) => self.dispatched.push(a),
+        // Sets the slice the way a reducer would, then notifies like Redux does
+        set: (next: GameType) => {
+          self.state = next;
+          listeners.forEach((fn) => fn());
+        },
+      };
+      return self;
+    }
+
+    function atMonth(base: GameType, monthsEllapsed: number): GameType {
+      return { ...base, date: { ...base.date, monthsEllapsed } };
+    }
+
+    function playing(base: GameType): GameType {
+      return { ...base, inGame: true };
+    }
+
+    it("writes the first month of a game immediately", () => {
+      const store = fakeStore({ ...game, inGame: false });
+      const stop = startAutosave(store as never, () => true);
+
+      store.set(playing(atMonth(game, 0)));
+      expect(readSave()!.game.date.monthsEllapsed).toBe(0);
+
+      stop();
+    });
+
+    /**
+     * The bug this guards: quitting from the in-game menu fires none of the page lifecycle events,
+     * and quit resets the slice before the subscriber sees it, so a player who quit mid-throttle
+     * came back a few months behind where they left off.
+     */
+    it("flushes what the throttle skipped when the player quits to the menu", () => {
+      const store = fakeStore({ ...game, inGame: false });
+      const stop = startAutosave(store as never, () => true);
+
+      store.set(playing(atMonth(game, 0)));
+      // Inside the throttle window, so these don't reach storage on their own
+      store.set(playing(atMonth(game, 1)));
+      store.set(playing(atMonth(game, 2)));
+      expect(readSave()!.game.date.monthsEllapsed).toBe(0);
+
+      // What quit leaves behind
+      store.set({ ...game, inGame: false });
+      expect(readSave()!.game.date.monthsEllapsed).toBe(2);
+
+      stop();
+    });
+
+    // Bankrupt and fired clear the save and then quit, and the flush must not undo that
+    it("doesn't resurrect a save the scenario ending cleared", () => {
+      const store = fakeStore({ ...game, inGame: false });
+      const stop = startAutosave(store as never, () => true);
+
+      store.set(playing(atMonth(game, 0)));
+      store.set(playing(atMonth(game, 1)));
+      clearSave();
+
+      store.set({ ...game, inGame: false });
+      expect(readSave()).toBeNull();
+
+      stop();
+    });
+
+    it("leaves tutorials alone", () => {
+      const store = fakeStore({ ...game, inGame: false });
+      const stop = startAutosave(store as never, () => false);
+
+      store.set(playing(atMonth(game, 0)));
+      store.set({ ...game, inGame: false });
+      expect(readSave()).toBeNull();
+
+      stop();
+    });
+
+    it("stops writing once torn down", () => {
+      const store = fakeStore({ ...game, inGame: false });
+      startAutosave(store as never, () => true)();
+
+      store.set(playing(atMonth(game, 0)));
+      expect(readSave()).toBeNull();
+    });
   });
 
   it("recognizes a restored slice by its timeline", () => {

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -151,20 +151,18 @@ export function startAutosave(
   store: AppStore,
   isSaveableScenario: (scenarioId: number) => boolean,
 ): () => void {
+  // The slice as of the last notification where a game was running. Quit resets the slice before
+  // the subscriber sees it, so flushing on the way out needs the state as it was, not as it is.
+  let live: GameType | undefined;
   let savedMonthsEllapsed = -1;
-  let lastWriteMs = 0;
-  // Set when a rollover was skipped by the throttle, so the change isn't lost if the player stops
-  // playing before the next one
-  let pending = false;
+  let lastWriteMs = -Infinity;
   // A full disk fails every month; saying so once is a warning, saying so every month is a bug
   let warnedAboutFailure = false;
 
-  const write = () => {
-    const game = store.getState().game;
+  const write = (game: GameType) => {
     if (writeSave(game)) {
       savedMonthsEllapsed = game.date.monthsEllapsed;
       lastWriteMs = performance.now();
-      pending = false;
     } else if (!warnedAboutFailure) {
       warnedAboutFailure = true;
       store.dispatch(
@@ -173,39 +171,55 @@ export function startAutosave(
     }
   };
 
-  const saveable = () => {
-    const game = store.getState().game;
-    return game.inGame && isSaveableScenario(game.scenarioId);
+  /**
+   * Writes whatever the throttle skipped, on the way out of a game -- quitting to the menu, hiding
+   * the tab, or closing it. Without this a player who quits mid-throttle comes back a few months
+   * behind where they left, since quit fires none of the page lifecycle events.
+   *
+   * Only ever updates a save that's still there. The first month of any game writes immediately
+   * (lastWriteMs is reset per game), so a missing save means the scenario ended and cleared it,
+   * and a bankrupt run shouldn't come back from the dead.
+   */
+  const flush = () => {
+    if (!live || live.date.monthsEllapsed === savedMonthsEllapsed) {
+      return;
+    }
+    if (readSave()?.game.scenarioId !== live.scenarioId) {
+      return;
+    }
+    write(live);
   };
 
   const unsubscribe = store.subscribe(() => {
-    if (!saveable()) {
+    const game = store.getState().game;
+    if (!game.inGame || !isSaveableScenario(game.scenarioId)) {
+      flush();
+      live = undefined;
       return;
     }
-    const { monthsEllapsed } = store.getState().game.date;
-    if (monthsEllapsed === savedMonthsEllapsed) {
+    if (!live) {
+      // A game just started or resumed. Nothing of it is written yet, and its first month should
+      // land right away rather than waiting out a throttle left over from the previous game.
+      savedMonthsEllapsed = -1;
+      lastWriteMs = -Infinity;
+    }
+    live = game;
+    if (game.date.monthsEllapsed === savedMonthsEllapsed) {
       return;
     }
-    pending = true;
     if (performance.now() - lastWriteMs < AUTOSAVE_THROTTLE_MS) {
       return;
     }
-    write();
+    write(game);
   });
 
-  // The write that actually matters: whatever the throttle skipped, flushed the moment the player
-  // leaves. pagehide rather than beforeunload, which mobile browsers routinely never fire.
-  const flush = () => {
-    if (pending && saveable()) {
-      write();
-    }
-  };
   const onVisibilityChange = () => {
     if (document.visibilityState === "hidden") {
       flush();
     }
   };
   document.addEventListener("visibilitychange", onVisibilityChange, false);
+  // pagehide rather than beforeunload, which mobile browsers routinely never fire
   window.addEventListener("pagehide", flush, false);
 
   return () => {

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -26,10 +26,6 @@ export const SAVE_KEY = "savedGame";
 // Bump on any breaking schema change. Mismatched saves are ignored rather than migrated.
 export const SAVE_VERSION = 1;
 
-// One write per game month is roughly one a second at FAST speed, and the blob is ~100KB, so
-// rollovers inside this window are collapsed into the next eligible one
-const AUTOSAVE_THROTTLE_MS = 5000;
-
 export interface SaveGameType {
   version: number;
   savedAt: string; // ISO 8601
@@ -141,7 +137,12 @@ export function isResumedGame(game: GameType): boolean {
 }
 
 /**
- * Writes the game slice to local storage as the player plays. Returns its own teardown.
+ * Writes the game slice to local storage as the player plays: once at the turn of each game year,
+ * plus whatever is left over on the way out. Returns its own teardown.
+ *
+ * A game year is 1152 ticks, so even at FAST speed this is a write every eleven seconds or so --
+ * infrequent enough that it doesn't need throttling, and unthrottled means every year boundary
+ * actually lands rather than being collapsed into a later one.
  *
  * isSaveableScenario is injected rather than looked up here (see the note at the top of the file);
  * pass a predicate that rejects tutorials, which are short enough not to be worth saving and would
@@ -154,15 +155,16 @@ export function startAutosave(
   // The slice as of the last notification where a game was running. Quit resets the slice before
   // the subscriber sees it, so flushing on the way out needs the state as it was, not as it is.
   let live: GameType | undefined;
-  let savedMonthsEllapsed = -1;
-  let lastWriteMs = -Infinity;
-  // A full disk fails every month; saying so once is a warning, saying so every month is a bug
+  let savedYear = -1;
+  // What was actually written, so the flush below can tell whether anything has happened since
+  let savedMinute = -1;
+  // A full disk fails every year; saying so once is a warning, saying so every year is a bug
   let warnedAboutFailure = false;
 
   const write = (game: GameType) => {
     if (writeSave(game)) {
-      savedMonthsEllapsed = game.date.monthsEllapsed;
-      lastWriteMs = performance.now();
+      savedYear = game.date.year;
+      savedMinute = game.date.minute;
     } else if (!warnedAboutFailure) {
       warnedAboutFailure = true;
       store.dispatch(
@@ -172,16 +174,16 @@ export function startAutosave(
   };
 
   /**
-   * Writes whatever the throttle skipped, on the way out of a game -- quitting to the menu, hiding
-   * the tab, or closing it. Without this a player who quits mid-throttle comes back a few months
-   * behind where they left, since quit fires none of the page lifecycle events.
+   * Writes the part-year since the last save, on the way out of a game -- quitting to the menu,
+   * hiding the tab, or closing it. Without this a player who quits partway through a year comes
+   * back to the start of it, since quit fires none of the page lifecycle events.
    *
-   * Only ever updates a save that's still there. The first month of any game writes immediately
-   * (lastWriteMs is reset per game), so a missing save means the scenario ended and cleared it,
-   * and a bankrupt run shouldn't come back from the dead.
+   * Only ever updates a save that's still there. The first moment of any game writes immediately,
+   * so a missing save means the scenario ended and cleared it, and a bankrupt run shouldn't come
+   * back from the dead.
    */
   const flush = () => {
-    if (!live || live.date.monthsEllapsed === savedMonthsEllapsed) {
+    if (!live || live.date.minute === savedMinute) {
       return;
     }
     if (readSave()?.game.scenarioId !== live.scenarioId) {
@@ -198,19 +200,15 @@ export function startAutosave(
       return;
     }
     if (!live) {
-      // A game just started or resumed. Nothing of it is written yet, and its first month should
-      // land right away rather than waiting out a throttle left over from the previous game.
-      savedMonthsEllapsed = -1;
-      lastWriteMs = -Infinity;
+      // A game just started or resumed, and nothing of it is written yet. Saving immediately is
+      // what lets the flush above treat a missing save as "the scenario ended".
+      savedYear = -1;
+      savedMinute = -1;
     }
     live = game;
-    if (game.date.monthsEllapsed === savedMonthsEllapsed) {
-      return;
+    if (game.date.year !== savedYear) {
+      write(game);
     }
-    if (performance.now() - lastWriteMs < AUTOSAVE_THROTTLE_MS) {
-      return;
-    }
-    write(game);
   });
 
   const onVisibilityChange = () => {

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -1,0 +1,216 @@
+import packageJson from "../package.json";
+import {
+  getStorageJson,
+  removeStorageKey,
+  setStorageKeyValue,
+} from "./LocalStorage";
+import { snackbarOpen } from "./reducers/UI";
+import { GameType } from "./Types";
+import type { AppStore } from "./Store";
+
+/**
+ * Saving and restoring a game.
+ *
+ * Only the game slice is persisted. Every random draw in the simulation is addressed by
+ * (seed, stream, index) rather than pulled from a running generator, so the weather and fuel price
+ * caches -- which live outside Redux -- rebuild themselves identically from state.seed on the other
+ * side of a reload. Nothing sequential has to be carried in the save.
+ *
+ * This module deliberately imports almost nothing: reducers/Game reaches back here for
+ * clearSaveFor, and data/Scenarios imports reducers/Game, so importing the scenarios from here
+ * would close the cycle that reducers/ImportOrder.test.tsx guards against. Callers that need to
+ * know about scenarios (whether one is a tutorial, what it's called) pass that in.
+ */
+
+export const SAVE_KEY = "savedGame";
+// Bump on any breaking schema change. Mismatched saves are ignored rather than migrated.
+export const SAVE_VERSION = 1;
+
+// One write per game month is roughly one a second at FAST speed, and the blob is ~100KB, so
+// rollovers inside this window are collapsed into the next eligible one
+const AUTOSAVE_THROTTLE_MS = 5000;
+
+export interface SaveGameType {
+  version: number;
+  savedAt: string; // ISO 8601
+  appVersion: string; // For bug reports
+  game: GameType;
+}
+
+// mapStateToProps runs on every dispatch, and re-parsing ~100KB of JSON each time to decide whether
+// to show a Continue button would be silly. Only ever populated by an actual read: writing and
+// clearing invalidate it rather than filling it in, so what's cached is always what's in storage
+// and never an alias of the live (and still mutating) game slice.
+let cached: SaveGameType | null | undefined;
+
+export function serializeSave(game: GameType): SaveGameType {
+  return {
+    version: SAVE_VERSION,
+    savedAt: new Date().toISOString(),
+    appVersion: packageJson.version,
+    game,
+  };
+}
+
+/**
+ * Validates an untrusted blob and returns it as a save, or null if it isn't one. Takes unknown
+ * rather than reading storage itself so that the same checks cover an imported file, where a
+ * malformed facility would otherwise crash the sim mid-tick.
+ */
+export function parseSave(raw: unknown): SaveGameType | null {
+  if (typeof raw !== "object" || raw === null) {
+    return null;
+  }
+  const save = raw as Partial<SaveGameType>;
+  if (save.version !== SAVE_VERSION) {
+    return null;
+  }
+  const game = save.game as Partial<GameType> | undefined;
+  if (typeof game !== "object" || game === null) {
+    return null;
+  }
+  if (
+    typeof game.scenarioId !== "number" ||
+    typeof game.seed !== "number" ||
+    typeof game.startingYear !== "number" ||
+    typeof game.location !== "object" ||
+    game.location === null
+  ) {
+    return null;
+  }
+  if (
+    typeof game.date !== "object" ||
+    game.date === null ||
+    typeof game.date.minute !== "number"
+  ) {
+    return null;
+  }
+  if (
+    !Array.isArray(game.facilities) ||
+    !Array.isArray(game.timeline) ||
+    !Array.isArray(game.monthlyHistory)
+  ) {
+    return null;
+  }
+  return save as SaveGameType;
+}
+
+export function readSave(): SaveGameType | null {
+  if (cached === undefined) {
+    // getStorageJson already returns the fallback for missing keys and unparseable JSON
+    cached = parseSave(getStorageJson<object>(SAVE_KEY, {}));
+  }
+  return cached;
+}
+
+// Returns false when the write didn't land, so the caller can tell the player rather than silently
+// losing their game
+export function writeSave(game: GameType): boolean {
+  cached = undefined;
+  try {
+    setStorageKeyValue(SAVE_KEY, serializeSave(game), false);
+  } catch (_err) {
+    return false;
+  }
+  return true;
+}
+
+export function clearSave() {
+  cached = undefined;
+  removeStorageKey(SAVE_KEY);
+}
+
+/**
+ * Clears the save only if it belongs to the given scenario. Scenarios end for reasons that have
+ * nothing to do with what's in the save -- a tutorial runs a single month and "wins" on the way
+ * past -- and throwing away someone else's saved run over that would be a nasty way to lose a game.
+ */
+export function clearSaveFor(scenarioId: number) {
+  if (readSave()?.game.scenarioId === scenarioId) {
+    clearSave();
+  }
+}
+
+/**
+ * Whether the slice arriving at the loading screen was restored by resume() rather than being a
+ * fresh game waiting for initGame. The timeline is the tell: it's empty on a new game (start clears
+ * it, and initialGame starts it empty) and only initGame or resume ever fills it.
+ */
+export function isResumedGame(game: GameType): boolean {
+  return game.timeline.length > 0;
+}
+
+/**
+ * Writes the game slice to local storage as the player plays. Returns its own teardown.
+ *
+ * isSaveableScenario is injected rather than looked up here (see the note at the top of the file);
+ * pass a predicate that rejects tutorials, which are short enough not to be worth saving and would
+ * need their mid-Joyride step restored too.
+ */
+export function startAutosave(
+  store: AppStore,
+  isSaveableScenario: (scenarioId: number) => boolean,
+): () => void {
+  let savedMonthsEllapsed = -1;
+  let lastWriteMs = 0;
+  // Set when a rollover was skipped by the throttle, so the change isn't lost if the player stops
+  // playing before the next one
+  let pending = false;
+  // A full disk fails every month; saying so once is a warning, saying so every month is a bug
+  let warnedAboutFailure = false;
+
+  const write = () => {
+    const game = store.getState().game;
+    if (writeSave(game)) {
+      savedMonthsEllapsed = game.date.monthsEllapsed;
+      lastWriteMs = performance.now();
+      pending = false;
+    } else if (!warnedAboutFailure) {
+      warnedAboutFailure = true;
+      store.dispatch(
+        snackbarOpen("Couldn't save your game - browser storage is full."),
+      );
+    }
+  };
+
+  const saveable = () => {
+    const game = store.getState().game;
+    return game.inGame && isSaveableScenario(game.scenarioId);
+  };
+
+  const unsubscribe = store.subscribe(() => {
+    if (!saveable()) {
+      return;
+    }
+    const { monthsEllapsed } = store.getState().game.date;
+    if (monthsEllapsed === savedMonthsEllapsed) {
+      return;
+    }
+    pending = true;
+    if (performance.now() - lastWriteMs < AUTOSAVE_THROTTLE_MS) {
+      return;
+    }
+    write();
+  });
+
+  // The write that actually matters: whatever the throttle skipped, flushed the moment the player
+  // leaves. pagehide rather than beforeunload, which mobile browsers routinely never fire.
+  const flush = () => {
+    if (pending && saveable()) {
+      write();
+    }
+  };
+  const onVisibilityChange = () => {
+    if (document.visibilityState === "hidden") {
+      flush();
+    }
+  };
+  document.addEventListener("visibilitychange", onVisibilityChange, false);
+  window.addEventListener("pagehide", flush, false);
+
+  return () => {
+    unsubscribe();
+    document.removeEventListener("visibilitychange", onVisibilityChange, false);
+    window.removeEventListener("pagehide", flush, false);
+  };
+}

--- a/src/components/views/LoadingContainer.tsx
+++ b/src/components/views/LoadingContainer.tsx
@@ -6,6 +6,7 @@ import { initWeather } from "../../data/Weather";
 import { LOCATIONS } from "../../Constants";
 import { SCENARIOS } from "../../data/Scenarios";
 import { initGame, loaded, delta } from "../../reducers/Game";
+import { isResumedGame } from "../../SaveGame";
 import { AppStateType, GameType } from "../../Types";
 import Loading, { DispatchProps, StateProps } from "./Loading";
 
@@ -27,37 +28,44 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
       }
 
       lastLoad = performance.now();
+      // resume() has already restored the whole slice by the time a saved game reaches this
+      // screen, so all that's left is re-reading the CSVs it couldn't carry
+      const resumed = isResumedGame(game);
       logEvent("scenario_start", {
         id: game.scenarioId,
         difficulty: game.difficulty,
+        resumed,
       });
       const scenario = SCENARIOS.find((s) => s.id === game.scenarioId);
       if (!scenario) {
         return alert("Unknown scenario ID " + game.scenarioId);
       }
-      const location = LOCATIONS[scenario.locationId];
+      // A resumed game keeps the location it was saved with, so the weather CSV that gets loaded
+      // is the one its forecasts were built from
+      const location = resumed ? game.location : LOCATIONS[scenario.locationId];
       if (!location) {
         return alert("Unknown location ID " + scenario.locationId);
       }
 
       initWeather(location.id, () => {
-        // TODO load game state from localstorage if loading
-
         initFuelPrices(() => {
-          // Otherwise, generate from scratch
-          // TODO different scenarios - for example, start with Natural Gas if year is 2000+, otherwise coal
-          dispatch(
-            initGame({
-              facilities: scenario.facilities,
-              cash: scenario.cash,
-              customers: 1030000,
-              location,
-            }),
-          );
+          if (!resumed) {
+            // Otherwise, generate from scratch
+            // TODO different scenarios - for example, start with Natural Gas if year is 2000+, otherwise coal
+            dispatch(
+              initGame({
+                facilities: scenario.facilities,
+                cash: scenario.cash,
+                customers: 1030000,
+                location,
+              }),
+            );
+          }
 
           dispatch(loaded());
 
-          if (scenario.tutorialSteps) {
+          // Tutorials are never autosaved, so a resumed game shouldn't restart a walkthrough
+          if (scenario.tutorialSteps && !resumed) {
             setTimeout(() => dispatch(delta({ tutorialStep: 0 })), 300);
           }
         });

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -1,17 +1,24 @@
 import * as React from "react";
-import { Button, IconButton } from "@mui/material";
+import { Button, IconButton, Typography } from "@mui/material";
 import EmailIcon from "@mui/icons-material/Email";
 import InfoIcon from "@mui/icons-material/Info";
 import { login } from "../../Globals";
 import { interactiveColor } from "../../Theme";
 
+export interface SavedGameSummary {
+  scenarioName: string;
+  year: number;
+}
+
 export interface StateProps {
   audioEnabled?: boolean;
+  savedGame?: SavedGameSummary;
   uid?: string;
 }
 
 export interface DispatchProps {
   onAudioChange: (change: boolean) => void;
+  onContinue: () => void;
   onSettings: () => void;
   onManual: () => void;
   onStart: () => void;
@@ -26,12 +33,27 @@ const MainMenu = (props: Props): React.JSX.Element => {
         <img src="images/logo.svg" alt="Logo"></img>
       </div>
       <div id="centeredMenu">
+        {props.savedGame && (
+          <Button
+            size="large"
+            variant="contained"
+            color="primary"
+            onClick={props.onContinue}
+            autoFocus={true}
+            style={{ flexDirection: "column", lineHeight: 1.2 }}
+          >
+            Continue
+            <Typography variant="caption" style={{ textTransform: "none" }}>
+              {props.savedGame.scenarioName} &middot; {props.savedGame.year}
+            </Typography>
+          </Button>
+        )}
         <Button
           size="large"
-          variant="contained"
+          variant={props.savedGame ? "outlined" : "contained"}
           color="primary"
           onClick={props.onStart}
-          autoFocus={true}
+          autoFocus={!props.savedGame}
         >
           Play
         </Button>

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -1,18 +1,13 @@
 import * as React from "react";
-import { Button, IconButton, Typography } from "@mui/material";
+import { Button, IconButton } from "@mui/material";
 import EmailIcon from "@mui/icons-material/Email";
 import InfoIcon from "@mui/icons-material/Info";
 import { login } from "../../Globals";
 import { interactiveColor } from "../../Theme";
 
-export interface SavedGameSummary {
-  scenarioName: string;
-  year: number;
-}
-
 export interface StateProps {
   audioEnabled?: boolean;
-  savedGame?: SavedGameSummary;
+  hasSavedGame: boolean;
   uid?: string;
 }
 
@@ -33,27 +28,23 @@ const MainMenu = (props: Props): React.JSX.Element => {
         <img src="images/logo.svg" alt="Logo"></img>
       </div>
       <div id="centeredMenu">
-        {props.savedGame && (
+        {props.hasSavedGame && (
           <Button
             size="large"
             variant="contained"
             color="primary"
             onClick={props.onContinue}
             autoFocus={true}
-            style={{ flexDirection: "column", lineHeight: 1.2 }}
           >
             Continue
-            <Typography variant="caption" style={{ textTransform: "none" }}>
-              {props.savedGame.scenarioName} &middot; {props.savedGame.year}
-            </Typography>
           </Button>
         )}
         <Button
           size="large"
-          variant={props.savedGame ? "outlined" : "contained"}
+          variant={props.hasSavedGame ? "outlined" : "contained"}
           color="primary"
           onClick={props.onStart}
-          autoFocus={!props.savedGame}
+          autoFocus={!props.hasSavedGame}
         >
           Play
         </Button>

--- a/src/components/views/MainMenuContainer.tsx
+++ b/src/components/views/MainMenuContainer.tsx
@@ -6,39 +6,18 @@ import { navigate } from "../../reducers/Card";
 import { resume } from "../../reducers/Game";
 import { change as changeSettings } from "../../reducers/Settings";
 import { readSave } from "../../SaveGame";
-import MainMenu, {
-  DispatchProps,
-  SavedGameSummary,
-  StateProps,
-} from "./MainMenu";
-
-// mapStateToProps runs on every dispatch, and connect compares its result shallowly, so a fresh
-// summary object each time would re-render the menu constantly. readSave is memoized and hands back
-// the same save until it changes, which makes it a usable cache key.
-let summarizedSave: ReturnType<typeof readSave>;
-let summary: SavedGameSummary | undefined;
+import MainMenu, { DispatchProps, StateProps } from "./MainMenu";
 
 // A save whose scenario no longer exists can't be resumed, so it may as well not be offered
-function savedGameSummary(): SavedGameSummary | undefined {
+function hasSavedGame(): boolean {
   const save = readSave();
-  if (save === summarizedSave) {
-    return summary;
-  }
-  summarizedSave = save;
-  const scenario = save
-    ? SCENARIOS.find((s) => s.id === save.game.scenarioId)
-    : undefined;
-  summary =
-    save && scenario
-      ? { scenarioName: scenario.name, year: save.game.date.year }
-      : undefined;
-  return summary;
+  return !!save && SCENARIOS.some((s) => s.id === save.game.scenarioId);
 }
 
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
     audioEnabled: state.settings.audioEnabled,
-    savedGame: savedGameSummary(),
+    hasSavedGame: hasSavedGame(),
     uid: state.user.uid,
   };
 };

--- a/src/components/views/MainMenuContainer.tsx
+++ b/src/components/views/MainMenuContainer.tsx
@@ -1,13 +1,44 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { AppStateType } from "../../Types";
+import { SCENARIOS } from "../../data/Scenarios";
 import { navigate } from "../../reducers/Card";
+import { resume } from "../../reducers/Game";
 import { change as changeSettings } from "../../reducers/Settings";
-import MainMenu, { DispatchProps, StateProps } from "./MainMenu";
+import { readSave } from "../../SaveGame";
+import MainMenu, {
+  DispatchProps,
+  SavedGameSummary,
+  StateProps,
+} from "./MainMenu";
+
+// mapStateToProps runs on every dispatch, and connect compares its result shallowly, so a fresh
+// summary object each time would re-render the menu constantly. readSave is memoized and hands back
+// the same save until it changes, which makes it a usable cache key.
+let summarizedSave: ReturnType<typeof readSave>;
+let summary: SavedGameSummary | undefined;
+
+// A save whose scenario no longer exists can't be resumed, so it may as well not be offered
+function savedGameSummary(): SavedGameSummary | undefined {
+  const save = readSave();
+  if (save === summarizedSave) {
+    return summary;
+  }
+  summarizedSave = save;
+  const scenario = save
+    ? SCENARIOS.find((s) => s.id === save.game.scenarioId)
+    : undefined;
+  summary =
+    save && scenario
+      ? { scenarioName: scenario.name, year: save.game.date.year }
+      : undefined;
+  return summary;
+}
 
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
     audioEnabled: state.settings.audioEnabled,
+    savedGame: savedGameSummary(),
     uid: state.user.uid,
   };
 };
@@ -16,6 +47,13 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onAudioChange: (v: boolean) => {
       dispatch(changeSettings({ audioEnabled: v }));
+    },
+    onContinue: () => {
+      const save = readSave();
+      if (save) {
+        // Card sends this to LOADING, which re-reads the CSVs and then dispatches loaded()
+        dispatch(resume(save.game));
+      }
     },
     onManual: () => {
       dispatch(navigate("MANUAL"));

--- a/src/components/views/NewGameDetailsContainer.tsx
+++ b/src/components/views/NewGameDetailsContainer.tsx
@@ -1,7 +1,10 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
+import { SCENARIOS } from "../../data/Scenarios";
 import { navigateBack } from "../../reducers/Card";
 import { start, delta } from "../../reducers/Game";
+import { dialogClose, dialogOpen } from "../../reducers/UI";
+import { readSave } from "../../SaveGame";
 import { AppStateType, GameType } from "../../Types";
 import NewGameDetails, { DispatchProps, StateProps } from "./NewGameDetails";
 
@@ -21,7 +24,29 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
       dispatch(delta(d));
     },
     onStart: (scenarioId: number) => {
-      dispatch(start(scenarioId));
+      // Autosave keeps one slot, so a new game replaces whatever's in it. Tutorials aren't saved,
+      // which is why the other entry point into start() doesn't need this.
+      const save = readSave();
+      const saved = save
+        ? SCENARIOS.find((s) => s.id === save.game.scenarioId)
+        : undefined;
+      if (!save || !saved) {
+        return dispatch(start(scenarioId));
+      }
+      dispatch(
+        dialogOpen({
+          title: "Start a new game?",
+          message: `Your saved game (${saved.name}, ${save.game.date.year}) will be replaced.`,
+          open: true,
+          closeText: "Cancel",
+          actionLabel: "Start new game",
+          // The dialog's action button doesn't close the dialog on its own
+          action: () => {
+            dispatch(dialogClose());
+            dispatch(start(scenarioId));
+          },
+        }),
+      );
     },
   };
 };

--- a/src/reducers/Card.tsx
+++ b/src/reducers/Card.tsx
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { getHistoryApi, logEvent } from "../Globals";
 import { NAVIGATION_DEBOUNCE_MS } from "../Constants";
 import { CardNameType, CardType, NavigateActionType } from "../Types";
-import { start, loaded, quit } from "./GameActions";
+import { start, loaded, quit, resume } from "./GameActions";
 import type { RootState } from "../Store";
 
 /**
@@ -61,6 +61,15 @@ export const cardSlice = createSlice({
         history: state.history, // Don't store loading screen in history
       };
       return state;
+    });
+    // A resumed game takes the same route as a new one: the loading screen is what re-reads the
+    // weather and fuel price CSVs, which don't survive a reload
+    builder.addCase(resume, (state) => {
+      return {
+        name: "LOADING" as CardNameType,
+        ts: Date.now(),
+        history: state.history,
+      };
     });
     builder.addCase(loaded, (state) => {
       state = {

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -50,7 +50,8 @@ import { logEvent } from "../Globals";
 import { recordScenarioPlayed } from "../LocalStorage";
 import { SCENARIOS } from "../data/Scenarios";
 import { getStore } from "../StoreRegistry";
-import { start, loaded, quit } from "./GameActions";
+import { start, loaded, quit, resume } from "./GameActions";
+import { clearSaveFor } from "../SaveGame";
 import {
   DateType,
   FacilityOperatingType,
@@ -277,6 +278,25 @@ export const gameSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(start, (state, action) => {
       state.scenarioId = action.payload;
+      // An empty timeline is how the loading screen tells a new game from a resumed one, so make
+      // that true by construction rather than by whichever paths happen to lead here
+      state.timeline = [] as TickPresentFutureType[];
+    });
+    builder.addCase(resume, (_state, action) => {
+      const restored = cloneDeep(action.payload);
+      // The tick loop's module-level locals have to line up with the state being restored.
+      // Unlike initGame, this one keeps the month: clearing it would make the first tick record a
+      // second history entry for a month that's already in the log.
+      previousMonth = restored.date.month;
+      const now = getTimeFromTimeline(restored.date.minute, restored.timeline);
+      previouslyInBlackout = now ? now.supplyW < now.demandW : false;
+      speedBeforeDialog = "PAUSED";
+      // Never resume mid-tick; loaded() flips inGame once the CSVs are back
+      restored.speed = "PAUSED";
+      restored.inGame = false;
+      // tickLoopRunning is deliberately left alone: any loop still alive clears the flag and stops
+      // on its next tick, since tick() bails while !inGame or PAUSED
+      return restored;
     });
     builder.addCase(loaded, (state) => {
       // Start ticking in game
@@ -311,7 +331,7 @@ export const {
 } = gameSlice.actions;
 
 // Re-exported so that everything still imports the game's actions from one place
-export { start, loaded, quit };
+export { start, loaded, quit, resume };
 
 export default gameSlice.reducer;
 
@@ -384,6 +404,9 @@ export function tickState(state: GameType) {
         });
         const summary = summarizeHistory(history);
         setTimeout(() => {
+          // In the timeout rather than here in the reducer: the autosave subscriber runs as soon
+          // as this returns and would write the run straight back
+          clearSaveFor(state.scenarioId);
           const finished = getStore().getState().game;
           getStore().dispatch(
             dialogOpen({
@@ -417,6 +440,7 @@ export function tickState(state: GameType) {
         });
         const summary = summarizeHistory(history);
         setTimeout(() => {
+          clearSaveFor(state.scenarioId);
           const finished = getStore().getState().game;
           getStore().dispatch(
             dialogOpen({
@@ -493,50 +517,50 @@ export function tickState(state: GameType) {
           difficulty,
           score: finalScore,
         });
-        setTimeout(
-          () =>
-            getStore().dispatch(
-              dialogOpen({
-                title: scenario.endTitle || `You've retired!`,
-                message: scenario.endMessage || (
-                  <div>
-                    Your final score is {finalScore}:<br />
-                    <br />
-                    {score.supply} pts from electricity supplied
-                    <br />
-                    {scenario.ownership === "Investor" && (
-                      <span>
-                        {score.netWorth} pts from final net worth
-                        <br />
-                      </span>
-                    )}
-                    {scenario.ownership === "Investor" && (
-                      <span>
-                        {score.customers} pts from final customers
-                        <br />
-                      </span>
-                    )}
-                    {scenario.ownership === "Public" && (
-                      <span>
-                        {score.rate} pts from electric rates
-                        <br />
-                      </span>
-                    )}
-                    {score.emissions} pts from emissions
-                    <br />
-                    {score.blackouts} pts from blackouts
-                    <br />
-                  </div>
-                ),
-                open: true,
-                closeText: "Keep playing",
-                actionLabel: "Return to scenarios",
-                action: () =>
-                  getStore().dispatch(quit({ toScenarioList: true })),
-              }),
-            ),
-          1,
-        );
+        setTimeout(() => {
+          // The scenario is over even if the player takes "Keep playing"; autosave simply writes a
+          // fresh save at the next month rollover if they do
+          clearSaveFor(state.scenarioId);
+          getStore().dispatch(
+            dialogOpen({
+              title: scenario.endTitle || `You've retired!`,
+              message: scenario.endMessage || (
+                <div>
+                  Your final score is {finalScore}:<br />
+                  <br />
+                  {score.supply} pts from electricity supplied
+                  <br />
+                  {scenario.ownership === "Investor" && (
+                    <span>
+                      {score.netWorth} pts from final net worth
+                      <br />
+                    </span>
+                  )}
+                  {scenario.ownership === "Investor" && (
+                    <span>
+                      {score.customers} pts from final customers
+                      <br />
+                    </span>
+                  )}
+                  {scenario.ownership === "Public" && (
+                    <span>
+                      {score.rate} pts from electric rates
+                      <br />
+                    </span>
+                  )}
+                  {score.emissions} pts from emissions
+                  <br />
+                  {score.blackouts} pts from blackouts
+                  <br />
+                </div>
+              ),
+              open: true,
+              closeText: "Keep playing",
+              actionLabel: "Return to scenarios",
+              action: () => getStore().dispatch(quit({ toScenarioList: true })),
+            }),
+          );
+        }, 1);
       }
     }
   }

--- a/src/reducers/GameActions.tsx
+++ b/src/reducers/GameActions.tsx
@@ -1,4 +1,5 @@
 import { createAction } from "@reduxjs/toolkit";
+import type { GameType } from "../Types";
 
 /**
  * The game actions that other slices react to, declared here rather than by the game slice so that
@@ -7,8 +8,8 @@ import { createAction } from "@reduxjs/toolkit";
  * Game reaches out to Store (to dispatch follow-up actions) and to Scenarios (which imports Card),
  * so a direct Card -> Game import closes a cycle. Because Card needs these action creators while
  * its own slice is still being built, whichever module happened to load first would find them
- * undefined and the store would fail to assemble. This module imports nothing but Redux Toolkit,
- * so nothing can cycle back through it.
+ * undefined and the store would fail to assemble. This module imports nothing but Redux Toolkit
+ * and types, so nothing can cycle back through it.
  *
  * The type strings are the ones createSlice generated for a slice named "game", so devtools traces
  * and anything matching on action type are unaffected.
@@ -23,3 +24,8 @@ export const loaded = createAction("game/loaded");
 export const quit = createAction<{ toScenarioList?: boolean } | undefined>(
   "game/quit",
 );
+/**
+ * Restores a saved game slice, then routes to the loading screen the same way start does so that
+ * the weather and fuel price CSVs are back in memory before the first tick.
+ */
+export const resume = createAction<GameType>("game/resume");

--- a/src/reducers/Resume.test.tsx
+++ b/src/reducers/Resume.test.tsx
@@ -1,0 +1,87 @@
+import cloneDeep from "lodash.clonedeep";
+import gameReducer, { loaded, resume, start, tickState } from "./Game";
+import { parseSave, serializeSave } from "../SaveGame";
+import { createGame } from "../testing/Simulator";
+import { GameType } from "../Types";
+
+jest.setTimeout(60000);
+
+// Rise of Renewables, entirely inside the recorded weather and price data
+const OPTIONS = { scenarioId: 101, seed: 8675309 };
+const PLAYED_MONTHS = 6;
+
+function runMonths(state: GameType, months: number) {
+  const until = state.date.monthsEllapsed + months;
+  while (state.date.monthsEllapsed < until) {
+    tickState(state);
+  }
+}
+
+// Redux Toolkit freezes reducer output in development, and tickState mutates state in place
+function restore(saved: GameType): GameType {
+  return cloneDeep(gameReducer(undefined, resume(saved)));
+}
+
+// What a reload hands back: the slice after a trip through JSON and the save envelope
+function serialized(state: GameType): GameType {
+  return parseSave(JSON.parse(JSON.stringify(serializeSave(state))))!.game;
+}
+
+describe("resume", () => {
+  let played: GameType;
+
+  beforeAll(() => {
+    played = createGame(OPTIONS);
+    runMonths(played, PLAYED_MONTHS);
+  });
+
+  it("restores the saved slice", () => {
+    const restored = restore(serialized(played));
+    expect(restored.seed).toBe(played.seed);
+    expect(restored.scenarioId).toBe(played.scenarioId);
+    expect(restored.date.minute).toBe(played.date.minute);
+    expect(restored.facilities).toEqual(played.facilities);
+    expect(restored.monthlyHistory).toEqual(played.monthlyHistory);
+  });
+
+  it("comes back paused and out of game until loaded", () => {
+    const restored = restore({ ...serialized(played), speed: "FAST" });
+    expect(restored.speed).toBe("PAUSED");
+    expect(restored.inGame).toBe(false);
+    expect(gameReducer(restored, loaded()).inGame).toBe(true);
+  });
+
+  /**
+   * The regression the restored previousMonth guards: the tick loop's month tracker lives outside
+   * Redux, so a resume that cleared it (the way initGame does) would roll the month over on the
+   * very first tick and record a second history entry for a month already in the log.
+   */
+  it("doesn't re-record the month it was saved in", () => {
+    const restored = restore(serialized(played));
+    const before = restored.monthlyHistory.length;
+
+    // One tick past the resume shouldn't roll anything over...
+    tickState(restored);
+    expect(restored.monthlyHistory.length).toBe(before);
+
+    // ...and a full month should add exactly one entry
+    runMonths(restored, 1);
+    expect(restored.monthlyHistory.length).toBe(before + 1);
+  });
+
+  it("picks up the run the save was taken from", () => {
+    // Built from scratch rather than cloned, so the tick loop's out-of-store locals are reset the
+    // way they would be for a run that was never interrupted
+    const uninterrupted = createGame(OPTIONS);
+    runMonths(uninterrupted, PLAYED_MONTHS + 3);
+
+    const restored = restore(serialized(played));
+    runMonths(restored, 3);
+
+    expect(restored.monthlyHistory).toEqual(uninterrupted.monthlyHistory);
+  });
+
+  it("starts a new game with an empty timeline so the loading screen can tell them apart", () => {
+    expect(gameReducer(played, start(101)).timeline).toEqual([]);
+  });
+});

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -5,6 +5,7 @@ import { loadSimData } from "./SimData";
 import { TICKS_PER_MONTH } from "../Constants";
 import { getTimeFromTimeline } from "../helpers/DateTime";
 import { tickState } from "../reducers/Game";
+import { parseSave, serializeSave } from "../SaveGame";
 
 jest.setTimeout(120000);
 
@@ -124,7 +125,12 @@ describe("simulation determinism", () => {
 
     const interrupted = createGame(options);
     runMonths(interrupted, HALF_MONTHS);
-    const saved: GameType = JSON.parse(JSON.stringify(interrupted));
+    // Through the real save envelope, so the shipped serialize/validate path is what's covered
+    const parsed = parseSave(
+      JSON.parse(JSON.stringify(serializeSave(interrupted))),
+    );
+    expect(parsed).not.toBeNull();
+    const saved: GameType = parsed!.game;
     // Everything a reload throws away: the parsed CSVs, and the forecast weather and prices
     // appended to them
     loadSimData(uninterrupted.location.id);


### PR DESCRIPTION
Phase 1 of #109, item 1: a game now survives closing the tab. [Plan comment](https://github.com/toddmedema/electrify/issues/109#issuecomment-5381478256).

Phase 0 (#149) did the hard part. Every random draw is addressed by `(seed, stream, index)` and both caches fill forward from the CSVs, so a save has to carry only the game slice — weather and fuel prices rebuild themselves identically on the other side of a reload. `Simulation.test.tsx` already proved a serialized run resumes into the run it would have had. What was left is plumbing.

## The save

New `src/SaveGame.tsx` owns the envelope:

```ts
interface SaveGameType {
  version: number;    // bumped on a breaking change; mismatches are ignored, not migrated
  savedAt: string;
  appVersion: string; // for bug reports
  game: GameType;     // the whole slice
}
```

The whole slice, `timeline` included. It looks like derived data, but current cash and customers live inside it (`getTimeFromTimeline(...).cash`) rather than in scalar fields, so dropping it would lose the player's money. Measured 71 KB at 28 game-months, so a 100-year run lands around 350 KB against a ~5 MB budget.

`parseSave` takes `unknown` and validates shape as well as version, which is stricter than localStorage needs — it's the same check Phase 2's imported files will need, and an untrusted blob should be rejected before it reaches the reducer rather than crashing the sim mid-tick.

The module deliberately imports almost nothing. `reducers/Game` reaches back into it for `clearSaveFor`, and `data/Scenarios` imports `reducers/Game`, so importing the scenarios from here would close the cycle `ImportOrder.test.tsx` guards against. Anything scenario-shaped is passed in by the caller.

## Autosave

A `store.subscribe` (the first in the app) writes once at the turn of each game year, unthrottled. A game year is 1152 ticks, so even at FAST speed that's a write roughly every fifteen seconds — infrequent enough not to need a throttle, and unthrottled means every year boundary actually lands rather than being collapsed into a later one.

That leaves up to a year of play unwritten at any moment, so flushing when the player stops matters. There are two ways out, only one of which the page tells you about:

- **`pagehide` / `visibilitychange`** — closing or backgrounding the tab. `pagehide` rather than `beforeunload`, which mobile browsers routinely never fire.
- **Quitting from the in-game menu** — fires no lifecycle event at all, and `quit` returns `cloneDeep(initialGame)`, so by the time the subscriber runs the state worth writing is already gone. The subscriber therefore holds the last slice it saw while a game was live and writes *that* on the way out.

The flush only ever *updates* a save that's still there. Bankrupt and fired clear the save and then dispatch `quit`, so without that guard the flush would write the dead run straight back and offer Continue into a bankrupt game. It leans on any game writing immediately the moment it starts, which makes "no save present" mean "the scenario ended and cleared it".

Tutorials are excluded — they're short, restoring a mid-Joyride `tutorialStep` isn't worth the complexity, and it means starting one can't clobber a real save. The predicate is injected from `App.tsx`, which sits above both `SaveGame` and `Scenarios` in the import graph.

## Loading a save

New `resume` action, declared in `GameActions.tsx` alongside `start`/`loaded`/`quit` for the same reason — Card has to react to it without importing the reducer. Card routes it to `LOADING`, because the loading screen is what re-reads the CSVs, and `getFuelPricesPerMBTU` throws until `initFuelPrices` resolves.

The game reducer restores the slice and lines up the tick loop's out-of-store locals with it:

- `previousMonth` is set to the **restored** month, not cleared. `initGame` clears it because a new game must roll over on its first tick; a resumed game must not, or `tickState` records a second `monthlyHistory` entry for a month already in the log.
- `previouslyInBlackout` is derived from the restored timeline, so the toast doesn't misfire.
- `speed` is forced to `PAUSED` and `inGame` left false until `loaded()`.
- `tickLoopRunning` is deliberately untouched: any loop still alive clears the flag and stops on its next tick, since `tick()` bails while `!inGame` or paused.

`LoadingContainer` tells a resumed game from a fresh one by its timeline — empty on a new game, filled only by `initGame` or `resume`. `start` now clears it explicitly so that holds by construction rather than by whichever paths happen to lead there.

## UI

A Continue button above Play, and a confirm before a new game replaces the one save slot. That guard is only needed in `NewGameDetailsContainer`, since the other entry into `start` is tutorials, which aren't saved. The dialog's action button doesn't close the dialog itself, hence the explicit `dialogClose()`.

## A bug the browser pass caught

Clearing the save whenever a scenario ended was wrong. Tutorials run a single month and hit the win trigger on the way past, so starting a tutorial wiped an unrelated saved game — reproduced live before fixing. It's `clearSaveFor(scenarioId)` now, which clears only a save belonging to the scenario that ended.

## Testing

`npm run check` passes — 180 tests, 16 suites.

- **`src/SaveGame.test.tsx`** — round trip through storage; the memo never aliasing the live slice; version mismatch, corrupt JSON and malformed game objects each rejected; scenario-scoped clearing. Plus the autosave subscriber against a fake store: writing as soon as a game starts, writing once a year and only at the year turn, the mid-year flush on quit, the bankrupt non-resurrection, tutorials skipped, teardown.
- **`src/reducers/Resume.test.tsx`** — the restored slice, paused-until-loaded, and the double-record regression (one tick after resume adds nothing, one month adds exactly one entry), plus resuming into the same history an uninterrupted run produces.
- **`Simulation.test.tsx`** — the existing determinism test now round-trips through the real `serializeSave`/`parseSave` rather than raw JSON, so the shipped envelope is what's covered.

Verified in the running app. Sampling localStorage while a Carbon Fee run played at FAST recorded writes at 2023, 2024, 2025, 2026 and 2027 — every one on a January boundary, consecutive, none skipped, ~14.7 s apart. Quitting mid-year moved the save from Jan 2029 to Feb 2029, matching the screen. A full page reload restored the exact month and cash, and `monthlyHistory === monthsEllapsed + 1` held afterward. The overwrite confirm cancels cleanly, a tutorial leaves a real save alone, and there are no console errors.

## Worth knowing

A yearly cadence means a hard crash (rather than a close, a background, or a quit — all three of which flush) can cost up to a game year. That's the tradeoff for not writing ~100 KB every second at FAST speed.

## Not in this PR

Import/export (#109 item 2) and replay (item 3), which the plan sequences independently. `checkStorageFreeBytes` also stayed unused — a failed write in a try/catch reports the actual problem rather than predicting one, and warns once per session rather than every year.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
