### PR TITLE
Fix revoked-draft crash when a scenario ends

### DIFF
--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -431,10 +431,14 @@ export function tickState(state: GameType) {
       }
 
       // ===== TRIGGERS ======
+      // state is an Immer draft, and it's revoked the moment this reducer returns - so anything
+      // the timeouts below need has to be read out here rather than from inside their callbacks
+      const scenarioId = state.scenarioId;
+
       // Failure: Bankrupt
       if (now.cash < 0) {
         logEvent("scenario_end", {
-          id: state.scenarioId,
+          id: scenarioId,
           type: "bankrupt",
           difficulty: state.difficulty,
         });
@@ -442,7 +446,7 @@ export function tickState(state: GameType) {
         setTimeout(() => {
           // In the timeout rather than here in the reducer: the autosave subscriber runs as soon
           // as this returns and would write the run straight back
-          clearSaveFor(state.scenarioId);
+          clearSaveFor(scenarioId);
           const finished = getStore().getState().game;
           getStore().dispatch(
             dialogOpen({
@@ -470,13 +474,13 @@ export function tickState(state: GameType) {
         history[3].supplyWh < history[3].demandWh * 0.9
       ) {
         logEvent("scenario_end", {
-          id: state.scenarioId,
+          id: scenarioId,
           type: "blackouts",
           difficulty: state.difficulty,
         });
         const summary = summarizeHistory(history);
         setTimeout(() => {
-          clearSaveFor(state.scenarioId);
+          clearSaveFor(scenarioId);
           const finished = getStore().getState().game;
           getStore().dispatch(
             dialogOpen({
@@ -505,7 +509,7 @@ export function tickState(state: GameType) {
         if (ranked) {
           // Tutorials are already marked played once their walkthrough ends, so this is a
           // no-op for the ones the player sat all the way through
-          recordScenarioPlayed(state.scenarioId);
+          recordScenarioPlayed(scenarioId);
         }
 
         // Calculate score - This is also described in the manual; if I update the algorithm, update the manual too!
@@ -536,6 +540,14 @@ export function tickState(state: GameType) {
 
         const finalScore = Object.values(score).reduce((a, b) => a + b);
         const difficulty = state.difficulty; // pulling out of state for functions running inside of setTimeout
+        // For a custom game getScenario() returns state.customScenario, which belongs to the same
+        // draft, so the fields the timeouts below read come out here too
+        const {
+          id: scoredScenarioId,
+          endTitle,
+          endMessage,
+          ownership,
+        } = scenario;
 
         // The leaderboard is keyed on scenario id alone, so custom runs - whatever cash, duration
         // and rules the player gave themselves - would be scored against each other as if they
@@ -547,7 +559,7 @@ export function tickState(state: GameType) {
                 submitHighscore({
                   score: finalScore,
                   scoreBreakdown: score, // For analytics purposes only
-                  scenarioId: scenario.id,
+                  scenarioId: scoredScenarioId,
                   difficulty,
                 }),
               ),
@@ -556,7 +568,7 @@ export function tickState(state: GameType) {
         }
 
         logEvent("scenario_end", {
-          id: scenario.id,
+          id: scoredScenarioId,
           type: "win",
           difficulty,
           score: finalScore,
@@ -564,29 +576,29 @@ export function tickState(state: GameType) {
         setTimeout(() => {
           // The scenario is over even if the player takes "Keep playing"; autosave simply writes a
           // fresh save at the next month rollover if they do
-          clearSaveFor(state.scenarioId);
+          clearSaveFor(scenarioId);
           getStore().dispatch(
             dialogOpen({
-              title: scenario.endTitle || `You've retired!`,
-              message: scenario.endMessage || (
+              title: endTitle || `You've retired!`,
+              message: endMessage || (
                 <div>
                   Your final score is {finalScore}:<br />
                   <br />
                   {score.supply} pts from electricity supplied
                   <br />
-                  {scenario.ownership === "Investor" && (
+                  {ownership === "Investor" && (
                     <span>
                       {score.netWorth} pts from final net worth
                       <br />
                     </span>
                   )}
-                  {scenario.ownership === "Investor" && (
+                  {ownership === "Investor" && (
                     <span>
                       {score.customers} pts from final customers
                       <br />
                     </span>
                   )}
-                  {scenario.ownership === "Public" && (
+                  {ownership === "Public" && (
                     <span>
                       {score.rate} pts from electric rates
                       <br />

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -1,0 +1,60 @@
+import { produce } from "immer";
+import { CUSTOM_SCENARIO_ID, SCENARIOS } from "../data/Scenarios";
+import { createGame } from "../testing/Simulator";
+import { tickState } from "./Game";
+import { GameType, ScenarioType } from "../Types";
+
+/**
+ * The end of scenario triggers hand their dialogs off to setTimeout so that the autosave
+ * subscriber doesn't write the finished run straight back. Everything those callbacks read has to
+ * come out of the Immer draft first, because the draft is revoked the moment the reducer returns.
+ *
+ * The rest of the suite ticks a plain object rather than a draft, so it can't see this - these run
+ * through produce() the way createSlice does.
+ */
+
+// Custom rather than authored: for a custom game the scenario itself lives on the slice, so the
+// end of game dialog reads its title, message and ownership off the draft too
+function customScenario(overrides: Partial<ScenarioType>): ScenarioType {
+  return {
+    ...SCENARIOS[0],
+    id: CUSTOM_SCENARIO_ID,
+    tutorialSteps: undefined,
+    ...overrides,
+  };
+}
+
+function tick(state: GameType): GameType {
+  return produce(state, (draft: GameType) => {
+    tickState(draft);
+  });
+}
+
+describe("ending a scenario from inside the reducer", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it("survives to the end of the term without reading the revoked draft", () => {
+    const scenario = customScenario({ durationMonths: 2 });
+    let state = createGame({ scenarioId: CUSTOM_SCENARIO_ID, scenario });
+    while (state.date.monthsEllapsed < (scenario.durationMonths as number)) {
+      state = tick(state);
+    }
+    expect(() => jest.runOnlyPendingTimers()).not.toThrow();
+  });
+
+  it("goes bankrupt without reading the revoked draft", () => {
+    // No cash and a marketing budget far past what the fleet earns: it is under within a month
+    const scenario = customScenario({ cash: 0, durationMonths: 12 * 20 });
+    let state = createGame({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario,
+      monthlyMarketingSpend: 1000000000,
+    });
+    while (state.date.monthsEllapsed < 2) {
+      state = tick(state);
+    }
+    expect(state.monthlyHistory[0].cash).toBeLessThan(0);
+    expect(() => jest.runOnlyPendingTimers()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

Ending a scenario threw `TypeError: Cannot perform 'get' on a proxy that has been revoked` — reproducible by playing any scenario at FAST speed until the term ends. The save was never cleared and the end-of-game dialog never opened.

All three end-of-scenario triggers in `tickState` hand their dialogs off to `setTimeout` (deliberately — the autosave subscriber runs as soon as the reducer returns and would write the finished run straight back). But those callbacks read `state.scenarioId`, and `state` is the Immer draft, which is revoked the moment the reducer returns.

## Fix

`scenarioId` is now read out into a local at the top of the triggers block and used by all three `clearSaveFor` calls.

Auditing the other draft fields those timeouts touch turned up a second escape on the very next line: for a custom game `getScenario(state.scenarioId, state.customScenario)` returns `state.customScenario`, which belongs to that same draft. The win dialog reads `scenario.endTitle`, `scenario.endMessage` and `scenario.ownership` from inside the callback, and the highscore timeout reads `scenario.id`. Those are now destructured out alongside the existing `difficulty` local, which was already being pulled out for exactly this reason.

Every other `setTimeout` in the file is clean: the two tick-loop ones evaluate `TICK_MS[state.speed]` as the *delay argument* (synchronous) and their callbacks only dispatch, and the blackout and construction-complete toasts already build their `message` outside the callback. There are no other async patterns in the file.

## Tests

`src/reducers/ScenarioEnd.test.tsx` covers the term-end and bankruptcy triggers. The rest of the suite ticks a plain object via `tickState(state)`, which is exactly why it never caught this — these run through `produce()` the way `createSlice` does, on a custom scenario so the `state.customScenario` path is covered too.

Both fail with the original error when the fix is reverted.

## Verification

`typecheck`, `lint` and `format:check` pass; full suite is 21 suites / 218 tests green.

Note: `npm run check`'s test step reports "No tests found" when run from a git worktree — jest builds a `testMatch` with a mixed path separator (`C:/Users/toddm/electrify\.claude/worktrees/...`) that matches nothing. Pre-existing and unrelated to this change; it runs normally from the main checkout. I ran the suite here with `--testMatch='**/*.test.tsx'` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
