### PR TITLE
Fill the window on desktop instead of a centered frame

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -108,7 +108,6 @@ $absmaxdimension: 1025px;
 // Wide enough to show Facilities/Finances/Forecasts side by side -- keep in sync with
 // isDesktopScreen() in Globals.tsx. Below this, panes render too narrow to be worth it.
 $desktop_breakpoint: 1300px;
-$desktop_bodymax: 1500px;
 
 $sizemap: (
   large: 6vmin,
@@ -134,7 +133,7 @@ $sizemap: (
 html {
   width: 100%;
   height: 100%;
-  background: #eee;
+  background: $bg_primary;
 }
 
 body {
@@ -151,11 +150,11 @@ body {
   user-select: none;
 }
 
+// Anything wider than a phone gets the whole window: the frame's width cap - and the side
+// borders that bounded it - only earned their keep while there was a grey page showing around it
 @media screen and (min-width: $abswidthmax) {
-  #root {
-    border-left: 1px solid #bdbdbd; /* grey400 */
-    border-right: 1px solid #bdbdbd; /* grey400 */
-    box-sizing: border-box;
+  body {
+    max-width: 100%;
   }
 }
 
@@ -184,7 +183,7 @@ body {
 .snackbar {
   .MuiSnackbarContent-root {
     background-color: $bg_primary;
-    border: 1px solid #bdbdbd; /* grey400, matches the app frame edges */
+    border: 1px solid #bdbdbd; /* grey400 */
     border-radius: 4px;
   }
 
@@ -805,10 +804,6 @@ $sizemap: (
 // Finances and Forecasts can render as panes side by side instead of one screen at a time
 // ===============================================
 @media screen and (min-width: $desktop_breakpoint) {
-  body {
-    max-width: $desktop_bodymax;
-  }
-
   // Redundant once all three nav destinations are visible at the same time as panes
   #navfooter {
     display: none;


### PR DESCRIPTION
On desktop-sized screens the app sat in a centered column with grey page showing on either side — 650px wide on phones, 1500px above the desktop breakpoint. Past phone width there's no reason to hold that shape, so the app now runs edge to edge and every page expands with it.

## Changes

All in `src/app.scss`:

- **`body { max-width: 100% }` above 650px** — replaces the `#root` grey side borders, which only earned their keep while there was a grey page behind them to separate from.
- **`html` background is white** instead of `#eee`, so no grey can peek through at any size.
- **Dropped the 1500px `body` cap** from the `≥1300px` desktop block, and the now-unused `$desktop_bodymax` variable.

The three-pane game layout already used `flex: 1 1 0`, so lifting the body cap is what lets Facilities, Finances and Forecasts each take a third of the whole screen.

## Verification

Measured in the browser against the dev server:

| Viewport | Result |
| --- | --- |
| 1600×900, in game | body 1600, columns 533 / 533 / 533 |
| 2560×1400, in game | body 2560, columns 854 / 854 / 853 |
| 1920×1000, main menu | menu card 1920, logo still capped at 1025 and centered |
| 1920×1000, scenario list | cards 1888 wide |
| 1000×800, in game | single card 1000 wide, bottom nav still shown |
| Manual, 2560 wide | full width, no horizontal overflow |

No console errors. `tsc --noEmit`, Prettier, and all 180 tests pass.

## One thing worth a look

On very wide monitors the Manual now runs text lines the full window width (~2540px at 2560), and its screenshots (~576–834px natural) upscale to match. That follows from making every page full width — the game panes benefit, a text page doesn't. Happy to cap just the Manual's reading column in a follow-up if that reads badly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
