### PR TITLE
Save a replay with each high score, and let anyone watch it

### DIFF
--- a/src/Replay.test.tsx
+++ b/src/Replay.test.tsx
@@ -1,0 +1,204 @@
+import {
+  decodeReplay,
+  encodeReplay,
+  MAX_REPLAY_ACTIONS,
+  recordReplayAction,
+  recordedDelta,
+  replayByteLength,
+  REPLAY_VERSION,
+} from "./Replay";
+import { GameType, ReplayActionType, ReplayType } from "./Types";
+
+// Only the two fields the recorder touches, so these tests don't need a whole simulation to run
+function aGame(minute: number, log?: ReplayActionType[]): GameType {
+  return {
+    date: { minute },
+    replayLog: log,
+  } as unknown as GameType;
+}
+
+function aReplay(overrides: Partial<ReplayType> = {}): ReplayType {
+  return {
+    version: REPLAY_VERSION,
+    appVersion: "0.1.0",
+    scenarioId: 101,
+    difficulty: "Employee",
+    seed: 12345,
+    startingYear: 2020,
+    durationMinutes: 43200,
+    actions: [
+      { minute: 0, type: "delta", payload: { dollarsPerkWh: 0.12 } },
+      { minute: 1440, type: "sellFacility", payload: 3 },
+    ],
+    ...overrides,
+  };
+}
+
+describe("recordedDelta", () => {
+  it("keeps the fields the simulation reads", () => {
+    expect(
+      recordedDelta({ dollarsPerkWh: 0.11, monthlyMarketingSpend: 5000 }),
+    ).toEqual({ dollarsPerkWh: 0.11, monthlyMarketingSpend: 5000 });
+  });
+
+  it("ignores a delta that changes nothing about the run", () => {
+    // The UI fires far more of these than it does rate changes -- tutorial steps, the custom
+    // scenario, the difficulty picked before the game began
+    expect(recordedDelta({ tutorialStep: 3 })).toBeNull();
+    expect(recordedDelta({ difficulty: "CEO" })).toBeNull();
+  });
+});
+
+describe("recordReplayAction", () => {
+  it("does nothing when the run isn't being recorded", () => {
+    const game = aGame(60);
+    recordReplayAction(game, "sellFacility", 1);
+    expect(game.replayLog).toBeUndefined();
+  });
+
+  it("stamps the action with the minute it happened", () => {
+    const game = aGame(1440, []);
+    recordReplayAction(game, "sellFacility", 7);
+    expect(game.replayLog).toEqual([
+      { minute: 1440, type: "sellFacility", payload: 7 },
+    ]);
+  });
+
+  it("copies the payload, since the simulation mutates the object it was handed", () => {
+    const game = aGame(60, []);
+    const facility = { name: "Coal", peakW: 100 };
+    recordReplayAction(game, "buildFacility", { facility, financed: true });
+    facility.peakW = 999;
+    expect(
+      (game.replayLog![0].payload as { facility: { peakW: number } }).facility
+        .peakW,
+    ).toBe(100);
+  });
+
+  it("merges deltas fired within one minute", () => {
+    const game = aGame(60, []);
+    recordReplayAction(game, "delta", { dollarsPerkWh: 0.1 });
+    recordReplayAction(game, "delta", { dollarsPerkWh: 0.2 });
+    recordReplayAction(game, "delta", { monthlyMarketingSpend: 100 });
+    expect(game.replayLog).toEqual([
+      {
+        minute: 60,
+        type: "delta",
+        payload: { dollarsPerkWh: 0.2, monthlyMarketingSpend: 100 },
+      },
+    ]);
+  });
+
+  it("keeps deltas from different minutes apart", () => {
+    const game = aGame(60, []);
+    recordReplayAction(game, "delta", { dollarsPerkWh: 0.1 });
+    game.date.minute = 75;
+    recordReplayAction(game, "delta", { dollarsPerkWh: 0.2 });
+    expect(game.replayLog!.length).toBe(2);
+  });
+
+  /**
+   * Half a replay would play back as a different game while claiming to be the real one, so a run
+   * that outgrows the cap gives up on its replay rather than shipping a truncated one.
+   */
+  it("stops recording rather than truncating once the cap is reached", () => {
+    const game = aGame(60, []);
+    for (let i = 0; i < MAX_REPLAY_ACTIONS; i++) {
+      game.date.minute = 15 * i;
+      recordReplayAction(game, "sellFacility", i);
+    }
+    expect(game.replayLog!.length).toBe(MAX_REPLAY_ACTIONS);
+
+    game.date.minute = 15 * MAX_REPLAY_ACTIONS;
+    recordReplayAction(game, "sellFacility", MAX_REPLAY_ACTIONS);
+    expect(game.replayLog).toBeUndefined();
+  });
+});
+
+describe("encodeReplay", () => {
+  it("stores the actions as JSON, so nothing nests inside a Firestore array", () => {
+    const doc = encodeReplay(aReplay());
+    expect(typeof doc.actions).toBe("string");
+    expect(JSON.parse(doc.actions).length).toBe(2);
+  });
+
+  it("measures what will actually be stored", () => {
+    expect(replayByteLength(encodeReplay(aReplay()))).toBe(
+      JSON.stringify(encodeReplay(aReplay())).length,
+    );
+  });
+});
+
+describe("decodeReplay", () => {
+  it("round-trips a replay through the document shape", () => {
+    const replay = aReplay();
+    expect(
+      decodeReplay(JSON.parse(JSON.stringify(encodeReplay(replay)))),
+    ).toEqual(replay);
+  });
+
+  it("ignores anything that isn't a replay", () => {
+    expect(decodeReplay(null)).toBeNull();
+    expect(decodeReplay("nope")).toBeNull();
+    expect(decodeReplay({})).toBeNull();
+  });
+
+  it("ignores a replay from a schema it doesn't understand", () => {
+    expect(
+      decodeReplay(encodeReplay(aReplay({ version: REPLAY_VERSION + 1 }))),
+    ).toBeNull();
+  });
+
+  it("ignores a replay missing the fields the run is rebuilt from", () => {
+    const doc = encodeReplay(aReplay()) as unknown as Record<string, unknown>;
+    delete doc.seed;
+    expect(decodeReplay(doc)).toBeNull();
+  });
+
+  /**
+   * Playback drives the real reducer, so everything below would otherwise reach the simulation
+   * mid-tick. These are documents off the network -- another player's, or a hand-edited one.
+   */
+  it("ignores actions that aren't valid JSON", () => {
+    expect(
+      decodeReplay({ ...encodeReplay(aReplay()), actions: "{" }),
+    ).toBeNull();
+  });
+
+  it("ignores an action the reducer has no handler for", () => {
+    const doc = encodeReplay(aReplay());
+    doc.actions = JSON.stringify([
+      { minute: 0, type: "dropTheDatabase", payload: {} },
+    ]);
+    expect(decodeReplay(doc)).toBeNull();
+  });
+
+  it("ignores an action with no usable timestamp", () => {
+    const doc = encodeReplay(aReplay());
+    doc.actions = JSON.stringify([{ minute: -1, type: "sellFacility" }]);
+    expect(decodeReplay(doc)).toBeNull();
+  });
+
+  it("ignores actions that run backwards", () => {
+    // Applied against a clock that only moves forwards, so everything after the step backwards
+    // would silently never be applied
+    const doc = encodeReplay(aReplay());
+    doc.actions = JSON.stringify([
+      { minute: 1440, type: "sellFacility", payload: 1 },
+      { minute: 60, type: "sellFacility", payload: 2 },
+    ]);
+    expect(decodeReplay(doc)).toBeNull();
+  });
+
+  it("ignores a replay with more actions than one could ever record", () => {
+    const doc = encodeReplay(aReplay());
+    doc.actions = JSON.stringify(
+      new Array(MAX_REPLAY_ACTIONS + 1).fill({
+        minute: 0,
+        type: "sellFacility",
+        payload: 1,
+      }),
+    );
+    expect(decodeReplay(doc)).toBeNull();
+  });
+});

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -1,0 +1,241 @@
+import cloneDeep from "lodash.clonedeep";
+import packageJson from "../package.json";
+import {
+  GameType,
+  ReplayActionNameType,
+  ReplayActionType,
+  ReplayDocType,
+  ReplayType,
+} from "./Types";
+
+/**
+ * Recording and re-watching a run.
+ *
+ * A run is fully determined by its seed plus the player's own actions: every random draw in the
+ * simulation is addressed by (seed, stream, index) rather than pulled from a running generator,
+ * so the weather and fuel prices a replay sees are the ones the original player saw. That leaves
+ * the action list as the whole of what has to be stored -- kilobytes, against the hundreds of
+ * kilobytes a full save of the same run takes.
+ *
+ * Recording happens in the game reducer, next to the code being recorded, so that an action
+ * can't be applied without being logged. Playback happens inside tickState, for the same reason:
+ * a driver sitting outside the tick loop would fall behind it at FAST speed, where a single
+ * dispatch advances the simulation several ticks.
+ *
+ * Like SaveGame, this module deliberately imports almost nothing but types -- reducers/Game
+ * imports it, and anything reaching back into the reducers from here would close a cycle that
+ * reducers/ImportOrder.test.tsx guards against.
+ */
+
+// Bump on any breaking schema change. Mismatched replays are ignored rather than migrated.
+export const REPLAY_VERSION = 1;
+
+/**
+ * How many actions a run may record before recording is abandoned. A twenty year game is a few
+ * dozen builds and a handful of rate changes, so this sits far past normal play; it's here so
+ * that a pathological run can't grow the save (or the upload) without bound. Recording stops
+ * rather than truncating, because half a replay would play back as a different game while
+ * claiming to be the real one.
+ */
+export const MAX_REPLAY_ACTIONS = 2000;
+
+/**
+ * The largest replay document that will be uploaded. Firestore's hard limit is 1,048,576 bytes
+ * per document; this leaves room for the field names and the rest of the metadata, and a replay
+ * that somehow reaches it is dropped rather than failing the score write behind it.
+ */
+export const MAX_REPLAY_BYTES = 800000;
+
+// Only the fields of a `delta` that change how the simulation runs. Everything else the action
+// carries -- the tutorial step, the custom scenario, the difficulty picked before the game began
+// -- either doesn't affect the sim or is already in the replay header.
+export const RECORDED_DELTA_KEYS = [
+  "dollarsPerkWh",
+  "monthlyMarketingSpend",
+] as const;
+
+export type RecordedDeltaType = Partial<
+  Pick<GameType, (typeof RECORDED_DELTA_KEYS)[number]>
+>;
+
+const REPLAY_ACTION_NAMES: ReplayActionNameType[] = [
+  "buildFacility",
+  "sellFacility",
+  "togglePauseFacility",
+  "reprioritizeFacility",
+  "delta",
+];
+
+/**
+ * The part of a delta worth recording, or null if it changed nothing the simulation reads.
+ * Called on every `delta`, including the many the UI fires that have nothing to do with the run.
+ */
+export function recordedDelta(
+  payload: Partial<GameType>,
+): RecordedDeltaType | null {
+  const recorded: RecordedDeltaType = {};
+  let any = false;
+  RECORDED_DELTA_KEYS.forEach((key) => {
+    if (payload[key] !== undefined) {
+      recorded[key] = payload[key];
+      any = true;
+    }
+  });
+  return any ? recorded : null;
+}
+
+/**
+ * Appends an action to the run's log, if the run is being recorded at all.
+ *
+ * Consecutive deltas within the same game minute are merged rather than appended: the rate and
+ * marketing sliders fire an action per pixel dragged, and since nothing reads either value until
+ * the next tick, only the one the player let go on ever mattered. Merging is exact, and it's the
+ * difference between a few dozen entries and a few thousand.
+ */
+export function recordReplayAction(
+  game: GameType,
+  type: ReplayActionNameType,
+  payload: unknown,
+) {
+  const log = game.replayLog;
+  if (!log) {
+    return;
+  }
+  const last = log[log.length - 1];
+  if (
+    type === "delta" &&
+    last &&
+    last.type === "delta" &&
+    last.minute === game.date.minute
+  ) {
+    last.payload = {
+      ...(last.payload as RecordedDeltaType),
+      ...(payload as RecordedDeltaType),
+    };
+    return;
+  }
+  if (log.length >= MAX_REPLAY_ACTIONS) {
+    game.replayLog = undefined;
+    return;
+  }
+  // Cloned because the same payload object is also handed to the simulation, which goes on to
+  // mutate the facility it was given
+  log.push({ minute: game.date.minute, type, payload: cloneDeep(payload) });
+}
+
+/**
+ * The run so far as a replay, or undefined if it wasn't recorded end to end. Has to be called
+ * from inside the reducer: the game slice is an Immer draft, and it's revoked the moment the
+ * reducer returns.
+ */
+export function serializeReplay(game: GameType): ReplayType | undefined {
+  if (!game.replayLog) {
+    return undefined;
+  }
+  return {
+    version: REPLAY_VERSION,
+    appVersion: packageJson.version,
+    scenarioId: game.scenarioId,
+    difficulty: game.difficulty,
+    seed: game.seed,
+    startingYear: game.startingYear,
+    durationMinutes: game.date.minute,
+    actions: cloneDeep(game.replayLog),
+  };
+}
+
+export function encodeReplay(replay: ReplayType): ReplayDocType {
+  return { ...replay, actions: JSON.stringify(replay.actions) };
+}
+
+/** Bytes the encoded replay will occupy, for checking against Firestore's document limit. */
+export function replayByteLength(doc: ReplayDocType): number {
+  const json = JSON.stringify(doc);
+  return typeof TextEncoder === "undefined"
+    ? json.length
+    : new TextEncoder().encode(json).length;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function parseActions(raw: unknown): ReplayActionType[] | null {
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch (_err) {
+      return null;
+    }
+  }
+  if (!Array.isArray(parsed) || parsed.length > MAX_REPLAY_ACTIONS) {
+    return null;
+  }
+  const actions: ReplayActionType[] = [];
+  for (const entry of parsed) {
+    if (typeof entry !== "object" || entry === null) {
+      return null;
+    }
+    const action = entry as Partial<ReplayActionType>;
+    if (
+      !isFiniteNumber(action.minute) ||
+      action.minute < 0 ||
+      !REPLAY_ACTION_NAMES.includes(action.type as ReplayActionNameType)
+    ) {
+      return null;
+    }
+    actions.push({
+      minute: action.minute,
+      type: action.type as ReplayActionNameType,
+      payload: action.payload,
+    });
+  }
+  // Applied in order against a clock that only moves forwards, so an out of order list would
+  // silently drop everything after the first step backwards
+  for (let i = 1; i < actions.length; i++) {
+    if (actions[i].minute < actions[i - 1].minute) {
+      return null;
+    }
+  }
+  return actions;
+}
+
+/**
+ * Validates an untrusted blob -- a Firestore document, most of the time -- and returns it as a
+ * replay, or null if it isn't one. Playback drives the real reducer, so a malformed action would
+ * otherwise crash the sim mid-tick; the payloads themselves are checked as they are applied.
+ */
+export function decodeReplay(raw: unknown): ReplayType | null {
+  if (typeof raw !== "object" || raw === null) {
+    return null;
+  }
+  const doc = raw as Partial<ReplayDocType>;
+  if (doc.version !== REPLAY_VERSION) {
+    return null;
+  }
+  if (
+    !isFiniteNumber(doc.scenarioId) ||
+    !isFiniteNumber(doc.seed) ||
+    !isFiniteNumber(doc.startingYear) ||
+    typeof doc.difficulty !== "string"
+  ) {
+    return null;
+  }
+  const actions = parseActions(doc.actions);
+  if (!actions) {
+    return null;
+  }
+  return {
+    version: REPLAY_VERSION,
+    appVersion: typeof doc.appVersion === "string" ? doc.appVersion : "unknown",
+    scenarioId: doc.scenarioId,
+    difficulty: doc.difficulty as ReplayType["difficulty"],
+    seed: doc.seed,
+    startingYear: doc.startingYear,
+    durationMinutes: isFiniteNumber(doc.durationMinutes)
+      ? doc.durationMinutes
+      : 0,
+    actions,
+  };
+}

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -194,7 +194,13 @@ export function startAutosave(
 
   const unsubscribe = store.subscribe(() => {
     const game = store.getState().game;
-    if (!game.inGame || !isSaveableScenario(game.scenarioId)) {
+    // A replay is somebody else's run being re-simulated; writing it over the watcher's own save
+    // would cost them their game
+    if (
+      !game.inGame ||
+      game.replayPlayback ||
+      !isSaveableScenario(game.scenarioId)
+    ) {
       flush();
       live = undefined;
       return;

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -104,6 +104,54 @@ export interface ScoreType {
   // Timestamp on the way back in
   date: Timestamp | FieldValue;
   uid: string;
+  // Id of the document in the `replays` collection holding the run that set this score, when one
+  // was small enough to keep. A reference rather than the replay itself, so that opening a
+  // leaderboard downloads fifty scores instead of fifty replays
+  replayId?: string;
+}
+
+// The player actions a replay has to reproduce. Everything else about a run -- weather, fuel
+// prices, demand -- falls out of the seed, so this is the whole of what the player contributed.
+export type ReplayActionNameType =
+  | "buildFacility"
+  | "sellFacility"
+  | "togglePauseFacility"
+  | "reprioritizeFacility"
+  | "delta";
+
+export interface ReplayActionType {
+  // Game minute the action was taken at, which is always a tick boundary
+  minute: number;
+  type: ReplayActionNameType;
+  // The reducer's own payload, verbatim. Untyped here because it differs per action and comes
+  // back off the network as untrusted JSON; decodeReplay is what makes it safe to apply
+  payload: unknown;
+}
+
+export interface ReplayType {
+  version: number;
+  appVersion: string; // For bug reports
+  scenarioId: number;
+  difficulty: DifficultyType;
+  seed: number;
+  startingYear: number;
+  durationMinutes: number; // How far the recorded run got
+  actions: ReplayActionType[];
+}
+
+/**
+ * A replay on its way to or from Firestore. `actions` is a JSON string rather than a real array
+ * so that the nested payloads can't run into Firestore's rules about what may sit inside one, and
+ * so that the size measured against the 1 MiB document limit is the size actually stored.
+ */
+export interface ReplayDocType extends Omit<ReplayType, "actions"> {
+  actions: string;
+}
+
+// Where a replay has got to while it's being watched
+export interface ReplayPlaybackType {
+  actions: ReplayActionType[];
+  index: number; // Next action to apply
 }
 
 export interface LocalStoragePlayedType {
@@ -304,6 +352,14 @@ export interface GameType {
   timeline: TickPresentFutureType[]; // anything before currentMinute is history, anything after is a forecast
   monthlyHistory: MonthlyHistoryType[]; // live updated; for calculation simplicity, 0 = most recent (prepend new entries)
   facilities: Array<StorageOperatingType | GeneratorOperatingType>;
+  // Every simulation-affecting thing the player has done this run, for the replay attached to a
+  // high score. Undefined means the run isn't being recorded: before a game starts, while one is
+  // being watched, after resuming a save from before replays existed, or once a run has grown
+  // past MAX_REPLAY_ACTIONS. Persisted with the rest of the slice, so a replay survives a reload
+  replayLog?: ReplayActionType[];
+  // Set only while watching a replay. Doubles as the "this is a replay" flag: player controls are
+  // hidden, nothing is autosaved, and no score is submitted while it's here
+  replayPlayback?: ReplayPlaybackType;
 }
 
 export interface SettingsType {

--- a/src/app.scss
+++ b/src/app.scss
@@ -298,6 +298,20 @@ span.weak {
   font-weight: 100;
 }
 
+// Says which of the two things sharing the game UI you're looking at. Deliberately loud: the
+// controls a replay hides are the other clue, and their absence is easy to miss
+.replayBadge {
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: $interactive_blue;
+  color: $bg_primary;
+  font-size: 0.6em;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  vertical-align: middle;
+}
+
 // Fixed so the primary topbar and every pane header in the desktop 3-pane layout share the
 // exact same height, regardless of their differing content (icon buttons vs. plain text)
 $topbar_height: 56px;

--- a/src/components/base/GameCard.tsx
+++ b/src/components/base/GameCard.tsx
@@ -194,6 +194,9 @@ export function GameCard(props: Props) {
   const smallScreen = isSmallScreen();
   const bigScreen = isBigScreen();
   const speed = game.speed;
+  // Watching somebody else's run rather than playing your own. The speed controls stay live --
+  // being able to pause and fast forward is most of the point of a replay
+  const isReplay = !!game.replayPlayback;
 
   const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
     setMenuAnchorEl(event.currentTarget);
@@ -246,12 +249,14 @@ export function GameCard(props: Props) {
           <MenuItem onClick={() => openWindow("mailto:todd@fabricate.io")}>
             Send feedback
           </MenuItem>
-          <MenuItem onClick={onQuit}>Quit</MenuItem>
+          <MenuItem onClick={onQuit}>
+            {isReplay ? "Exit replay" : "Quit"}
+          </MenuItem>
         </Menu>
       </>
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [menuAnchorEl, onManual, onQuit],
+    [menuAnchorEl, onManual, onQuit, isReplay],
   );
 
   const nav = React.useMemo(() => <NavigationContainer />, []);
@@ -288,6 +293,7 @@ export function GameCard(props: Props) {
               {date.month} {date.year}
               {bigScreen ? `, ${formatHour(date)}` : ""}
             </span>
+            {isReplay && <span className="replayBadge">REPLAY</span>}
           </Typography>
           <div id="speedChangeButtons">{speedOptions}</div>
         </Toolbar>

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -55,6 +55,9 @@ interface FacilityListItemProps {
   facility: FacilityOperatingType;
   spotInList: number;
   listLength: number;
+  // A replay is a recording of somebody else's decisions; letting the viewer make their own
+  // would desync the run from the actions still queued up against it
+  readOnly: boolean;
   onTogglePause: DispatchProps["onTogglePause"];
   onPause: DispatchProps["onPause"];
   onSell: DispatchProps["onSell"];
@@ -111,7 +114,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
     setOpen(!open);
   };
 
-  const { facility, onTogglePause, onPause } = props;
+  const { facility, onTogglePause, onPause, readOnly } = props;
   const underConstruction = facility.yearsToBuildLeft > 0;
   const isStorage = facility.peakWh > 0;
 
@@ -158,6 +161,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
       key={"f" + facility.id}
       draggableId={"f" + facility.id}
       index={props.spotInList}
+      isDragDisabled={readOnly}
     >
       {(provided, snapshot) => (
         <div
@@ -180,7 +184,8 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
             }
             secondaryAction={
               <>
-                {!underConstruction &&
+                {!readOnly &&
+                  !underConstruction &&
                   props.listLength > 1 &&
                   !facility.paused && (
                     <IconButton
@@ -193,7 +198,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                       <PauseIcon />
                     </IconButton>
                   )}
-                {facility.paused && (
+                {!readOnly && facility.paused && (
                   <IconButton
                     onClick={() => onTogglePause(facility.id)}
                     aria-label={`Resume ${facility.name}`}
@@ -204,7 +209,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                     <PlayIcon />
                   </IconButton>
                 )}
-                {!underConstruction && props.listLength > 1 && (
+                {!readOnly && !underConstruction && props.listLength > 1 && (
                   <IconButton
                     onClick={toggleDialog}
                     aria-label={`Sell ${facility.name}`}
@@ -215,7 +220,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                     <DeleteForeverIcon />
                   </IconButton>
                 )}
-                {underConstruction && (
+                {!readOnly && underConstruction && (
                   <IconButton
                     onClick={toggleDialog}
                     aria-label={`Cancel construction of ${facility.name}`}
@@ -229,10 +234,12 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
               </>
             }
           >
-            <DragIndicatorIcon
-              className="draggable-indicator"
-              color="primary"
-            />
+            {!readOnly && (
+              <DragIndicatorIcon
+                className="draggable-indicator"
+                color="primary"
+              />
+            )}
             {/* Tinted by fuel so the list reads as the same dispatch stack the supply-by-fuel
                 chart draws, and transitioned in CSS so ramping is visible as movement */}
             {!underConstruction && (
@@ -374,6 +381,7 @@ export default class Facilities extends React.Component<Props, {}> {
       onStorageBuild,
     } = this.props;
     const facilitiesCount = game.facilities.length;
+    const readOnly = !!game.replayPlayback;
 
     return (
       <GameCard>
@@ -388,25 +396,29 @@ export default class Facilities extends React.Component<Props, {}> {
         <List dense className="scrollable">
           <Toolbar style={{ paddingBottom: "4px" }}>
             <Typography variant="h6">Facilities</Typography>
-            <Button
-              size="small"
-              variant="outlined"
-              color="primary"
-              onClick={onGeneratorBuild}
-              className="button-buildGenerator"
-            >
-              + Generator
-            </Button>
-            &nbsp;&nbsp;&nbsp;
-            <Button
-              size="small"
-              variant="outlined"
-              color="primary"
-              onClick={onStorageBuild}
-              className="button-buildStorage"
-            >
-              + Storage
-            </Button>
+            {!readOnly && (
+              <>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="primary"
+                  onClick={onGeneratorBuild}
+                  className="button-buildGenerator"
+                >
+                  + Generator
+                </Button>
+                &nbsp;&nbsp;&nbsp;
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="primary"
+                  onClick={onStorageBuild}
+                  className="button-buildStorage"
+                >
+                  + Storage
+                </Button>
+              </>
+            )}
           </Toolbar>
           <DragDropContext onDragEnd={this.onDragEnd}>
             <Droppable droppableId="droppable">
@@ -423,6 +435,7 @@ export default class Facilities extends React.Component<Props, {}> {
                         onReprioritize={onReprioritize}
                         spotInList={i}
                         listLength={facilitiesCount}
+                        readOnly={readOnly}
                       />
                     ),
                   )}
@@ -431,7 +444,7 @@ export default class Facilities extends React.Component<Props, {}> {
               )}
             </Droppable>
           </DragDropContext>
-          {facilitiesCount < 2 && (
+          {facilitiesCount < 2 && !readOnly && (
             <Typography
               color="textSecondary"
               variant="body2"

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -392,6 +392,7 @@ export default class Finances extends React.Component<Props, State> {
             {scenario.ownership === "Investor" && (
               <Slider
                 id="marketingSlider"
+                disabled={!!game.replayPlayback}
                 value={getTickFromValue(game.monthlyMarketingSpend)}
                 aria-labelledby="marketing monthly budget"
                 valueLabelDisplay="off"
@@ -430,6 +431,7 @@ export default class Finances extends React.Component<Props, State> {
             {scenario.ownership === "Public" && (
               <Slider
                 id="rateSlider"
+                disabled={!!game.replayPlayback}
                 value={game.dollarsPerkWh}
                 aria-labelledby="The rate you charge for electricity generation"
                 valueLabelDisplay="off"

--- a/src/components/views/LoadingContainer.tsx
+++ b/src/components/views/LoadingContainer.tsx
@@ -31,11 +31,16 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
       // resume() has already restored the whole slice by the time a saved game reaches this
       // screen, so all that's left is re-reading the CSVs it couldn't carry
       const resumed = isResumedGame(game);
-      logEvent("scenario_start", {
-        id: game.scenarioId,
-        difficulty: game.difficulty,
-        resumed,
-      });
+      // A replay is closer to a new game than a resumed one: nothing of the run is restored, it
+      // is simulated again from the seed startReplay put on the slice
+      const replaying = !!game.replayPlayback;
+      if (!replaying) {
+        logEvent("scenario_start", {
+          id: game.scenarioId,
+          difficulty: game.difficulty,
+          resumed,
+        });
+      }
       const scenario = getScenario(game.scenarioId, game.customScenario);
       if (!scenario) {
         return alert("Unknown scenario ID " + game.scenarioId);
@@ -58,9 +63,10 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
                 cash: scenario.cash,
                 customers: 1030000,
                 location,
-                // Only ever set by the custom game screen; every authored scenario leaves it
-                // undefined and draws a fresh seed
-                seed: scenario.seed,
+                // A replay has to run on the seed it was recorded with. Otherwise only the custom
+                // game screen sets one; every authored scenario leaves it undefined and draws a
+                // fresh seed
+                seed: replaying ? game.seed : scenario.seed,
               }),
             );
           }
@@ -68,7 +74,7 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
           dispatch(loaded());
 
           // Tutorials are never autosaved, so a resumed game shouldn't restart a walkthrough
-          if (scenario.tutorialSteps && !resumed) {
+          if (scenario.tutorialSteps && !resumed && !replaying) {
             setTimeout(() => dispatch(delta({ tutorialStep: 0 })), 300);
           }
         });

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import {
   collection,
+  doc,
+  getDoc,
   getDocs,
   query,
   where,
@@ -29,14 +31,18 @@ import {
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import CloseIcon from "@mui/icons-material/Close";
 import InfoIcon from "@mui/icons-material/Info";
+import PlayCircleIcon from "@mui/icons-material/PlayCircleOutlined";
+import CircularProgress from "@mui/material/CircularProgress";
 import VictoryConditions from "../base/VictoryConditions";
 import { DIFFICULTIES, LOCATIONS } from "../../Constants";
 import { getDb, login } from "../../Globals";
 import { getScenario } from "../../data/Scenarios";
+import { decodeReplay } from "../../Replay";
 import {
   DifficultyType,
   GameType,
   LocationType,
+  ReplayType,
   ScenarioType,
   ScoreType,
 } from "../../Types";
@@ -52,6 +58,8 @@ export interface DispatchProps {
   onBack: () => void;
   onDelta: (delta: Partial<GameType>) => void;
   onStart: (scenarioId: number) => void;
+  onWatchReplay: (replay: ReplayType) => void;
+  onReplayError: (message: string) => void;
 }
 
 interface State {
@@ -60,6 +68,8 @@ interface State {
   scenario: ScenarioType | null;
   location: LocationType | null;
   victoryDialogOpen?: boolean;
+  // The replay currently being fetched, so its row can show a spinner instead of the play button
+  loadingReplayId?: string;
 }
 
 export interface Props extends StateProps, DispatchProps {}
@@ -108,6 +118,58 @@ export default class NewGameDetails extends React.Component<Props, State> {
         this.setState({ myTopScore: doc.data() as ScoreType });
       });
     }
+  }
+
+  /**
+   * Fetches a replay and hands it to the game. Replays live in their own collection rather than
+   * on the score, so opening a leaderboard costs fifty small documents and watching one costs a
+   * single extra read -- the alternative downloads every replay to show a table of numbers.
+   */
+  private async watchReplay(replayId: string) {
+    if (this.state.loadingReplayId) {
+      return;
+    }
+    this.setState({ loadingReplayId: replayId });
+    try {
+      const snapshot = await getDoc(doc(getDb(), "replays", replayId));
+      const replay = snapshot.exists() ? decodeReplay(snapshot.data()) : null;
+      if (replay) {
+        this.props.onWatchReplay(replay);
+      } else {
+        this.props.onReplayError("Sorry, that replay couldn't be loaded.");
+      }
+    } catch (err) {
+      console.warn("Couldn't load the replay: ", err);
+      this.props.onReplayError("Sorry, that replay couldn't be loaded.");
+    } finally {
+      this.setState({ loadingReplayId: undefined });
+    }
+  }
+
+  private renderReplayCell(score: ScoreType) {
+    if (!score.replayId) {
+      return <TableCell padding="none" />;
+    }
+    const replayId = score.replayId;
+    if (this.state.loadingReplayId === replayId) {
+      return (
+        <TableCell padding="none">
+          <CircularProgress size={20} />
+        </TableCell>
+      );
+    }
+    return (
+      <TableCell padding="none">
+        <IconButton
+          onClick={() => this.watchReplay(replayId)}
+          aria-label="Watch replay"
+          color="primary"
+          size="small"
+        >
+          <PlayCircleIcon />
+        </IconButton>
+      </TableCell>
+    );
   }
 
   public shouldComponentUpdate(nextProps: Props) {
@@ -246,7 +308,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
         <Table id="HighScores">
           <TableHead>
             <TableRow>
-              <TableCell colSpan={2}>
+              <TableCell colSpan={3}>
                 <Typography variant="h6">Global High Scores</Typography>
               </TableCell>
             </TableRow>
@@ -254,13 +316,14 @@ export default class NewGameDetails extends React.Component<Props, State> {
               <TableRow>
                 <TableCell>Score</TableCell>
                 <TableCell>Difficulty</TableCell>
+                <TableCell padding="none">Replay</TableCell>
               </TableRow>
             )}
           </TableHead>
           {!uid && (
             <TableBody>
               <TableRow>
-                <TableCell colSpan={2} style={{ textAlign: "center" }}>
+                <TableCell colSpan={3} style={{ textAlign: "center" }}>
                   <Button variant="outlined" color="primary" onClick={login}>
                     Log in
                   </Button>
@@ -283,11 +346,12 @@ export default class NewGameDetails extends React.Component<Props, State> {
                     })}
                   </TableCell>
                   <TableCell>{myTopScore.difficulty}</TableCell>
+                  {this.renderReplayCell(myTopScore)}
                 </TableRow>
               )}
               {!scores && (
                 <TableRow>
-                  <TableCell colSpan={2}>
+                  <TableCell colSpan={3}>
                     <Typography variant="body2" color="textSecondary">
                       Loading...
                     </Typography>
@@ -296,7 +360,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
               )}
               {scores && scores.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={2}>
+                  <TableCell colSpan={3}>
                     <Typography variant="body2" color="textSecondary">
                       Play the scenario to set a high score
                     </Typography>
@@ -314,6 +378,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                         })}
                       </TableCell>
                       <TableCell>{score.difficulty}</TableCell>
+                      {this.renderReplayCell(score)}
                     </TableRow>
                   );
                 })}

--- a/src/components/views/NewGameDetailsContainer.tsx
+++ b/src/components/views/NewGameDetailsContainer.tsx
@@ -1,9 +1,10 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigateBack } from "../../reducers/Card";
-import { start, delta } from "../../reducers/Game";
+import { start, delta, startReplay } from "../../reducers/Game";
+import { snackbarOpen } from "../../reducers/UI";
 import { startWithSaveGuard } from "./StartGame";
-import { AppStateType, GameType } from "../../Types";
+import { AppStateType, GameType, ReplayType } from "../../Types";
 import NewGameDetails, { DispatchProps, StateProps } from "./NewGameDetails";
 
 const mapStateToProps = (state: AppStateType): StateProps => {
@@ -23,6 +24,14 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     },
     onStart: (scenarioId: number) => {
       startWithSaveGuard(dispatch, () => dispatch(start(scenarioId)));
+    },
+    // Watching a replay simulates a whole game, but never writes one, so unlike onStart it has
+    // no autosave to clobber and needs no confirmation
+    onWatchReplay: (replay: ReplayType) => {
+      dispatch(startReplay(replay));
+    },
+    onReplayError: (message: string) => {
+      dispatch(snackbarOpen(message));
     },
   };
 };

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -509,13 +509,20 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
   {
     title: MANUAL_ENTRY.SCORE,
     group: "Gameplay",
-    keywords: "points scoring high score end of game investor public",
+    keywords:
+      "points scoring high score end of game investor public replay watch",
     entry: (
       <div>
         <p>
           At the end of your term as CEO (each scenario has a different length),
           you'll receive a score for how well you did. Try to beat your score
           the next time you play!
+        </p>
+        <p>
+          If you're logged in, your score goes on the scenario's global
+          leaderboard along with a replay of the run that set it. Any score with
+          a play button beside it can be watched from the start, at whatever
+          speed you like - a good way to see how somebody else got there.
         </p>
         <p>Investor-owned scenarios are scored as follows:</p>
         <table className="points">

--- a/src/reducers/Card.tsx
+++ b/src/reducers/Card.tsx
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { getHistoryApi, logEvent } from "../Globals";
 import { NAVIGATION_DEBOUNCE_MS } from "../Constants";
 import { CardNameType, CardType, NavigateActionType } from "../Types";
-import { start, loaded, quit, resume } from "./GameActions";
+import { start, loaded, quit, resume, startReplay } from "./GameActions";
 import type { RootState } from "../Store";
 
 /**
@@ -68,6 +68,14 @@ export const cardSlice = createSlice({
     // A resumed game takes the same route as a new one: the loading screen is what re-reads the
     // weather and fuel price CSVs, which don't survive a reload
     builder.addCase(resume, (state) => {
+      return {
+        name: "LOADING" as CardNameType,
+        ts: Date.now(),
+        history: state.history,
+      };
+    });
+    // Watching a replay goes the same way, since it re-runs the simulation from the seed
+    builder.addCase(startReplay, (state) => {
       return {
         name: "LOADING" as CardNameType,
         ts: Date.now(),

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -51,8 +51,9 @@ import { logEvent } from "../Globals";
 import { recordScenarioPlayed } from "../LocalStorage";
 import { CUSTOM_SCENARIO_ID, getScenario, SCENARIOS } from "../data/Scenarios";
 import { getStore } from "../StoreRegistry";
-import { start, loaded, quit, resume } from "./GameActions";
+import { start, loaded, quit, resume, startReplay } from "./GameActions";
 import { clearSaveFor } from "../SaveGame";
+import { recordReplayAction, recordedDelta, serializeReplay } from "../Replay";
 import {
   DateType,
   FacilityOperatingType,
@@ -66,6 +67,7 @@ import {
   StorageOperatingType,
   TickPresentFutureType,
   FuelProductionType,
+  ReplayActionType,
 } from "../Types";
 
 interface BuildFacilityAction {
@@ -170,7 +172,14 @@ export const gameSlice = createSlice({
       );
     },
     delta: (state, action: PayloadAction<Partial<GameType>>) => {
-      return { ...state, ...action.payload };
+      // Assigned onto the draft rather than spread into a new object, which is equivalent for a
+      // partial merge and is what lets the recorder below append to the draft's own log. Immer
+      // rejects a reducer that both mutates its draft and returns a replacement for it
+      Object.assign(state, action.payload);
+      const recorded = recordedDelta(action.payload);
+      if (recorded) {
+        recordReplayAction(state, "delta", recorded);
+      }
     },
     initGame: (state, action: PayloadAction<NewGameAction>) => {
       const a = action.payload;
@@ -179,6 +188,9 @@ export const gameSlice = createSlice({
       previousMonth = "";
       previouslyInBlackout = false;
       state.timeline = [] as TickPresentFutureType[];
+      // A game being watched is not a game being recorded; anything else starts an empty log,
+      // which is also what tells serializeReplay the run was recorded from its very first minute
+      state.replayLog = state.replayPlayback ? undefined : [];
       state.seed = a.seed !== undefined ? a.seed : newSeed();
       const scenario =
         getScenario(state.scenarioId, state.customScenario) || SCENARIOS[0];
@@ -240,54 +252,28 @@ export const gameSlice = createSlice({
         );
       }
       state.timeline = reforecastSupply(state);
+      // Anything the player did before the clock first moved -- setting a rate or a marketing
+      // budget on the way in. tickState picks up everything after this
+      applyPendingReplayActions(state);
     },
     buildFacility: (state, action: PayloadAction<BuildFacilityAction>) => {
-      state = buildFacilityHelper(
-        state,
-        action.payload.facility,
-        action.payload.financed,
-      );
-      // Assigned rather than spread into a new object: this is an immer draft, so a fresh object
-      // assigned to the parameter is discarded and the forecast would never reach state
-      state.timeline = reforecastSupply(state);
+      applyBuildFacility(state, action.payload);
+      recordReplayAction(state, "buildFacility", action.payload);
     },
     sellFacility: (state, action: PayloadAction<number>) => {
-      const id = action.payload; // (action as SellFacilityAction).id;
-      // in one loop, refund cash from selling + remove from list
-      state.facilities = state.facilities.filter(
-        (g: GeneratorOperatingType | StorageOperatingType) => {
-          if (g.id === id) {
-            const now = getTimeFromTimeline(state.date.minute, state.timeline);
-            if (now) {
-              now.cash += facilityCashBack(g);
-            }
-            return false;
-          }
-          return true;
-        },
-      );
-      state.timeline = reforecastSupply(state);
+      applySellFacility(state, action.payload);
+      recordReplayAction(state, "sellFacility", action.payload);
     },
     togglePauseFacility: (state, action: PayloadAction<number>) => {
-      state.facilities.forEach(
-        (g: GeneratorOperatingType | StorageOperatingType) => {
-          if (g.id === action.payload) {
-            g.paused = !g.paused;
-          }
-        },
-      );
-      state.timeline = reforecastSupply(state);
+      applyTogglePauseFacility(state, action.payload);
+      recordReplayAction(state, "togglePauseFacility", action.payload);
     },
     reprioritizeFacility: (
       state,
       action: PayloadAction<ReprioritizeFacilityAction>,
     ) => {
-      arrayMove(
-        state.facilities,
-        action.payload.spotInList,
-        action.payload.spotInList + action.payload.delta,
-      );
-      state.timeline = reforecastSupply(state);
+      applyReprioritizeFacility(state, action.payload);
+      recordReplayAction(state, "reprioritizeFacility", action.payload);
     },
     setSpeed: (state, action: PayloadAction<SpeedType>) => {
       state.speed = action.payload;
@@ -315,9 +301,34 @@ export const gameSlice = createSlice({
       // Never resume mid-tick; loaded() flips inGame once the CSVs are back
       restored.speed = "PAUSED";
       restored.inGame = false;
+      // Saves written before replays existed have no log, and a run recorded from halfway
+      // through would play back as a different game. Undefined is how the recorder is told to
+      // stay off for the rest of this run, so the score it eventually sets carries no replay
+      if (!Array.isArray(restored.replayLog)) {
+        restored.replayLog = undefined;
+      }
+      // Nothing ever autosaves a replay, so anything here came out of a hand-edited save
+      restored.replayPlayback = undefined;
       // tickLoopRunning is deliberately left alone: any loop still alive clears the flag and stops
       // on its next tick, since tick() bails while !inGame or PAUSED
       return restored;
+    });
+    /**
+     * Sets a replay up to be watched. Nothing is simulated here: this only puts the scenario, the
+     * difficulty and the seed in place, then hands over to the loading screen, which reloads the
+     * data files and calls initGame the same way it does for a new game.
+     */
+    builder.addCase(startReplay, (_state, action) => {
+      const replay = action.payload;
+      speedBeforeManual = undefined;
+      speedBeforeDialog = "PAUSED";
+      return {
+        ...cloneDeep(initialGame),
+        scenarioId: replay.scenarioId,
+        difficulty: replay.difficulty,
+        seed: replay.seed,
+        replayPlayback: { actions: cloneDeep(replay.actions), index: 0 },
+      };
     });
     builder.addCase(loaded, (state) => {
       // Start ticking in game
@@ -367,11 +378,131 @@ export const {
 } = gameSlice.actions;
 
 // Re-exported so that everything still imports the game's actions from one place
-export { start, loaded, quit, resume };
+export { start, loaded, quit, resume, startReplay };
 
 export default gameSlice.reducer;
 
 // ====== HELPERS ======
+
+/**
+ * The simulation-affecting player actions, as plain functions of (state, payload).
+ *
+ * Both the reducers above and replay playback go through these, which is what makes a replay
+ * reproduce the original run rather than an approximation of it: there is one implementation of
+ * "the player built a plant", not two that have to be kept in step.
+ */
+function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
+  state = buildFacilityHelper(state, payload.facility, payload.financed);
+  // Assigned rather than spread into a new object: this is an immer draft, so a fresh object
+  // assigned to the parameter is discarded and the forecast would never reach state
+  state.timeline = reforecastSupply(state);
+}
+
+function applySellFacility(state: GameType, id: number) {
+  // in one loop, refund cash from selling + remove from list
+  state.facilities = state.facilities.filter(
+    (g: GeneratorOperatingType | StorageOperatingType) => {
+      if (g.id === id) {
+        const now = getTimeFromTimeline(state.date.minute, state.timeline);
+        if (now) {
+          now.cash += facilityCashBack(g);
+        }
+        return false;
+      }
+      return true;
+    },
+  );
+  state.timeline = reforecastSupply(state);
+}
+
+function applyTogglePauseFacility(state: GameType, id: number) {
+  state.facilities.forEach(
+    (g: GeneratorOperatingType | StorageOperatingType) => {
+      if (g.id === id) {
+        g.paused = !g.paused;
+      }
+    },
+  );
+  state.timeline = reforecastSupply(state);
+}
+
+function applyReprioritizeFacility(
+  state: GameType,
+  payload: ReprioritizeFacilityAction,
+) {
+  arrayMove(
+    state.facilities,
+    payload.spotInList,
+    payload.spotInList + payload.delta,
+  );
+  state.timeline = reforecastSupply(state);
+}
+
+/**
+ * Replays one recorded action. The payload came off the network, so anything shaped wrong is
+ * skipped rather than allowed to crash the sim mid-tick -- a replay that plays back slightly
+ * wrong is a disappointment, one that throws takes the whole game down with it.
+ */
+function applyReplayAction(state: GameType, entry: ReplayActionType) {
+  const payload = entry.payload;
+  switch (entry.type) {
+    case "buildFacility": {
+      const build = payload as Partial<BuildFacilityAction>;
+      if (typeof build?.facility === "object" && build.facility !== null) {
+        applyBuildFacility(state, {
+          facility: build.facility,
+          financed: !!build.financed,
+        });
+      }
+      break;
+    }
+    case "sellFacility":
+      if (typeof payload === "number") {
+        applySellFacility(state, payload);
+      }
+      break;
+    case "togglePauseFacility":
+      if (typeof payload === "number") {
+        applyTogglePauseFacility(state, payload);
+      }
+      break;
+    case "reprioritizeFacility": {
+      const move = payload as Partial<ReprioritizeFacilityAction>;
+      if (Number.isFinite(move?.spotInList) && Number.isFinite(move?.delta)) {
+        applyReprioritizeFacility(state, move as ReprioritizeFacilityAction);
+      }
+      break;
+    }
+    case "delta": {
+      const recorded = recordedDelta((payload || {}) as Partial<GameType>);
+      if (recorded) {
+        Object.assign(state, recorded);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+/**
+ * Applies every recorded action the clock has reached. Called from inside the tick rather than
+ * from a store subscriber because at FAST speed one dispatch of `tick` runs several ticks, and a
+ * subscriber would only see the last of them -- every action in between would land late.
+ */
+function applyPendingReplayActions(state: GameType) {
+  const playback = state.replayPlayback;
+  if (!playback) {
+    return;
+  }
+  while (
+    playback.index < playback.actions.length &&
+    playback.actions[playback.index].minute <= state.date.minute
+  ) {
+    applyReplayAction(state, playback.actions[playback.index]);
+    playback.index++;
+  }
+}
 
 // Ticks the state forward in place
 // Exported so the headless simulator (src/testing/Simulator.tsx) can drive the sim
@@ -434,19 +565,28 @@ export function tickState(state: GameType) {
       // state is an Immer draft, and it's revoked the moment this reducer returns - so anything
       // the timeouts below need has to be read out here rather than from inside their callbacks
       const scenarioId = state.scenarioId;
+      // A replay reaches every one of these the same way the original run did, and must set off
+      // none of their side effects: it is not a played game, it has no score of its own to
+      // submit, and the save it would clear belongs to whoever is watching. The dialogs still
+      // show, since a replay ending with "Bankrupt!" is the point of watching it
+      const isReplay = !!state.replayPlayback;
 
       // Failure: Bankrupt
       if (now.cash < 0) {
-        logEvent("scenario_end", {
-          id: scenarioId,
-          type: "bankrupt",
-          difficulty: state.difficulty,
-        });
+        if (!isReplay) {
+          logEvent("scenario_end", {
+            id: scenarioId,
+            type: "bankrupt",
+            difficulty: state.difficulty,
+          });
+        }
         const summary = summarizeHistory(history);
         setTimeout(() => {
           // In the timeout rather than here in the reducer: the autosave subscriber runs as soon
           // as this returns and would write the run straight back
-          clearSaveFor(scenarioId);
+          if (!isReplay) {
+            clearSaveFor(scenarioId);
+          }
           const finished = getStore().getState().game;
           getStore().dispatch(
             dialogOpen({
@@ -473,14 +613,18 @@ export function tickState(state: GameType) {
         history[2].supplyWh < history[2].demandWh * 0.9 &&
         history[3].supplyWh < history[3].demandWh * 0.9
       ) {
-        logEvent("scenario_end", {
-          id: scenarioId,
-          type: "blackouts",
-          difficulty: state.difficulty,
-        });
+        if (!isReplay) {
+          logEvent("scenario_end", {
+            id: scenarioId,
+            type: "blackouts",
+            difficulty: state.difficulty,
+          });
+        }
         const summary = summarizeHistory(history);
         setTimeout(() => {
-          clearSaveFor(scenarioId);
+          if (!isReplay) {
+            clearSaveFor(scenarioId);
+          }
           const finished = getStore().getState().game;
           getStore().dispatch(
             dialogOpen({
@@ -505,7 +649,7 @@ export function tickState(state: GameType) {
       if (state.date.monthsEllapsed === (scenario.durationMonths || 12 * 20)) {
         // Every custom game shares one id, so recording it would light up a completion marker for
         // a scenario nobody authored, and its score belongs to nothing comparable
-        const ranked = scenario.id !== CUSTOM_SCENARIO_ID;
+        const ranked = scenario.id !== CUSTOM_SCENARIO_ID && !isReplay;
         if (ranked) {
           // Tutorials are already marked played once their walkthrough ends, so this is a
           // no-op for the ones the player sat all the way through
@@ -553,6 +697,9 @@ export function tickState(state: GameType) {
         // and rules the player gave themselves - would be scored against each other as if they
         // were the same scenario
         if (!scenario.tutorialSteps && ranked) {
+          // Pulled out of the draft here rather than inside the timeout, which runs after the
+          // reducer has returned and revoked it
+          const replay = serializeReplay(state);
           setTimeout(
             () =>
               getStore().dispatch(
@@ -561,22 +708,27 @@ export function tickState(state: GameType) {
                   scoreBreakdown: score, // For analytics purposes only
                   scenarioId: scoredScenarioId,
                   difficulty,
+                  replay,
                 }),
               ),
             1,
           );
         }
 
-        logEvent("scenario_end", {
-          id: scoredScenarioId,
-          type: "win",
-          difficulty,
-          score: finalScore,
-        });
+        if (!isReplay) {
+          logEvent("scenario_end", {
+            id: scoredScenarioId,
+            type: "win",
+            difficulty,
+            score: finalScore,
+          });
+        }
         setTimeout(() => {
           // The scenario is over even if the player takes "Keep playing"; autosave simply writes a
           // fresh save at the next month rollover if they do
-          clearSaveFor(scenarioId);
+          if (!isReplay) {
+            clearSaveFor(scenarioId);
+          }
           getStore().dispatch(
             dialogOpen({
               title: endTitle || `You've retired!`,
@@ -620,6 +772,9 @@ export function tickState(state: GameType) {
       }
     }
   }
+
+  // After the tick, the way a player's click lands after the tick that brought the clock to it
+  applyPendingReplayActions(state);
 }
 
 // Simplified customer forecast, assumes no blackouts since supply calculation depends on demand (circular depedency)

--- a/src/reducers/GameActions.tsx
+++ b/src/reducers/GameActions.tsx
@@ -1,5 +1,5 @@
 import { createAction } from "@reduxjs/toolkit";
-import type { GameType } from "../Types";
+import type { GameType, ReplayType } from "../Types";
 
 /**
  * The game actions that other slices react to, declared here rather than by the game slice so that
@@ -29,3 +29,9 @@ export const quit = createAction<{ toScenarioList?: boolean } | undefined>(
  * the weather and fuel price CSVs are back in memory before the first tick.
  */
 export const resume = createAction<GameType>("game/resume");
+/**
+ * Starts watching a replay. Takes the same route as start and resume -- the loading screen is
+ * what re-reads the weather and fuel price CSVs, and it's initGame, with the replay's own seed,
+ * that rebuilds the run the actions will be applied to.
+ */
+export const startReplay = createAction<ReplayType>("game/startReplay");

--- a/src/reducers/Replay.test.tsx
+++ b/src/reducers/Replay.test.tsx
@@ -1,0 +1,200 @@
+import cloneDeep from "lodash.clonedeep";
+import gameReducer, {
+  buildFacility,
+  delta,
+  reprioritizeFacility,
+  sellFacility,
+  togglePauseFacility,
+  tickState,
+} from "./Game";
+import { GENERATORS } from "../data/Facilities";
+import { decodeReplay, encodeReplay, serializeReplay } from "../Replay";
+import { createGame, createGameFromReplay } from "../testing/Simulator";
+import { GameType, GeneratorShoppingType, ReplayType } from "../Types";
+
+jest.setTimeout(120000);
+
+// Rise of Renewables, entirely inside the recorded weather and price data
+const OPTIONS = { scenarioId: 101, seed: 20260824 };
+const PLAYED_MONTHS = 12;
+
+function runMonths(state: GameType, months: number) {
+  const until = state.date.monthsEllapsed + months;
+  while (state.date.monthsEllapsed < until) {
+    tickState(state);
+  }
+}
+
+// Redux Toolkit freezes reducer output in development, and tickState mutates state in place
+function dispatch(state: GameType, action: Parameters<typeof gameReducer>[1]) {
+  return cloneDeep(gameReducer(state, action));
+}
+
+function aGeneratorToBuild(state: GameType): GeneratorShoppingType {
+  const generator = GENERATORS(state, 500000000, [20], [500]).find(
+    (g: GeneratorShoppingType) => g.available && g.fuel === "Natural Gas",
+  );
+  if (!generator) {
+    throw new Error("No natural gas generator available to build");
+  }
+  return generator;
+}
+
+/**
+ * A run with one of every recorded action in it, spread across the months so that each lands on a
+ * different tick. Returns the finished state, from which the replay is taken.
+ */
+function playAScriptedGame(): GameType {
+  let state = createGame(OPTIONS);
+
+  runMonths(state, 2);
+  state = dispatch(
+    state,
+    buildFacility({ facility: aGeneratorToBuild(state), financed: true }),
+  );
+
+  runMonths(state, 2);
+  state = dispatch(state, delta({ monthlyMarketingSpend: 40000 }));
+  // Two deltas in the same minute: the sliders fire one of these per pixel dragged, and only the
+  // last matters, so the recorder merges them
+  state = dispatch(state, delta({ monthlyMarketingSpend: 60000 }));
+
+  runMonths(state, 2);
+  state = dispatch(state, togglePauseFacility(state.facilities[0].id));
+
+  runMonths(state, 2);
+  state = dispatch(state, reprioritizeFacility({ spotInList: 0, delta: 1 }));
+
+  runMonths(state, 2);
+  state = dispatch(state, togglePauseFacility(state.facilities[1].id));
+  state = dispatch(state, sellFacility(state.facilities[0].id));
+
+  runMonths(state, PLAYED_MONTHS - 10);
+  return state;
+}
+
+// What comes back off the network: a trip through the Firestore document shape and JSON
+function roundTripped(replay: ReplayType): ReplayType {
+  const doc = JSON.parse(JSON.stringify(encodeReplay(replay)));
+  const decoded = decodeReplay(doc);
+  if (!decoded) {
+    throw new Error("A replay this module just wrote failed to decode");
+  }
+  return decoded;
+}
+
+describe("recording a run", () => {
+  let played: GameType;
+
+  beforeAll(() => {
+    played = playAScriptedGame();
+  });
+
+  it("logs every simulation-affecting action the player took", () => {
+    const types = played.replayLog!.map((a) => a.type);
+    expect(types).toEqual([
+      "buildFacility",
+      "delta",
+      "togglePauseFacility",
+      "reprioritizeFacility",
+      "togglePauseFacility",
+      "sellFacility",
+    ]);
+  });
+
+  it("merges the deltas fired within one minute into the value that stuck", () => {
+    const deltas = played.replayLog!.filter((a) => a.type === "delta");
+    expect(deltas.length).toBe(1);
+    expect(deltas[0].payload).toEqual({ monthlyMarketingSpend: 60000 });
+  });
+
+  it("stamps each action with a tick boundary inside the run", () => {
+    played.replayLog!.forEach((action) => {
+      expect(action.minute % 15).toBe(0);
+      expect(action.minute).toBeGreaterThan(0);
+      expect(action.minute).toBeLessThanOrEqual(played.date.minute);
+    });
+  });
+
+  it("stays small enough to hang off a high score", () => {
+    // A whole save of the same run is hundreds of kilobytes; this is the reason replays are
+    // stored as actions rather than as states
+    const bytes = JSON.stringify(encodeReplay(serializeReplay(played)!)).length;
+    expect(bytes).toBeLessThan(10000);
+  });
+});
+
+describe("watching a replay", () => {
+  let played: GameType;
+  let replay: ReplayType;
+
+  beforeAll(() => {
+    played = playAScriptedGame();
+    replay = roundTripped(serializeReplay(played)!);
+  });
+
+  /**
+   * The whole point of the feature: the seed fixes the weather and the fuel prices, the log fixes
+   * everything the player did, and between them the run comes out the same to the cent.
+   */
+  it("reproduces the original run exactly", () => {
+    const watched = createGameFromReplay(replay);
+    runMonths(watched, PLAYED_MONTHS);
+
+    expect(watched.date.minute).toBe(played.date.minute);
+    expect(watched.monthlyHistory).toEqual(played.monthlyHistory);
+    expect(watched.facilities).toEqual(played.facilities);
+  });
+
+  it("applies each action at the minute it was taken", () => {
+    const watched = createGameFromReplay(replay);
+    const buildAt = replay.actions.find(
+      (a) => a.type === "buildFacility",
+    )!.minute;
+    const before = watched.facilities.length;
+
+    while (watched.date.minute < buildAt) {
+      tickState(watched);
+    }
+    expect(watched.facilities.length).toBe(before + 1);
+  });
+
+  it("doesn't record itself", () => {
+    const watched = createGameFromReplay(replay);
+    runMonths(watched, PLAYED_MONTHS);
+
+    expect(watched.replayLog).toBeUndefined();
+    expect(serializeReplay(watched)).toBeUndefined();
+  });
+
+  it("runs out of actions without running out of game", () => {
+    const watched = createGameFromReplay(replay);
+    runMonths(watched, PLAYED_MONTHS + 6);
+
+    expect(watched.replayPlayback!.index).toBe(replay.actions.length);
+    expect(watched.monthlyHistory.length).toBeGreaterThan(
+      played.monthlyHistory.length,
+    );
+  });
+});
+
+describe("resuming a recorded run", () => {
+  /**
+   * A save from before replays existed carries no log, and a run recorded from halfway through
+   * would play back as a different game. Recording stays off rather than starting mid-run.
+   */
+  it("gives up on the replay rather than recording half of one", () => {
+    const played = createGame(OPTIONS);
+    runMonths(played, 2);
+
+    const { replayLog: _dropped, ...withoutLog } = played;
+    let resumed = cloneDeep(withoutLog) as GameType;
+    resumed = dispatch(
+      resumed,
+      buildFacility({ facility: aGeneratorToBuild(resumed), financed: true }),
+    );
+
+    expect(resumed.replayLog).toBeUndefined();
+    expect(serializeReplay(resumed)).toBeUndefined();
+  });
+});

--- a/src/reducers/User.test.tsx
+++ b/src/reducers/User.test.tsx
@@ -1,0 +1,133 @@
+import userReducer, { submitHighscore } from "./User";
+import { MAX_REPLAY_BYTES, REPLAY_VERSION } from "../Replay";
+import { ReplayType, UserType } from "../Types";
+
+const mockAddDoc = jest.fn();
+
+jest.mock("firebase/firestore", () => ({
+  addDoc: (...args: unknown[]) => mockAddDoc(...args),
+  collection: (_db: unknown, name: string) => ({ name }),
+  serverTimestamp: () => "SERVER_TIMESTAMP",
+}));
+
+jest.mock("../Globals", () => ({
+  getDb: () => ({}),
+}));
+
+const SIGNED_IN: UserType = { uid: "player-1" };
+
+function aReplay(overrides: Partial<ReplayType> = {}): ReplayType {
+  return {
+    version: REPLAY_VERSION,
+    appVersion: "0.1.0",
+    scenarioId: 101,
+    difficulty: "Employee",
+    seed: 12345,
+    startingYear: 2020,
+    durationMinutes: 43200,
+    actions: [{ minute: 1440, type: "sellFacility", payload: 3 }],
+    ...overrides,
+  };
+}
+
+function aSubmission(replay?: ReplayType) {
+  return {
+    score: 420,
+    scoreBreakdown: { supply: 400, blackouts: 20 },
+    scenarioId: 101,
+    difficulty: "Employee" as const,
+    replay,
+  };
+}
+
+// The writes are fired off without being awaited -- nothing in the app waits on them either
+function settled() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function writesTo(name: string) {
+  return mockAddDoc.mock.calls.filter((call) => call[0].name === name);
+}
+
+describe("submitHighscore", () => {
+  beforeEach(() => {
+    mockAddDoc.mockReset();
+    mockAddDoc.mockResolvedValue({ id: "replay-1" });
+  });
+
+  it("writes nothing for a player who isn't signed in", async () => {
+    userReducer({}, submitHighscore(aSubmission(aReplay())));
+    await settled();
+    expect(mockAddDoc).not.toHaveBeenCalled();
+  });
+
+  it("stores the replay and points the score at it", async () => {
+    userReducer(SIGNED_IN, submitHighscore(aSubmission(aReplay())));
+    await settled();
+
+    const [replayWrite] = writesTo("replays");
+    expect(replayWrite[1].seed).toBe(12345);
+    // JSON rather than an array of maps, so it can't run into Firestore's rules about arrays
+    expect(typeof replayWrite[1].actions).toBe("string");
+    expect(replayWrite[1].uid).toBe("player-1");
+
+    const [scoreWrite] = writesTo("scores");
+    expect(scoreWrite[1].score).toBe(420);
+    expect(scoreWrite[1].replayId).toBe("replay-1");
+  });
+
+  it("still submits the score when the run wasn't recorded", async () => {
+    userReducer(SIGNED_IN, submitHighscore(aSubmission()));
+    await settled();
+
+    expect(writesTo("replays").length).toBe(0);
+    const [scoreWrite] = writesTo("scores");
+    expect(scoreWrite[1].score).toBe(420);
+    // Firestore rejects a document carrying an undefined field
+    expect("replayId" in scoreWrite[1]).toBe(false);
+  });
+
+  /**
+   * A replay is a bonus on top of a score. Every way the extra write can fail -- rules that
+   * haven't been deployed yet, a dropped network, an oversized run -- costs the replay and not
+   * the score the player actually earned.
+   */
+  it("submits the score even when the replay write is rejected", async () => {
+    const warn = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    mockAddDoc.mockRejectedValueOnce(new Error("permission-denied"));
+    mockAddDoc.mockResolvedValueOnce({ id: "score-1" });
+
+    userReducer(SIGNED_IN, submitHighscore(aSubmission(aReplay())));
+    await settled();
+
+    const [scoreWrite] = writesTo("scores");
+    expect(scoreWrite[1].score).toBe(420);
+    expect("replayId" in scoreWrite[1]).toBe(false);
+    warn.mockRestore();
+  });
+
+  it("drops a replay too big for a Firestore document", async () => {
+    const warn = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    // One oversized payload rather than a realistic action list; what matters is the byte count
+    const huge = aReplay({
+      actions: [
+        {
+          minute: 0,
+          type: "sellFacility",
+          payload: "x".repeat(MAX_REPLAY_BYTES + 1),
+        },
+      ],
+    });
+
+    userReducer(SIGNED_IN, submitHighscore(aSubmission(huge)));
+    await settled();
+
+    expect(writesTo("replays").length).toBe(0);
+    expect(writesTo("scores").length).toBe(1);
+    warn.mockRestore();
+  });
+});

--- a/src/reducers/User.tsx
+++ b/src/reducers/User.tsx
@@ -1,10 +1,80 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { UserType, ScoreType } from "../Types";
+import {
+  DifficultyType,
+  ReplayType,
+  ScoreBreakdownType,
+  ScoreType,
+  UserType,
+} from "../Types";
 import type { RootState } from "../Store";
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 import { getDb } from "../Globals";
+import { encodeReplay, MAX_REPLAY_BYTES, replayByteLength } from "../Replay";
 
 export const initialUser: UserType = {};
+
+export interface HighscoreSubmissionType {
+  score: number;
+  scoreBreakdown: ScoreBreakdownType; // For analytics purposes only
+  scenarioId: number;
+  difficulty: DifficultyType;
+  // The run that set the score, when it was recorded end to end. Stored beside the score rather
+  // than in it, so that reading a leaderboard doesn't download fifty runs
+  replay?: ReplayType;
+}
+
+/**
+ * Uploads the replay and hands back the id to hang off the score, or undefined if there is
+ * nothing to upload or the upload didn't land.
+ *
+ * A replay is a bonus on top of a score, so every way this can fail -- an oversized run, a
+ * rejected write, a network that dropped -- gives up on the replay rather than on the score.
+ */
+async function uploadReplay(
+  uid: string,
+  replay: ReplayType,
+): Promise<string | undefined> {
+  const doc = encodeReplay(replay);
+  const bytes = replayByteLength(doc);
+  if (bytes > MAX_REPLAY_BYTES) {
+    console.warn(
+      `Replay is ${bytes} bytes, past the ${MAX_REPLAY_BYTES} limit; submitting the score without it.`,
+    );
+    return undefined;
+  }
+  try {
+    const ref = await addDoc(collection(getDb(), "replays"), {
+      ...doc,
+      uid,
+      date: serverTimestamp(),
+    });
+    return ref.id;
+  } catch (err) {
+    console.warn("Couldn't save the replay: ", err);
+    return undefined;
+  }
+}
+
+async function submitScore(uid: string, submission: HighscoreSubmissionType) {
+  const replayId = submission.replay
+    ? await uploadReplay(uid, submission.replay)
+    : undefined;
+  const scoreSubmission = {
+    score: submission.score,
+    scoreBreakdown: submission.scoreBreakdown, // For analytics purposes only
+    scenarioId: submission.scenarioId,
+    difficulty: submission.difficulty,
+    date: serverTimestamp(),
+    uid,
+    // Spread rather than assigned: Firestore rejects a document with an undefined field
+    ...(replayId ? { replayId } : {}),
+  } as ScoreType;
+  try {
+    await addDoc(collection(getDb(), "scores"), scoreSubmission);
+  } catch (err) {
+    console.warn("Couldn't submit the score: ", err);
+  }
+}
 
 export const userSlice = createSlice({
   name: "user",
@@ -13,17 +83,14 @@ export const userSlice = createSlice({
     delta: (state, action: PayloadAction<Partial<UserType>>) => {
       return { ...state, ...action.payload };
     },
-    submitHighscore: (state, action: PayloadAction<Partial<ScoreType>>) => {
+    submitHighscore: (
+      state,
+      action: PayloadAction<HighscoreSubmissionType>,
+    ) => {
       if (state.uid) {
-        const scoreSubmission = {
-          score: action.payload.score,
-          scoreBreakdown: action.payload.scoreBreakdown, // For analytics purposes only
-          scenarioId: action.payload.scenarioId,
-          difficulty: action.payload.difficulty,
-          date: serverTimestamp(),
-          uid: state.uid,
-        } as ScoreType;
-        addDoc(collection(getDb(), "scores"), scoreSubmission);
+        // Deliberately not awaited: the reducer can't be async, and nothing in the app is
+        // waiting on the write. Every failure inside is caught and logged
+        void submitScore(state.uid, action.payload);
       }
     },
   },

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -8,6 +8,7 @@ import gameReducer, {
   delta,
   initGame,
   start,
+  startReplay,
   tickState,
 } from "../reducers/Game";
 import { DIFFICULTIES, LOCATIONS } from "../Constants";
@@ -20,6 +21,7 @@ import {
   GameType,
   GeneratorShoppingType,
   MonthlyHistoryType,
+  ReplayType,
   ScenarioType,
   TickPresentFutureType,
 } from "../Types";
@@ -139,6 +141,34 @@ function setUpGame(
   if (options.dollarsPerkWh !== null) {
     state = gameReducer(state, delta({ dollarsPerkWh: options.dollarsPerkWh }));
   }
+  // Redux Toolkit freezes reducer output in development; the tick loop mutates state in place
+  return cloneDeep(state);
+}
+
+/**
+ * Sets a game up to play a replay back, the way the loading screen does in the browser: the
+ * scenario and the seed the replay carries, and nothing else of the original run. Ticking the
+ * result forward re-runs that run, applying each recorded action as the clock reaches it.
+ *
+ * Also a regression harness -- replay a recorded game against a new build and diff the monthly
+ * history to see what a balance change actually did.
+ */
+export function createGameFromReplay(replay: ReplayType): GameType {
+  const scenario =
+    SCENARIOS.find((s: ScenarioType) => s.id === replay.scenarioId) ||
+    SCENARIOS[0];
+  loadSimData(scenario.locationId);
+  let state = gameReducer(undefined, startReplay(replay));
+  state = gameReducer(
+    state,
+    initGame({
+      facilities: scenario.facilities,
+      cash: scenario.cash,
+      customers: DEFAULT_CUSTOMERS,
+      location: LOCATIONS[scenario.locationId],
+      seed: replay.seed,
+    }),
+  );
   // Redux Toolkit freezes reducer output in development; the tick loop mutates state in place
   return cloneDeep(state);
 }


### PR DESCRIPTION
Phase 3 of #109 — store and view replays — plus the extra ask: a replay is saved alongside the high score it set, and any leaderboard row that has one gets a link to watch it.

## Why this is small

Phase 0 already made the seed authoritative: every random draw is addressed by `(seed, stream, index)` rather than pulled from a running generator, so weather and fuel prices rebuild identically anywhere. That leaves the player's own decisions as the only thing a replay has to carry. A twelve-month run with three actions in it serializes to **647 bytes**; a full save of the same run is hundreds of kilobytes.

## Recording

`game.replayLog` is a list of `{minute, type, payload}`, appended by the reducers themselves rather than by middleware, so an action can't be applied without being logged. Recorded actions: `buildFacility`, `sellFacility`, `togglePauseFacility`, `reprioritizeFacility`, and the two `delta` fields the simulation reads (`dollarsPerkWh`, `monthlyMarketingSpend`).

- **Deltas within one minute are merged.** The rate and marketing sliders fire an action per pixel dragged, and nothing reads either value until the next tick, so only the one the player let go on ever mattered. Merging is exact and turns a few thousand entries into a few dozen.
- **The log lives on the game slice**, so autosave persists it for free and a replay survives a reload. A save written before this PR has no log; rather than start recording halfway through and produce a replay that plays back as a different game, recording stays off for that run.
- **`MAX_REPLAY_ACTIONS` (2000) stops recording rather than truncating**, for the same reason.

## Playback

`startReplay(replay)` routes through the loading screen exactly as `start` and `resume` do, then `initGame` rebuilds the run from the replay's seed. Actions are applied **inside `tickState`**, not from a store subscriber: at FAST speed one dispatch of `tick` advances the simulation several ticks, and a subscriber would only see the last of them, landing every action in between late.

Both the reducers and playback go through one set of `apply*` helpers, so there is a single implementation of "the player built a plant" rather than two that have to be kept in step. That is what makes the reproduction exact rather than approximate.

While a replay is playing, the run isn't the viewer's:

- Player controls are hidden — build buttons, sell/pause/cancel, drag-to-reprioritize, and the two Finances sliders. Speed and pause stay live, since choosing your own pace is most of the point.
- A `REPLAY` badge sits in the top bar and the menu's Quit becomes "Exit replay".
- Autosave skips it, so watching never writes over the viewer's own game.
- The end-of-scenario dialogs still fire (a replay ending in "Bankrupt!" is what you came to see) but none of their side effects do: no score submitted, no completion marker, no analytics event, and no clearing of a save that belongs to somebody else.

## Storage, and why the replay isn't on the score

Replays go in their own `replays` collection; `ScoreType.replayId` points at one. Inlining them would mean opening a leaderboard downloads fifty replays to render a table of numbers — this way it costs fifty small documents, and watching one costs a single extra read.

`actions` is stored as a JSON string rather than an array of maps, which keeps the nested payloads clear of Firestore's rules about what may sit inside an array and makes the size measured against the 1 MiB document limit the size actually stored. Anything over `MAX_REPLAY_BYTES` (800 KB) is dropped.

A replay is a bonus on top of a score, so every way the extra write can fail — an oversized run, a rejected write, a dropped network — costs the replay and never the score the player earned.

> [!IMPORTANT]
> **Firestore rules need a `replays` collection before this does anything in production.** Rules aren't in this repo, so I couldn't include them. Until they allow authenticated create on `replays` and read for the leaderboard, the replay write is rejected, `console.warn`s, and the score submits without a `replayId` — which is the intended degradation, not a crash, but no replays will ever appear.

## Testing

`npm run typecheck`, `npm run lint`, `npm run format:check` and the full suite pass — **24 suites, 251 tests**. New coverage:

- `src/reducers/Replay.test.tsx` — the one that matters: play a scripted twelve-month game through the real reducer with one of every recorded action, take the replay, round-trip it through the Firestore document shape and JSON, re-simulate, and assert `monthlyHistory` and `facilities` match **exactly**. Also: actions land on the minute they were taken, a replay doesn't record itself, playback runs out of actions without running out of game, and a log-less resumed run gives up on its replay.
- `src/Replay.test.tsx` — the delta whitelist, same-minute merging, the action cap, and `decodeReplay` rejecting every shape of bad document: wrong version, missing seed, unparseable JSON, an unknown action type, a negative timestamp, actions that run backwards, and an impossible action count. Playback drives the real reducer, so these would otherwise reach the simulation mid-tick.
- `src/reducers/User.test.tsx` — the replay is written first and its id lands on the score; a run with no replay still submits; a rejected replay write still submits the score; an oversized replay is dropped and the score still submits.

`npm run sim -- --all` is **byte-for-byte identical to master** across all twelve scenarios, confirming none of this shifted the economy.

Also verified in the browser end to end: played a real game through the UI (build dialog, take loan, pause a plant), confirmed the log recorded it, started a replay of that run, and got the same monthly cash **to the cent** (`$149,034,602` → `$215,306,937` on both), with the badge showing, the build buttons gone, and the original autosave untouched.

## One thing worth flagging

Immer rejects a reducer that both mutates its draft and returns a replacement, which `delta` would have done once the recorder appended to `state.replayLog`. It now assigns onto the draft instead — equivalent for a partial merge, and the sim sweep confirms nothing moved.

Closes the third item of #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
