### PR TITLE
Fix manual search, add contextual entry points and keyboard access

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -79,6 +79,8 @@ export type CardNameType =
 export interface NavigateActionType {
   name: CardNameType;
   dontRemember?: boolean;
+  // Manual entry to open and scroll to, for deep links from terms the game shows elsewhere
+  entry?: string;
 }
 
 export interface CardType {
@@ -86,6 +88,7 @@ export interface CardType {
   ts: number;
   history?: CardNameType[];
   toPrevious?: boolean;
+  entry?: string;
 }
 
 // The per-category points that sum to `score`. Investor and public-ownership scenarios are

--- a/src/app.scss
+++ b/src/app.scss
@@ -517,8 +517,10 @@ $topbar_height: 56px;
   font-size: 0.85em;
 }
 
-// Keyboard shortcut listings (Settings + Manual)
-.shortcuts {
+// Two-column "key(s) -> meaning" listings: keyboard shortcuts (Settings + Manual) and the
+// manual's score tables, whose point values need to line up in a column to be comparable
+.shortcuts,
+.points {
   margin: 8px auto;
   border-collapse: collapse;
   text-align: left;
@@ -533,6 +535,10 @@ $topbar_height: 56px;
     white-space: nowrap;
   }
 
+  kbd + kbd {
+    margin-left: 4px;
+  }
+
   kbd {
     display: inline-block;
     min-width: 1.6em;
@@ -545,6 +551,46 @@ $topbar_height: 56px;
     font-size: 0.85em;
     line-height: 1.5;
     text-align: center;
+  }
+}
+
+.points {
+  max-width: 100%;
+
+  td:first-child {
+    font-weight: 500;
+  }
+}
+
+// Pushed to the trailing edge of the manual's toolbar, opposite the back button. Toolbars in
+// here wrap (see .base_main .MuiToolbar-root), so on a phone this drops to its own row rather
+// than crowding the title; min-width lets it shrink to fit instead of overflowing.
+.manual-search {
+  margin-left: auto;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 220px;
+
+  input {
+    min-width: 0;
+  }
+}
+
+// The "?" next to a term the game shows, which opens that term's manual entry
+.manual-link {
+  padding: 0 2px;
+  border: none;
+  background: none;
+  color: $interactive_blue;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  vertical-align: middle;
+
+  &:focus-visible {
+    outline: 2px solid $interactive_blue;
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 }
 
@@ -651,8 +697,79 @@ $topbar_height: 56px;
   }
 
   #manual {
+    figure {
+      margin: size(base) 0;
+    }
+
     img {
-      width: 100%;
+      // Sized from the intrinsic width/height on the tag, shrinking to fit a narrow phone but
+      // never stretching past the file's own resolution - the source charts are 576-834px
+      // wide, and blowing them up to fill a desktop pane just blurs them
+      max-width: 100%;
+      height: auto;
+    }
+
+    figcaption {
+      font-size: 0.75rem;
+      opacity: 0.7;
+      margin-top: size(small);
+    }
+
+    .manual-intro {
+      display: block;
+      padding: 0 size(base) size(base) size(base);
+      opacity: 0.7;
+    }
+
+    .manual-empty {
+      padding: size(base) size(base) size(base) size(base);
+      text-align: center;
+    }
+
+    // Sticky so the player can still tell which section they're scrolling through
+    .manual-group {
+      background: #eceff1; /* blueGray50, matches .cardList behind it */
+      line-height: 32px;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-size: 0.75rem;
+    }
+
+    mark {
+      background: #ffe082; /* amber200 */
+      color: inherit;
+    }
+  }
+
+  // Manual entries are Accordions rather than clickable Cards, which is what gets them
+  // keyboard focus, aria-expanded and a real heading for free
+  .manual-entry {
+    margin: 0 size(small) size(base) size(small);
+
+    // MUI zeroes the radius on a square Accordion but keeps the before-pseudo divider that
+    // stacked accordions use; these are separate cards, so it isn't wanted
+    &:before {
+      display: none;
+    }
+
+    .MuiAccordionSummary-root {
+      padding: 0 size(base);
+
+      &:hover {
+        background: #eeeeee; /* grey200 - grey50 on white was effectively invisible */
+      }
+
+      // WCAG 2.4.7: keyboard users need to see which entry they're on
+      &:focus-visible {
+        background: #e3f2fd; /* blue50 */
+        outline: 2px solid $interactive_blue;
+        outline-offset: -2px;
+      }
+    }
+
+    .MuiAccordionDetails-root {
+      padding: 0 size(base) size(base) size(base);
     }
   }
 

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -50,7 +50,8 @@ import { store } from "../Store";
 // switching among them shouldn't slide/remount the pane group, since nothing visibly changes
 const DESKTOP_PANES_KEY = "DESKTOP_PANES";
 
-// Keep in sync with the Keyboard Shortcuts entry in the Manual and Settings
+// Keep in sync with SHORTCUTS in base/KeyboardShortcuts, which is what the Manual and Settings
+// both list. react-hotkeys ignores key events from inputs, so `?` still types into a text field
 const keyMap = {
   PAUSED: ["`", "space", "0"],
   SLOW: "1",
@@ -59,6 +60,7 @@ const keyMap = {
   FACILITIES: "q",
   FINANCES: "w",
   FORECASTS: "e",
+  MANUAL: ["?", "shift+/"],
 };
 
 const shortcutHandlers = {
@@ -82,6 +84,9 @@ const shortcutHandlers = {
   },
   FORECASTS: () => {
     store.dispatch(navigate("FORECASTS"));
+  },
+  MANUAL: () => {
+    store.dispatch(navigate("MANUAL"));
   },
 };
 

--- a/src/components/base/KeyboardShortcuts.tsx
+++ b/src/components/base/KeyboardShortcuts.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+interface ShortcutType {
+  keys: string[];
+  description: string;
+}
+
+// The single definition of the game's keyboard shortcuts, rendered in both Settings and the
+// Manual. They used to be two hand-maintained copies of the same table, which is exactly the
+// kind of thing that drifts. Keep in sync with keyMap in Compositor.tsx, which is the other
+// half of the contract -- the keys themselves.
+export const SHORTCUTS: ShortcutType[] = [
+  { keys: ["`", "space", "0"], description: "Pause" },
+  { keys: ["1", "2", "3"], description: "Slow / normal / fast speed" },
+  { keys: ["Q"], description: "Facilities tab" },
+  { keys: ["W"], description: "Finances tab" },
+  { keys: ["E"], description: "Forecasts tab" },
+  { keys: ["?"], description: "Open the manual" },
+];
+
+// The shortcuts render as a component rather than as plain markup, so the manual's search has
+// nothing to walk -- this is what its entry lists as keywords instead
+export const SHORTCUTS_SEARCH_TEXT = SHORTCUTS.map(
+  (s) => `${s.keys.join(" ")} ${s.description}`,
+).join(" ");
+
+export default function KeyboardShortcuts(): React.JSX.Element {
+  return (
+    <table className="shortcuts">
+      <tbody>
+        {SHORTCUTS.map((shortcut: ShortcutType) => (
+          <tr key={shortcut.description}>
+            <td>
+              {shortcut.keys.map((key: string) => (
+                <kbd key={key}>{key}</kbd>
+              ))}
+            </td>
+            <td>{shortcut.description}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/base/ManualLink.tsx
+++ b/src/components/base/ManualLink.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { useDispatch } from "react-redux";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutlineOutlined";
+import type { AppDispatch } from "../../Store";
+import { navigate } from "../../reducers/Card";
+import type { ManualEntryTitleType } from "../../data/Manual";
+
+interface Props {
+  entry: ManualEntryTitleType;
+  // The term as it reads on screen, if it differs from the entry's title
+  label?: string;
+}
+
+// A term the game already shows, turned into a way into the manual. Without these the search
+// box only helps players who already know the term exists, which is the wrong way round.
+export default function ManualLink(props: Props): React.JSX.Element {
+  const dispatch = useDispatch<AppDispatch>();
+  const label = props.label || props.entry;
+  return (
+    <button
+      type="button"
+      className="manual-link"
+      aria-label={`What is ${label}?`}
+      onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+        // These sit inside rows that expand when clicked, and looking a term up shouldn't
+        // also toggle the row underneath it
+        event.stopPropagation();
+        dispatch(navigate({ name: "MANUAL", entry: props.entry }));
+      }}
+    >
+      <HelpOutlineIcon fontSize="inherit" />
+    </button>
+  );
+}

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -50,6 +50,8 @@ import {
   SpeedType,
 } from "../../Types";
 import { generateNewTimeline } from "../../reducers/Game";
+import { MANUAL_ENTRY } from "../../data/Manual";
+import ManualLink from "../base/ManualLink";
 
 interface GeneratorBuildItemProps {
   cash: number;
@@ -157,6 +159,7 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
                 <TableRow>
                   <TableCell>
                     Total energy cost
+                    <ManualLink entry={MANUAL_ENTRY.TOTAL_COST_OF_ENERGY} />
                     <Typography variant="body2" color="textSecondary">
                       Across life, based on{" "}
                       {Math.round(generator.capacityFactor * 100)}% uptime
@@ -170,6 +173,10 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
               <TableRow>
                 <TableCell>
                   Average output
+                  <ManualLink
+                    entry={MANUAL_ENTRY.CAPACITY_FACTOR}
+                    label="capacity factor"
+                  />
                   <Typography variant="body2" color="textSecondary">
                     Across a year
                   </Typography>
@@ -211,6 +218,10 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
                 <TableRow>
                   <TableCell>
                     Ramp up/down time
+                    <ManualLink
+                      entry={MANUAL_ENTRY.RAMP_RATE}
+                      label="ramp rate"
+                    />
                     <Typography variant="body2" color="textSecondary">
                       To go from zero to full output
                     </Typography>
@@ -237,6 +248,10 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
               <TableRow>
                 <TableCell>
                   Air pollution
+                  <ManualLink
+                    entry={MANUAL_ENTRY.EMISSIONS}
+                    label="CO2e emissions"
+                  />
                   <Typography variant="body2" color="textSecondary">
                     Greenhouse gas released per unit generated
                   </Typography>

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -40,6 +40,8 @@ import {
   LOAN_MONTHS,
 } from "../../Constants";
 import { STORAGE } from "../../data/Facilities";
+import { MANUAL_ENTRY } from "../../data/Manual";
+import ManualLink from "../base/ManualLink";
 import { GameType, SpeedType, StorageShoppingType } from "../../Types";
 
 interface StorageBuildItemProps {
@@ -148,6 +150,10 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
               <TableRow>
                 <TableCell>
                   Ramp up/down time
+                  <ManualLink
+                    entry={MANUAL_ENTRY.RAMP_RATE}
+                    label="ramp rate"
+                  />
                   <Typography variant="body2" color="textSecondary">
                     To go from zero to full output
                   </Typography>

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -37,6 +37,8 @@ import {
 } from "../../LocalStorage";
 import { isDesktopScreen } from "../../Globals";
 import { generateNewTimeline } from "../../reducers/Game";
+import { MANUAL_ENTRY } from "../../data/Manual";
+import ManualLink from "../base/ManualLink";
 import {
   DerivedHistoryKeysType,
   GameType,
@@ -413,7 +415,12 @@ export default class Finances extends React.Component<Props, State> {
                 variant="body2"
                 color="textSecondary"
               >
-                Electricity Rate:&nbsp;
+                Electricity Rate
+                <ManualLink
+                  entry={MANUAL_ENTRY.RATES}
+                  label="electricity rates"
+                />
+                :&nbsp;
                 <Typography color="primary" component="strong">
                   {formatMoneyConcise(game.dollarsPerkWh)}
                 </Typography>

--- a/src/components/views/Manual.test.tsx
+++ b/src/components/views/Manual.test.tsx
@@ -1,0 +1,181 @@
+import * as React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Manual, { clearManualMemory } from "./Manual";
+import { MANUAL_ENTRY } from "../../data/Manual";
+
+function renderManual(focusEntry?: string) {
+  return render(<Manual onBack={() => undefined} focusEntry={focusEntry} />);
+}
+
+function entryHeader(title: string): HTMLElement {
+  return screen.getByRole("button", { name: new RegExp(title, "i") });
+}
+
+async function search(term: string) {
+  const box = screen.getByLabelText("Search the manual");
+  await userEvent.clear(box);
+  await userEvent.type(box, term);
+}
+
+// The headers of every entry currently listed, in the order they're shown
+function listedTitles(): string[] {
+  return screen
+    .getAllByRole("button", { expanded: undefined })
+    .filter((el: HTMLElement) => el.id.startsWith("manual-"))
+    .map((el: HTMLElement) => el.textContent || "");
+}
+
+describe("Manual", () => {
+  beforeEach(() => {
+    clearManualMemory();
+  });
+
+  it("pins How to Play above the grouped entries", () => {
+    renderManual();
+    const titles = listedTitles();
+    expect(titles[0]).toContain(MANUAL_ENTRY.HOW_TO_PLAY);
+    // Alphabetical ordering used to open on these two, which tell a new player nothing
+    expect(titles[1]).not.toContain(MANUAL_ENTRY.BTU);
+    expect(screen.getByText("Gameplay")).toBeInTheDocument();
+    expect(screen.getByText("Physics & Units")).toBeInTheDocument();
+  });
+
+  // The old filter only looked at children that were plain strings, so any paragraph
+  // containing an element (<strong>, a nested list, ...) was invisible to search
+  it.each([
+    ["merit order", MANUAL_ENTRY.FORECASTS],
+    ["dispatch order", MANUAL_ENTRY.FORECASTS],
+    ["peak shortage", MANUAL_ENTRY.FORECASTS],
+    ["board of directors", MANUAL_ENTRY.BLACKOUTS],
+  ])("finds %s inside mixed markup", async (term: string, title: string) => {
+    renderManual();
+    await search(term);
+    expect(entryHeader(title)).toBeInTheDocument();
+  });
+
+  it("finds terms by keyword as well as by title", async () => {
+    renderManual();
+    await search("LCOE");
+    expect(entryHeader(MANUAL_ENTRY.TOTAL_COST_OF_ENERGY)).toBeInTheDocument();
+  });
+
+  it("has entries for the terms the game shows on screen", async () => {
+    renderManual();
+    for (const term of [
+      "capacity factor",
+      "ramp rate",
+      "peaker",
+      "round-trip efficiency",
+      "rates",
+      "carbon fee",
+    ]) {
+      await search(term);
+      expect(listedTitles().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("expands matched entries and highlights the match", async () => {
+    renderManual();
+    // Collapsed to start with, so the body isn't in the DOM at all
+    expect(entryHeader(MANUAL_ENTRY.BLACKOUTS)).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    await search("rolling blackouts");
+    expect(entryHeader(MANUAL_ENTRY.BLACKOUTS)).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    // The phrase is mid-paragraph, so only the highlight wrapper matches it exactly
+    expect(screen.getByText("rolling blackouts").tagName).toBe("MARK");
+  });
+
+  it("lets the player collapse an auto-expanded result", async () => {
+    renderManual();
+    await search("rolling blackouts");
+    await userEvent.click(entryHeader(MANUAL_ENTRY.BLACKOUTS));
+    expect(entryHeader(MANUAL_ENTRY.BLACKOUTS)).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("shows an empty state with somewhere to ask", async () => {
+    renderManual();
+    await search("hydrogen fuel cells");
+    expect(listedTitles()).toHaveLength(0);
+    expect(
+      screen.getByText(/No entries match "hydrogen fuel cells"/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Discord" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("discord"),
+    );
+  });
+
+  it("clears the search from the adornment button", async () => {
+    renderManual();
+    await search("carbon");
+    await userEvent.click(screen.getByLabelText("clear search"));
+    expect(screen.getByLabelText("Search the manual")).toHaveValue("");
+    // Back to the full list rather than the filtered one
+    expect(entryHeader(MANUAL_ENTRY.BTU)).toBeInTheDocument();
+  });
+
+  it("has no clear button until there's something to clear", () => {
+    renderManual();
+    expect(screen.queryByLabelText("clear search")).not.toBeInTheDocument();
+  });
+
+  it("opens the entry a deep link points at, and nothing else", () => {
+    renderManual(MANUAL_ENTRY.TOTAL_COST_OF_ENERGY);
+    expect(entryHeader(MANUAL_ENTRY.TOTAL_COST_OF_ENERGY)).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(entryHeader(MANUAL_ENTRY.BLACKOUTS)).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("gives every entry a keyboard-reachable, labelled control", () => {
+    renderManual();
+    const header = entryHeader(MANUAL_ENTRY.SCORE);
+    expect(header).toHaveAttribute("tabindex", "0");
+    expect(header).toHaveAttribute("aria-expanded");
+    expect(header).toHaveAttribute("aria-controls");
+  });
+
+  it("lists the point values in a column rather than as run-on text", async () => {
+    renderManual();
+    await userEvent.click(entryHeader(MANUAL_ENTRY.SCORE));
+    const row = screen
+      .getAllByRole("row")
+      .find((r: HTMLElement) =>
+        (r.textContent || "").includes("per TWh of blackouts"),
+      );
+    expect(row).toBeDefined();
+    // The investor penalty, in its own cell rather than run together with the text
+    expect(within(row as HTMLElement).getByText("-8")).toBeInTheDocument();
+  });
+
+  it("remembers the search term across visits", async () => {
+    const view = renderManual();
+    await search("carbon");
+    view.unmount();
+
+    renderManual();
+    expect(screen.getByLabelText("Search the manual")).toHaveValue("carbon");
+  });
+
+  it("starts a deep link fresh rather than inside the last search", async () => {
+    const view = renderManual();
+    await search("carbon");
+    view.unmount();
+
+    renderManual(MANUAL_ENTRY.RAMP_RATE);
+    expect(screen.getByLabelText("Search the manual")).toHaveValue("");
+  });
+});

--- a/src/components/views/Manual.tsx
+++ b/src/components/views/Manual.tsx
@@ -1,413 +1,351 @@
 import * as React from "react";
 import {
-  Card,
-  CardContent,
-  CardHeader,
-  Collapse,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   IconButton,
+  InputAdornment,
+  InputBase,
   List,
+  ListSubheader,
   Toolbar,
   Typography,
 } from "@mui/material";
-import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
-import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ClearIcon from "@mui/icons-material/Clear";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import SearchIcon from "@mui/icons-material/Search";
-import InputBase from "@mui/material/InputBase";
+import {
+  MANUAL_ENTRIES,
+  MANUAL_GROUPS,
+  ManualEntryType,
+  ManualGroupType,
+  manualEntryText,
+} from "../../data/Manual";
 
-export interface StateProps {}
+export interface StateProps {
+  // Set when the player arrived via a deep link from a term shown elsewhere in the game
+  // (see ManualLink) - that entry opens and scrolls into view
+  focusEntry?: string;
+}
 
 export interface DispatchProps {
   onBack: () => void;
 }
 
-interface ManualEntry {
-  title: string;
-  entry: React.JSX.Element;
+export interface Props extends StateProps, DispatchProps {}
+
+const DISCORD_URL = "https://discord.gg/2fTDHE7";
+
+// Pinned first, then by group in the order the groups are declared, then alphabetically. Sorted
+// once here rather than on every keystroke
+const SORTED_ENTRIES = [...MANUAL_ENTRIES].sort((a, b) => {
+  if (Boolean(a.pinned) !== Boolean(b.pinned)) {
+    return a.pinned ? -1 : 1;
+  }
+  const groupDelta =
+    MANUAL_GROUPS.indexOf(a.group) - MANUAL_GROUPS.indexOf(b.group);
+  return groupDelta !== 0 ? groupDelta : a.title.localeCompare(b.title);
+});
+
+// Everything an entry can be found by, lowercased once at load
+const SEARCH_TEXT: Record<string, string> = {};
+SORTED_ENTRIES.forEach((entry: ManualEntryType) => {
+  SEARCH_TEXT[entry.title] =
+    `${entry.title} ${entry.keywords || ""} ${manualEntryText(entry.entry)}`.toLowerCase();
+});
+
+// The manual unmounts whenever the player leaves it, so "where was I" has to live outside the
+// component: looking up a second term shouldn't mean re-typing the first one and scrolling back
+// down the list. Deep links deliberately start fresh instead (see below).
+let lastSearchTerm = "";
+let lastScrollTop = 0;
+
+export function clearManualMemory() {
+  lastSearchTerm = "";
+  lastScrollTop = 0;
 }
 
-function ManualItem(props: ManualEntry): React.JSX.Element {
-  const [expanded, setExpanded] = React.useState(false);
+function entryId(title: string): string {
+  return `manual-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+}
 
-  const toggleExpand = () => {
-    setExpanded(!expanded);
-  };
+// Wraps each occurrence of the search term in a <mark>, so a hit inside a long entry is
+// findable by eye rather than by re-reading the paragraph
+function markMatches(
+  text: string,
+  term: string,
+  keyPrefix: string,
+): React.ReactNode {
+  const haystack = text.toLowerCase();
+  if (haystack.indexOf(term) === -1) {
+    return text;
+  }
+  const parts: React.ReactNode[] = [];
+  let cursor = 0;
+  let n = 0;
+  let found = haystack.indexOf(term);
+  while (found !== -1) {
+    if (found > cursor) {
+      parts.push(text.slice(cursor, found));
+    }
+    parts.push(
+      <mark key={`${keyPrefix}-${n++}`}>
+        {text.slice(found, found + term.length)}
+      </mark>,
+    );
+    cursor = found + term.length;
+    found = haystack.indexOf(term, cursor);
+  }
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor));
+  }
+  return parts;
+}
 
+// Rebuilds an entry's markup with the matches highlighted. Walks the whole tree rather than
+// just the top level, since that's where the interesting text is
+function highlight(
+  node: React.ReactNode,
+  term: string,
+  keyPrefix = "m",
+): React.ReactNode {
+  if (!term) {
+    return node;
+  }
+  if (typeof node === "string") {
+    return markMatches(node, term, keyPrefix);
+  }
+  if (Array.isArray(node)) {
+    return node.map((child: React.ReactNode, i: number) => (
+      <React.Fragment key={i}>
+        {highlight(child, term, `${keyPrefix}-${i}`)}
+      </React.Fragment>
+    ));
+  }
+  if (React.isValidElement(node)) {
+    const children = (node.props as { children?: React.ReactNode }).children;
+    // Void elements (<img>) and component elements (<KeyboardShortcuts/>) have nothing to
+    // walk - their text, if any, only exists once React renders them
+    if (children === undefined) {
+      return node;
+    }
+    return React.cloneElement(
+      node as React.ReactElement<{ children?: React.ReactNode }>,
+      undefined,
+      highlight(children, term, keyPrefix),
+    );
+  }
+  return node;
+}
+
+interface ManualItemProps {
+  entry: ManualEntryType;
+  searchTerm: string;
+  expanded: boolean;
+  onToggle: (title: string, expanded: boolean) => void;
+  itemRef?: React.Ref<HTMLDivElement>;
+}
+
+function ManualItem(props: ManualItemProps): React.JSX.Element {
+  const { entry, searchTerm, expanded } = props;
+  const id = entryId(entry.title);
   return (
-    <Card onClick={toggleExpand} className="build-list-item expandable">
-      <CardHeader title={props.title} />
-      {!expanded && (
-        <ArrowDropDownIcon color="primary" className="expand-icon" />
-      )}
-      {expanded && <ArrowDropUpIcon color="primary" className="expand-icon" />}
-      <Collapse in={expanded} timeout="auto" unmountOnExit>
-        <CardContent>{props.entry}</CardContent>
-      </Collapse>
-    </Card>
+    <Accordion
+      className="manual-entry"
+      expanded={expanded}
+      onChange={(_event: React.SyntheticEvent, isExpanded: boolean) =>
+        props.onToggle(entry.title, isExpanded)
+      }
+      ref={props.itemRef}
+      square
+      disableGutters
+      slotProps={{ transition: { unmountOnExit: true } }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon color="primary" />}
+        aria-controls={`${id}-content`}
+        id={`${id}-header`}
+      >
+        <Typography variant="h6" component="span">
+          {highlight(entry.title, searchTerm, `${id}-title`)}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails id={`${id}-content`}>
+        {highlight(entry.entry, searchTerm, id)}
+      </AccordionDetails>
+    </Accordion>
   );
 }
 
-export interface Props extends StateProps, DispatchProps {}
+export default function Manual(props: Props): React.JSX.Element {
+  const { focusEntry, onBack } = props;
+  // A deep link is a fresh question, so it ignores (and clears) whatever the last visit left
+  const [searchTerm, setSearchTerm] = React.useState<string>(
+    focusEntry ? "" : lastSearchTerm,
+  );
+  // Which entries the player has explicitly opened or closed. Anything not in here falls back
+  // to the default for the current mode: open while searching, closed while browsing
+  const [toggled, setToggled] = React.useState<Record<string, boolean>>({});
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const focusRef = React.useRef<HTMLDivElement>(null);
 
-export default class Manual extends React.PureComponent<
-  Props,
-  { searchTerm: string }
-> {
-  state = {
-    searchTerm: "",
-  };
+  const term = searchTerm.trim().toLowerCase();
+  const searching = term.length > 0;
 
-  handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ searchTerm: event.target.value });
-  };
-
-  filterEntries = () => {
-    return MANUAL_ENTRIES.filter((entry) => {
-      const titleMatch = entry.title
-        .toLowerCase()
-        .includes(this.state.searchTerm.toLowerCase());
-
-      let contentMatch = false;
-      const children = entry.entry.props.children;
-
-      if (typeof children === "string") {
-        contentMatch = children
-          .toLowerCase()
-          .includes(this.state.searchTerm.toLowerCase());
-      } else if (Array.isArray(children)) {
-        contentMatch = children.some((child) => {
-          if (typeof child === "string") {
-            return child
-              .toLowerCase()
-              .includes(this.state.searchTerm.toLowerCase());
-          }
-          if (child && typeof child === "object" && "props" in child) {
-            const childText = child.props.children;
-            if (typeof childText === "string") {
-              return childText
-                .toLowerCase()
-                .includes(this.state.searchTerm.toLowerCase());
-            }
-          }
-          return false;
-        });
-      } else if (
-        children &&
-        typeof children === "object" &&
-        "props" in children
-      ) {
-        const childText = children.props.children;
-        if (typeof childText === "string") {
-          contentMatch = childText
-            .toLowerCase()
-            .includes(this.state.searchTerm.toLowerCase());
-        }
-      }
-
-      return titleMatch || contentMatch;
-    });
-  };
-
-  public render() {
-    const filteredEntries = this.state.searchTerm
-      ? this.filterEntries()
-      : MANUAL_ENTRIES;
-
-    return (
-      <div className="flexContainer" id="gameCard">
-        <div id="topbar">
-          <Toolbar>
-            <IconButton
-              onClick={this.props.onBack}
-              aria-label="back"
-              edge="start"
-              color="primary"
-              size="large"
-            >
-              <ChevronLeftIcon />
-            </IconButton>
-            <Typography variant="h6">Electrify Manual</Typography>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                marginLeft: "auto",
-              }}
-            >
-              <InputBase
-                placeholder="Search..."
-                value={this.state.searchTerm}
-                onChange={this.handleSearch}
-                style={{ marginRight: "8px" }}
-              />
-              <IconButton
-                aria-label="search"
-                edge="end"
-                color="primary"
-                size="large"
-              >
-                <SearchIcon />
-              </IconButton>
-            </div>
-          </Toolbar>
-        </div>
-        <List dense className="scrollable cardList" id="manual">
-          <Card>
-            <CardContent>
-              Here, you can look up specific terms and mechanics to learn more
-              about how they work in game - and in real life.
-            </CardContent>
-          </Card>
-          {filteredEntries.map((entry: ManualEntry) => (
-            <ManualItem {...entry} key={entry.title} />
-          ))}
-        </List>
-      </div>
-    );
+  // Entering or leaving search changes what "expanded" defaults to, so the player's per-entry
+  // overrides from the other mode no longer mean anything
+  const wasSearching = React.useRef(searching);
+  if (wasSearching.current !== searching) {
+    wasSearching.current = searching;
+    setToggled({});
   }
-}
 
-const MANUAL_ENTRIES = [
-  {
-    title: `Blackouts`,
-    entry: (
-      <div>
-        <p>
-          If you don't supply enough electricity to meet demand, you'll cause
-          rolling blackouts that cost you customers (and thus revenue).
-        </p>
-        <p>
-          Like utilities in real life, you aren't financially responsible for
-          blackouts. But, if you have chronic blackouts, your board of directors
-          might fire you!
-        </p>
+  React.useEffect(() => {
+    lastSearchTerm = searchTerm;
+  }, [searchTerm]);
+
+  // Restore the scroll position from the last visit. Before paint, so the list doesn't flash
+  // at the top first - and a deep link scrolls to its own entry instead (below)
+  React.useLayoutEffect(() => {
+    if (listRef.current && !focusEntry) {
+      listRef.current.scrollTop = lastScrollTop;
+    }
+  }, [focusEntry]);
+
+  React.useEffect(() => {
+    const focused = focusRef.current;
+    // jsdom has no layout, and so no scrollIntoView
+    if (focusEntry && focused && focused.scrollIntoView) {
+      focused.scrollIntoView({ block: "start" });
+    }
+  }, [focusEntry]);
+
+  const matches = React.useMemo(
+    () =>
+      searching
+        ? SORTED_ENTRIES.filter((entry: ManualEntryType) =>
+            SEARCH_TEXT[entry.title].includes(term),
+          )
+        : SORTED_ENTRIES,
+    [searching, term],
+  );
+
+  const onToggle = React.useCallback((title: string, expanded: boolean) => {
+    setToggled((previous: Record<string, boolean>) => ({
+      ...previous,
+      [title]: expanded,
+    }));
+  }, []);
+
+  const renderEntry = (entry: ManualEntryType) => {
+    const isFocused = entry.title === focusEntry;
+    return (
+      <ManualItem
+        key={entry.title}
+        entry={entry}
+        searchTerm={term}
+        expanded={toggled[entry.title] ?? (searching || isFocused)}
+        onToggle={onToggle}
+        itemRef={isFocused ? focusRef : undefined}
+      />
+    );
+  };
+
+  const pinned = matches.filter((entry: ManualEntryType) => entry.pinned);
+
+  return (
+    <div className="flexContainer" id="gameCard">
+      <div id="topbar">
+        <Toolbar>
+          <IconButton
+            onClick={onBack}
+            aria-label="back"
+            edge="start"
+            color="primary"
+            size="large"
+          >
+            <ChevronLeftIcon />
+          </IconButton>
+          <Typography variant="h6">Electrify Manual</Typography>
+          <InputBase
+            className="manual-search"
+            placeholder="Search..."
+            value={searchTerm}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              setSearchTerm(event.target.value)
+            }
+            inputProps={{ "aria-label": "Search the manual" }}
+            startAdornment={
+              <InputAdornment position="start">
+                <SearchIcon color="primary" fontSize="small" />
+              </InputAdornment>
+            }
+            endAdornment={
+              searchTerm ? (
+                <InputAdornment position="end">
+                  <IconButton
+                    onClick={() => setSearchTerm("")}
+                    aria-label="clear search"
+                    color="primary"
+                    size="small"
+                  >
+                    <ClearIcon fontSize="small" />
+                  </IconButton>
+                </InputAdornment>
+              ) : null
+            }
+          />
+        </Toolbar>
       </div>
-    ),
-  },
-  {
-    title: `BTU and MMBTU`,
-    entry: (
-      <p>
-        The British Thermal Unit is a measure of heat energy. MMBTU is one
-        million BTU, and equals approximately 300 kWh of electrical energy.
-      </p>
-    ),
-  },
-  {
-    // Credit to https://www.e-education.psu.edu/ebf200/node/151
-    title: `Customers, Demand & Marketing`,
-    entry: (
-      <div>
-        <p>
-          More customers drives more demand. Although individual customer types
-          (residential, commercial, industrial) have different demand curves,
-          we've aggregated them into a single "customers" number that reflects a
-          blend of customer types. Here's what demand by type looks like in real
-          life:
-        </p>
-        <img
-          src="/images/manual-demand-customer-types.png"
-          alt="Source: https://www.eia.gov/todayinenergy/detail.php?id=10211"
-        />
-        <p>
-          Like in real life, you as a company can spend money on marketing to
-          acquire more customers (you exist as one of many electricity
-          generation companies customers can select from). Your customer base
-          also naturally grows or shrinks depending on if you provide them good
-          service (i.e. few blackouts).
-        </p>
-        <p>
-          Load changes continuously as people turn stuff on and off, as
-          temperature changes, as the natural light comes and goes, and so on.
-          This pattern of changing load is called a "load shape". We can have
-          daily load shapes, weekly ones, and annual ones. The following diagram
-          shows the path of load for three different weeks at three different
-          times of year in 2009:
-        </p>
-        <img src="/images/manual-demand.jpg" alt="Demand chart" />
-      </div>
-    ),
-  },
-  {
-    title: `Emissions and CO2e`,
-    entry: (
-      <div>
-        <p>
-          CO2e stands for Carbon Dioxide equivalent, a measure of the greenhouse
-          warming impact of various pollutants.
-        </p>
-        <p>
-          Electricity generation is the 2nd largest source of greenhouse gas in
-          the United States, but our utilities have no financial incentive to
-          reduce their emissions.
-        </p>
-        <p>
-          One of the highest-rated proposals to reduce emissions is a "Carbon
-          Fee" that creates a financial incentive for businesses to reduce their
-          carbon footprint through innovation. Electrify lets you experiment
-          with different levels of carbon fees, and see how technology
-          innovation can enable better business decisions than the fossil fuels
-          of the past.
-        </p>
-      </div>
-    ),
-  },
-  {
-    title: `Forecasts`,
-    entry: (
-      <div>
-        <p>
-          The Forecasts tab projects your company forward, so you can spot
-          problems before they cost you customers. Use the dropdown at the top
-          right to look ahead 1, 5, 10 or 20 years - the further out you look,
-          the coarser (and less certain) the projection.
-        </p>
-        <p>
-          <strong>Supply &amp; Demand</strong> plots your projected output
-          against projected demand. Wherever demand rises above supply, the gap
-          is shaded as a blackout. If any are forecasted, the table underneath
-          breaks them down: total energy not served, the size of the single
-          worst event, the peak shortage (how much extra capacity you'd need to
-          cover it) and when it happens. That "when" is the most useful number
-          on the page - it tells you whether you need generation that can ramp
-          up for a few hours, or baseload for a whole season.
-        </p>
-        <p>
-          <strong>Supply by Fuel</strong> breaks that same supply down by fuel,
-          in dispatch order. This is where you can see your merit order at work:
-          cheap, always-on sources carry the base, and expensive or fast-ramping
-          ones fill the peaks. Re-ordering your facilities changes this chart.
-        </p>
-        <p>
-          <strong>Stored power</strong> (shown once you own storage) tracks the
-          energy in your batteries and reservoirs as they charge off surplus and
-          discharge into peaks.
-        </p>
-        <p>
-          <strong>Fuel Prices</strong> projects the cost of each fuel you can
-          burn, based on real historical price data. Fuel prices move suddenly
-          and by a lot, which can flip a profitable plant into a money-loser -
-          watch this chart before committing to a decades-long build.
-        </p>
-        <p>
-          <strong>Weather</strong> projects temperature and sunlight for your
-          region. It drives demand (heating and air conditioning) as well as the
-          output of your solar and wind generators.
-        </p>
-        <p>
-          Forecasts assume you make no further changes, so treat them as "what
-          happens if I do nothing" rather than a promise. Pausing a generator or
-          reordering your stack updates them immediately, which makes them a
-          cheap way to test a decision before you pay for it.
-        </p>
-      </div>
-    ),
-  },
-  {
-    title: `Keyboard Shortcuts`,
-    entry: (
-      <div>
-        <p>
-          While a scenario is running, you can drive the game from the keyboard:
-        </p>
-        <table className="shortcuts">
-          <tbody>
-            <tr>
-              <td>
-                <kbd>`</kbd> <kbd>space</kbd> <kbd>0</kbd>
-              </td>
-              <td>Pause</td>
-            </tr>
-            <tr>
-              <td>
-                <kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd>
-              </td>
-              <td>Slow / normal / fast speed</td>
-            </tr>
-            <tr>
-              <td>
-                <kbd>Q</kbd>
-              </td>
-              <td>Facilities tab</td>
-            </tr>
-            <tr>
-              <td>
-                <kbd>W</kbd>
-              </td>
-              <td>Finances tab</td>
-            </tr>
-            <tr>
-              <td>
-                <kbd>E</kbd>
-              </td>
-              <td>Forecasts tab</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    ),
-  },
-  {
-    // Credit to https://www.e-education.psu.edu/ebf200/node/151
-    title: `Prioritizing Generators`,
-    entry: (
-      <div>
-        <p>
-          Companies prioritize their generation stack based on how long they
-          take to ramp up and down, their marginal cost (fuel) and whether
-          they're controllable.
-        </p>
-        <p>
-          Here's a real-world generation stack from the PJM
-          (Pennsylvania-Jersey-Maryland) market in 2008:
-        </p>
-        <img src="/images/manual-generation-stack.jpg" alt="Generation stack" />
-      </div>
-    ),
-  },
-  {
-    title: `Score`,
-    entry: (
-      <div>
-        <p>
-          At the end of your term as CEO (each scenario has a different length),
-          you'll receive a score for how well you did. Try to beat your score
-          the next time you play!
-        </p>
-        <p>Investor-owned scenarios are scored as follows:</p>
-        <p>
-          4 pts for each $100M of net worth at the end
-          <br />
-          2 pts for each 100k customers at the end
-          <br />
-          1 pt for each TWh supplied
-          <br />
-          -2 pts for each megaton (1M tons) of CO2e emitted
-          <br />
-          -8 pts for each TWh of blackouts
-        </p>
-        <p>Public-owned scenarios are scored as follows:</p>
-        <p>
-          +/-80 pts for each $0.01/kWh that your lifetime average rate lands
-          below/above the scenario's target rate
-          <br />
-          10 pts for each TWh supplied
-          <br />
-          -5 pts for each megaton (1M tons) of CO2e emitted
-          <br />
-          -10 pts for each TWh of blackouts
-        </p>
-      </div>
-    ),
-  },
-  {
-    title: `Total Cost of Energy`,
-    entry: (
-      <p>
-        Also known as "Levelized Cost of Energy", it's the expected cost of all
-        energy produced by the plant during its lifetime, including
-        construction, maintenance and fuel.
-      </p>
-    ),
-  },
-].sort((a, b) => (a.title > b.title ? 1 : -1)) as ManualEntry[];
+      <List
+        dense
+        component="div"
+        className="scrollable cardList"
+        id="manual"
+        ref={listRef}
+        // Recorded as it happens rather than on unmount: by the time an unmount cleanup runs,
+        // React has already detached the node and every detached node reports a scrollTop of 0
+        onScroll={(event: React.UIEvent<HTMLDivElement>) => {
+          lastScrollTop = event.currentTarget.scrollTop;
+        }}
+      >
+        <Typography variant="caption" component="p" className="manual-intro">
+          Look up terms and mechanics to learn more about how they work in game
+          - and in real life.
+        </Typography>
+        {matches.length === 0 && (
+          <div className="manual-empty">
+            <Typography variant="body1">
+              No entries match "{searchTerm}".
+            </Typography>
+            <Typography variant="body2">
+              Think it belongs in here? Ask us on{" "}
+              <a href={DISCORD_URL} target="_blank" rel="noreferrer">
+                Discord
+              </a>
+              .
+            </Typography>
+          </div>
+        )}
+        {pinned.map(renderEntry)}
+        {MANUAL_GROUPS.map((group: ManualGroupType) => {
+          const entries = matches.filter(
+            (entry: ManualEntryType) => !entry.pinned && entry.group === group,
+          );
+          if (entries.length === 0) {
+            return null;
+          }
+          return (
+            <React.Fragment key={group}>
+              <ListSubheader component="div" className="manual-group">
+                {group}
+              </ListSubheader>
+              {entries.map(renderEntry)}
+            </React.Fragment>
+          );
+        })}
+      </List>
+    </div>
+  );
+}

--- a/src/components/views/ManualContainer.tsx
+++ b/src/components/views/ManualContainer.tsx
@@ -1,10 +1,12 @@
-import type { AppDispatch } from "../../Store";
+import type { AppDispatch, RootState } from "../../Store";
 import { connect } from "react-redux";
 import { navigateBack } from "../../reducers/Card";
 import Manual, { DispatchProps, StateProps } from "./Manual";
 
-const mapStateToProps = (): StateProps => {
-  return {};
+const mapStateToProps = (state: RootState): StateProps => {
+  return {
+    focusEntry: state.card.entry,
+  };
 };
 
 const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Checkbox, IconButton, Toolbar, Typography } from "@mui/material";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { SettingsType } from "../../Types";
+import KeyboardShortcuts from "../base/KeyboardShortcuts";
 import packageJson from "../../../package.json";
 
 export interface StateProps {
@@ -65,44 +66,10 @@ export default function Settings(props: Props): React.JSX.Element {
         {props.settings.audioEnabled
           ? "Music and sound effects enabled."
           : "Music and sound effects disabled."}
-        {/* Keep in sync with keyMap in Compositor.tsx and the Manual entry */}
         <Typography variant="h6" style={{ marginTop: 24 }}>
           Keyboard Shortcuts
         </Typography>
-        <table className="shortcuts">
-          <tbody>
-            <tr>
-              <td>
-                <kbd>`</kbd> <kbd>space</kbd> <kbd>0</kbd>
-              </td>
-              <td>Pause</td>
-            </tr>
-            <tr>
-              <td>
-                <kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd>
-              </td>
-              <td>Slow / normal / fast speed</td>
-            </tr>
-            <tr>
-              <td>
-                <kbd>Q</kbd>
-              </td>
-              <td>Facilities tab</td>
-            </tr>
-            <tr>
-              <td>
-                <kbd>W</kbd>
-              </td>
-              <td>Finances tab</td>
-            </tr>
-            <tr>
-              <td>
-                <kbd>E</kbd>
-              </td>
-              <td>Forecasts tab</td>
-            </tr>
-          </tbody>
-        </table>
+        <KeyboardShortcuts />
         <Typography className="version">
           Electrify App v{packageJson.version}
         </Typography>

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -1,0 +1,584 @@
+import * as React from "react";
+import KeyboardShortcuts, {
+  SHORTCUTS_SEARCH_TEXT,
+} from "../components/base/KeyboardShortcuts";
+
+// Groups the entries into sections, so the list doesn't open on "Blackouts" and "BTU" purely
+// because the alphabet says so. Ordered the way they're shown.
+export const MANUAL_GROUPS = ["Gameplay", "Money", "Physics & Units"] as const;
+export type ManualGroupType = (typeof MANUAL_GROUPS)[number];
+
+// Entry titles are the deep link ids -- anywhere in the game that shows one of these terms can
+// send the player straight to it with navigate({name: "MANUAL", entry: MANUAL_ENTRY.X}). Naming
+// them here rather than passing raw strings means renaming an entry breaks the build instead of
+// silently breaking the link.
+export const MANUAL_ENTRY = {
+  HOW_TO_PLAY: "How to Play",
+  BASELOAD_VS_PEAKER: "Baseload vs Peaker",
+  BLACKOUTS: "Blackouts",
+  BTU: "BTU and MMBTU",
+  CAPACITY_FACTOR: "Capacity Factor",
+  CARBON_FEE: "Carbon Fee",
+  CUSTOMERS: "Customers, Demand & Marketing",
+  EMISSIONS: "Emissions and CO2e",
+  FORECASTS: "Forecasts",
+  KEYBOARD_SHORTCUTS: "Keyboard Shortcuts",
+  PRIORITIZING_GENERATORS: "Prioritizing Generators",
+  RAMP_RATE: "Ramp Rate",
+  RATES: "Rates",
+  ROUND_TRIP_EFFICIENCY: "Round-trip Efficiency",
+  SCORE: "Score",
+  TOTAL_COST_OF_ENERGY: "Total Cost of Energy",
+} as const;
+
+export type ManualEntryTitleType =
+  (typeof MANUAL_ENTRY)[keyof typeof MANUAL_ENTRY];
+
+export interface ManualEntryType {
+  title: ManualEntryTitleType;
+  group: ManualGroupType;
+  entry: React.JSX.Element;
+  // Terms a player would plausibly search for that aren't spelled out in the body, plus the
+  // text of anything the body renders as a component (which has no children to walk). Body
+  // prose is searched automatically -- see manualEntryText below -- so this is only for the
+  // words that aren't there.
+  keywords?: string;
+  // Pins the entry above the grouped list. Only "How to Play" uses it; a new player shouldn't
+  // have to scroll past the glossary to find the overview.
+  pinned?: boolean;
+}
+
+// The source line for an image, shown to the player rather than hidden in the alt attribute:
+// on an educational game a citation is worth reading, and alt text is for describing the
+// picture to someone who can't see it
+interface FigureProps {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+  sourceName: string;
+  sourceUrl: string;
+}
+
+function Figure(props: FigureProps): React.JSX.Element {
+  return (
+    <figure>
+      <img
+        src={props.src}
+        alt={props.alt}
+        // Intrinsic dimensions reserve the right box before the file loads, so expanding an
+        // entry doesn't shove the text below it around once the image arrives
+        width={props.width}
+        height={props.height}
+        loading="lazy"
+      />
+      <figcaption>
+        Source:{" "}
+        <a href={props.sourceUrl} target="_blank" rel="noreferrer">
+          {props.sourceName}
+        </a>
+      </figcaption>
+    </figure>
+  );
+}
+
+// Flattens an entry down to the words in it, so search can match body text. The old version
+// only looked one level deep and only at children that were plain strings, so any paragraph
+// with a <strong> in it dropped out of search entirely -- "merit order" and "peak shortage"
+// were both in the manual and both unfindable. Walking the whole tree also means new entries
+// are searchable the moment they're written, without anyone maintaining a parallel string.
+export function manualEntryText(node: React.ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(manualEntryText).join(" ");
+  }
+  if (React.isValidElement(node)) {
+    const props = node.props as { children?: React.ReactNode };
+    return manualEntryText(props.children);
+  }
+  return "";
+}
+
+export const MANUAL_ENTRIES: ManualEntryType[] = [
+  {
+    title: MANUAL_ENTRY.HOW_TO_PLAY,
+    group: "Gameplay",
+    pinned: true,
+    keywords: "getting started tutorial basics overview intro new player",
+    entry: (
+      <div>
+        <p>
+          You're the incoming CEO of an electric utility. Every hour of game
+          time your customers demand a certain amount of power, and every hour
+          your generators have to supply it. Supply too little and you cause{" "}
+          blackouts; spend too much supplying it and you go broke.
+        </p>
+        <p>
+          <strong>Facilities</strong> is your fleet. Generators higher in the
+          list are asked to run first, so the order you put them in decides
+          which ones burn fuel and which ones sit idle. Build from here, and
+          pause or sell anything that's costing more than it earns.
+        </p>
+        <p>
+          <strong>Finances</strong> shows where the money went, and is where you
+          set marketing spend (which buys customers) and, in public-ownership
+          scenarios, the rate you charge.
+        </p>
+        <p>
+          <strong>Forecasts</strong> projects all of that forward so you can see
+          a shortfall coming while there's still time to build for it - plants
+          take months or years to finish.
+        </p>
+        <p>
+          A good first move is to open Forecasts, find the first blackout, and
+          work out whether it needs something cheap that runs constantly or
+          something expensive that starts quickly. The rest of this manual
+          explains the terms you'll meet along the way.
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.BASELOAD_VS_PEAKER,
+    group: "Gameplay",
+    keywords: "peaking plant intermediate load following mid-merit",
+    entry: (
+      <div>
+        <p>
+          Demand never sits still, so a fleet needs two very different kinds of
+          plant.
+        </p>
+        <p>
+          <strong>Baseload</strong> plants - nuclear, coal, large hydro - are
+          cheap per unit of energy but slow and expensive to start and stop, so
+          they run flat out around the clock and cover the demand that's always
+          there. They're the wrong answer to a four-hour evening peak: by the
+          time one has ramped up, the peak is over.
+        </p>
+        <p>
+          <strong>Peakers</strong> - typically gas turbines - are the opposite.
+          Cheap to build, expensive to run, and able to go from cold to full
+          output in minutes. They spend most of the year switched off and earn
+          their keep on the handful of days when demand spikes.
+        </p>
+        <p>
+          Most of the cost of a peaker is the fuel it burns, so an idle one
+          costs you little; most of the cost of a baseload plant is paid whether
+          it runs or not. That's why a fleet made only of peakers loses money on
+          fuel, and a fleet made only of baseload plants blacks out every summer
+          afternoon.
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.BLACKOUTS,
+    group: "Gameplay",
+    entry: (
+      <div>
+        <p>
+          If you don't supply enough electricity to meet demand, you'll cause
+          rolling blackouts that cost you customers (and thus revenue).
+        </p>
+        <p>
+          Like utilities in real life, you aren't financially responsible for
+          blackouts. But, if you have chronic blackouts, your board of directors
+          might fire you!
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.BTU,
+    group: "Physics & Units",
+    keywords: "british thermal unit mmbtu heat energy kwh mwh",
+    entry: (
+      <p>
+        The British Thermal Unit is a measure of heat energy. MMBTU is one
+        million BTU, and equals approximately 300 kWh of electrical energy.
+      </p>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.CAPACITY_FACTOR,
+    group: "Physics & Units",
+    keywords: "uptime utilization average output nameplate capacity",
+    entry: (
+      <div>
+        <p>
+          Capacity factor is the share of a generator's nameplate capacity it
+          actually delivers over a year. A 100 MW plant at a 45% capacity factor
+          produces as much energy in a year as a 45 MW plant running
+          continuously would.
+        </p>
+        <p>
+          It's shown in the build screen as "% uptime", and it's why nameplate
+          size alone tells you very little. Nuclear runs above 90%. Coal and gas
+          sit in the middle, limited by fuel cost and by how often you choose to
+          dispatch them. Wind and solar are set by the weather and the seasons
+          at your location, not by you - which is why the same solar farm is a
+          much better deal in one scenario than another.
+        </p>
+        <p>
+          Capacity factor is what turns a build cost into a cost per MWh, so
+          it's baked into every Total Cost of Energy figure you see.
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.CARBON_FEE,
+    group: "Money",
+    keywords: "carbon tax carbon price pollution fee co2 per ton",
+    entry: (
+      <div>
+        <p>
+          A carbon fee is a charge on pollution, meant to cover the damage it
+          does to everyone else. It's billed by the amount of greenhouse gas
+          emitted, measured in tons of CO2 equivalent, and it shows up in your
+          P&amp;L as an operating expense on every dirty MWh you generate.
+        </p>
+        <p>
+          Electricity generation is the 2nd largest source of greenhouse gas in
+          the United States, and without a fee a utility has no financial reason
+          to cut its emissions - the cheapest plant to run wins no matter what
+          comes out of the stack. A fee changes the merit order itself: at $50
+          per ton a coal plant can become more expensive to run than the gas
+          plant beside it, without a single rule telling you to shut it down.
+        </p>
+        <p>
+          Scenarios set their own fee, and custom games let you dial it from $0
+          upwards. Turning it up is the fastest way to see how much of the
+          fossil fuel fleet is only economic because the pollution is free.
+        </p>
+      </div>
+    ),
+  },
+  {
+    // Credit to https://www.e-education.psu.edu/ebf200/node/151
+    title: MANUAL_ENTRY.CUSTOMERS,
+    group: "Gameplay",
+    keywords: "load shape residential commercial industrial growth churn",
+    entry: (
+      <div>
+        <p>
+          More customers drives more demand. Although individual customer types
+          (residential, commercial, industrial) have different demand curves,
+          we've aggregated them into a single "customers" number that reflects a
+          blend of customer types. Here's what demand by type looks like in real
+          life:
+        </p>
+        <Figure
+          src="/images/manual-demand-customer-types.png"
+          alt="Three charts of monthly US retail electricity sales from 2009 to 2012. Residential sales swing hardest, peaking each summer and winter; commercial sales follow the same shape but with about half the swing; industrial sales stay nearly flat all year."
+          width={576}
+          height={288}
+          sourceName="U.S. Energy Information Administration"
+          sourceUrl="https://www.eia.gov/todayinenergy/detail.php?id=10211"
+        />
+        <p>
+          Like in real life, you as a company can spend money on marketing to
+          acquire more customers (you exist as one of many electricity
+          generation companies customers can select from). Your customer base
+          also naturally grows or shrinks depending on if you provide them good
+          service (i.e. few blackouts).
+        </p>
+        <p>
+          Load changes continuously as people turn stuff on and off, as
+          temperature changes, as the natural light comes and goes, and so on.
+          This pattern of changing load is called a "load shape". We can have
+          daily load shapes, weekly ones, and annual ones. The following diagram
+          shows the path of load for three different weeks at three different
+          times of year in 2009:
+        </p>
+        <Figure
+          src="/images/manual-demand.jpg"
+          alt="Hourly electricity load across a week in the PJM Mid-Atlantic region, plotted for a hot week, a cold week and a mild week of 2009. All three rise and fall once a day and drop over the weekend; the hot week peaks around 50,000 MW, roughly 20,000 MW above the mild week's overnight low."
+          width={834}
+          height={560}
+          sourceName="Penn State, EBF 200"
+          sourceUrl="https://www.e-education.psu.edu/ebf200/node/151"
+        />
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.EMISSIONS,
+    group: "Physics & Units",
+    keywords: "greenhouse gas pollution carbon dioxide equivalent tons",
+    entry: (
+      <div>
+        <p>
+          CO2e stands for Carbon Dioxide equivalent, a measure of the greenhouse
+          warming impact of various pollutants. Each generator lists the
+          kilograms of CO2e it releases per MWh, which is what makes a coal
+          plant and a gas plant of the same size comparable.
+        </p>
+        <p>
+          Electricity generation is the 2nd largest source of greenhouse gas in
+          the United States, but our utilities have no financial incentive to
+          reduce their emissions.
+        </p>
+        <p>
+          One of the highest-rated proposals to reduce emissions is a Carbon
+          Fee, which creates a financial incentive for businesses to reduce
+          their carbon footprint through innovation. Electrify lets you
+          experiment with different levels of carbon fees, and see how
+          technology innovation can enable better business decisions than the
+          fossil fuels of the past.
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.FORECASTS,
+    group: "Gameplay",
+    keywords: "projection supply demand fuel prices weather peak shortage",
+    entry: (
+      <div>
+        <p>
+          The Forecasts tab projects your company forward, so you can spot
+          problems before they cost you customers. Use the dropdown at the top
+          right to look ahead 1, 5, 10 or 20 years - the further out you look,
+          the coarser (and less certain) the projection.
+        </p>
+        <p>
+          <strong>Supply &amp; Demand</strong> plots your projected output
+          against projected demand. Wherever demand rises above supply, the gap
+          is shaded as a blackout. If any are forecasted, the table underneath
+          breaks them down: total energy not served, the size of the single
+          worst event, the peak shortage (how much extra capacity you'd need to
+          cover it) and when it happens. That "when" is the most useful number
+          on the page - it tells you whether you need generation that can ramp
+          up for a few hours, or baseload for a whole season.
+        </p>
+        <p>
+          <strong>Supply by Fuel</strong> breaks that same supply down by fuel,
+          in dispatch order. This is where you can see your merit order at work:
+          cheap, always-on sources carry the base, and expensive or fast-ramping
+          ones fill the peaks. Re-ordering your facilities changes this chart.
+        </p>
+        <p>
+          <strong>Stored power</strong> (shown once you own storage) tracks the
+          energy in your batteries and reservoirs as they charge off surplus and
+          discharge into peaks.
+        </p>
+        <p>
+          <strong>Fuel Prices</strong> projects the cost of each fuel you can
+          burn, based on real historical price data. Fuel prices move suddenly
+          and by a lot, which can flip a profitable plant into a money-loser -
+          watch this chart before committing to a decades-long build.
+        </p>
+        <p>
+          <strong>Weather</strong> projects temperature and sunlight for your
+          region. It drives demand (heating and air conditioning) as well as the
+          output of your solar and wind generators.
+        </p>
+        <p>
+          Forecasts assume you make no further changes, so treat them as "what
+          happens if I do nothing" rather than a promise. Pausing a generator or
+          reordering your stack updates them immediately, which makes them a
+          cheap way to test a decision before you pay for it.
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.KEYBOARD_SHORTCUTS,
+    group: "Gameplay",
+    keywords: `hotkeys keys controls ${SHORTCUTS_SEARCH_TEXT}`,
+    entry: (
+      <div>
+        <p>
+          While a scenario is running, you can drive the game from the keyboard:
+        </p>
+        <KeyboardShortcuts />
+      </div>
+    ),
+  },
+  {
+    // Credit to https://www.e-education.psu.edu/ebf200/node/151
+    title: MANUAL_ENTRY.PRIORITIZING_GENERATORS,
+    group: "Gameplay",
+    keywords: "merit order dispatch order generation stack marginal cost",
+    entry: (
+      <div>
+        <p>
+          Companies prioritize their generation stack based on how long they
+          take to ramp up and down, their marginal cost (fuel) and whether
+          they're controllable. That ordering is called the merit order, and in
+          Electrify it's simply the order of your Facilities list: the top of
+          the list is asked to generate first, and each plant below only runs
+          once the ones above it are maxed out.
+        </p>
+        <p>
+          Here's a real-world generation stack from the PJM
+          (Pennsylvania-Jersey-Maryland) market in 2008:
+        </p>
+        <Figure
+          src="/images/manual-generation-stack.jpg"
+          alt="Scatter chart of PJM generation capacity sorted from cheapest to most expensive. Renewables and nuclear supply the first 40 GW at under $20/MWh, coal carries the next 60 GW below $50/MWh, natural gas climbs steeply from there, and oil tops out around $300/MWh for the last few GW."
+          width={825}
+          height={471}
+          sourceName="Penn State, EBF 200"
+          sourceUrl="https://www.e-education.psu.edu/ebf200/node/151"
+        />
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.RAMP_RATE,
+    group: "Physics & Units",
+    keywords: "spin up spin down startup time ramping responsive dispatchable",
+    entry: (
+      <div>
+        <p>
+          Ramp rate is how fast a plant can change its output, shown on the
+          build screen as the ramp up/down time needed to go from zero to full.
+        </p>
+        <p>
+          It's set by physics, not by choice. A gas turbine is essentially a jet
+          engine and reaches full power in a minute or two. A coal or nuclear
+          plant has to heat thousands of tons of metal and water evenly, and
+          rushing it cracks things, so it takes hours. Batteries respond in
+          under a second; pumped hydro needs about ten minutes to get the water
+          moving.
+        </p>
+        <p>
+          Demand can swing by a third between 4am and 6pm, so a fleet has to be
+          able to follow it. A slow plant is only useful for the demand that's
+          there all day, which is why ramp rate, not price, is usually what
+          decides whether a plant can help with a peak.
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.RATES,
+    group: "Money",
+    keywords: "price per kwh electricity rate revenue tariff bill",
+    entry: (
+      <div>
+        <p>
+          Your rate is what you charge customers per kWh of electricity, and it
+          multiplied by the energy you supply is essentially all of your
+          revenue. Real US residential rates run somewhere around $0.10-$0.30
+          per kWh depending on the state.
+        </p>
+        <p>
+          In <strong>investor-owned</strong> scenarios the rate is fixed by the
+          regulator and you can't change it, so the only lever you have on
+          revenue is supplying more energy to more customers.
+        </p>
+        <p>
+          In <strong>public-owned</strong> scenarios you set the rate yourself
+          on the Finances tab, and it's part of how you're scored: your lifetime
+          average rate is compared against the scenario's target, and every cent
+          per kWh above or below moves your score. Charging more makes the books
+          easy and the score bad, so the game is to keep the rate down while
+          still funding the plants you need.
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.ROUND_TRIP_EFFICIENCY,
+    group: "Physics & Units",
+    keywords: "storage losses battery pumped hydro charge discharge",
+    entry: (
+      <div>
+        <p>
+          Storage never gives back everything you put in. Round-trip efficiency
+          is the share that survives the trip: charge a battery with 100 MWh at
+          85% round-trip efficiency, and you get 85 MWh back out. The rest is
+          lost as heat in the conversion, or - for pumped hydro, at about 80% -
+          as friction and evaporation moving water uphill and back down.
+        </p>
+        <p>
+          That loss is what storage costs you, on top of the build cost. It only
+          pays off when the power you charge with is much cheaper than the power
+          you displace, which is why storage earns its keep soaking up surplus
+          wind and solar and discharging into the evening peak, and loses money
+          shuttling energy around for its own sake.
+        </p>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.SCORE,
+    group: "Gameplay",
+    keywords: "points scoring high score end of game investor public",
+    entry: (
+      <div>
+        <p>
+          At the end of your term as CEO (each scenario has a different length),
+          you'll receive a score for how well you did. Try to beat your score
+          the next time you play!
+        </p>
+        <p>Investor-owned scenarios are scored as follows:</p>
+        <table className="points">
+          <tbody>
+            <tr>
+              <td>+4</td>
+              <td>per $100M of net worth at the end</td>
+            </tr>
+            <tr>
+              <td>+2</td>
+              <td>per 100k customers at the end</td>
+            </tr>
+            <tr>
+              <td>+1</td>
+              <td>per TWh supplied</td>
+            </tr>
+            <tr>
+              <td>-2</td>
+              <td>per megaton (1M tons) of CO2e emitted</td>
+            </tr>
+            <tr>
+              <td>-8</td>
+              <td>per TWh of blackouts</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>Public-owned scenarios are scored as follows:</p>
+        <table className="points">
+          <tbody>
+            <tr>
+              <td>+/-80</td>
+              <td>
+                per $0.01/kWh that your lifetime average rate lands below/above
+                the scenario's target rate
+              </td>
+            </tr>
+            <tr>
+              <td>+10</td>
+              <td>per TWh supplied</td>
+            </tr>
+            <tr>
+              <td>-5</td>
+              <td>per megaton (1M tons) of CO2e emitted</td>
+            </tr>
+            <tr>
+              <td>-10</td>
+              <td>per TWh of blackouts</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.TOTAL_COST_OF_ENERGY,
+    group: "Money",
+    keywords: "lcoe levelized cost of energy cost per mwh total energy cost",
+    entry: (
+      <p>
+        Also known as "Levelized Cost of Energy", it's the expected cost of all
+        energy produced by the plant during its lifetime, including
+        construction, maintenance and fuel.
+      </p>
+    ),
+  },
+];

--- a/src/reducers/Card.tsx
+++ b/src/reducers/Card.tsx
@@ -37,6 +37,9 @@ export const cardSlice = createSlice({
       return {
         ...state,
         name: a.name,
+        // Cleared rather than carried over, so a plain visit to the manual doesn't reopen
+        // whichever entry the last deep link pointed at
+        entry: a.entry,
         history: [
           a.dontRemember ? state.name : a.name,
           ...(state.history || []),

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -25,6 +25,7 @@ import { getSolarOutputFactor, getWindOutputFactor } from "../helpers/Energy";
 import { getFuelPricesPerMBTU } from "../data/FuelPrices";
 import { getWeather, getRawSolarIrradianceWM2 } from "../data/Weather";
 import { dialogOpen, dialogClose, snackbarOpen } from "./UI";
+import { navigate, navigateBack } from "./Card";
 import {
   DIFFICULTIES,
   DOWNPAYMENT_PERCENT,
@@ -90,6 +91,10 @@ let previousTickMs = 0;
 // decide whether the tick loop needs restarting, since state.speed can change without going
 // through setSpeed (e.g. dialogClose below), which would desync a "previous speed" comparison.
 let speedBeforeDialog = "PAUSED" as SpeedType;
+// Same idea for the manual, which is a full-screen card over a game that would otherwise keep
+// ticking -- looking up "Blackouts" mid-crisis used to cause blackouts. Undefined whenever the
+// manual isn't what paused us, so leaving any other card doesn't resume a deliberate pause.
+let speedBeforeManual: SpeedType | undefined;
 // Tracks whether the self-rescheduling tick() loop is currently alive, so that any transition
 // out of PAUSED (manual speed click, tutorial script, dialog closing) reliably restarts it.
 let tickLoopRunning = false;
@@ -127,6 +132,16 @@ function ensureTicking(state: GameType) {
       TICK_MS[state.speed],
     );
   }
+}
+
+// Puts the clock back the way the player left it before the manual paused it
+function restoreSpeedAfterManual(state: GameType) {
+  if (speedBeforeManual === undefined) {
+    return;
+  }
+  state.speed = speedBeforeManual;
+  speedBeforeManual = undefined;
+  ensureTicking(state);
 }
 
 export const gameSlice = createSlice({
@@ -312,8 +327,23 @@ export const gameSlice = createSlice({
       state.inGame = true;
     });
     builder.addCase(quit, () => {
+      speedBeforeManual = undefined;
       return cloneDeep(initialGame);
     });
+    // Opening the manual pauses the game, and closing it puts the speed back. Without this the
+    // sim runs on while the player reads, which punishes them for looking something up
+    builder.addCase(navigate, (state, action) => {
+      const payload = action.payload;
+      const name = typeof payload === "string" ? payload : payload?.name;
+      if (name !== "MANUAL") {
+        // Navigating anywhere else (rather than backing out) still counts as leaving it
+        restoreSpeedAfterManual(state);
+      } else if (state.inGame && speedBeforeManual === undefined) {
+        speedBeforeManual = state.speed;
+        state.speed = "PAUSED";
+      }
+    });
+    builder.addCase(navigateBack, restoreSpeedAfterManual);
     builder.addCase(dialogOpen, (state) => {
       speedBeforeDialog = state.speed;
       state.speed = "PAUSED";

--- a/src/reducers/ManualPause.test.tsx
+++ b/src/reducers/ManualPause.test.tsx
@@ -1,0 +1,73 @@
+import gameReducer, { setSpeed } from "./Game";
+import cardReducer, { navigate, navigateBack } from "./Card";
+import { quit } from "./GameActions";
+import { GameType } from "../Types";
+
+function running(speed: "SLOW" | "NORMAL" | "FAST" = "FAST"): GameType {
+  const state = gameReducer(undefined, setSpeed(speed));
+  return { ...state, inGame: true };
+}
+
+describe("the manual pausing the game", () => {
+  it("pauses on the way in and restores the speed on the way back", () => {
+    const paused = gameReducer(running("FAST"), navigate("MANUAL"));
+    expect(paused.speed).toBe("PAUSED");
+    expect(gameReducer(paused, navigateBack()).speed).toBe("FAST");
+  });
+
+  it("restores the speed when leaving the manual forwards too", () => {
+    const paused = gameReducer(running("SLOW"), navigate("MANUAL"));
+    expect(gameReducer(paused, navigate("FACILITIES")).speed).toBe("SLOW");
+  });
+
+  it("leaves a deliberate pause alone", () => {
+    const state = {
+      ...gameReducer(undefined, setSpeed("PAUSED")),
+      inGame: true,
+    };
+    const inManual = gameReducer(state, navigate("MANUAL"));
+    expect(gameReducer(inManual, navigateBack()).speed).toBe("PAUSED");
+  });
+
+  it("restores the speed the player arrived with", () => {
+    const paused = gameReducer(running("NORMAL"), navigate("MANUAL"));
+    // Re-pausing an already-paused game shouldn't change what we put back
+    const stillPaused = gameReducer(paused, setSpeed("PAUSED"));
+    expect(gameReducer(stillPaused, navigateBack()).speed).toBe("NORMAL");
+  });
+
+  it("doesn't touch the clock outside a game", () => {
+    // The manual is reachable from the title screen and the scenario list, where there's no
+    // game to pause and nothing to put back
+    const outOfGame = gameReducer(undefined, navigate("MANUAL"));
+    expect(outOfGame.speed).toBe("PAUSED");
+    expect(gameReducer(outOfGame, navigateBack()).speed).toBe("PAUSED");
+  });
+
+  it("forgets the remembered speed when the scenario ends", () => {
+    const paused = gameReducer(running("FAST"), navigate("MANUAL"));
+    const quitted = gameReducer(paused, quit());
+    expect(gameReducer(quitted, navigateBack()).speed).toBe("PAUSED");
+  });
+});
+
+describe("deep linking into a manual entry", () => {
+  it("carries the entry through navigation", () => {
+    const state = cardReducer(
+      undefined,
+      navigate({ name: "MANUAL", entry: "Total Cost of Energy" }),
+    );
+    expect(state.name).toBe("MANUAL");
+    expect(state.entry).toBe("Total Cost of Energy");
+  });
+
+  it("doesn't reopen the last deep link on a later plain visit", () => {
+    const deepLinked = cardReducer(
+      undefined,
+      navigate({ name: "MANUAL", entry: "Ramp Rate" }),
+    );
+    const back = cardReducer(deepLinked, navigateBack());
+    expect(back.entry).toBeUndefined();
+    expect(cardReducer(back, navigate("MANUAL")).entry).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Addresses the collected UI feedback on the in-app Manual.

## Bugs / actively misleading

- [x] **Search misses most content.** `filterEntries` only looked at children that were plain strings, or one-level elements whose `children` was a string, so any `<p>` with mixed content was invisible — "merit order", "dispatch order", "peak shortage" and "carbon fee" all returned zero results despite being in the manual. Entries now live in `src/data/Manual.tsx` with a `group` and an optional `keywords` field, and their prose is flattened by `manualEntryText`, which walks the whole tree. Deviates slightly from the suggestion of a hand-written `text` field: deriving the prose means a new entry is searchable the moment it's written, with `keywords` covering only synonyms (LCOE, peaker) and content that's rendered by a component rather than spelled out in markup.
- [x] **Search results stay collapsed.** Matching entries auto-expand, and every occurrence of the term is wrapped in a `<mark>`. The player can still collapse one; entering or leaving search resets those overrides, since "expanded" means something different in each mode.
- [x] **No empty state.** Zero matches renders `No entries match "X"` plus a Discord link.
- [x] **The search `IconButton` is a no-op.** The magnifier is now a non-focusable `InputAdornment`, and the end slot holds a clear (×) button that only appears when there's something to clear.
- [x] **The sim keeps running while the manual is open.** `reducers/Game` reacts to `navigate`/`navigateBack`: entering the manual mid-game records the speed and pauses, and leaving it — backwards or forwards — puts the speed back. Out of a game it does nothing.

## Structure

- [x] **No contextual entry points.** New `ManualLink` renders a "?" next to a term the game already shows and dispatches `navigate({name: "MANUAL", entry})`; the manual opens that entry and scrolls to it. Wired up on the generator build rows (total energy cost, average output → capacity factor, ramp up/down time, air pollution), the storage build rows, and the public-ownership rate slider.
- [x] **Pure alphabetical ordering.** "How to Play" is pinned above Gameplay / Money / Physics & Units, with sticky subheaders and alphabetical ordering inside each group.
- [x] **Missing entries.** Added Capacity Factor, Ramp Rate, Baseload vs Peaker, Round-trip Efficiency, Rates and Carbon Fee (lifted out of Emissions), plus How to Play.
- [x] **Keyboard shortcuts duplicated in Settings.** Extracted to `base/KeyboardShortcuts`, used by both. Added `?` to open the manual — wired into `keyMap` and listed in the table.

## Polish

- [x] `Card` + custom `Collapse` → MUI **Accordion**: real `<button>` headers, `aria-expanded`, `aria-controls`, and an `<h3>` heading per entry.
- [x] The floating centred `.expand-icon` is gone from the manual — the Accordion's chevron sits at the right end of the header row.
- [x] Images get descriptive `alt` text and a visible `<figcaption>` source link, and images are no longer upscaled: dropping `width: 100%` in favour of intrinsic `width`/`height` plus `max-width: 100%` renders them at their native 576–834px on a wide pane and shrinks them on a phone. `loading="lazy"` throughout.
- [x] The **Score** entry uses a `.points` table sharing the `.shortcuts` styling, so the values align in a column.
- [x] Hover is `grey200` rather than an invisible `grey50`-on-white, and there's a `:focus-visible` outline on entry headers and manual links.
- [x] The intro is plain caption text rather than a card that looks tappable.
- [x] Search term and scroll position survive leaving and coming back. Recorded on `onScroll` rather than in an unmount cleanup — by then React has detached the node and every detached node reports `scrollTop` 0. Deep links deliberately start fresh.

## Testing

`npm run check` passes (216 tests). New: `src/components/views/Manual.test.tsx` (17 tests covering search of mixed markup, auto-expand and highlighting, the empty state, the clear button, deep links, grouping, and the keyboard-reachable headers) and `src/reducers/ManualPause.test.tsx` (8 tests covering pause/restore and the deep-link plumbing).

Also verified by hand in the running app: `?` opens the manual, the clock freezes for the duration and resumes at the same speed, the build-screen "?" deep-links into Total Cost of Energy with only that entry open and scrolled to, and search/scroll persist across visits.

## Noted but not fixed

`src/reducers/Game.tsx` throws `Cannot perform 'get' on a proxy that has been revoked` when a scenario ends — three end-of-scenario paths call `clearSaveFor(state.scenarioId)` inside a `setTimeout`, reading the Immer draft after the reducer has returned. Pre-existing and unrelated, so it's left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
