### PR TITLE
Fix & re-enable custom game creation

### DIFF
--- a/src/LocalStorage.tsx
+++ b/src/LocalStorage.tsx
@@ -1,5 +1,5 @@
 import { getLocalStorage } from "./Globals";
-import { LocalStoragePlayedType } from "./Types";
+import { LocalStoragePlayedType, ScenarioType } from "./Types";
 
 // Force specifying a default, since just doing (|| fallback) would bork on stored falsey values
 export function getStorageBoolean(key: string, fallback: boolean): boolean {
@@ -89,6 +89,22 @@ export function recordScenarioPlayed(scenarioId: number) {
       { scenarioId, date: new Date().toString() } as LocalStoragePlayedType,
     ],
   });
+}
+
+const CUSTOM_GAME_KEY = "customGame";
+
+// The last game the player set up on the custom game screen, so it opens where they left it
+// rather than back at the defaults. Unlike a save, this is only the setup, never a game in
+// progress - see SaveGame for the latter
+export function getCustomScenario(fallback: ScenarioType): ScenarioType {
+  const stored = getStorageJson<Partial<ScenarioType>>(CUSTOM_GAME_KEY, {});
+  // A config written by an older version can be missing fields the screen now expects, and
+  // spreading over the defaults is cheaper than versioning something this small
+  return { ...fallback, ...stored };
+}
+
+export function recordCustomScenario(scenario: ScenarioType) {
+  setStorageKeyValue(CUSTOM_GAME_KEY, scenario);
 }
 
 // Check for free space in local storage by allocating space.

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -269,6 +269,9 @@ export interface ScenarioType {
   summary?: string;
   ownership: "Investor" | "Public";
   tutorialSteps?: TutorialStepType[];
+  // Pins the run's RNG so it plays out identically every time. Every authored scenario leaves
+  // this off and draws a fresh seed each play; only the custom game screen sets it
+  seed?: number;
   startingYear: number;
   cash: number;
   dollarsPerkWh: number;
@@ -283,6 +286,9 @@ export interface GameType {
   seed: number;
   difficulty: DifficultyType;
   scenarioId: number;
+  // The scenario the player assembled on the custom game screen. Authored scenarios live in
+  // SCENARIOS, this one only ever exists here, so every lookup has to go through getScenario()
+  customScenario?: ScenarioType;
   location: LocationType;
   speed: SpeedType;
   inGame: boolean;

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -30,6 +30,7 @@ import {
 import AudioContainer from "./base/AudioContainer";
 import BuildGeneratorsContainer from "./views/BuildGeneratorsContainer";
 import BuildStorageContainer from "./views/BuildStorageContainer";
+import CustomGameContainer from "./views/CustomGameContainer";
 import FacilitiesContainer from "./views/FacilitiesContainer";
 import FinancesContainer from "./views/FinancesContainer";
 import ForecastsContainer from "./views/ForecastsContainer";
@@ -279,6 +280,8 @@ export default class Compositor extends React.Component<Props, {}> {
         return <NewGameContainer />;
       case "NEW_GAME_DETAILS":
         return <NewGameDetailsContainer />;
+      case "CUSTOM_GAME":
+        return <CustomGameContainer />;
       default:
         throw new Error("Unknown card " + this.props.card.name);
     }

--- a/src/components/CompositorContainer.tsx
+++ b/src/components/CompositorContainer.tsx
@@ -3,9 +3,14 @@ import { connect } from "react-redux";
 import { delta, quit } from "../reducers/Game";
 import { dialogClose, snackbarClose, snackbarOpen } from "../reducers/UI";
 import { recordScenarioPlayed } from "../LocalStorage";
-import { SCENARIOS } from "../data/Scenarios";
+import { getScenario } from "../data/Scenarios";
 import { navigate } from "../reducers/Card";
-import { AppStateType, TransitionClassType, TutorialStepType } from "../Types";
+import {
+  AppStateType,
+  ScenarioType,
+  TransitionClassType,
+  TutorialStepType,
+} from "../Types";
 import Compositor, {
   DispatchProps,
   isNavCard,
@@ -37,8 +42,10 @@ const mapStateToProps = (state: AppStateType): StateProps => {
     transition,
     scenarioId: state.game.scenarioId,
     tutorialStep: state.game.tutorialStep,
-    tutorialSteps: (SCENARIOS.find((s) => s.id === state.game.scenarioId) || {})
-      .tutorialSteps,
+    tutorialSteps: (
+      getScenario(state.game.scenarioId, state.game.customScenario) ||
+      ({} as Partial<ScenarioType>)
+    ).tutorialSteps,
   };
 };
 

--- a/src/components/base/VictoryConditions.tsx
+++ b/src/components/base/VictoryConditions.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { ScenarioType } from "../../Types";
+
+export interface Props {
+  ownership: ScenarioType["ownership"];
+  dollarsPerkWh: number;
+}
+
+/**
+ * How a scenario is scored, in the player's terms. Shared by the scenario details screen and the
+ * custom game screen, which both offer it behind an info button.
+ *
+ * Scoring algorithm should also be updated in Game.tsx and in the Manual.
+ */
+export default function VictoryConditions(props: Props): React.JSX.Element {
+  const { ownership, dollarsPerkWh } = props;
+  if (ownership === "Investor") {
+    return (
+      <div>
+        <p>+40 pts per $1B of net worth at the end</p>
+        <p>+2 pts per 100k customers at the end</p>
+        <p>+1 pt per TWh of electricity supplied</p>
+        <p>-2 pts per megaton (1M tons) of greenhouse gas emissions</p>
+        <p>-8 pts per TWh of blackouts</p>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <p>
+        +/-80 pts per lifetime average $0.01/kWh charged above/below $
+        {dollarsPerkWh}/kWh
+      </p>
+      <p>+10 pts per TWh of electricity supplied</p>
+      <p>-5 pts per megaton (1M tons) of greenhouse gas emissions</p>
+      <p>-10 pts per TWh of blackouts</p>
+    </div>
+  );
+}

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -1,0 +1,578 @@
+import * as React from "react";
+import {
+  Button,
+  Card,
+  CardHeader,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  TextField,
+  Toolbar,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import CasinoIcon from "@mui/icons-material/Casino";
+import CloseIcon from "@mui/icons-material/Close";
+import DeleteIcon from "@mui/icons-material/Delete";
+import InfoIcon from "@mui/icons-material/Info";
+import VictoryConditions from "../base/VictoryConditions";
+import { DIFFICULTIES, LOCATIONS } from "../../Constants";
+import { GENERATORS, STORAGE } from "../../data/Facilities";
+import { getDateFromMinute } from "../../helpers/DateTime";
+import { formatWattHours, formatWatts } from "../../helpers/Format";
+import { newSeed } from "../../helpers/Math";
+import {
+  DifficultyType,
+  FacilityShoppingType,
+  GameType,
+  LocationIdType,
+  LocationType,
+  ScenarioType,
+} from "../../Types";
+
+export interface StateProps {
+  game: GameType;
+  scenario: ScenarioType;
+}
+
+export interface DispatchProps {
+  onBack: () => void;
+  onDelta: (delta: Partial<GameType>) => void;
+  onStart: (scenario: ScenarioType) => void;
+}
+
+export interface Props extends StateProps, DispatchProps {}
+
+// Weather data runs 1980 - 2019 and is projected forwards from there, so anything from 1980 on
+// plays; earlier would have nothing to project from
+const STARTING_YEARS = [1980, 1990, 2000, 2010, 2020];
+const DURATION_YEARS = [1, 5, 10, 20, 40];
+const STARTING_CASH = [100000000, 200000000, 500000000, 1000000000];
+const RATES_PER_KWH = [0.05, 0.07, 0.1, 0.15];
+const FEES_PER_TON = [0, 20, 50, 100];
+const GENERATOR_SIZES_W = [
+  100000000, 250000000, 500000000, 1000000000, 2000000000,
+];
+const STORAGE_SIZES_WH = [100000000, 500000000, 1000000000, 2000000000];
+
+interface TechnologyType {
+  name: string;
+  storage: boolean;
+  maxSize: number; // maxPeakW for generators, maxPeakWh for storage
+}
+
+/**
+ * The technologies buildable in a given year, straight from the same functions initGame resolves
+ * starting facilities against - so the picker can't offer something that would be silently dropped
+ * on the way into the game (no solar before 1982, no batteries before 2008, and so on).
+ */
+function technologiesFor(
+  scenario: ScenarioType,
+  difficulty: DifficultyType,
+): TechnologyType[] {
+  // Only the fields those two read; a full game state doesn't exist yet at setup time
+  const state = {
+    date: getDateFromMinute(0, scenario.startingYear),
+    difficulty,
+    feePerKgCO2e: scenario.feePerKgCO2e,
+    seed: 0,
+    facilities: [],
+  } as unknown as GameType;
+  // GENERATORS and STORAGE have already filtered out whatever isn't available in the year
+  return [
+    ...GENERATORS(state, GENERATOR_SIZES_W[0], [], []).map(
+      (g: FacilityShoppingType) => ({
+        name: g.name,
+        storage: false,
+        maxSize: g.maxPeakW,
+      }),
+    ),
+    ...STORAGE(state, STORAGE_SIZES_WH[0]).map((s: FacilityShoppingType) => ({
+      name: s.name,
+      storage: true,
+      maxSize: s.maxPeakWh,
+    })),
+    // A technology can be available in a year and still cap out below the smallest plant on
+    // offer - batteries were 50MWh-scale in 2010 - which would leave nothing to pick
+  ].filter(
+    (t: TechnologyType) =>
+      t.maxSize >= (t.storage ? STORAGE_SIZES_WH : GENERATOR_SIZES_W)[0],
+  );
+}
+
+function facilityName(facility: Partial<FacilityShoppingType>): string {
+  return (facility.name as string) || "";
+}
+
+function facilitySize(facility: Partial<FacilityShoppingType>): string {
+  return facility.peakWh
+    ? formatWattHours(facility.peakWh)
+    : formatWatts(facility.peakW || 0);
+}
+
+export default function CustomGame(props: Props): React.JSX.Element {
+  const { game, onBack, onDelta, onStart } = props;
+  const [scenario, setScenario] = React.useState<ScenarioType>(props.scenario);
+  const [victoryDialogOpen, setVictoryDialogOpen] = React.useState(false);
+  const [feeDialogOpen, setFeeDialogOpen] = React.useState(false);
+  const [addName, setAddName] = React.useState("");
+  const [addSize, setAddSize] = React.useState(GENERATOR_SIZES_W[2]);
+
+  const technologies = React.useMemo(
+    () => technologiesFor(scenario, game.difficulty),
+    [scenario, game.difficulty],
+  );
+  const adding = technologies.find((t) => t.name === addName);
+  const sizes = (adding?.storage ? STORAGE_SIZES_WH : GENERATOR_SIZES_W).filter(
+    (size) => !adding || size <= adding.maxSize,
+  );
+  // Starting facilities are built free and already finished, so the only limit is what the
+  // technology could actually be built at in that year
+  const totalPeakW = scenario.facilities.reduce(
+    (sum: number, f: Partial<FacilityShoppingType>) => sum + (f.peakW || 0),
+    0,
+  );
+
+  // Rolling the year back past a technology's invention would otherwise leave a facility in the
+  // list that quietly disappears once the game loads
+  const unavailable = scenario.facilities.filter(
+    (f: Partial<FacilityShoppingType>) =>
+      !technologies.some((t) => t.name === facilityName(f)),
+  );
+
+  const change = (delta: Partial<ScenarioType>) => {
+    setScenario({ ...scenario, ...delta });
+  };
+
+  const addFacility = () => {
+    if (!adding) {
+      return;
+    }
+    const facility = adding.storage
+      ? { name: adding.name, peakWh: addSize }
+      : { name: adding.name, peakW: addSize };
+    change({ facilities: [...scenario.facilities, facility] });
+  };
+
+  const removeFacility = (index: number) => {
+    change({
+      facilities: scenario.facilities.filter(
+        (_f: Partial<FacilityShoppingType>, i: number) => i !== index,
+      ),
+    });
+  };
+
+  return (
+    <div id="listCard" className="flexContainer">
+      <div id="topbar">
+        <Toolbar>
+          <IconButton
+            onClick={onBack}
+            aria-label="back"
+            edge="start"
+            color="primary"
+            size="large"
+          >
+            <ArrowBackIosIcon />
+          </IconButton>
+          <Typography variant="h6">Custom Game Setup</Typography>
+        </Toolbar>
+      </div>
+
+      <div className="scrollable">
+        <Table size="small" id="gameSetupTable">
+          <TableBody>
+            <TableRow>
+              <TableCell>Location</TableCell>
+              <TableCell>
+                <Select
+                  id="location"
+                  value={scenario.locationId}
+                  onChange={(e: SelectChangeEvent<LocationIdType>) =>
+                    change({ locationId: e.target.value as LocationIdType })
+                  }
+                >
+                  {Object.values(LOCATIONS).map((l: LocationType) => {
+                    return (
+                      <MenuItem value={l.id} key={l.id}>
+                        {l.name}
+                      </MenuItem>
+                    );
+                  })}
+                </Select>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Starting year</TableCell>
+              <TableCell>
+                <Select
+                  id="startingYear"
+                  value={scenario.startingYear}
+                  onChange={(e: SelectChangeEvent<number>) =>
+                    change({ startingYear: Number(e.target.value) })
+                  }
+                >
+                  {STARTING_YEARS.map((y: number) => {
+                    return (
+                      <MenuItem value={y} key={y}>
+                        {y}
+                      </MenuItem>
+                    );
+                  })}
+                </Select>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Duration</TableCell>
+              <TableCell>
+                <Select
+                  id="duration"
+                  value={scenario.durationMonths}
+                  onChange={(e: SelectChangeEvent<number>) =>
+                    change({ durationMonths: Number(e.target.value) })
+                  }
+                >
+                  {DURATION_YEARS.map((y: number) => {
+                    return (
+                      <MenuItem value={y * 12} key={y}>
+                        {y} {y === 1 ? "year" : "years"}
+                      </MenuItem>
+                    );
+                  })}
+                </Select>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                Ownership&nbsp;
+                <IconButton
+                  onClick={() => setVictoryDialogOpen(true)}
+                  aria-label="Victory conditions"
+                  color="primary"
+                  size="small"
+                >
+                  <InfoIcon />
+                </IconButton>
+              </TableCell>
+              <TableCell>
+                <Select
+                  id="ownership"
+                  value={scenario.ownership}
+                  onChange={(e: SelectChangeEvent<ScenarioType["ownership"]>) =>
+                    change({
+                      ownership: e.target.value as ScenarioType["ownership"],
+                    })
+                  }
+                >
+                  <MenuItem value="Investor">Investor-Owned</MenuItem>
+                  <MenuItem value="Public">Public-Owned</MenuItem>
+                </Select>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Starting cash</TableCell>
+              <TableCell>
+                <Select
+                  id="cash"
+                  value={scenario.cash}
+                  onChange={(e: SelectChangeEvent<number>) =>
+                    change({ cash: Number(e.target.value) })
+                  }
+                >
+                  {STARTING_CASH.map((c: number) => {
+                    return (
+                      <MenuItem value={c} key={c}>
+                        ${c / 1000000}M
+                      </MenuItem>
+                    );
+                  })}
+                </Select>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Electricity rate</TableCell>
+              <TableCell>
+                <Select
+                  id="dollarsPerkWh"
+                  value={scenario.dollarsPerkWh}
+                  onChange={(e: SelectChangeEvent<number>) =>
+                    change({ dollarsPerkWh: Number(e.target.value) })
+                  }
+                >
+                  {RATES_PER_KWH.map((r: number) => {
+                    return (
+                      <MenuItem value={r} key={r}>
+                        ${r.toFixed(2)}/kWh
+                      </MenuItem>
+                    );
+                  })}
+                </Select>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                Carbon fee&nbsp;
+                <IconButton
+                  onClick={() => setFeeDialogOpen(true)}
+                  aria-label="What is a carbon fee?"
+                  color="primary"
+                  size="small"
+                >
+                  <InfoIcon />
+                </IconButton>
+              </TableCell>
+              <TableCell>
+                <Select
+                  id="feePerKgCO2e"
+                  value={scenario.feePerKgCO2e}
+                  onChange={(e: SelectChangeEvent<number>) =>
+                    change({ feePerKgCO2e: Number(e.target.value) })
+                  }
+                >
+                  {FEES_PER_TON.map((f: number) => {
+                    return (
+                      <MenuItem value={f / 1000} key={f}>
+                        ${f}/ton
+                      </MenuItem>
+                    );
+                  })}
+                </Select>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Difficulty</TableCell>
+              <TableCell>
+                {/* Difficulty lives on the game rather than the scenario, the same way it does
+                    on the scenario details screen */}
+                <Select
+                  id="difficulty"
+                  value={game.difficulty}
+                  onChange={(e: SelectChangeEvent<DifficultyType>) =>
+                    onDelta({ difficulty: e.target.value as DifficultyType })
+                  }
+                >
+                  {Object.keys(DIFFICULTIES).map((d: string) => {
+                    return (
+                      <MenuItem value={d} key={d}>
+                        <Tooltip
+                          title={DIFFICULTIES[d].description}
+                          placement="right"
+                        >
+                          <span>{d}</span>
+                        </Tooltip>
+                      </MenuItem>
+                    );
+                  })}
+                </Select>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Seed</TableCell>
+              <TableCell>
+                {/* Everything random in a run - weather, fuel prices - comes from the seed, so
+                    the same seed and settings replay the same game */}
+                <TextField
+                  id="seed"
+                  variant="standard"
+                  placeholder="Random"
+                  value={scenario.seed === undefined ? "" : scenario.seed}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    const digits = e.target.value.replace(/[^0-9]/g, "");
+                    change({
+                      seed: digits === "" ? undefined : Number(digits),
+                    });
+                  }}
+                />
+                <IconButton
+                  onClick={() => change({ seed: newSeed() })}
+                  aria-label="Random seed"
+                  color="primary"
+                  size="small"
+                >
+                  <CasinoIcon />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+
+        <Typography variant="h6" sx={{ paddingLeft: 1, paddingTop: 1 }}>
+          Starting facilities
+        </Typography>
+        <Typography
+          variant="body2"
+          color="textSecondary"
+          sx={{ paddingLeft: 1 }}
+        >
+          {scenario.facilities.length === 0
+            ? "None - you'll be blacking out until you build something"
+            : `${formatWatts(totalPeakW)} of generation, free and already running`}
+        </Typography>
+        {unavailable.length > 0 && (
+          <Typography variant="body2" color="error" sx={{ paddingLeft: 1 }}>
+            {unavailable.map(facilityName).join(", ")} can't be built in{" "}
+            {scenario.startingYear} - remove{" "}
+            {unavailable.length === 1 ? "it" : "them"} or pick a later year.
+          </Typography>
+        )}
+
+        {scenario.facilities.map(
+          (f: Partial<FacilityShoppingType>, i: number) => {
+            return (
+              <Card className="build-list-item" key={`${facilityName(f)}${i}`}>
+                <CardHeader
+                  title={facilityName(f)}
+                  subheader={facilitySize(f)}
+                  action={
+                    <IconButton
+                      onClick={() => removeFacility(i)}
+                      aria-label={`Remove ${facilityName(f)}`}
+                      color="primary"
+                      size="large"
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  }
+                />
+              </Card>
+            );
+          },
+        )}
+
+        <div style={{ padding: "8px", textAlign: "center" }}>
+          <Select
+            id="addFacilityName"
+            displayEmpty
+            value={adding ? adding.name : ""}
+            onChange={(e: SelectChangeEvent<string>) => {
+              const next = technologies.find((t) => t.name === e.target.value);
+              setAddName(e.target.value);
+              // Sizes differ between generators and storage, so carrying the old one over would
+              // offer a watt-hour capacity for a generator. Opens on a middling plant rather
+              // than the biggest one the year allows, which is a lot to hand someone by default
+              if (next) {
+                const options = (
+                  next.storage ? STORAGE_SIZES_WH : GENERATOR_SIZES_W
+                ).filter((s) => s <= next.maxSize);
+                setAddSize(
+                  options[Math.min(next.storage ? 1 : 2, options.length - 1)],
+                );
+              }
+            }}
+          >
+            <MenuItem value="" disabled>
+              Add a facility
+            </MenuItem>
+            {technologies.map((t: TechnologyType) => {
+              return (
+                <MenuItem value={t.name} key={t.name}>
+                  {t.name}
+                </MenuItem>
+              );
+            })}
+          </Select>
+          &nbsp;
+          <Select
+            id="addFacilitySize"
+            value={sizes.indexOf(addSize) === -1 ? sizes[0] : addSize}
+            disabled={!adding}
+            onChange={(e: SelectChangeEvent<number>) =>
+              setAddSize(Number(e.target.value))
+            }
+          >
+            {sizes.map((size: number) => {
+              return (
+                <MenuItem value={size} key={size}>
+                  {adding?.storage ? formatWattHours(size) : formatWatts(size)}
+                </MenuItem>
+              );
+            })}
+          </Select>
+          <IconButton
+            onClick={addFacility}
+            aria-label="Add facility"
+            color="primary"
+            disabled={!adding}
+            size="large"
+          >
+            <AddIcon />
+          </IconButton>
+        </div>
+
+        <div style={{ textAlign: "center", padding: "12px" }}>
+          <Button
+            size="large"
+            variant="contained"
+            color="primary"
+            disabled={unavailable.length > 0}
+            onClick={() => onStart(scenario)}
+            autoFocus
+          >
+            Play
+          </Button>
+        </div>
+      </div>
+
+      <Dialog
+        open={victoryDialogOpen}
+        onClose={() => setVictoryDialogOpen(false)}
+      >
+        <DialogTitle>
+          Victory Conditions: {scenario.ownership}-Owned
+          <IconButton
+            aria-label="close"
+            onClick={() => setVictoryDialogOpen(false)}
+            className="top-right"
+            size="large"
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          <VictoryConditions
+            ownership={scenario.ownership}
+            dollarsPerkWh={scenario.dollarsPerkWh}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={() => setVictoryDialogOpen(false)}
+          >
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={feeDialogOpen} onClose={() => setFeeDialogOpen(false)}>
+        <DialogTitle>Carbon fee</DialogTitle>
+        <DialogContent>
+          A fee placed on pollution to cover its damage to society. Charged by
+          the amount of greenhouse gas emitted, generally measured in "tons of
+          CO2 equivalent".
+        </DialogContent>
+        <DialogActions>
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={() => setFeeDialogOpen(false)}
+          >
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/views/CustomGameContainer.tsx
+++ b/src/components/views/CustomGameContainer.tsx
@@ -1,0 +1,51 @@
+import type { AppDispatch } from "../../Store";
+import { connect } from "react-redux";
+import {
+  CUSTOM_SCENARIO_ID,
+  DEFAULT_CUSTOM_SCENARIO,
+} from "../../data/Scenarios";
+import { getCustomScenario, recordCustomScenario } from "../../LocalStorage";
+import { navigateBack } from "../../reducers/Card";
+import { delta, start } from "../../reducers/Game";
+import { startWithSaveGuard } from "./StartGame";
+import { AppStateType, GameType, ScenarioType } from "../../Types";
+import CustomGame, { DispatchProps, StateProps } from "./CustomGame";
+
+const mapStateToProps = (state: AppStateType): StateProps => {
+  return {
+    game: state.game,
+    // The game the player set up last time, so tweaking one setting and replaying doesn't mean
+    // re-entering all of them
+    scenario:
+      state.game.customScenario || getCustomScenario(DEFAULT_CUSTOM_SCENARIO),
+  };
+};
+
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
+  return {
+    onBack: () => {
+      dispatch(navigateBack());
+    },
+    onDelta: (d: Partial<GameType>) => {
+      dispatch(delta(d));
+    },
+    onStart: (scenario: ScenarioType) => {
+      recordCustomScenario(scenario);
+      startWithSaveGuard(dispatch, () => {
+        // The scenario has to be on the slice before start(), since the loading screen resolves
+        // it straight back out of there
+        dispatch(
+          delta({ scenarioId: CUSTOM_SCENARIO_ID, customScenario: scenario }),
+        );
+        dispatch(start(CUSTOM_SCENARIO_ID));
+      });
+    },
+  };
+};
+
+const CustomGameContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(CustomGame);
+
+export default CustomGameContainer;

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -44,7 +44,7 @@ import {
 } from "../../Types";
 import ChartFinances from "../base/ChartFinances";
 import GameCard from "../base/GameCard";
-import { SCENARIOS } from "../../data/Scenarios";
+import { getScenario, SCENARIOS } from "../../data/Scenarios";
 
 import numbro from "numbro";
 
@@ -327,7 +327,7 @@ export default class Finances extends React.Component<Props, State> {
     }
 
     const scenario =
-      SCENARIOS.find((s) => s.id === game.scenarioId) || SCENARIOS[0];
+      getScenario(game.scenarioId, game.customScenario) || SCENARIOS[0];
     const years = []; // Go in reverse so that newest value (current year) is on top
     for (let i = date.year; i >= startingYear; i--) {
       years.push(i);

--- a/src/components/views/LoadingContainer.tsx
+++ b/src/components/views/LoadingContainer.tsx
@@ -4,7 +4,7 @@ import { logEvent } from "../../Globals";
 import { initFuelPrices } from "../../data/FuelPrices";
 import { initWeather } from "../../data/Weather";
 import { LOCATIONS } from "../../Constants";
-import { SCENARIOS } from "../../data/Scenarios";
+import { getScenario } from "../../data/Scenarios";
 import { initGame, loaded, delta } from "../../reducers/Game";
 import { isResumedGame } from "../../SaveGame";
 import { AppStateType, GameType } from "../../Types";
@@ -36,7 +36,7 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
         difficulty: game.difficulty,
         resumed,
       });
-      const scenario = SCENARIOS.find((s) => s.id === game.scenarioId);
+      const scenario = getScenario(game.scenarioId, game.customScenario);
       if (!scenario) {
         return alert("Unknown scenario ID " + game.scenarioId);
       }
@@ -58,6 +58,9 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
                 cash: scenario.cash,
                 customers: 1030000,
                 location,
+                // Only ever set by the custom game screen; every authored scenario leaves it
+                // undefined and draws a fresh seed
+                seed: scenario.seed,
               }),
             );
           }

--- a/src/components/views/MainMenuContainer.tsx
+++ b/src/components/views/MainMenuContainer.tsx
@@ -1,17 +1,20 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { AppStateType } from "../../Types";
-import { SCENARIOS } from "../../data/Scenarios";
+import { getScenario } from "../../data/Scenarios";
 import { navigate } from "../../reducers/Card";
 import { resume } from "../../reducers/Game";
 import { change as changeSettings } from "../../reducers/Settings";
 import { readSave } from "../../SaveGame";
 import MainMenu, { DispatchProps, StateProps } from "./MainMenu";
 
-// A save whose scenario no longer exists can't be resumed, so it may as well not be offered
+// A save whose scenario no longer exists can't be resumed, so it may as well not be offered. A
+// custom game carries its own scenario in the save, so it resolves the same way any other does
 function hasSavedGame(): boolean {
   const save = readSave();
-  return !!save && SCENARIOS.some((s) => s.id === save.game.scenarioId);
+  return (
+    !!save && !!getScenario(save.game.scenarioId, save.game.customScenario)
+  );
 }
 
 const mapStateToProps = (state: AppStateType): StateProps => {

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -17,7 +17,12 @@ import HelpOutlineIcon from "@mui/icons-material/HelpOutlineOutlined";
 import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import { getPlayedScenarioIds } from "../../LocalStorage";
 import { LOCATIONS } from "../../Constants";
-import { SCENARIOS, TUTORIALS } from "../../data/Scenarios";
+import {
+  CUSTOM_SCENARIO_ID,
+  DEFAULT_CUSTOM_SCENARIO,
+  SCENARIOS,
+  TUTORIALS,
+} from "../../data/Scenarios";
 import { GameType, ScenarioType } from "../../Types";
 
 export interface StateProps {
@@ -26,6 +31,7 @@ export interface StateProps {
 
 export interface DispatchProps {
   onBack: () => void;
+  onCustomGame: () => void;
   onDetails: (delta: Partial<GameType>) => void;
   onManual: () => void;
   onTutorial: (scenarioId: number) => void;
@@ -82,16 +88,18 @@ function TutorialListItem(props: TutorialListItemProps): React.JSX.Element {
 
 interface ScenarioListItemProps {
   s: ScenarioType;
-  onDetails: DispatchProps["onDetails"];
+  // The custom game row opens its own setup screen rather than the scenario details one, so the
+  // row doesn't get to assume what selecting it does
+  onSelect: () => void;
 }
 
 function ScenarioListItem(props: ScenarioListItemProps): React.JSX.Element {
-  const { s, onDetails } = props;
+  const { s, onSelect } = props;
   const location = LOCATIONS[s.locationId] || {
     name: "UNKNOWN",
   };
   const summary =
-    s.id === 999 ? (
+    s.id === CUSTOM_SCENARIO_ID ? (
       s.summary
     ) : (
       <span>
@@ -104,20 +112,13 @@ function ScenarioListItem(props: ScenarioListItemProps): React.JSX.Element {
       </span>
     );
   return (
-    <Card
-      className="build-list-item clickable-card"
-      onClick={() => onDetails({ scenarioId: s.id })}
-    >
+    <Card className="build-list-item clickable-card" onClick={onSelect}>
       <CardHeader
         avatar={<Avatar src={`/images/${s.icon.toLowerCase()}.svg`} />}
         title={s.name}
         subheader={summary}
         action={
-          <IconButton
-            color="primary"
-            onClick={() => onDetails({ scenarioId: s.id })}
-            size="large"
-          >
+          <IconButton color="primary" onClick={onSelect} size="large">
             <ArrowRightIcon />
           </IconButton>
         }
@@ -195,9 +196,18 @@ export default function NewGame(props: Props): React.JSX.Element {
         </Typography>
         {SCENARIOS.filter((s: ScenarioType) => !s.tutorialSteps).map((s) => {
           return (
-            <ScenarioListItem key={s.id} onDetails={props.onDetails} s={s} />
+            <ScenarioListItem
+              key={s.id}
+              onSelect={() => props.onDetails({ scenarioId: s.id })}
+              s={s}
+            />
           );
         })}
+        <ScenarioListItem
+          key={CUSTOM_SCENARIO_ID}
+          onSelect={props.onCustomGame}
+          s={DEFAULT_CUSTOM_SCENARIO}
+        />
       </List>
     </div>
   );

--- a/src/components/views/NewGameContainer.tsx
+++ b/src/components/views/NewGameContainer.tsx
@@ -16,6 +16,9 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     onBack: () => {
       dispatch(quit());
     },
+    onCustomGame: () => {
+      dispatch(navigate("CUSTOM_GAME"));
+    },
     onDetails: (d: Partial<GameType>) => {
       dispatch(delta(d));
       dispatch(navigate("NEW_GAME_DETAILS"));

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -29,9 +29,10 @@ import {
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import CloseIcon from "@mui/icons-material/Close";
 import InfoIcon from "@mui/icons-material/Info";
+import VictoryConditions from "../base/VictoryConditions";
 import { DIFFICULTIES, LOCATIONS } from "../../Constants";
 import { getDb, login } from "../../Globals";
-import { SCENARIOS } from "../../data/Scenarios";
+import { getScenario } from "../../data/Scenarios";
 import {
   DifficultyType,
   GameType,
@@ -67,7 +68,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     const scenario =
-      SCENARIOS.find((s) => s.id === props.game.scenarioId) || null;
+      getScenario(props.game.scenarioId, props.game.customScenario) || null;
     this.state = {
       scenario,
       location: scenario ? LOCATIONS[scenario.locationId || null] : null,
@@ -224,27 +225,10 @@ export default class NewGameDetails extends React.Component<Props, State> {
             </IconButton>
           </DialogTitle>
           <DialogContent>
-            {/* Scoring algorithm should also be updated in Game.tsx */}
-            {scenario.ownership === "Investor" && (
-              <div>
-                <p>+40 pts per $1B of net worth at the end</p>
-                <p>+2 pts per 100k customers at the end</p>
-                <p>+1 pt per TWh of electricity supplied</p>
-                <p>-2 pts per megaton (1M tons) of greenhouse gas emissions</p>
-                <p>-8 pts per TWh of blackouts</p>
-              </div>
-            )}
-            {scenario.ownership === "Public" && (
-              <div>
-                <p>
-                  +/-80 pts per lifetime average $0.01/kWh charged above/below $
-                  {scenario.dollarsPerkWh}/kWh
-                </p>
-                <p>+10 pts per TWh of electricity supplied</p>
-                <p>-5 pts per megaton (1M tons) of greenhouse gas emissions</p>
-                <p>-10 pts per TWh of blackouts</p>
-              </div>
-            )}
+            <VictoryConditions
+              ownership={scenario.ownership}
+              dollarsPerkWh={scenario.dollarsPerkWh}
+            />
           </DialogContent>
           <DialogActions>
             <Button

--- a/src/components/views/NewGameDetailsContainer.tsx
+++ b/src/components/views/NewGameDetailsContainer.tsx
@@ -1,10 +1,8 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
-import { SCENARIOS } from "../../data/Scenarios";
 import { navigateBack } from "../../reducers/Card";
 import { start, delta } from "../../reducers/Game";
-import { dialogClose, dialogOpen } from "../../reducers/UI";
-import { readSave } from "../../SaveGame";
+import { startWithSaveGuard } from "./StartGame";
 import { AppStateType, GameType } from "../../Types";
 import NewGameDetails, { DispatchProps, StateProps } from "./NewGameDetails";
 
@@ -24,29 +22,7 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
       dispatch(delta(d));
     },
     onStart: (scenarioId: number) => {
-      // Autosave keeps one slot, so a new game replaces whatever's in it. Tutorials aren't saved,
-      // which is why the other entry point into start() doesn't need this.
-      const save = readSave();
-      const saved = save
-        ? SCENARIOS.find((s) => s.id === save.game.scenarioId)
-        : undefined;
-      if (!save || !saved) {
-        return dispatch(start(scenarioId));
-      }
-      dispatch(
-        dialogOpen({
-          title: "Start a new game?",
-          message: `Your saved game (${saved.name}, ${save.game.date.year}) will be replaced.`,
-          open: true,
-          closeText: "Cancel",
-          actionLabel: "Start new game",
-          // The dialog's action button doesn't close the dialog on its own
-          action: () => {
-            dispatch(dialogClose());
-            dispatch(start(scenarioId));
-          },
-        }),
-      );
+      startWithSaveGuard(dispatch, () => dispatch(start(scenarioId)));
     },
   };
 };

--- a/src/components/views/StartGame.tsx
+++ b/src/components/views/StartGame.tsx
@@ -1,0 +1,39 @@
+import type { AppDispatch } from "../../Store";
+import { getScenario } from "../../data/Scenarios";
+import { dialogClose, dialogOpen } from "../../reducers/UI";
+import { readSave } from "../../SaveGame";
+
+/**
+ * Starts a game, first asking about the autosave if starting would overwrite it.
+ *
+ * Shared by the scenario details screen and the custom game screen, which reach start() with
+ * different payloads - hence the callback rather than a scenario id. Tutorials don't go through
+ * here: they're never autosaved, so they have nothing to clobber.
+ */
+export function startWithSaveGuard(
+  dispatch: AppDispatch,
+  startGame: () => void,
+) {
+  // Autosave keeps one slot, so a new game replaces whatever's in it
+  const save = readSave();
+  const saved = save
+    ? getScenario(save.game.scenarioId, save.game.customScenario)
+    : undefined;
+  if (!save || !saved) {
+    return startGame();
+  }
+  dispatch(
+    dialogOpen({
+      title: "Start a new game?",
+      message: `Your saved game (${saved.name}, ${save.game.date.year}) will be replaced.`,
+      open: true,
+      closeText: "Cancel",
+      actionLabel: "Start new game",
+      // The dialog's action button doesn't close the dialog on its own
+      action: () => {
+        dispatch(dialogClose());
+        startGame();
+      },
+    }),
+  );
+}

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -1,4 +1,5 @@
 import { LCWH } from "../helpers/Financials";
+import { hasFuelPrices } from "./FuelPrices";
 import { DIFFICULTIES } from "../Constants";
 import {
   FacilityOperatingType,
@@ -315,7 +316,12 @@ export function GENERATORS(
     g.buildCost *= difficulty.buildCost;
     g.annualOperatingCost *= difficulty.expensesOM;
     g.yearsToBuild *= difficulty.buildTime;
-    g.lcWh = LCWH(g, state.date, state.feePerKgCO2e, state.seed);
+    // The custom game screen asks what can be built in a year before any game has loaded the
+    // price data a levelized cost needs. Nothing there reads lcWh, and a cost per Wh with no
+    // fuel prices behind it is genuinely unknown rather than zero
+    g.lcWh = hasFuelPrices()
+      ? LCWH(g, state.date, state.feePerKgCO2e, state.seed)
+      : Infinity;
     return g.available;
   });
 

--- a/src/data/FuelPrices.tsx
+++ b/src/data/FuelPrices.tsx
@@ -40,6 +40,15 @@ interface RawFuelPricesType {
 // year -> month (1-12) -> price per MBTU by fuel
 const fuelPrices: Record<number, Record<number, FuelPricesType>> = {};
 
+/**
+ * Whether any prices have been loaded yet. The game screens all run after the loading screen has
+ * read the CSV, but the new game screens don't - and asking for a price there is a question with
+ * no answer rather than the programming error getFuelPricesPerMBTU otherwise throws over.
+ */
+export function hasFuelPrices(): boolean {
+  return Object.keys(fuelPrices).length > 0;
+}
+
 // Emptied in place rather than reassigned so that the closure in projectYear keeps referring to
 // a const, which no-loop-func requires
 function resetFuelPrices() {

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -1,0 +1,43 @@
+import {
+  CUSTOM_SCENARIO_ID,
+  DEFAULT_CUSTOM_SCENARIO,
+  getScenario,
+  SCENARIOS,
+} from "./Scenarios";
+import { ScenarioType } from "../Types";
+
+describe("getScenario", () => {
+  it("finds an authored scenario by id", () => {
+    const authored = SCENARIOS[SCENARIOS.length - 1];
+    expect(getScenario(authored.id)).toBe(authored);
+  });
+
+  it("returns the custom scenario for the custom id", () => {
+    const custom = {
+      ...DEFAULT_CUSTOM_SCENARIO,
+      startingYear: 1990,
+    } as ScenarioType;
+    expect(getScenario(CUSTOM_SCENARIO_ID, custom)).toBe(custom);
+  });
+
+  it("ignores the custom scenario when asked for an authored one", () => {
+    const authored = SCENARIOS[0];
+    expect(getScenario(authored.id, DEFAULT_CUSTOM_SCENARIO)).toBe(authored);
+  });
+
+  it("finds nothing for a custom game that has no config", () => {
+    expect(getScenario(CUSTOM_SCENARIO_ID)).toBeUndefined();
+  });
+
+  it("finds nothing for an id that doesn't exist", () => {
+    expect(getScenario(-1)).toBeUndefined();
+  });
+
+  // Every custom game reuses one id, so an authored scenario taking it would be resolved as
+  // whatever the player last set up
+  it("keeps the custom id out of the authored scenarios", () => {
+    expect(
+      SCENARIOS.some((s: ScenarioType) => s.id === CUSTOM_SCENARIO_ID),
+    ).toBe(false);
+  });
+});

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -632,3 +632,46 @@ export const SCENARIOS = [
 
 // The numbered 101-106 walkthroughs, in the order a new player should work through them
 export const TUTORIALS = SCENARIOS.filter((s) => s.tutorialSteps);
+
+// Reserved for the game the player builds themselves; no authored scenario may use it
+export const CUSTOM_SCENARIO_ID = 999;
+
+/**
+ * The one place the game turns a scenario id into a scenario.
+ *
+ * Authored scenarios live in SCENARIOS, but a custom game is assembled at runtime and rides along
+ * on the game slice instead, so a bare SCENARIOS.find() silently falls back to the wrong scenario
+ * for it - which is what broke the custom game screen in the first place.
+ */
+export function getScenario(
+  scenarioId: number,
+  custom?: ScenarioType,
+): ScenarioType | undefined {
+  if (scenarioId === CUSTOM_SCENARIO_ID) {
+    return custom;
+  }
+  return SCENARIOS.find((s: ScenarioType) => s.id === scenarioId);
+}
+
+/**
+ * What the custom game screen opens on before the player has set one up, and the row that opens
+ * it in the scenario list - which shows only its name, icon and summary, since the rest is
+ * whatever they last chose rather than anything fixed.
+ *
+ * Deliberately not in SCENARIOS: everything that walks that array (the sim CLI and its tests, the
+ * scenario list itself) means the authored scenarios.
+ */
+export const DEFAULT_CUSTOM_SCENARIO = {
+  id: CUSTOM_SCENARIO_ID,
+  name: "Custom Game",
+  icon: "battery",
+  summary: "Set your own location, era and rules",
+  locationId: "SF",
+  ownership: "Investor",
+  startingYear: 2020,
+  cash: 200000000,
+  dollarsPerkWh: 0.07,
+  durationMonths: 12 * 20,
+  feePerKgCO2e: 0,
+  facilities: [{ name: "Natural Gas", peakW: 500000000 }],
+} as ScenarioType;

--- a/src/reducers/Card.test.tsx
+++ b/src/reducers/Card.test.tsx
@@ -1,7 +1,14 @@
-import cardReducer from "./Card";
+import cardReducer, { navigate, navigateBack } from "./Card";
 import { quit } from "./GameActions";
 
 describe("card reducer", () => {
+  it("goes to the custom game screen and back to the scenario list", () => {
+    const list = cardReducer(undefined, navigate("NEW_GAME"));
+    const custom = cardReducer(list, navigate("CUSTOM_GAME"));
+    expect(custom.name).toBe("CUSTOM_GAME");
+    expect(cardReducer(custom, navigateBack()).name).toBe("NEW_GAME");
+  });
+
   it("returns to the title screen on a plain quit", () => {
     const state = cardReducer(undefined, quit());
     expect(state.name).toBe("MAIN_MENU");

--- a/src/reducers/CustomGame.test.tsx
+++ b/src/reducers/CustomGame.test.tsx
@@ -1,0 +1,101 @@
+import { CUSTOM_SCENARIO_ID, DEFAULT_CUSTOM_SCENARIO } from "../data/Scenarios";
+import { getTimeFromTimeline } from "../helpers/DateTime";
+import { getPlayedScenarioIds } from "../LocalStorage";
+import { createGame, runSimulation } from "../testing/Simulator";
+import { FacilityOperatingType, ScenarioType } from "../Types";
+
+// The settings a player might pick on the custom game screen, all different from both the slice
+// defaults and the first authored scenario, which is what a broken lookup falls back to
+const CUSTOM = {
+  ...DEFAULT_CUSTOM_SCENARIO,
+  locationId: "PIT",
+  ownership: "Public",
+  startingYear: 1990,
+  cash: 500000000,
+  dollarsPerkWh: 0.1,
+  feePerKgCO2e: 50 / 1000,
+  durationMonths: 12 * 5,
+  seed: 1234,
+  facilities: [
+    { name: "Coal", peakW: 200000000 },
+    { name: "Pumped Hydro", peakWh: 500000000 },
+  ],
+} as ScenarioType;
+
+describe("a custom game", () => {
+  it("starts on the player's settings rather than an authored scenario's", () => {
+    const state = createGame({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: CUSTOM,
+    });
+
+    expect(state.scenarioId).toBe(CUSTOM_SCENARIO_ID);
+    expect(state.customScenario).toEqual(CUSTOM);
+    expect(state.startingYear).toBe(1990);
+    expect(state.date.year).toBe(1990);
+    expect(state.location.id).toBe("PIT");
+    expect(state.feePerKgCO2e).toBe(50 / 1000);
+    expect(state.dollarsPerkWh).toBe(0.1);
+    // Within a rounding error of the starting cash: initGame pre-rolls a few frames, which
+    // already earns and spends a little
+    const cash = getTimeFromTimeline(state.date.minute, state.timeline)!.cash;
+    expect(cash).toBeGreaterThan(499000000);
+    expect(cash).toBeLessThan(501000000);
+  });
+
+  it("builds the starting facilities it was given", () => {
+    const state = createGame({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: CUSTOM,
+    });
+
+    // Specs that match nothing are skipped rather than built, which is how a starting portfolio
+    // silently empties out - name and size have to line up with what the year can build
+    expect(state.facilities.map((f: FacilityOperatingType) => f.name)).toEqual([
+      "Coal",
+      "Pumped Hydro",
+    ]);
+    expect(state.facilities[0].peakW).toBe(200000000);
+    expect(state.facilities[1].peakWh).toBe(500000000);
+    // Starting facilities are finished and free, unlike anything bought mid-game
+    state.facilities.forEach((f: FacilityOperatingType) => {
+      expect(f.yearsToBuildLeft).toBe(0);
+      expect(f.loanAmountLeft).toBe(0);
+    });
+  });
+
+  it("runs on the seed the player pinned, and replays identically from it", () => {
+    const first = createGame({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: CUSTOM,
+    });
+    const second = createGame({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: CUSTOM,
+    });
+
+    expect(first.seed).toBe(1234);
+    expect(second.seed).toBe(first.seed);
+    expect(second.timeline[0].temperatureC).toBe(
+      first.timeline[0].temperatureC,
+    );
+  });
+
+  // Every custom game shares one id, so a finished one must not tick off a completion marker
+  // (or, for the same reason, post a score to a leaderboard it has nothing in common with)
+  it("isn't recorded as a scenario the player has completed", () => {
+    localStorage.clear();
+
+    // A one-month game so the run reaches its end, which is where completion is recorded
+    runSimulation({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: { ...CUSTOM, durationMonths: 1 } as ScenarioType,
+    });
+    expect(getPlayedScenarioIds()).not.toContain(CUSTOM_SCENARIO_ID);
+
+    // The same run of an authored scenario does get recorded, so the assertion above isn't
+    // passing because nothing reaches the end
+    runSimulation({ scenarioId: 4 }); // 104: Finances, also one month long
+    expect(getPlayedScenarioIds()).toContain(4);
+  });
+});

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -48,7 +48,7 @@ import {
 import { GENERATORS, STORAGE } from "../data/Facilities";
 import { logEvent } from "../Globals";
 import { recordScenarioPlayed } from "../LocalStorage";
-import { SCENARIOS } from "../data/Scenarios";
+import { CUSTOM_SCENARIO_ID, getScenario, SCENARIOS } from "../data/Scenarios";
 import { getStore } from "../StoreRegistry";
 import { start, loaded, quit, resume } from "./GameActions";
 import { clearSaveFor } from "../SaveGame";
@@ -166,7 +166,7 @@ export const gameSlice = createSlice({
       state.timeline = [] as TickPresentFutureType[];
       state.seed = a.seed !== undefined ? a.seed : newSeed();
       const scenario =
-        SCENARIOS.find((s) => s.id === state.scenarioId) || SCENARIOS[0];
+        getScenario(state.scenarioId, state.customScenario) || SCENARIOS[0];
       state.date = getDateFromMinute(0, scenario.startingYear);
       state.startingYear = scenario.startingYear;
       state.feePerKgCO2e = scenario.feePerKgCO2e;
@@ -205,6 +205,12 @@ export const gameSlice = createSlice({
           );
           if (storage) {
             state = buildFacilityHelper(state, storage, false, true);
+          } else {
+            // A spec that matches nothing used to vanish without a trace, which is a rough way to
+            // find out that the technology you picked wasn't invented yet in the year you started
+            console.warn(
+              `No facility matches ${JSON.stringify(search)} in ${scenario.startingYear}, skipping it`,
+            );
           }
         }
       });
@@ -459,13 +465,18 @@ export function tickState(state: GameType) {
       }
 
       const scenario =
-        SCENARIOS.find((s) => s.id === state.scenarioId) || SCENARIOS[0];
+        getScenario(state.scenarioId, state.customScenario) || SCENARIOS[0];
 
       // Success: Survived duration
       if (state.date.monthsEllapsed === (scenario.durationMonths || 12 * 20)) {
-        // Tutorials are already marked played once their walkthrough ends, so this is a
-        // no-op for the ones the player sat all the way through
-        recordScenarioPlayed(state.scenarioId);
+        // Every custom game shares one id, so recording it would light up a completion marker for
+        // a scenario nobody authored, and its score belongs to nothing comparable
+        const ranked = scenario.id !== CUSTOM_SCENARIO_ID;
+        if (ranked) {
+          // Tutorials are already marked played once their walkthrough ends, so this is a
+          // no-op for the ones the player sat all the way through
+          recordScenarioPlayed(state.scenarioId);
+        }
 
         // Calculate score - This is also described in the manual; if I update the algorithm, update the manual too!
         const summary = summarizeHistory(history);
@@ -496,7 +507,10 @@ export function tickState(state: GameType) {
         const finalScore = Object.values(score).reduce((a, b) => a + b);
         const difficulty = state.difficulty; // pulling out of state for functions running inside of setTimeout
 
-        if (!scenario.tutorialSteps) {
+        // The leaderboard is keyed on scenario id alone, so custom runs - whatever cash, duration
+        // and rules the player gave themselves - would be scored against each other as if they
+        // were the same scenario
+        if (!scenario.tutorialSteps && ranked) {
           setTimeout(
             () =>
               getStore().dispatch(

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -35,6 +35,9 @@ export type StrategyType = "none" | "keepUp";
 
 export interface SimOptionsType {
   scenarioId: number;
+  // A scenario that isn't in SCENARIOS - a custom game, or one being tried out. Its id wins over
+  // scenarioId, the same way the real game treats the one on the slice
+  scenario?: ScenarioType;
   difficulty?: DifficultyType;
   months?: number; // Defaults to the scenario's own duration
   seed?: number;
@@ -96,6 +99,7 @@ function formatWhen(state: GameType): string {
  */
 export function createGame(options: SimOptionsType): GameType {
   const scenario =
+    options.scenario ||
     SCENARIOS.find((s: ScenarioType) => s.id === options.scenarioId) ||
     SCENARIOS[0];
   loadSimData(scenario.locationId);
@@ -113,6 +117,11 @@ function setUpGame(
     delta({
       difficulty: options.difficulty,
       monthlyMarketingSpend: options.monthlyMarketingSpend,
+      // A scenario that isn't in SCENARIOS can only be found again through the slice, which is
+      // exactly what the custom game screen does before it starts a game
+      customScenario: SCENARIOS.some((s: ScenarioType) => s.id === scenario.id)
+        ? undefined
+        : scenario,
     }),
   );
   state = gameReducer(
@@ -182,7 +191,14 @@ function resolveOptions(
     scenarioId: scenario.id,
     difficulty: options.difficulty || "Employee",
     months: options.months || scenario.durationMonths || 12 * 20,
-    seed: options.seed === undefined ? DEFAULT_SEED : options.seed,
+    // A scenario carrying its own seed is pinned to it, the same as in a real game; the sim's
+    // fixed default only covers the authored scenarios, none of which set one
+    seed:
+      options.seed !== undefined
+        ? options.seed
+        : scenario.seed !== undefined
+          ? scenario.seed
+          : DEFAULT_SEED,
     dollarsPerkWh:
       options.dollarsPerkWh === undefined ? null : options.dollarsPerkWh,
     monthlyMarketingSpend: options.monthlyMarketingSpend || 0,
@@ -192,6 +208,7 @@ function resolveOptions(
 
 export function runSimulation(options: SimOptionsType): SimResultType {
   const scenario =
+    options.scenario ||
     SCENARIOS.find((s: ScenarioType) => s.id === options.scenarioId) ||
     SCENARIOS[0];
   const resolved = resolveOptions(scenario, options);


### PR DESCRIPTION
Closes #76.

## Why it was broken

The custom game screen wasn't just commented out — the reason it stopped working is structural. The game turns a scenario id into a scenario with `SCENARIOS.find(s => s.id === game.scenarioId)` in **eight** separate places, and a scenario the player builds at runtime is in no array, so every one of those lookups silently fell back to `SCENARIOS[0]` (the first tutorial). Wrong year, wrong location, wrong duration, wrong ownership, wrong scoring.

## The fix

`getScenario(scenarioId, custom)` in `data/Scenarios.tsx` is now the one place that lookup happens, checking the `customScenario` carried on the game slice for the reserved id 999. All eight call sites go through it — including `MainMenuContainer`'s "can this save be resumed" check, which would otherwise never offer Continue for a saved custom game.

## The screen

`CustomGame.tsx` + container: location, starting year, duration, ownership, starting cash, retail rate, carbon fee, difficulty, an optional seed (new `ScenarioType.seed`, plumbed through `initGame`), and a starting-facility builder.

The builder is built from the real `GENERATORS` / `STORAGE` for the chosen year, so it can only offer what the game can actually build — no Solar before 1982, no Battery before 2008, sizes capped by each technology's `maxPeakW` / `maxPeakWh`. Rolling the year back flags stranded facilities and disables Play, instead of letting them vanish at load time.

Custom runs stay off the leaderboard and out of the completion markers: every one shares a single id, so those scores aren't comparable to each other, let alone to an authored scenario.

## Two bugs found while verifying

- `GENERATORS` threw before any game had loaded, because a levelized cost needs fuel prices. Added `hasFuelPrices()` and left `lcWh` at `Infinity` when there's no price data rather than crashing the setup screen.
- Picking a technology defaulted to the largest size the year allowed, handing the player 2GW of free coal. It now opens on a middling plant.

## Also

Extracted the duplicated save-overwrite prompt into `StartGame.tsx` and the scoring blurb into `VictoryConditions.tsx`, both now shared with the scenario details screen. `SimOptionsType` takes an optional `scenario`, which gives the headless sim custom-scenario support and makes this testable at the reducer level.

## Verification

- `npm run check` passes — typecheck, lint, prettier, **191 tests** (11 new, in `data/Scenarios.test.tsx` and `reducers/CustomGame.test.tsx`).
- `npm run sim` on scenarios 103 and 104: no invariant violations, authored results unchanged.
- In the browser: set up Pittsburgh / 1980 / Public / $0.10 / $50-a-ton / seed 42424 with two coal plants and a pumped hydro. The game starts in **Jan 1980** with all four facilities already running, Finances shows the Public rate slider rather than the Investor marketing slider, and the autosave holds `{loc: "PIT", year: 1980, seed: 42424, scenarioId: 999}`. Continue resumes it; reopening the screen remembers the config. Switching 2020 → 1980 with a solar plant listed shows "Solar can't be built in 1980" and disables Play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
