### PR TITLE
Celebrate tutorial completion, and drop Discord/launch list

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -2,9 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Electrify: About and Contact</title>
   <meta name="description" content="Electrify: Take Charge of the Power Market" />
+  <meta name="theme-color" content="#0084f8">
+  <link rel="icon" href="/favicon.ico">
 
   <!-- Twitter Card data -->
   <meta name="twitter:card" content="Take Charge of the Power Market">
@@ -21,49 +23,309 @@
   <meta property="og:image" content="https://electrifygame.com/images/icon/1024x1024.png" />
   <meta property="og:description" content="Take Charge of the Power Market" />
 
-  <link href="//cdn.muicss.com/mui-0.10.0/css/mui.min.css" rel="stylesheet" type="text/css" />
-  <script src="//cdn.muicss.com/mui-0.10.0/js/mui.min.js"></script>
   <style>
-    .mui-appbar a {
-      color: white;
-      padding-left: 15px;
+    /* Self-contained rather than pulling MUI off a CDN: this is three panels of static text, and
+       the stylesheet it needed weighed more than the page itself - plus it put a blocking request
+       to a third party in front of anything rendering on a phone. */
+    :root {
+      /* The logo's blue only clears 3.8:1 on white, so it stays on the things contrast is
+         measured differently for - borders, focus rings, washes - and anything carrying text
+         (links, the filled button) uses the darkened one at 5.2:1 */
+      --brand: #0084f8;
+      --brand-text: #0a6cc9;
+      --brand-text-hover: #084e93;
+      --brand-wash: rgba(0, 132, 248, 0.1);
+      --bg: #ffffff;
+      --bg-sunk: #f4f7fa;
+      --surface: #ffffff;
+      --border: #dfe5ec;
+      --text: #16191d;
+      --text-muted: #5a636e;
+      --shadow: 0 1px 2px rgba(16, 24, 40, 0.04), 0 4px 16px rgba(16, 24, 40, 0.06);
+      --radius: 14px;
+      --maxwidth: 46rem;
     }
-    button a {
-      color: white;
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --brand: #4ea9ff;
+        --brand-text: #7cc0ff;
+        --brand-text-hover: #a8d4ff;
+        --brand-wash: rgba(124, 192, 255, 0.12);
+        --bg: #14171b;
+        --bg-sunk: #0f1216;
+        --surface: #1c2026;
+        /* Lighter than the light theme's border is dark, because on a dark surface a button's
+           outline is the only thing separating it from the panel behind it */
+        --border: #39424e;
+        --text: #eef1f5;
+        --text-muted: #a3adba;
+        --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 4px 16px rgba(0, 0, 0, 0.3);
+      }
     }
-    button a:hover {
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    html {
+      -webkit-text-size-adjust: 100%;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg-sunk);
+      color: var(--text);
+      font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 17px;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* ===== Top bar ===== */
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding-top: env(safe-area-inset-top);
+    }
+
+    .topbar-inner {
+      max-width: var(--maxwidth);
+      margin: 0 auto;
+      padding-left: max(1rem, env(safe-area-inset-left));
+      padding-right: max(1rem, env(safe-area-inset-right));
+      display: flex;
+      align-items: center;
+      min-height: 3.25rem;
+    }
+
+    /* 44px tall so it clears the minimum touch target on a phone, where this is the only
+       way back to the game */
+    .back {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      min-height: 44px;
+      margin-left: -0.5rem;
+      padding: 0 0.5rem;
+      border-radius: 8px;
+      color: var(--brand-text);
+      font-weight: 500;
       text-decoration: none;
+    }
+
+    .back:hover {
+      background: var(--brand-wash);
+    }
+
+    .back svg {
+      flex: none;
+    }
+
+    /* ===== Hero ===== */
+    .hero {
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      text-align: center;
+      padding: 2.5rem 1rem 2.75rem;
+    }
+
+    .hero img {
+      width: 100%;
+      max-width: 15rem;
+      height: auto;
+      display: block;
+      margin: 0 auto 1.25rem;
+    }
+
+    .hero p {
+      max-width: 30rem;
+      margin: 0 auto;
+      color: var(--text-muted);
+    }
+
+    /* ===== Panels ===== */
+    main {
+      max-width: var(--maxwidth);
+      margin: 0 auto;
+      padding: 1.5rem max(1rem, env(safe-area-inset-right)) 3rem max(1rem, env(safe-area-inset-left));
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      padding: 1.5rem;
+    }
+
+    h1 {
+      margin: 0 0 0.75rem;
+      font-size: 1.5rem;
+      line-height: 1.25;
+      letter-spacing: -0.01em;
+    }
+
+    section p {
+      margin: 0 0 1rem;
+    }
+
+    section p:last-child {
+      margin-bottom: 0;
+    }
+
+    a {
+      color: var(--brand-text);
+    }
+
+    a:hover {
+      color: var(--brand-text-hover);
+    }
+
+    /* ===== Buttons ===== */
+    .actions {
+      display: grid;
+      gap: 0.625rem;
+      margin-top: 1.25rem;
+    }
+
+    /* One per row on a phone, where thumbs need the width; side by side once there's room, so
+       a desktop doesn't get a stack of full-width slabs. auto-fill rather than auto-fit keeps
+       the empty column, so a panel with a single button gets a button rather than a banner */
+    @media (min-width: 33rem) {
+      .actions {
+        grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+      }
+    }
+
+    .btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+      padding: 0.625rem 1.125rem;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--bg);
+      color: var(--text);
+      font: inherit;
+      font-weight: 500;
+      text-align: center;
+      text-decoration: none;
+      transition:
+        background-color 120ms ease,
+        border-color 120ms ease,
+        transform 120ms ease;
+    }
+
+    .btn:hover {
+      background: var(--bg-sunk);
+      border-color: var(--brand);
+      color: var(--text);
+    }
+
+    .btn:active {
+      transform: translateY(1px);
+    }
+
+    .btn--primary {
+      background: var(--brand-text);
+      border-color: var(--brand-text);
+      color: #ffffff;
+    }
+
+    .btn--primary:hover {
+      background: var(--brand-text-hover);
+      border-color: var(--brand-text-hover);
+      color: #ffffff;
+    }
+
+    /* The dark palette lightens the blue so it reads against the page, which flips which label
+       color the filled button needs */
+    @media (prefers-color-scheme: dark) {
+      .btn--primary,
+      .btn--primary:hover {
+        color: #10161d;
+      }
+    }
+
+    :focus-visible {
+      outline: 3px solid var(--brand);
+      outline-offset: 2px;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      * {
+        transition: none !important;
+      }
+    }
+
+    footer {
+      max-width: var(--maxwidth);
+      margin: 0 auto;
+      padding: 0 1rem 2.5rem;
+      color: var(--text-muted);
+      font-size: 0.875rem;
+      text-align: center;
     }
   </style>
 </head>
 <body>
-  <div class="mui-container">
-    <div class="mui-appbar">
-    <table width="100%">
-      <tr style="vertical-align:middle;">
-        <td class="mui--appbar-height"><a href="/">< Back to game</a></td>
-      </tr>
-    </table>
+  <div class="topbar">
+    <div class="topbar-inner">
+      <a class="back" href="/">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false">
+          <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
+        </svg>
+        Back to game
+      </a>
+    </div>
   </div>
-    <div class="mui-panel">
+
+  <div class="hero">
+    <img src="/images/logo.svg" alt="Electrify" width="300" height="70">
+    <p>Take charge of the power market.</p>
+  </div>
+
+  <main>
+    <section>
       <h1>About Electrify</h1>
       <p>Think RollerCoaster Tycoon, but for electricity. Electrify uses the time-honored tradition of simulation games to teach about the challenges and opportunities in the modern electricity market, including renewables and energy storage.</p>
-      <p>Electrify is built upon hundreds of hours of research into the electricity market and power generation technologies - all of the numbers are based on real electric companies and power plants. You can find all of the sources and referneces in <a href="https://github.com/toddmedema/electrify">the Electrify source code</a> (did we mention that Electrify is 100% free and open source?)</p>
-      <button class="mui-btn mui-btn--primary"><a href="https://fabricate.us10.list-manage.com/subscribe?u=792afb261df839e73b669f83f&id=8ccd05ccba">Join the launch list</a></button>
-      <button class="mui-btn mui-btn--primary"><a href="https://discord.gg/2fTDHE7">Join the Discord community</a></button>
-    </div>
-    <div class="mui-panel">
+      <p>Electrify is built upon hundreds of hours of research into the electricity market and power generation technologies &mdash; all of the numbers are based on real electric companies and power plants. You can find all of the sources and references in <a href="https://github.com/toddmedema/electrify">the Electrify source code</a> (did we mention that Electrify is 100% free and open source?)</p>
+      <div class="actions">
+        <a class="btn btn--primary" href="/">Play Electrify</a>
+        <a class="btn" href="https://github.com/toddmedema/electrify">View the source</a>
+      </div>
+    </section>
+
+    <section>
       <h1>Take Action</h1>
       <p>Want to help the planet? In our research for Electrify, here are some of the most effective ways to have an impact:</p>
-      <button class="mui-btn mui-btn--primary"><a href="https://arcadia.com/referral/?promo=todd64599">Switch to Arcadia Power</a></button>
-      <button class="mui-btn mui-btn--primary"><a href="https://citizensclimatelobby.org/donate/">Donate to Citizen's Climate Lobby</a></button>
-      <button class="mui-btn mui-btn--primary"><a href="https://medium.com/@toddmedema/how-to-invest-in-the-environment-d280f6c5f41">Tweak your investment portfolio</a></button>
-    </div>
-    <div class="mui-panel">
+      <div class="actions">
+        <a class="btn" href="https://arcadia.com/referral/?promo=todd64599">Switch to Arcadia Power</a>
+        <a class="btn" href="https://citizensclimatelobby.org/donate/">Donate to Citizen&rsquo;s Climate Lobby</a>
+        <a class="btn" href="https://medium.com/@toddmedema/how-to-invest-in-the-environment-d280f6c5f41">Tweak your investment portfolio</a>
+      </div>
+    </section>
+
+    <section>
       <h1>Contact Us</h1>
-      <p>Questions? Feedback? Want to collaborate? <a href="mailto:todd@fabricate.io">Send us an email</a></p>
-    </div>
-  </div>
+      <p>Questions? Feedback? Want to collaborate? We&rsquo;d love to hear from you.</p>
+      <div class="actions">
+        <a class="btn btn--primary" href="mailto:todd@fabricate.io">Send us an email</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>Electrify is free and open source, released under the MIT license.</footer>
+
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-BYRYY6BG1Y"></script>
   <script>

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -315,6 +315,11 @@ export interface DialogType {
   title: string;
   action?: (e: React.MouseEvent<HTMLElement>) => void;
   actionLabel?: string;
+  // For dialogs where the second choice is an action of its own rather than "never mind" - the
+  // end of a tutorial offers the next tutorial or the main menu, and neither is a dismissal.
+  // Set alongside notCancellable, this replaces the close button rather than adding a third one
+  secondaryAction?: (e: React.MouseEvent<HTMLElement>) => void;
+  secondaryLabel?: string;
   notCancellable?: boolean;
   closeText?: string;
   open: boolean;

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -234,7 +234,11 @@ export default class Compositor extends React.Component<Props, {}> {
       EVENTS.STEP_AFTER,
       EVENTS.TARGET_NOT_FOUND,
     ];
-    if (advancingEvents.includes(type)) {
+    // Quitting tears the walkthrough's targets out of the DOM, and Joyride reports that as
+    // TARGET_NOT_FOUND on the way out. Advancing on it navigated the just-reset game back onto
+    // the step's card, which then rendered nothing because the game was over - a blank screen
+    // where the main menu should be. tutorialStep is only >= 0 while a walkthrough is live
+    if (advancingEvents.includes(type) && this.props.tutorialStep >= 0) {
       this.props.onTutorialStep({
         fromStep: index,
         toStep: index + (action === ACTIONS.PREV ? -1 : 1),
@@ -384,9 +388,12 @@ export default class Compositor extends React.Component<Props, {}> {
         )}
         <Dialog
           open={ui.dialog.open}
-          // v9 replaced `disableEscapeKeyDown` with filtering on the close reason
-          onClose={(_event, reason) => {
-            if (ui.dialog.notCancellable && reason === "escapeKeyDown") {
+          // v9 replaced `disableEscapeKeyDown` with filtering on the close reason. A
+          // notCancellable dialog is one whose buttons are the only way forward - the end of a
+          // run, the end of a tutorial - so a backdrop click has to be refused alongside Esc,
+          // or dismissing it strands the player in a game that's already over
+          onClose={() => {
+            if (ui.dialog.notCancellable) {
               return;
             }
             closeDialog();
@@ -395,6 +402,11 @@ export default class Compositor extends React.Component<Props, {}> {
           <DialogTitle>{ui.dialog.title}</DialogTitle>
           <DialogContent>{ui.dialog.message}</DialogContent>
           <DialogActions>
+            {ui.dialog.secondaryAction && (
+              <Button color="primary" onClick={ui.dialog.secondaryAction}>
+                {ui.dialog.secondaryLabel || "Close"}
+              </Button>
+            )}
             {!ui.dialog.notCancellable && (
               <Button color="primary" onClick={closeDialog}>
                 {ui.dialog.closeText || (ui.dialog.action ? "Cancel" : "OK")}

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 import type { UnknownAction } from "redux";
+import { ACTIONS, EVENTS, type EventData } from "react-joyride";
 import type { AppDispatch } from "../Store";
 import { SCENARIOS } from "../data/Scenarios";
 import { CardNameType, NavigateActionType, TutorialStepType } from "../Types";
+import Compositor, { type Props as CompositorProps } from "./Compositor";
 import { mapDispatchToProps } from "./CompositorContainer";
 
 // Where `loaded` drops the player, and so where every walkthrough starts
@@ -206,5 +208,54 @@ describe("walkthrough steps", () => {
         ]);
       });
     });
+  });
+});
+
+describe("handleJoyrideCallback", () => {
+  const steps = walkthrough("102: Generators");
+
+  function fire(tutorialStep: number, event: Partial<EventData>) {
+    const onTutorialStep = jest.fn();
+    const onTutorialEnd = jest.fn();
+    const compositor = new Compositor({
+      tutorialStep,
+      tutorialSteps: steps,
+      scenarioId: 1,
+      card: { name: STARTING_CARD, ts: 0 },
+      onTutorialStep,
+      onTutorialEnd,
+    } as unknown as CompositorProps);
+    compositor.handleJoyrideCallback(event as EventData);
+    return { onTutorialStep, onTutorialEnd };
+  }
+
+  it("advances past a target that never turns up mid-walkthrough", () => {
+    const { onTutorialStep } = fire(2, {
+      action: ACTIONS.NEXT,
+      index: 2,
+      type: EVENTS.TARGET_NOT_FOUND,
+    });
+    expect(onTutorialStep).toHaveBeenCalled();
+  });
+
+  // Quitting takes the targets out of the DOM, which Joyride reports the same way. Acting on it
+  // navigated the freshly reset game back onto the walkthrough's card, which had nothing left to
+  // render - a blank screen where the main menu should be
+  it("ignores targets disappearing once the walkthrough is over", () => {
+    const { onTutorialStep } = fire(-1, {
+      action: ACTIONS.NEXT,
+      index: 2,
+      type: EVENTS.TARGET_NOT_FOUND,
+    });
+    expect(onTutorialStep).not.toHaveBeenCalled();
+  });
+
+  it("still ends the walkthrough when the player closes it", () => {
+    const { onTutorialEnd } = fire(2, {
+      action: ACTIONS.CLOSE,
+      index: 2,
+      type: EVENTS.STEP_AFTER,
+    });
+    expect(onTutorialEnd).toHaveBeenCalledWith(steps);
   });
 });

--- a/src/components/base/GameCard.tsx
+++ b/src/components/base/GameCard.tsx
@@ -11,7 +11,8 @@ import { formatHour, getTimeFromTimeline } from "../../helpers/DateTime";
 import { formatMoneyStable } from "../../helpers/Format";
 import { navigate } from "../../reducers/Card";
 import { isBigScreen, isSmallScreen, openWindow } from "../../Globals";
-import { quit, setSpeed } from "../../reducers/Game";
+import { getNextTutorial } from "../../data/Scenarios";
+import { quit, setSpeed, startTutorial } from "../../reducers/Game";
 import { AppStateType, GameType, SpeedType } from "../../Types";
 import NavigationContainer from "./NavigationContainer";
 
@@ -30,6 +31,7 @@ export interface GameCardProps extends React.ComponentPropsWithoutRef<"div"> {
 export interface DispatchProps {
   onManual: () => void;
   onSpeedChange: (speed: SpeedType) => void;
+  onNextTutorial: (scenarioId: number) => void;
   onQuit: () => void;
 }
 
@@ -181,7 +183,7 @@ function buildSpeedOptions({
 }
 
 export function GameCard(props: Props) {
-  const { game, onManual, onQuit, onSpeedChange } = props;
+  const { game, onManual, onNextTutorial, onQuit, onSpeedChange } = props;
   const date = game.date;
   const now = getTimeFromTimeline(date.minute, game.timeline);
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<HTMLElement | null>(
@@ -194,6 +196,9 @@ export function GameCard(props: Props) {
   const smallScreen = isSmallScreen();
   const bigScreen = isBigScreen();
   const speed = game.speed;
+  // Undefined outside a tutorial, and on the last one - so this doubles as "is there a next
+  // tutorial to offer?" for the menu item below
+  const nextTutorial = getNextTutorial(game.scenarioId);
 
   const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
     setMenuAnchorEl(event.currentTarget);
@@ -246,12 +251,19 @@ export function GameCard(props: Props) {
           <MenuItem onClick={() => openWindow("mailto:todd@fabricate.io")}>
             Send feedback
           </MenuItem>
+          {/* Mid-tutorial, the thing a player who has seen enough wants is the next tutorial,
+              not the scenario list they'd have to go back through to reach it */}
+          {nextTutorial && (
+            <MenuItem onClick={() => onNextTutorial(nextTutorial.id)}>
+              Next tutorial
+            </MenuItem>
+          )}
           <MenuItem onClick={onQuit}>Quit</MenuItem>
         </Menu>
       </>
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [menuAnchorEl, onManual, onQuit],
+    [menuAnchorEl, onManual, onNextTutorial, onQuit, nextTutorial],
   );
 
   const nav = React.useMemo(() => <NavigationContainer />, []);
@@ -319,6 +331,9 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     },
     onSpeedChange: (speed: SpeedType) => {
       dispatch(setSpeed(speed));
+    },
+    onNextTutorial: (scenarioId: number) => {
+      startTutorial(dispatch, scenarioId);
     },
     onQuit: () => {
       dispatch(quit());

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -3,7 +3,6 @@ import { Button, IconButton } from "@mui/material";
 import EmailIcon from "@mui/icons-material/Email";
 import InfoIcon from "@mui/icons-material/Info";
 import { login } from "../../Globals";
-import { interactiveColor } from "../../Theme";
 
 export interface StateProps {
   audioEnabled?: boolean;
@@ -81,29 +80,18 @@ const MainMenu = (props: Props): React.JSX.Element => {
       >
         <IconButton
           color="primary"
-          href="https://fabricate.us10.list-manage.com/subscribe?u=792afb261df839e73b669f83f&id=8ccd05ccba"
+          href="mailto:todd@fabricate.io"
+          aria-label="Send feedback"
           size="large"
         >
           <EmailIcon />
         </IconButton>
         <IconButton
           color="primary"
-          href="https://discord.gg/2fTDHE7"
+          href="/about.html"
+          aria-label="About Electrify"
           size="large"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 245 240"
-            width={24}
-          >
-            <path d="M104.4 103.9c-5.7 0-10.2 5-10.2 11.1s4.6 11.1 10.2 11.1c5.7 0 10.2-5 10.2-11.1.1-6.1-4.5-11.1-10.2-11.1zM140.9 103.9c-5.7 0-10.2 5-10.2 11.1s4.6 11.1 10.2 11.1c5.7 0 10.2-5 10.2-11.1s-4.5-11.1-10.2-11.1z" />
-            <path
-              style={{ fill: interactiveColor }}
-              d="M189.5 20h-134C44.2 20 35 29.2 35 40.6v135.2c0 11.4 9.2 20.6 20.5 20.6h113.4l-5.3-18.5 12.8 11.9 12.1 11.2 21.5 19V40.6c0-11.4-9.2-20.6-20.5-20.6zm-38.6 130.6s-3.6-4.3-6.6-8.1c13.1-3.7 18.1-11.9 18.1-11.9-4.1 2.7-8 4.6-11.5 5.9-5 2.1-9.8 3.5-14.5 4.3-9.6 1.8-18.4 1.3-25.9-.1-5.7-1.1-10.6-2.7-14.7-4.3-2.3-.9-4.8-2-7.3-3.4-.3-.2-.6-.3-.9-.5-.2-.1-.3-.2-.4-.3-1.8-1-2.8-1.7-2.8-1.7s4.8 8 17.5 11.8c-3 3.8-6.7 8.3-6.7 8.3-22.1-.7-30.5-15.2-30.5-15.2 0-32.2 14.4-58.3 14.4-58.3 14.4-10.8 28.1-10.5 28.1-10.5l1 1.2c-18 5.2-26.3 13.1-26.3 13.1s2.2-1.2 5.9-2.9c10.7-4.7 19.2-6 22.7-6.3.6-.1 1.1-.2 1.7-.2 6.1-.8 13-1 20.2-.2 9.5 1.1 19.7 3.9 30.1 9.6 0 0-7.9-7.5-24.9-12.7l1.4-1.6s13.7-.3 28.1 10.5c0 0 14.4 26.1 14.4 58.3 0 0-8.5 14.5-30.6 15.2z"
-            />
-          </svg>
-        </IconButton>
-        <IconButton color="primary" href="/about.html" size="large">
           <InfoIcon />
         </IconButton>
       </div>

--- a/src/components/views/Manual.test.tsx
+++ b/src/components/views/Manual.test.tsx
@@ -108,9 +108,9 @@ describe("Manual", () => {
     expect(
       screen.getByText(/No entries match "hydrogen fuel cells"/),
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Discord" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Let us know" })).toHaveAttribute(
       "href",
-      expect.stringContaining("discord"),
+      expect.stringContaining("mailto:"),
     );
   });
 

--- a/src/components/views/Manual.tsx
+++ b/src/components/views/Manual.tsx
@@ -35,7 +35,7 @@ export interface DispatchProps {
 
 export interface Props extends StateProps, DispatchProps {}
 
-const DISCORD_URL = "https://discord.gg/2fTDHE7";
+const FEEDBACK_EMAIL = "mailto:todd@fabricate.io";
 
 // Pinned first, then by group in the order the groups are declared, then alphabetically. Sorted
 // once here rather than on every keystroke
@@ -320,10 +320,7 @@ export default function Manual(props: Props): React.JSX.Element {
               No entries match "{searchTerm}".
             </Typography>
             <Typography variant="body2">
-              Think it belongs in here? Ask us on{" "}
-              <a href={DISCORD_URL} target="_blank" rel="noreferrer">
-                Discord
-              </a>
+              Think it belongs in here? <a href={FEEDBACK_EMAIL}>Let us know</a>
               .
             </Typography>
           </div>

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -1,8 +1,10 @@
 import {
   CUSTOM_SCENARIO_ID,
   DEFAULT_CUSTOM_SCENARIO,
+  getNextTutorial,
   getScenario,
   SCENARIOS,
+  TUTORIALS,
 } from "./Scenarios";
 import { ScenarioType } from "../Types";
 
@@ -39,5 +41,22 @@ describe("getScenario", () => {
     expect(
       SCENARIOS.some((s: ScenarioType) => s.id === CUSTOM_SCENARIO_ID),
     ).toBe(false);
+  });
+});
+
+describe("getNextTutorial", () => {
+  it("follows the authored order", () => {
+    expect(getNextTutorial(TUTORIALS[0].id)).toBe(TUTORIALS[1]);
+  });
+
+  it("finds nothing after the last tutorial", () => {
+    expect(getNextTutorial(TUTORIALS[TUTORIALS.length - 1].id)).toBeUndefined();
+  });
+
+  // Which is what both callers rely on to decide whether to offer one at all
+  it("finds nothing for a scenario that isn't a tutorial", () => {
+    const scenario = SCENARIOS.find((s: ScenarioType) => !s.tutorialSteps);
+    expect(getNextTutorial((scenario as ScenarioType).id)).toBeUndefined();
+    expect(getNextTutorial(CUSTOM_SCENARIO_ID)).toBeUndefined();
   });
 });

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -633,6 +633,19 @@ export const SCENARIOS = [
 // The numbered 101-106 walkthroughs, in the order a new player should work through them
 export const TUTORIALS = SCENARIOS.filter((s) => s.tutorialSteps);
 
+/**
+ * The tutorial that follows this one in the authored sequence, so that finishing one can hand
+ * the player straight into the next rather than back through the scenario list.
+ *
+ * Undefined for the last tutorial, and for anything that isn't a tutorial at all (a scenario or
+ * a custom game), which is what "is there a next tutorial to offer?" reduces to at both call
+ * sites - the in-game menu and the completion dialog
+ */
+export function getNextTutorial(scenarioId: number): ScenarioType | undefined {
+  const index = TUTORIALS.findIndex((s: ScenarioType) => s.id === scenarioId);
+  return index === -1 ? undefined : TUTORIALS[index + 1];
+}
+
 // Reserved for the game the player builds themselves; no authored scenario may use it
 export const CUSTOM_SCENARIO_ID = 999;
 

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1,3 +1,4 @@
+import type { AppDispatch } from "../Store";
 import cloneDeep from "lodash.clonedeep";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import numbro from "numbro";
@@ -48,8 +49,14 @@ import {
 } from "../Constants";
 import { GENERATORS, STORAGE } from "../data/Facilities";
 import { logEvent } from "../Globals";
-import { recordScenarioPlayed } from "../LocalStorage";
-import { CUSTOM_SCENARIO_ID, getScenario, SCENARIOS } from "../data/Scenarios";
+import { getPlayedScenarioIds, recordScenarioPlayed } from "../LocalStorage";
+import {
+  CUSTOM_SCENARIO_ID,
+  getNextTutorial,
+  getScenario,
+  SCENARIOS,
+  TUTORIALS,
+} from "../data/Scenarios";
 import { getStore } from "../StoreRegistry";
 import { start, loaded, quit, resume } from "./GameActions";
 import { clearSaveFor } from "../SaveGame";
@@ -61,6 +68,7 @@ import {
   GameType,
   GeneratorOperatingType,
   MonthlyHistoryType,
+  ScenarioType,
   ScoreBreakdownType,
   SpeedType,
   StorageOperatingType,
@@ -373,6 +381,70 @@ export default gameSlice.reducer;
 
 // ====== HELPERS ======
 
+/**
+ * Ends whatever is running and drops the player straight into a tutorial.
+ *
+ * quit() first because start() only swaps the scenario id: on its own the new run would inherit
+ * the finished one's facilities, cash and walkthrough position.
+ */
+export function startTutorial(dispatch: AppDispatch, scenarioId: number) {
+  dispatch(quit());
+  dispatch(start(scenarioId));
+}
+
+/**
+ * The end of a tutorial, which is a different moment from the end of a scenario: there's no score
+ * to report and the useful next step is the next tutorial, so this celebrates, says where the
+ * player is in the sequence, and offers that next tutorial rather than a scoreboard.
+ */
+function tutorialCompleteDialog({
+  title,
+  message,
+  nextTutorial,
+}: {
+  title: string;
+  message?: string;
+  nextTutorial?: ScenarioType;
+}) {
+  const played = getPlayedScenarioIds();
+  const completed = TUTORIALS.filter(
+    (t: ScenarioType) => played.indexOf(t.id) !== -1,
+  ).length;
+  return dialogOpen({
+    title: `🎉 ${title}`,
+    message: (
+      <div>
+        {message && (
+          <span>
+            {message}
+            <br />
+            <br />
+          </span>
+        )}
+        <strong>
+          {completed} of {TUTORIALS.length} tutorials complete
+        </strong>
+        {nextTutorial && (
+          <span>
+            <br />
+            Up next: {nextTutorial.name}
+          </span>
+        )}
+      </div>
+    ),
+    open: true,
+    // Both buttons lead somewhere; dismissing would strand the player in a finished scenario
+    notCancellable: true,
+    secondaryLabel: "Main menu",
+    secondaryAction: () => getStore().dispatch(quit()),
+    actionLabel: nextTutorial ? "Next tutorial" : "Back to tutorials",
+    action: () =>
+      nextTutorial
+        ? startTutorial(getStore().dispatch, nextTutorial.id)
+        : getStore().dispatch(quit({ toScenarioList: true })),
+  });
+}
+
 // Ticks the state forward in place
 // Exported so the headless simulator (src/testing/Simulator.tsx) can drive the sim
 // without the wall-clock timers that the `tick` action uses.
@@ -548,6 +620,9 @@ export function tickState(state: GameType) {
           endMessage,
           ownership,
         } = scenario;
+        const isTutorial = Boolean(scenario.tutorialSteps);
+        // Read out here with everything else the timeouts need, rather than from inside them
+        const nextTutorial = getNextTutorial(scoredScenarioId);
 
         // The leaderboard is keyed on scenario id alone, so custom runs - whatever cash, duration
         // and rules the player gave themselves - would be scored against each other as if they
@@ -577,6 +652,15 @@ export function tickState(state: GameType) {
           // The scenario is over even if the player takes "Keep playing"; autosave simply writes a
           // fresh save at the next month rollover if they do
           clearSaveFor(scenarioId);
+          if (isTutorial) {
+            return getStore().dispatch(
+              tutorialCompleteDialog({
+                title: endTitle || "Tutorial complete!",
+                message: endMessage,
+                nextTutorial,
+              }),
+            );
+          }
           getStore().dispatch(
             dialogOpen({
               title: endTitle || `You've retired!`,

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -1,7 +1,14 @@
+import type * as React from "react";
 import { produce } from "immer";
-import { CUSTOM_SCENARIO_ID, SCENARIOS } from "../data/Scenarios";
+import {
+  CUSTOM_SCENARIO_ID,
+  getNextTutorial,
+  SCENARIOS,
+  TUTORIALS,
+} from "../data/Scenarios";
+import { getStore } from "../StoreRegistry";
 import { createGame } from "../testing/Simulator";
-import { tickState } from "./Game";
+import { quit, tickState } from "./Game";
 import { GameType, ScenarioType } from "../Types";
 
 /**
@@ -56,5 +63,62 @@ describe("ending a scenario from inside the reducer", () => {
     }
     expect(state.monthlyHistory[0].cash).toBeLessThan(0);
     expect(() => jest.runOnlyPendingTimers()).not.toThrow();
+  });
+});
+
+describe("finishing a tutorial", () => {
+  const tutorial = TUTORIALS[0];
+  const next = getNextTutorial(tutorial.id) as ScenarioType;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // The store is a module singleton, so each case starts from a game that isn't running
+    getStore().dispatch(quit());
+  });
+  afterEach(() => jest.useRealTimers());
+
+  // Runs the tutorial out to its end and hands back the dialog the reducer opened for it
+  function finishTutorial() {
+    let state = createGame({ scenarioId: tutorial.id });
+    while (state.date.monthsEllapsed < tutorial.durationMonths) {
+      state = tick(state);
+    }
+    jest.runOnlyPendingTimers();
+    return getStore().getState().ui.dialog;
+  }
+
+  it("celebrates rather than showing a score", () => {
+    const dialog = finishTutorial();
+    expect(dialog.open).toBe(true);
+    expect(dialog.title).toContain(tutorial.endTitle as string);
+    // Dismissing would leave the player sitting in a scenario that's already over
+    expect(dialog.notCancellable).toBe(true);
+  });
+
+  it("leads with the next tutorial and keeps the main menu as the way out", () => {
+    const dialog = finishTutorial();
+    expect(dialog.actionLabel).toBe("Next tutorial");
+    expect(dialog.secondaryLabel).toBe("Main menu");
+  });
+
+  it("starts the next tutorial without a trip through the scenario list", () => {
+    const dialog = finishTutorial();
+    (dialog.action as (e: React.MouseEvent<HTMLElement>) => void)(
+      {} as React.MouseEvent<HTMLElement>,
+    );
+    const state = getStore().getState();
+    expect(state.game.scenarioId).toBe(next.id);
+    // The loading screen is what re-reads the weather and fuel price CSVs for the new location
+    expect(state.card.name).toBe("LOADING");
+  });
+
+  it("goes back to the title screen from the secondary button", () => {
+    const dialog = finishTutorial();
+    (dialog.secondaryAction as (e: React.MouseEvent<HTMLElement>) => void)(
+      {} as React.MouseEvent<HTMLElement>,
+    );
+    const state = getStore().getState();
+    expect(state.card.name).toBe("MAIN_MENU");
+    expect(state.ui.dialog.open).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Three things asked for, plus two bugs that stood in the way of the third.

### Discord and Mailchimp are gone

Removed from the title screen, the manual's empty state, and the about page. The manual's "think it belongs in here?" prompt now points at email, and the title screen's envelope icon (previously the launch-list signup) is now a `mailto:` — same affordance, live destination. Both remaining title-screen icons picked up `aria-label`s, which they were missing.

### The about page is rebuilt

It was three panels of static text pulling MUI 0.10 off a CDN — a blocking third-party request in front of anything rendering on a phone, for a stylesheet heavier than the page. Now self-contained, and:

- **Mobile**: one button per row, 44px minimum touch targets, safe-area insets, no horizontal overflow at 375px.
- **Desktop**: buttons in columns rather than a stack of full-width slabs; a panel with a single button gets a button, not a banner.
- **Theme-aware**, with a sticky back bar, a logo hero, and proper focus rings.
- **Contrast**: every text/background pair clears WCAG AA in both themes. The logo blue only reaches 3.8:1 on white, so it stays on borders, focus rings and washes, and anything carrying text uses a darkened variant at 5.2:1.
- Fixed a `referneces` typo carried over from the old page.

### Tutorials now end with a celebration, and lead into the next one

Finishing a tutorial opened the same dialog a scenario ends with — a score breakdown, "Keep playing", "Return to scenarios" — which suits a 20-year run, not a five-minute walkthrough. Tutorials get their own modal instead:

> 🎉 **Tutorial complete!**
> Just a few tutorials to go
>
> **3 of 6 tutorials complete**
> Up next: 102: Generators
>
> `Main menu`  `Next tutorial`

`Next tutorial` (primary) goes straight into the next one, no trip through the scenario list. `Main menu` is the secondary. On the last tutorial the primary becomes `Back to tutorials`.

The same jump is available from the in-game overflow menu, directly above `Quit`, for a player who has seen enough before the clock runs out. It only appears while a tutorial with a successor is running.

This needed a new optional `secondaryAction` / `secondaryLabel` on `DialogType`, since the existing dialog only supported one action plus a dismissal, and here neither button is a dismissal.

## Two bugs fixed along the way

**`notCancellable` only filtered Esc.** A backdrop click still closed the dialog, so the Bankrupt / Fired / end-of-run modals could be dismissed into a finished game with nothing left to click. Now a `notCancellable` dialog refuses both.

**Quitting mid-tutorial left a blank screen** where the main menu should be. Joyride reports its targets leaving the DOM as `TARGET_NOT_FOUND`, and acting on that navigated the freshly-reset game back onto the walkthrough's card, which then rendered nothing because the game was over. Pre-existing on `master` (verified by reproducing it there), but both new routes go through `quit()`, so it had to go.

## Testing

- 228 tests pass, 21 suites. New coverage for `getNextTutorial`, the completion dialog's content and both its buttons, and the Joyride guard.
- `tsc --noEmit` clean; `CI=true react-scripts build` compiles with no lint errors; Prettier clean.
- Driven in the browser end to end: title screen → tutorial 101 → completion modal → `Next tutorial` lands in 102 with fresh state; `Main menu` lands on the title screen; the modal survives both a backdrop click and Esc; the overflow menu reads Manual / Send feedback / Next tutorial / Quit.
- About page measured at 375px and 1280px, in both themes, with computed contrast ratios checked against the rendered colors.

## Worth a look

- The about page now follows the OS light/dark preference, while the game itself is light-only — so "Back to game" can step from a dark page into a white app. Kept because a full-white page on a phone at night is the worse end of that trade, but easy to drop if you'd rather it match the app.
- The title screen's envelope icon was repointed rather than removed; say the word if you'd prefer just the info icon there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
