### PR TITLE
Forecast weather from each location's own climate record

### DIFF
--- a/src/data/Weather.test.tsx
+++ b/src/data/Weather.test.tsx
@@ -9,17 +9,66 @@ const HOURS_PER_MONTH = 24;
 const MONTHS_PER_YEAR = 12;
 const SEED = 1;
 
+// Several years rather than one, because everything the forecast does now is derived from the
+// spread of the loaded record: with a single year every month has a standard deviation of zero
+// and every forecast year comes out identical. Eight is enough for a stable mean and standard
+// deviation per month while keeping the fixture small enough to reason about.
+const FIXTURE_YEARS = 8;
+
+// 1 in January, 0 in July. The fixture is built around this so that the loader has a real
+// seasonal signal to find -- cold, cloudy, windy, wildly variable winters against warm, clear,
+// calm, steady summers -- which is exactly the shape the real CSVs have.
+function winterness(month: number): number {
+  return (1 + Math.cos((2 * Math.PI * (month - 1)) / MONTHS_PER_YEAR)) / 2;
+}
+
+// A zero mean wave over the fixture's span, so each month's average across the record is exactly
+// its stated level and the year to year spread is a known multiple of this. Deliberately not
+// random: every statistic the tests below assert on can be worked out by hand from these lines.
+function yearWave(yearIndex: number): number {
+  return Math.sin((2 * Math.PI * yearIndex) / FIXTURE_YEARS);
+}
+
+// The level each month sits at, which is what the forecast has to keep returning to
+const monthlyTempC = (month: number) => 25 - 25 * winterness(month);
+const monthlyCloudPct = (month: number) => 30 + 40 * winterness(month);
+const monthlyWindKph = (month: number) => 2 + 3 * winterness(month);
+// ...and how far a given year strays from it. Roughly 8x the swing in January that July gets,
+// mirroring Pittsburgh's real 5.8C January against its 2.3C August.
+const tempSpreadC = (month: number) => 1 + 7 * winterness(month);
+
+function fixtureRow(yearIndex: number, month: number, hour: number) {
+  const wave = yearWave(yearIndex);
+  // Amplitude varies by year so that the hour to hour shape genuinely differs between the
+  // historic days a forecast can borrow from, which is what makes the resampling observable
+  const diurnal =
+    (5 + 2 * wave) * Math.sin((2 * Math.PI * (hour - 6)) / HOURS_PER_MONTH);
+  return {
+    YEAR: FIXTURE_STARTING_YEAR + yearIndex,
+    MONTH: month,
+    // A full sine over the 24 hours, so the diurnal swing cancels out of a daily mean and each
+    // day's average is precisely its month's level plus that year's departure from it
+    TEMP_C: monthlyTempC(month) + diurnal + tempSpreadC(month) * wave,
+    CLOUD_PCT: Math.min(
+      100,
+      Math.max(0, monthlyCloudPct(month) + 6 * diurnal + 20 * wave),
+    ),
+    WIND_KPH: Math.max(0, monthlyWindKph(month) + 0.2 * diurnal + 1.5 * wave),
+  };
+}
+
 function fixtureCsv(): string {
   const rows = ["YEAR,MONTH,TEMP_C,CLOUD_PCT,WIND_KPH"];
-  for (let month = 1; month <= MONTHS_PER_YEAR; month++) {
-    for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
-      // Values chosen so every row is distinguishable from its neighbours, which is what makes
-      // "did it pick the right row" and "did it blend in the right direction" observable.
-      rows.push(
-        [FIXTURE_STARTING_YEAR, month, month * 100 + hour, hour, hour * 2].join(
-          ",",
-        ),
-      );
+  for (let yearIndex = 0; yearIndex < FIXTURE_YEARS; yearIndex++) {
+    for (let month = 1; month <= MONTHS_PER_YEAR; month++) {
+      for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
+        const row = fixtureRow(yearIndex, month, hour);
+        rows.push(
+          [row.YEAR, row.MONTH, row.TEMP_C, row.CLOUD_PCT, row.WIND_KPH].join(
+            ",",
+          ),
+        );
+      }
     }
   }
   return rows.join("\n");
@@ -30,11 +79,59 @@ function dateAt(month: number, hourOfDay: number, minuteOfHour = 0) {
   return getDateFromMinute(minute, FIXTURE_STARTING_YEAR);
 }
 
+// Absolute month index for a calendar month in a forecast year, counting on past the record
+function monthIndex(yearIndex: number, month: number) {
+  return yearIndex * MONTHS_PER_YEAR + month;
+}
+
+// The average of one forecast day, which is the level the forecast chose for it -- the diurnal
+// swing averages out, leaving only that year's departure from the month's norm
+function forecastDailyMean(
+  yearIndex: number,
+  month: number,
+  field: "TEMP_C" | "CLOUD_PCT" | "WIND_KPH",
+  cumulativeMegatons = 0,
+) {
+  let total = 0;
+  for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
+    total += getWeather(
+      dateAt(monthIndex(yearIndex, month), hour),
+      SEED,
+      cumulativeMegatons,
+    )[field];
+  }
+  return total / HOURS_PER_MONTH;
+}
+
+function forecastDailyMeans(
+  month: number,
+  field: "TEMP_C" | "CLOUD_PCT" | "WIND_KPH",
+  years: number,
+  cumulativeMegatons = 0,
+) {
+  const means = [];
+  for (
+    let yearIndex = FIXTURE_YEARS;
+    yearIndex < FIXTURE_YEARS + years;
+    yearIndex++
+  ) {
+    means.push(forecastDailyMean(yearIndex, month, field, cumulativeMegatons));
+  }
+  return means;
+}
+
+const mean = (values: number[]) =>
+  values.reduce((a, b) => a + b, 0) / values.length;
+const standardDeviation = (values: number[]) => {
+  const mu = mean(values);
+  return Math.sqrt(mean(values.map((v) => Math.pow(v - mu, 2))));
+};
+
 describe("getWeather", () => {
   let warn: jest.SpyInstance;
 
   beforeEach(() => {
-    // The fixture is deliberately one year rather than the forty the real data has, and the
+    // The fixture is deliberately eight years rather than the forty the real data has, and the
     // loader warns about that. Silence it so a passing run has a clean log.
     warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
     initWeatherFromCsv("PIT", fixtureCsv());
@@ -45,22 +142,18 @@ describe("getWeather", () => {
   });
 
   it("returns the current hour's reading exactly, on the hour", () => {
-    expect(getWeather(dateAt(3, 10), SEED)).toEqual({
-      YEAR: 1980,
-      MONTH: 3,
-      TEMP_C: 310,
-      CLOUD_PCT: 10,
-      WIND_KPH: 20,
-    });
+    expect(getWeather(dateAt(3, 10), SEED)).toEqual(fixtureRow(0, 3, 10));
   });
 
   it("blends towards the next hour as the minutes tick over", () => {
+    const here = fixtureRow(0, 3, 10).TEMP_C;
+    const next = fixtureRow(0, 3, 11).TEMP_C;
     // A quarter past is three parts this hour, one part the next.
     expect(getWeather(dateAt(3, 10, 15), SEED).TEMP_C).toBeCloseTo(
-      0.75 * 310 + 0.25 * 311,
+      0.75 * here + 0.25 * next,
     );
     expect(getWeather(dateAt(3, 10, 45), SEED).TEMP_C).toBeCloseTo(
-      0.25 * 310 + 0.75 * 311,
+      0.25 * here + 0.75 * next,
     );
   });
 
@@ -71,8 +164,10 @@ describe("getWeather", () => {
     for (let i = 1; i < readings.length; i++) {
       expect(readings[i]).toBeGreaterThan(readings[i - 1]);
     }
-    expect(readings[0]).toEqual(506);
-    expect(readings[readings.length - 1]).toBeLessThan(507);
+    expect(readings[0]).toBeCloseTo(fixtureRow(0, 5, 6).TEMP_C);
+    expect(readings[readings.length - 1]).toBeLessThan(
+      fixtureRow(0, 5, 7).TEMP_C,
+    );
   });
 
   it("stamps a blended reading with the hour it started in", () => {
@@ -82,8 +177,7 @@ describe("getWeather", () => {
   });
 
   it("forecasts past the end of the data rather than returning holes", () => {
-    // The fixture stops at the end of 1980, so this is a year past anything loaded.
-    const forecast = getWeather(dateAt(MONTHS_PER_YEAR + 2, 8), SEED);
+    const forecast = getWeather(dateAt(monthIndex(FIXTURE_YEARS, 2), 8), SEED);
     expect(Number.isFinite(forecast.TEMP_C)).toBe(true);
     expect(Number.isFinite(forecast.CLOUD_PCT)).toBe(true);
     expect(Number.isFinite(forecast.WIND_KPH)).toBe(true);
@@ -95,9 +189,12 @@ describe("getWeather", () => {
   // the data fell through to DUMMY_WEATHER and stayed there for as many calls as there were
   // missing days. A loaded save jumps straight to its own date, with nothing in between.
   it("forecasts a distant date on the first lookup rather than falling back to a dummy", () => {
-    const distant = getWeather(dateAt(MONTHS_PER_YEAR * 10 + 4, 8), SEED);
+    const distant = getWeather(
+      dateAt(monthIndex(FIXTURE_YEARS + 9, 4), 8),
+      SEED,
+    );
     expect(distant.TEMP_C).not.toEqual(0);
-    expect(distant.YEAR).toEqual(FIXTURE_STARTING_YEAR + 10);
+    expect(distant.YEAR).toEqual(FIXTURE_STARTING_YEAR + FIXTURE_YEARS + 9);
     expect(distant.MONTH).toEqual(4);
   });
 
@@ -106,42 +203,217 @@ describe("getWeather", () => {
   it("forecasts the same weather cold as it does warm", () => {
     const walked = [];
     for (
-      let month = MONTHS_PER_YEAR + 1;
-      month <= MONTHS_PER_YEAR * 4;
+      let month = monthIndex(FIXTURE_YEARS, 1);
+      month <= monthIndex(FIXTURE_YEARS + 3, 12);
       month++
     ) {
       walked.push(getWeather(dateAt(month, 8), SEED));
     }
 
     initWeatherFromCsv("PIT", fixtureCsv()); // Back to a cache holding only the loaded data
-    const jumped = getWeather(dateAt(MONTHS_PER_YEAR * 4, 8), SEED);
+    const jumped = getWeather(
+      dateAt(monthIndex(FIXTURE_YEARS + 3, 12), 8),
+      SEED,
+    );
 
     expect(jumped).toEqual(walked[walked.length - 1]);
   });
 
   it("forecasts different weather for a different seed", () => {
-    const first = getWeather(dateAt(MONTHS_PER_YEAR + 2, 8), SEED);
+    const first = getWeather(dateAt(monthIndex(FIXTURE_YEARS, 2), 8), SEED);
     initWeatherFromCsv("PIT", fixtureCsv());
-    const second = getWeather(dateAt(MONTHS_PER_YEAR + 2, 8), SEED + 1);
-    // Wind rather than temperature: the fixture's temperatures are high enough that both seeds
-    // clamp to the same 45 degree ceiling
-    expect(second.WIND_KPH).not.toEqual(first.WIND_KPH);
+    const second = getWeather(
+      dateAt(monthIndex(FIXTURE_YEARS, 2), 8),
+      SEED + 1,
+    );
+    expect(second.TEMP_C).not.toEqual(first.TEMP_C);
   });
 
-  it("keeps forecast values inside their physical bounds", () => {
-    for (
-      let month = MONTHS_PER_YEAR + 1;
-      month <= MONTHS_PER_YEAR + 6;
-      month++
-    ) {
-      for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
-        const forecast = getWeather(dateAt(month, hour), SEED);
-        expect(forecast.TEMP_C).toBeGreaterThanOrEqual(-20);
-        expect(forecast.TEMP_C).toBeLessThanOrEqual(45);
-        expect(forecast.CLOUD_PCT).toBeGreaterThanOrEqual(0);
-        expect(forecast.CLOUD_PCT).toBeLessThanOrEqual(100);
-        expect(forecast.WIND_KPH).toBeGreaterThanOrEqual(0);
+  it("keeps forecast values inside the range the location has actually recorded", () => {
+    for (let month = 1; month <= MONTHS_PER_YEAR; month++) {
+      // The widest single hourly readings on record for this month, across every fixture year
+      let low = Infinity;
+      let high = -Infinity;
+      for (let yearIndex = 0; yearIndex < FIXTURE_YEARS; yearIndex++) {
+        for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
+          const { TEMP_C } = fixtureRow(yearIndex, month, hour);
+          low = Math.min(low, TEMP_C);
+          high = Math.max(high, TEMP_C);
+        }
+      }
+      // Some headroom past the record is deliberate -- eight years is not every heatwave there
+      // will ever be -- but a forecast must not invent a climate
+      const headroom = 2 * tempSpreadC(month);
+      for (
+        let yearIndex = FIXTURE_YEARS;
+        yearIndex < FIXTURE_YEARS + 40;
+        yearIndex++
+      ) {
+        for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
+          const forecast = getWeather(
+            dateAt(monthIndex(yearIndex, month), hour),
+            SEED,
+          );
+          expect(forecast.TEMP_C).toBeGreaterThanOrEqual(low - headroom);
+          expect(forecast.TEMP_C).toBeLessThanOrEqual(high + headroom);
+          expect(forecast.CLOUD_PCT).toBeGreaterThanOrEqual(0);
+          expect(forecast.CLOUD_PCT).toBeLessThanOrEqual(100);
+          expect(forecast.WIND_KPH).toBeGreaterThanOrEqual(0);
+        }
       }
     }
+  });
+
+  // The regression this whole change exists for. Forecasting used to be an unbounded random walk
+  // off last year, one step per year with no pull back towards normal, so a long game wandered
+  // somewhere else entirely: a Pittsburgh January reached 17.6C by 2060 on one seed, -4.8C on
+  // another, and cloud cover pinned itself at 0 or 100 within about fifteen years on most.
+  describe("does not drift", () => {
+    it("keeps a century of forecasts centred on the month's own average", () => {
+      for (const month of [1, 4, 7, 10]) {
+        const means = forecastDailyMeans(month, "TEMP_C", 100);
+        // Standard error over 100 years is a tenth of the month's spread, so anything approaching
+        // a whole standard deviation of bias is a walk, not noise
+        expect(mean(means)).toBeCloseTo(monthlyTempC(month), 0);
+        expect(Math.abs(mean(means) - monthlyTempC(month))).toBeLessThan(
+          tempSpreadC(month),
+        );
+      }
+    });
+
+    it("holds the line over a thousand years, where a random walk would be long gone", () => {
+      const means = forecastDailyMeans(1, "TEMP_C", 1000);
+      expect(Math.abs(mean(means) - monthlyTempC(1))).toBeLessThan(1);
+      // A walk with this step size would be tens of degrees out by year 1000
+      const worst = Math.max(
+        ...means.map((m) => Math.abs(m - monthlyTempC(1))),
+      );
+      expect(worst).toBeLessThan(5 * tempSpreadC(1));
+    });
+
+    it("never lets cloud cover saturate at nothing or total overcast", () => {
+      const means = forecastDailyMeans(1, "CLOUD_PCT", 200);
+      // The old walk clamped to an extreme and stayed there; a well behaved forecast spends its
+      // time around the month's average
+      expect(mean(means)).toBeCloseTo(monthlyCloudPct(1), -1);
+      expect(Math.min(...means)).toBeGreaterThan(0);
+      expect(Math.max(...means)).toBeLessThan(100);
+    });
+  });
+
+  describe("seasonality", () => {
+    it("forecasts the winter the location actually has, not an average one", () => {
+      const januaryTemp = mean(forecastDailyMeans(1, "TEMP_C", 60));
+      const julyTemp = mean(forecastDailyMeans(7, "TEMP_C", 60));
+      const januaryCloud = mean(forecastDailyMeans(1, "CLOUD_PCT", 60));
+      const julyCloud = mean(forecastDailyMeans(7, "CLOUD_PCT", 60));
+      const januaryWind = mean(forecastDailyMeans(1, "WIND_KPH", 60));
+      const julyWind = mean(forecastDailyMeans(7, "WIND_KPH", 60));
+
+      expect(januaryTemp).toBeLessThan(julyTemp - 15);
+      expect(januaryCloud).toBeGreaterThan(julyCloud + 20);
+      expect(januaryWind).toBeGreaterThan(julyWind + 1);
+    });
+
+    it("carries each month's own year to year variability into the forecast", () => {
+      // January swings roughly eight times as much as July in the fixture, and the forecast has
+      // to reproduce that rather than applying one nudge to every month alike -- which is what
+      // the old fixed plus or minus 4C did
+      const januarySpread = standardDeviation(
+        forecastDailyMeans(1, "TEMP_C", 200),
+      );
+      const julySpread = standardDeviation(
+        forecastDailyMeans(7, "TEMP_C", 200),
+      );
+
+      // The fixture's own spread is the wave's standard deviation times the month's multiplier
+      const expected = (month: number) =>
+        tempSpreadC(month) *
+        standardDeviation(
+          Array.from({ length: FIXTURE_YEARS }, (_, y) => yearWave(y)),
+        );
+      expect(januarySpread).toBeGreaterThan(0.5 * expected(1));
+      expect(januarySpread).toBeLessThan(2 * expected(1));
+      expect(julySpread).toBeGreaterThan(0.5 * expected(7));
+      expect(julySpread).toBeLessThan(2 * expected(7));
+      expect(januarySpread).toBeGreaterThan(3 * julySpread);
+    });
+  });
+
+  describe("emissions", () => {
+    it("returns the record's own weather to a player who emits nothing", () => {
+      const clean = getWeather(
+        dateAt(monthIndex(FIXTURE_YEARS, 3), 14),
+        SEED,
+        0,
+      );
+      initWeatherFromCsv("PIT", fixtureCsv());
+      const unspecified = getWeather(
+        dateAt(monthIndex(FIXTURE_YEARS, 3), 14),
+        SEED,
+      );
+      expect(clean).toEqual(unspecified);
+      // ...including on historic rows, which are read straight from the CSV
+      expect(getWeather(dateAt(3, 10), SEED, 0)).toEqual(fixtureRow(0, 3, 10));
+    });
+
+    it("warms the weather in proportion to what the player has emitted", () => {
+      const clean = mean(forecastDailyMeans(7, "TEMP_C", 40, 0));
+      const dirty = mean(forecastDailyMeans(7, "TEMP_C", 40, 80));
+      const filthy = mean(forecastDailyMeans(7, "TEMP_C", 40, 400));
+
+      expect(dirty).toBeGreaterThan(clean + 1);
+      expect(filthy).toBeGreaterThan(dirty);
+    });
+
+    it("saturates rather than running away", () => {
+      const clean = mean(forecastDailyMeans(7, "TEMP_C", 40, 0));
+      const warming = (megatons: number) =>
+        mean(forecastDailyMeans(7, "TEMP_C", 40, megatons)) - clean;
+
+      // Ten times the emissions is nowhere near ten times the warming, and nothing exceeds the cap
+      expect(warming(800)).toBeLessThan(5 * warming(80));
+      expect(warming(100000)).toBeLessThan(3.01);
+    });
+
+    it("widens the gap between the hot hours and the cold ones", () => {
+      const spreadWithin = (cumulativeMegatons: number) => {
+        const readings = [];
+        for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
+          readings.push(
+            getWeather(
+              dateAt(monthIndex(FIXTURE_YEARS, 7), hour),
+              SEED,
+              cumulativeMegatons,
+            ).TEMP_C,
+          );
+        }
+        return Math.max(...readings) - Math.min(...readings);
+      };
+
+      expect(spreadWithin(400)).toBeGreaterThan(spreadWithin(0));
+    });
+
+    it("applies to historic weather too, so pre-2020 scenarios still respond", () => {
+      const clean = getWeather(dateAt(3, 14), SEED, 0).TEMP_C;
+      const dirty = getWeather(dateAt(3, 14), SEED, 200).TEMP_C;
+      expect(dirty).toBeGreaterThan(clean);
+    });
+
+    it("keeps forced readings inside their physical bounds", () => {
+      for (let month = 1; month <= MONTHS_PER_YEAR; month++) {
+        for (let hour = 0; hour < HOURS_PER_MONTH; hour++) {
+          const forced = getWeather(
+            dateAt(monthIndex(FIXTURE_YEARS + 5, month), hour),
+            SEED,
+            100000,
+          );
+          expect(forced.CLOUD_PCT).toBeGreaterThanOrEqual(0);
+          expect(forced.CLOUD_PCT).toBeLessThanOrEqual(100);
+          expect(forced.WIND_KPH).toBeGreaterThanOrEqual(0);
+          expect(Number.isFinite(forced.TEMP_C)).toBe(true);
+        }
+      }
+    });
   });
 });

--- a/src/data/Weather.tsx
+++ b/src/data/Weather.tsx
@@ -1,6 +1,6 @@
 import { DAYS_PER_MONTH, DAYS_PER_YEAR, EQUATOR_RADIANCE } from "../Constants";
 import { DateType, LocationType, RawWeatherType } from "../Types";
-import { getRandomRangeAt, RANDOM_STREAM } from "../helpers/Math";
+import { normalAt, randomAt, RANDOM_STREAM } from "../helpers/Math";
 import { getSunriseSunset } from "../helpers/DateTime";
 import Papa from "papaparse";
 
@@ -9,8 +9,31 @@ const ENDING_YEAR = 2019; // for weather data, Dec 31st, assumed to be the same 
 const ROWS_PER_DAY = 24;
 const ROWS_PER_YEAR = DAYS_PER_YEAR * ROWS_PER_DAY;
 const EXPECTED_ROWS = (ENDING_YEAR - STARTING_YEAR + 1) * ROWS_PER_YEAR;
-// Temperature, wind and cloud cover, one draw each per forecast day
-const DRAWS_PER_FORECAST_DAY = 3;
+const MONTHS_PER_YEAR = 12;
+// One normal each for temperature, wind and cloud cover, plus a uniform to pick which historic
+// year the day borrows its hour to hour shape from
+const DRAWS_PER_FORECAST_DAY = 4;
+
+// How much of last year's departure from normal carries into this year's, for the same month.
+// The point of it being well under 1 is that the departure decays back towards normal instead of
+// accumulating: at 1 this is the unbounded random walk that used to send Pittsburgh Januaries
+// past 17C and pin cloud cover at 100% within a couple of decades of forecasting.
+const ANOMALY_PERSISTENCE = 0.3;
+
+// How far past the range the location has actually recorded a forecast is allowed to go, as a
+// multiple of that month's standard deviation. Some headroom matters -- forty years is not every
+// heatwave there will ever be -- but not so much that a forecast invents a climate.
+const FORECAST_HEADROOM_SDS = 1.5;
+
+// Emissions -> climate coupling. Warming approaches MAX_WARMING_C asymptotically rather than
+// linearly, so no amount of coal can produce a nonsense number, and WARMING_HALF_MEGATONS is the
+// cumulative total that gets halfway there. Calibrated against the headless simulator: a
+// fossil-heavy 20 year run of The Shale Boom emits about 80 megatons, which lands near +1.5C.
+const MAX_WARMING_C = 3;
+const WARMING_HALF_MEGATONS = 115;
+// At the same time the spread widens, which is the part a player feels: hotter peaks, colder
+// snaps, and a wider gap between them. Shares the saturating curve, so a clean run gets neither.
+const MAX_VARIANCE_GAIN = 0.35;
 
 // Ordered oldest first
 let weather: RawWeatherType[] = [];
@@ -21,6 +44,113 @@ const DUMMY_WEATHER = {
   CLOUD_PCT: 0,
   WIND_KPH: 10,
 };
+
+// The three fields that are forecast, and the physical floor and ceiling each one has to respect
+// whatever the data says. Keyed this way so climatology, the forecast and the emissions coupling
+// can all walk the same three fields rather than repeating themselves three times over.
+const FORECAST_FIELDS = ["TEMP_C", "CLOUD_PCT", "WIND_KPH"] as const;
+type ForecastFieldType = (typeof FORECAST_FIELDS)[number];
+const PHYSICAL_BOUNDS: Record<ForecastFieldType, { min: number; max: number }> =
+  {
+    TEMP_C: { min: -60, max: 60 },
+    CLOUD_PCT: { min: 0, max: 100 },
+    WIND_KPH: { min: 0, max: Infinity },
+  };
+
+interface FieldStatsType {
+  mean: number; // Of the daily mean, across every year that has this month
+  sd: number; // Interannual, also of the daily mean
+  min: number; // Lowest and highest single hourly reading on record for this month
+  max: number;
+}
+
+interface MonthClimatologyType {
+  // Row offsets of the real recorded days for this calendar month, which forecasts borrow their
+  // hour to hour shape from. Only ever holds loaded data, never a previously forecast day.
+  historicRows: number[];
+  stats: Record<ForecastFieldType, FieldStatsType>;
+}
+
+// One entry per calendar month, built once per load from whatever was loaded. Every location gets
+// its seasonality from its own forty years rather than from anything written per location here,
+// which is what makes this scale to a seventh city.
+let climatology: MonthClimatologyType[] = [];
+
+// Which calendar month a day index falls in, 0 based. Written against the constants rather than
+// assuming twelve days a year, so raising DAYS_PER_MONTH does not silently scramble the seasons.
+function monthSlotOf(dayIndex: number): number {
+  return Math.floor((dayIndex % DAYS_PER_YEAR) / DAYS_PER_MONTH);
+}
+
+function dailyMean(row: number, field: ForecastFieldType): number {
+  let total = 0;
+  for (let hour = 0; hour < ROWS_PER_DAY; hour++) {
+    total += weather[row + hour][field];
+  }
+  return total / ROWS_PER_DAY;
+}
+
+/**
+ * Reduces the loaded data to per month statistics: what a typical day of this month looks like at
+ * this location, how much year to year variation there is around that, and the extremes on record.
+ *
+ * Running this over the real rows is what gives the forecast its seasonality for free. Pittsburgh
+ * Januaries come out cloudy (66%), windy (4.3kph) and wildly variable year to year (5.8C), and
+ * Augusts come out clearer (41%), calmer (2.8kph) and steadier (2.3C), without a line of code
+ * knowing anything about Pittsburgh.
+ */
+function buildClimatology() {
+  // Built up locally and assigned at the end, so the closures below capture a const and
+  // no-loop-func stays satisfied -- the same reason resetFuelPrices empties in place
+  const months: MonthClimatologyType[] = [];
+  const rows = weather;
+  const loadedDays = Math.floor(rows.length / ROWS_PER_DAY);
+  const dailyMeans: number[][][] = [];
+  for (let slot = 0; slot < MONTHS_PER_YEAR; slot++) {
+    const stats = {} as Record<ForecastFieldType, FieldStatsType>;
+    FORECAST_FIELDS.forEach((field) => {
+      stats[field] = { mean: 0, sd: 0, min: Infinity, max: -Infinity };
+    });
+    months.push({ historicRows: [], stats });
+    dailyMeans.push(FORECAST_FIELDS.map(() => []));
+  }
+
+  for (let day = 0; day < loadedDays; day++) {
+    const slot = monthSlotOf(day);
+    const month = months[slot];
+    const row = day * ROWS_PER_DAY;
+    month.historicRows.push(row);
+    FORECAST_FIELDS.forEach((field, fieldIndex) => {
+      dailyMeans[slot][fieldIndex].push(dailyMean(row, field));
+      const stats = month.stats[field];
+      for (let hour = 0; hour < ROWS_PER_DAY; hour++) {
+        const value = rows[row + hour][field];
+        stats.min = Math.min(stats.min, value);
+        stats.max = Math.max(stats.max, value);
+      }
+    });
+  }
+
+  months.forEach((month, slot) => {
+    FORECAST_FIELDS.forEach((field, fieldIndex) => {
+      const samples = dailyMeans[slot][fieldIndex];
+      const stats = month.stats[field];
+      if (samples.length === 0) {
+        // Nothing recorded for this month, which only happens for data that never loaded.
+        // Leave the stats at values the forecast and the coupling can both divide by safely.
+        stats.min = 0;
+        stats.max = 0;
+        return;
+      }
+      stats.mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+      stats.sd = Math.sqrt(
+        samples.reduce((a, b) => a + Math.pow(b - stats.mean, 2), 0) /
+          samples.length,
+      );
+    });
+  });
+  climatology = months;
+}
 
 // TODO download weather for all locations at start with a 2s init delay, like loading audio (but after audio) for offline play
 // But only if worker: true starts working - TICKET: https://github.com/mholt/PapaParse/issues/753
@@ -50,6 +180,8 @@ export function initWeather(location: string, callback?: () => void) {
     step: collectWeatherRow,
     complete() {
       warnIfWeatherIncomplete(location);
+      // Has to run before anything is forecast, and while the array still holds only real data
+      buildClimatology();
       if (callback) {
         callback();
       }
@@ -69,6 +201,7 @@ export function initWeatherFromCsv(location: string, csv: string) {
     step: collectWeatherRow,
   });
   warnIfWeatherIncomplete(location);
+  buildClimatology();
 }
 
 /**
@@ -93,7 +226,16 @@ function forecastThroughDay(seed: number, throughDay: number) {
   }
 }
 
-export function getWeather(date: DateType, seed: number): RawWeatherType {
+/**
+ * @param cumulativeMegatons - Greenhouse gas the player has emitted so far, in megatons of CO2e,
+ *   which warms the temperature and widens the spread of all three fields. Defaults to zero, the
+ *   weather the location's own record describes.
+ */
+export function getWeather(
+  date: DateType,
+  seed: number,
+  cumulativeMegatons = 0,
+): RawWeatherType {
   const minuteOfHour = date.minuteOfDay % 60;
   const dayIndex =
     (date.year - STARTING_YEAR) * DAYS_PER_YEAR +
@@ -105,14 +247,22 @@ export function getWeather(date: DateType, seed: number): RawWeatherType {
   forecastThroughDay(seed, Math.floor(nextRow / ROWS_PER_DAY));
 
   if (!weather[row] || !weather[nextRow]) {
-    return weather[row] || DUMMY_WEATHER;
+    return weather[row]
+      ? applyClimateForcing(weather[row], dayIndex, cumulativeMegatons)
+      : DUMMY_WEATHER;
   }
 
   // Otherwise, blend hours for smoother weather.
   // The weights run with the clock: on the hour the reading is entirely the hour we are in,
   // and it slides to the next hour's reading as the minutes tick over.
-  const prev = weather[row];
-  const next = weather[nextRow];
+  // Each row is forced against its own month before blending, because the last hour of a month
+  // blends into the first hour of the next one -- they do not share a climatology.
+  const prev = applyClimateForcing(weather[row], dayIndex, cumulativeMegatons);
+  const next = applyClimateForcing(
+    weather[nextRow],
+    Math.floor(nextRow / ROWS_PER_DAY),
+    cumulativeMegatons,
+  );
   const nextPerc = minuteOfHour / 60;
   const prevPerc = 1 - nextPerc;
   return {
@@ -167,45 +317,135 @@ export function getRawSolarIrradianceWM2(
   return 0;
 }
 
+function clampToField(
+  value: number,
+  field: ForecastFieldType,
+  stats: FieldStatsType,
+): number {
+  const headroom = FORECAST_HEADROOM_SDS * stats.sd;
+  const physical = PHYSICAL_BOUNDS[field];
+  return Math.min(
+    Math.min(stats.max + headroom, physical.max),
+    Math.max(Math.max(stats.min - headroom, physical.min), value),
+  );
+}
+
 /**
- * Writes the 24 rows of one forecast day: the same day a year earlier, nudged by three modifiers
- * drawn from the day's own slice of the weather stream. Addressing the draws by day index rather
- * than taking the next three off a running generator is what lets a day be regenerated later, or
- * in a fresh process, and come out identical.
+ * Writes the 24 rows of one forecast day.
+ *
+ * The level and the shape come from different places, which is the whole idea. The level is an
+ * anomaly -- a departure from what this month normally looks like here -- carried forward from the
+ * same month last year and pulled back towards normal as it goes, so it wanders without ever
+ * drifting away. The shape, meaning how the day's hours sit relative to its own average, is lifted
+ * wholesale from a real recorded day of the same month, so forecast days keep the diurnal texture
+ * of actual weather instead of being a smooth curve plus noise. Drawing that day from anywhere in
+ * the record rather than always from last year is what stops the final year of data repeating
+ * itself for the rest of a long game.
+ *
+ * Addressing the draws by day index rather than taking the next few off a running generator is
+ * what lets a day be regenerated later, or in a fresh process, and come out identical.
  */
 function forecastDay(seed: number, dayIndex: number) {
+  const slot = monthSlotOf(dayIndex);
+  const month = climatology[slot];
   const previousYearRow = (dayIndex - DAYS_PER_YEAR) * ROWS_PER_DAY;
   const draw = dayIndex * DRAWS_PER_FORECAST_DAY;
-  const temperatureModifier = getRandomRangeAt(
-    seed,
-    RANDOM_STREAM.weather,
-    draw,
-    -4,
-    4.05,
-  );
-  const windModifier = getRandomRangeAt(
-    seed,
-    RANDOM_STREAM.weather,
-    draw + 1,
-    -3,
-    3.05,
-  );
-  const cloudModifier = getRandomRangeAt(
-    seed,
-    RANDOM_STREAM.weather,
-    draw + 2,
-    -20,
-    20,
-  );
+
+  // A real day of this same month, whose hour to hour shape this day borrows
+  const shapeRow =
+    month.historicRows[
+      Math.floor(
+        randomAt(seed, RANDOM_STREAM.weather, draw + FORECAST_FIELDS.length) *
+          month.historicRows.length,
+      )
+    ];
+
+  // Ornstein-Uhlenbeck in one line per field: keep some of last year's anomaly, then add a fresh
+  // shock scaled to the spread this month actually has. The sqrt keeps the resulting anomalies at
+  // the observed standard deviation rather than inflating it by the part that was carried over.
+  const shockScale = Math.sqrt(1 - Math.pow(ANOMALY_PERSISTENCE, 2));
+  const anomaly = {} as Record<ForecastFieldType, number>;
+  const shapeMean = {} as Record<ForecastFieldType, number>;
+  FORECAST_FIELDS.forEach((field, fieldIndex) => {
+    const stats = month.stats[field];
+    const previousAnomaly = dailyMean(previousYearRow, field) - stats.mean;
+    anomaly[field] =
+      ANOMALY_PERSISTENCE * previousAnomaly +
+      stats.sd *
+        shockScale *
+        normalAt(seed, RANDOM_STREAM.weather, draw + fieldIndex);
+    shapeMean[field] = dailyMean(shapeRow, field);
+  });
+
   for (let row = 0; row < ROWS_PER_DAY; row++) {
-    const prev = weather[previousYearRow + row];
-    weather[dayIndex * ROWS_PER_DAY + row] = {
-      // Forecast rows are last year's same hour nudged, so they belong to the following year
-      YEAR: prev.YEAR + 1,
-      MONTH: prev.MONTH,
-      TEMP_C: Math.min(45, Math.max(-20, prev.TEMP_C + temperatureModifier)),
-      CLOUD_PCT: Math.min(100, Math.max(0, prev.CLOUD_PCT + cloudModifier)),
-      WIND_KPH: Math.max(0, prev.WIND_KPH + windModifier),
-    };
+    const previous = weather[previousYearRow + row];
+    const shape = weather[shapeRow + row];
+    const forecast = {
+      // Forecast rows follow the same month a year earlier, so they belong to the following year
+      YEAR: previous.YEAR + 1,
+      MONTH: previous.MONTH,
+    } as RawWeatherType;
+    FORECAST_FIELDS.forEach((field) => {
+      const stats = month.stats[field];
+      // The shape day contributes only its within-day departure from its own average, so none of
+      // its year comes along with it
+      forecast[field] = clampToField(
+        stats.mean + anomaly[field] + (shape[field] - shapeMean[field]),
+        field,
+        stats,
+      );
+    });
+    weather[dayIndex * ROWS_PER_DAY + row] = forecast;
   }
+}
+
+/**
+ * How far a cumulative emissions total bends the weather: a warming bias on temperature, and a
+ * widening of every departure from normal.
+ *
+ * Both saturate, so a century of coal makes the climate hostile rather than absurd, and both are
+ * zero at zero -- a player who builds clean gets exactly the weather the data describes.
+ */
+function climateShift(cumulativeMegatons: number) {
+  const progress = 1 - Math.exp(-cumulativeMegatons / WARMING_HALF_MEGATONS);
+  return {
+    warmingC: MAX_WARMING_C * progress,
+    spread: 1 + MAX_VARIANCE_GAIN * progress,
+  };
+}
+
+/**
+ * Applies the player's own emissions to a single reading, at the point it is read.
+ *
+ * Deliberately not baked into the stored rows. Forecast days are written before the emissions that
+ * would shape them have happened, and a stored row has to come out the same whether the cache was
+ * built by walking to a date or by jumping to it -- so the cache stays a pure function of the seed
+ * and the coupling is applied on the way out. Historic rows get it too, which is what lets the
+ * scenarios set before 2020 respond to how their player generates rather than being fixed replays.
+ *
+ * Scaling the departure from the monthly mean rather than the reading itself is what turns a
+ * warmer average into a harsher one: the hot hours get hotter, the cold snaps get colder, and the
+ * gap between them widens, which is what the demand curve and the wind fleet actually feel.
+ */
+function applyClimateForcing(
+  reading: RawWeatherType,
+  dayIndex: number,
+  cumulativeMegatons: number,
+): RawWeatherType {
+  if (cumulativeMegatons <= 0 || climatology.length === 0) {
+    return reading;
+  }
+  const month = climatology[monthSlotOf(dayIndex)];
+  const { warmingC, spread } = climateShift(cumulativeMegatons);
+  const forced = { YEAR: reading.YEAR, MONTH: reading.MONTH } as RawWeatherType;
+  FORECAST_FIELDS.forEach((field) => {
+    const { mean } = month.stats[field];
+    const physical = PHYSICAL_BOUNDS[field];
+    const bias = field === "TEMP_C" ? warmingC : 0;
+    forced[field] = Math.min(
+      physical.max,
+      Math.max(physical.min, mean + (reading[field] - mean) * spread + bias),
+    );
+  });
+  return forced;
 }

--- a/src/helpers/Math.test.tsx
+++ b/src/helpers/Math.test.tsx
@@ -3,6 +3,7 @@ import {
   getIntersectionX,
   getRandomRangeAt,
   newSeed,
+  normalAt,
   randomAt,
 } from "./Math";
 
@@ -77,6 +78,57 @@ describe("getRandomRangeAt", () => {
     const result = getRandomRangeAt(12345, STREAM, 0, min, max);
     expect(result).toBeGreaterThanOrEqual(min);
     expect(result).toBeLessThan(max);
+  });
+});
+
+describe("normalAt", () => {
+  const sample = (seed: number, count: number) =>
+    Array.from({ length: count }, (_, index) => normalAt(seed, STREAM, index));
+
+  it("comes out standard normal", () => {
+    const values = sample(12345, 20000);
+    const mean = values.reduce((a, b) => a + b, 0) / values.length;
+    const sd = Math.sqrt(
+      values.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / values.length,
+    );
+    expect(mean).toBeCloseTo(0, 1);
+    expect(sd).toBeCloseTo(1, 1);
+  });
+
+  it("puts about two thirds of its draws within one standard deviation", () => {
+    // The property that makes this the right shape for a weather anomaly, and the one a uniform
+    // does not have: most departures are small, big ones are rare, and none are impossible
+    const values = sample(999, 20000);
+    const within = (limit: number) =>
+      values.filter((v) => Math.abs(v) < limit).length / values.length;
+    expect(within(1)).toBeCloseTo(0.68, 1);
+    expect(within(2)).toBeCloseTo(0.95, 1);
+    expect(Math.max(...values.map(Math.abs))).toBeGreaterThan(3);
+  });
+
+  it("returns the same value for the same coordinates, whatever came before", () => {
+    const expected = normalAt(12345, STREAM, 7);
+    for (let index = 0; index < 100; index++) {
+      normalAt(999, STREAM, index); // Draws that would have advanced a sequential generator
+    }
+    expect(normalAt(12345, STREAM, 7)).toEqual(expected);
+  });
+
+  it("gives neighbouring indexes unrelated values rather than a shared uniform", () => {
+    // One normal costs two uniforms, so a naive implementation would have index 0 and index 1
+    // drawing from overlapping pairs
+    const values = sample(12345, 500);
+    for (let index = 1; index < values.length; index++) {
+      expect(values[index]).not.toEqual(values[index - 1]);
+    }
+  });
+
+  it("never returns a value that would poison the simulation", () => {
+    for (let seed = 0; seed < 50; seed++) {
+      for (let index = 0; index < 200; index++) {
+        expect(Number.isFinite(normalAt(seed, STREAM, index))).toBe(true);
+      }
+    }
   });
 });
 

--- a/src/helpers/Math.tsx
+++ b/src/helpers/Math.tsx
@@ -75,6 +75,27 @@ export function getRandomRangeAt(
   return randomAt(seed, stream, index) * (max - min) + min;
 }
 
+/**
+ * A standard normal draw (mean 0, standard deviation 1) addressed the same way `randomAt` is.
+ *
+ * Box-Muller over a pair of uniforms, which is why one normal costs two indexes: the pair is
+ * taken from `2 * index` and `2 * index + 1` rather than from neighbouring indexes, so callers
+ * can walk their own index space one normal at a time without two of them ever sharing a uniform.
+ *
+ * Weather anomalies are the reason this exists. A uniform nudge gives every deviation inside its
+ * range the same likelihood and nothing at all outside it, which is the wrong shape for a
+ * departure from normal: real ones cluster near average with occasional outliers, and have no
+ * hard cutoff. Scaling a normal by an observed standard deviation reproduces the spread that was
+ * actually measured.
+ */
+export function normalAt(seed: number, stream: number, index: number): number {
+  // Guarded because Box-Muller takes a log of the first uniform, and randomAt's range is
+  // half open -- a draw of exactly 0 would return -Infinity
+  const u1 = Math.max(Number.MIN_VALUE, randomAt(seed, stream, index * 2));
+  const u2 = randomAt(seed, stream, index * 2 + 1);
+  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+}
+
 // Seeds are mixed as 32 bit integers, so a wider one (a float, or Date.now() times something) is
 // silently truncated and no longer describes the run it is stored alongside. Mint them here.
 export function newSeed(): number {

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -901,11 +901,33 @@ function getDemandW(
   return demandMultiple * now.customers;
 }
 
-function reforecastWeatherAndPrices(state: GameType): TickPresentFutureType[] {
+const KG_PER_MEGATON = 1000000000;
+
+/**
+ * Everything the player has emitted so far, in megatons of CO2e, which is what the weather warms
+ * and destabilises in proportion to.
+ *
+ * Summed from the monthly history rather than carried as its own field so that it needs no
+ * migration, no place in a save, and no chance of disagreeing with the emissions the player is
+ * actually scored on. The history is one entry per month -- a few hundred at the very most -- and
+ * this runs once per reforecast, not once per tick.
+ */
+function getCumulativeMegatons(monthlyHistory: MonthlyHistoryType[]): number {
+  let kgco2e = 0;
+  for (let i = 0; i < monthlyHistory.length; i++) {
+    kgco2e += monthlyHistory[i].kgco2e;
+  }
+  return kgco2e / KG_PER_MEGATON;
+}
+
+function reforecastWeatherAndPrices(
+  state: GameType,
+  cumulativeMegatons: number,
+): TickPresentFutureType[] {
   return state.timeline.map((t: TickPresentFutureType) => {
     if (t.minute >= state.date.minute) {
       const date = getDateFromMinute(t.minute, state.startingYear);
-      const weather = getWeather(date, state.seed);
+      const weather = getWeather(date, state.seed, cumulativeMegatons);
       const fuelPrices = getFuelPricesPerMBTU(date, state.seed);
       return {
         ...t,
@@ -1192,6 +1214,9 @@ export function generateNewTimeline(
     monthlyHistory: [] as MonthlyHistoryType[],
     timeline: new Array(ticks) as TickPresentFutureType[],
   };
+  const cumulativeMegatons = getCumulativeMegatons(
+    readOnlyState.monthlyHistory,
+  );
   // Loop invariant: the fleet is fixed across the horizon and the cash is a parameter, so this
   // was the same number recomputed for every one of up to a year's worth of ticks
   const netWorth = getNetWorth(state.facilities, cash);
@@ -1224,7 +1249,11 @@ export function generateNewTimeline(
       // reforecastWeatherAndPrices asserts its own tick literal.
     } as TickPresentFutureType;
   }
-  state.timeline = reforecastWeatherAndPrices(state);
+  // Read off the caller's history, not the blanked copy above, and frozen for the whole horizon:
+  // what the player emits over the coming month is exactly what the forecast cannot know. It
+  // advances at the month rollover, which is when this runs, so the forecast never shifts under a
+  // player mid-month.
+  state.timeline = reforecastWeatherAndPrices(state, cumulativeMegatons);
   state.timeline = reforecastDemand(state);
   state.timeline = reforecastSupply(state, true);
   return state.timeline;


### PR DESCRIPTION
Closes #106.

## The bug underneath the feature request

`forecastDay` was an unbounded random walk. Each forecast day was the same day a year earlier plus a uniform nudge (±4 °C, ±3 kph, ±20 pp cloud), with nothing pulling it back — and because `DAYS_PER_MONTH = 1`, each of the 12 months walked its own chain at one step per year.

Running the old algorithm forward from Pittsburgh's real January baseline (0.3 °C, 66 % cloud, 4.1 kph):

| seed | 2030 | 2040 | 2050 | 2060 |
|---|---|---|---|---|
| 1 | −4.8 °C, 42 %, 3.7 | 9.9 °C, **100 %**, 2.7 | 13.0 °C, 73 %, **0.0** | 14.8 °C, 78 %, 1.0 |
| 12345 | 2.1 °C, 62 %, 8.5 | 2.4 °C, 61 %, **16.3** | −2.3 °C, 15 %, 16.0 | −0.7 °C, 38 %, 15.2 |
| 999 | 13.4 °C, 21 %, 0.5 | 8.1 °C, 30 %, 2.0 | 10.6 °C, 41 %, 1.0 | **17.6 °C**, 46 %, 3.4 |

Cloud cover saturates at an extreme and stays there within ~15 years on most seeds. `Carbon Fee` is forecast end to end, so it was living in this.

## Climatology from the data, not from per-location code

Each CSV is 40 years × 12 months × 24 hours — one representative day per month, so **40 samples of every calendar month**. Reducing those at load time (one pass, ~11.5k rows, once per game) gives each location its own seasonality with nothing written per location:

```
PIT  Jan: 0.3 °C ±5.8   cloud 66  wind 4.1     Aug: 22.8 °C ±2.3   cloud 41  wind 2.8
HNL  Jan: 22.6 °C ±1.3  cloud 43  wind 3.8     Sep: 26.5 °C ±0.8   cloud 41  wind 6.8 ±7.9
SF   Jan: 9.8 °C ±2.3   cloud 54  wind 3.0     Jul: 17.2 °C ±2.2   cloud 38  wind 4.2
```

One correction to the issue's premise: interannual temperature σ is higher in **winter**, not summer (PIT 5.8 in January vs 2.3 in August). Diurnal *range* is the part that's wider in summer. Deriving from the record gets both right without anyone having to guess.

## What the forecast does now

A forecast day is built from two independent pieces:

- **Level** — an anomaly against that month's norm, carried forward from last year and pulled back towards normal as it goes (Ornstein–Uhlenbeck, φ = 0.3), with the fresh shock scaled by the spread that month actually has. It wanders without drifting, and winter varies more than summer because the record says so.
- **Shape** — the hour-to-hour structure lifted wholesale from a real recorded day of the same month, drawn from anywhere in the 40 years. Forecast days keep real diurnal texture instead of replaying 2019 forever.

Values are clamped to the location's own observed range plus headroom, rather than a global −20/45 °C.

## Emissions coupling

Warming and a wider spread, both on a saturating curve, calibrated against the headless simulator — a fossil-heavy `The Shale Boom` emits ~86 Mt and lands near **+1.6 °C**; `Carbon Fee` ~41 Mt, near **+0.9 °C**.

Two decisions worth flagging for review:

**Applied at read time, not baked into the cache.** Forecast days get written before the emissions that would shape them have happened, and a cached row has to come out identical whether the cache was built by walking to a date or jumping to it (the property `forecasts the same weather cold as it does warm` pins down). So the cache stays a pure function of the seed, and the coupling is applied on the way out. Scaling the departure from the monthly mean rather than the reading itself is what turns a warmer average into a *harsher* one — hot hours hotter, cold snaps colder, wider gap between — which is what the demand curve and the wind fleet actually feel.

**It applies to historic rows too.** Most scenarios are set before 2020; restricting the coupling to forecast years would have made it invisible in all but two of them. Happy to reverse this if you'd rather historic data stay literal.

Cumulative emissions are summed from `monthlyHistory` rather than carried as a new field, so there's nothing new to save, migrate, or keep in sync with the emissions the player is scored on.

## Testing

`Weather.test.tsx`'s fixture grows from one year to eight — everything here is derived from the spread of the record, and one year has none. The fixture is analytic (a winterness curve and a zero-mean wave), so every statistic the tests assert can be worked out by hand.

New coverage: no drift over 100 and 1000 forecast years; cloud never saturates; each month's own variability carries through (January swings >3× July); winter stays colder, cloudier and windier; zero emissions reproduces the record exactly; warming is monotonic and saturating; spread widens; forced readings stay physical. Plus `normalAt` in `Math.test.tsx` — distribution, addressability, and that neighbouring indexes don't share a uniform.

**Mutation-checked**: reverting the anomaly step to a random walk fails exactly the five drift and seasonality tests, and nothing else.

- `npm run check` — 277 tests, lint, typecheck, format all clean
- `npm run sim -- --all` — every invariant holds

Balance moves are small and land where forecasting actually happens:

| Scenario | before | after |
|---|---|---|
| Carbon Fee (2020–2032, all forecast) | $311M | $288M |
| The Shale Boom | $3,003M | $2,972M |
| The End of an Era | $4,143M | $4,090M |
| Hurricane Season | $1,297M | $1,310M |
| Rise of Renewables / Paradise / tutorials | unchanged | unchanged |

## Not included

No player-visible surfacing of the warming (a Manual entry, or a readout in Forecasts). The issue didn't ask for it and the coupling seemed worth getting right first — happy to follow up.

One pre-existing wrinkle this doesn't touch: `getWeather` blends hour 23 into hour 0 of the *next month*, so the last hour of January blends into February. Each row is now forced against its own month's climatology to avoid making that seam worse, but the seam itself is older than this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
