### PR TITLE
Right-align the supply/demand chart legend

### DIFF
--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -124,7 +124,8 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
     plugins: [
       bandsPlugin(() => getState().blackoutSpans, blackoutColor, 0.3),
       verticalLinePlugin(() => getState().currentMinute, "#000000", 0.5),
-      legendPlugin(() => getState().legendItems, 280, 18),
+      // Flush with the plot's right edge: 350 design units less the 5 of right padding
+      legendPlugin(() => getState().legendItems, 345, 18, "right"),
     ],
   };
 }

--- a/src/components/base/UPlotHelpers.ts
+++ b/src/components/base/UPlotHelpers.ts
@@ -202,12 +202,15 @@ export function verticalLinePlugin(
 
 /**
  * A legend inside the plot, where Victory's was. Position is in design units, so it lands in
- * the same place it used to at any pane width.
+ * the same place it used to at any pane width. `align` says which edge of the block designX
+ * anchors: "left" pins the dots, "right" pins the end of the longest label, so a legend can sit
+ * flush with the plot's right edge whatever its labels happen to be.
  */
 export function legendPlugin(
   getItems: () => LegendItem[],
   designX: number,
   designY: number,
+  align: "left" | "right" = "left",
 ): uPlot.Plugin {
   return {
     hooks: {
@@ -217,22 +220,30 @@ export function legendPlugin(
           return;
         }
         const scale = u.width / DESIGN_WIDTH;
-        const x = designX * scale;
-        let y = designY * scale;
         const radius = 3.5 * scale;
+        const gap = 5 * scale;
         const lineHeight = 16 * scale;
         u.ctx.save();
         u.ctx.font = chartFont(scale);
         // The axes leave their own alignment on the context, so say what this wants
         u.ctx.textAlign = "left";
         u.ctx.textBaseline = "middle";
+        // The dots share a column, so the block is only as wide as its longest label
+        let x = designX * scale;
+        if (align === "right") {
+          const widest = Math.max(
+            ...items.map((item) => u.ctx.measureText(item.name).width),
+          );
+          x -= radius + gap + widest;
+        }
+        let y = designY * scale;
         for (const item of items) {
           u.ctx.fillStyle = item.fill;
           u.ctx.beginPath();
           u.ctx.arc(x, y, radius, 0, Math.PI * 2);
           u.ctx.fill();
           u.ctx.fillStyle = LEGEND_TEXT;
-          u.ctx.fillText(item.name, x + radius + 5 * scale, y);
+          u.ctx.fillText(item.name, x + radius + gap, y);
           y += lineHeight;
         }
         u.ctx.restore();


### PR DESCRIPTION
The Supply/Demand/Blackout legend on the facilities chart was pinned to a fixed left edge (design x 280), leaving a ragged gap between the longest label and the right of the plot.

`legendPlugin` now takes an optional `align`: `"left"` keeps anchoring the dot column (what the weather chart still uses), `"right"` anchors the end of the longest label. The supply/demand chart anchors at design x 345 — the 350-unit design width less its 5 units of right padding — so the block sits flush with the plot's right edge and stays flush whether or not the Blackout key is showing.

Verified in the running app: with the game paused, the two legend rows share a dot column and the wider label ("Demand") ends at 1258px on a 1280px-wide canvas, against a plot right edge of 1261.7px — the ~4px being the glyph's right side bearing.

`npm run typecheck`, `npm run lint`, `prettier --check`, and the full test suite (261 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)