### PR TITLE
Fix the Finances chart selectors dropping the player's choice

### DIFF
--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -1,0 +1,140 @@
+import * as React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { produce } from "immer";
+import Finances from "./Finances";
+import { createGame } from "../../testing/Simulator";
+import { tickState } from "../../reducers/Game";
+import { GameType, SpeedType } from "../../Types";
+
+// The card chrome is connected to the store and hides its children until a game is running, none
+// of which this is about. A plain wrapper puts the pane's own contents straight into the document
+jest.mock("../base/GameCard", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+/**
+ * The "Plotting <metric> for <period>" selectors are the only way to ask the Finances chart for
+ * anything other than this year's profit, and both of them live in component state rather than on
+ * the game. That makes them the one part of this pane that a render throttle can silently eat, so
+ * these drive the real selects and assert against what the chart was actually handed.
+ */
+
+// jsdom never lays the chart out, so uPlot never builds; the accessible name of the chart's root
+// is the only thing that says which series was passed down, and it is what a screen reader gets
+function plottedMetric(): string {
+  return screen.getByRole("img").getAttribute("aria-label") || "";
+}
+
+function metricSelect(): HTMLElement {
+  return screen.getAllByRole("combobox")[0];
+}
+
+function periodSelect(): HTMLElement {
+  return screen.getAllByRole("combobox")[1];
+}
+
+// The period select doesn't reach the chart's accessible name -- it changes which months are in
+// it -- so the summary underneath, which is totalled over exactly the same months, stands in
+function summarised(label: string): string {
+  const row = screen.getByRole("row", { name: new RegExp(`^${label} `) });
+  return within(row).getAllByRole("cell")[1].textContent || "";
+}
+
+async function choose(select: HTMLElement, option: string) {
+  await userEvent.click(select);
+  await userEvent.click(await screen.findByRole("option", { name: option }));
+}
+
+// Carbon Fee: a twelve year scenario, so a couple of years in it is still running and none of the
+// end of game machinery (dialogs, high scores) fires while the pane is under test
+function playMonths(months: number): GameType {
+  let state = createGame({ scenarioId: 100 });
+  while (state.date.monthsEllapsed < months) {
+    state = produce(state, (draft: GameType) => {
+      tickState(draft);
+    });
+  }
+  return state;
+}
+
+function renderFinances(game: GameType, speed: SpeedType) {
+  return render(
+    <Finances game={{ ...game, speed }} onDelta={() => undefined} />,
+  );
+}
+
+describe("the Finances chart selectors", () => {
+  // Two years in, so that the period select has past years to offer and each one covers a
+  // different stretch of the history
+  const game = playMonths(26);
+
+  beforeEach(() => localStorage.clear());
+
+  // Every speed, because the pane skips frames at FAST and used to skip the player's own clicks
+  // along with them: the dropdown redrew itself with the new label while the chart kept plotting
+  // the old metric, which looks exactly like a selector that does nothing
+  it.each(["PAUSED", "SLOW", "NORMAL", "FAST"] as SpeedType[])(
+    "replots when the metric changes at %s speed",
+    async (speed: SpeedType) => {
+      renderFinances(game, speed);
+      expect(plottedMetric()).toContain("Profit");
+
+      await choose(metricSelect(), "Revenue");
+      expect(plottedMetric()).toContain("Revenue");
+
+      // The second change is the one the throttle used to swallow: the first update after mount
+      // always got through, and everything after it waited on the game clock
+      await choose(metricSelect(), "Net Worth");
+      expect(plottedMetric()).toContain("Net Worth");
+
+      await choose(metricSelect(), "Demand");
+      expect(plottedMetric()).toContain("Demand");
+    },
+  );
+
+  it.each(["PAUSED", "SLOW", "NORMAL", "FAST"] as SpeedType[])(
+    "keeps the metric dropdown showing what is plotted at %s speed",
+    async (speed: SpeedType) => {
+      renderFinances(game, speed);
+
+      await choose(metricSelect(), "Revenue");
+      await choose(metricSelect(), "Expenses");
+
+      expect(metricSelect()).toHaveTextContent("Expenses");
+      expect(plottedMetric()).toContain("Expenses");
+    },
+  );
+
+  it.each(["PAUSED", "SLOW", "NORMAL", "FAST"] as SpeedType[])(
+    "replots when the period changes at %s speed",
+    async (speed: SpeedType) => {
+      renderFinances(game, speed);
+      const thisYear = summarised("Revenue");
+
+      await choose(periodSelect(), "All time");
+      expect(periodSelect()).toHaveTextContent("All time");
+      const allTime = summarised("Revenue");
+      // Two years of revenue against this year's, so they cannot agree
+      expect(allTime).not.toEqual(thisYear);
+
+      // And back again, which is the change the throttle used to swallow
+      await choose(periodSelect(), "Current year");
+      expect(periodSelect()).toHaveTextContent("Current year");
+      expect(summarised("Revenue")).toEqual(thisYear);
+    },
+  );
+
+  it("remembers the metric across a remount, dropdown and chart together", async () => {
+    const view = renderFinances(game, "PAUSED");
+    await choose(metricSelect(), "Net Worth");
+    view.unmount();
+
+    renderFinances(game, "PAUSED");
+    expect(metricSelect()).toHaveTextContent("Net Worth");
+    expect(plottedMetric()).toContain("Net Worth");
+  });
+});

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -223,8 +223,15 @@ export default class Finances extends React.Component<Props, State> {
   // Left at 1 in 2 when the charts moved to uPlot: measured either way this pane costs about
   // 3ms a render, because its chart is memoised and only redraws on a month rollover. What the
   // cheaper chart bought here is a calmer worst frame, not a cheaper typical one.
-  public shouldComponentUpdate(nextProps: Props) {
-    if (nextProps.game.speed !== "FAST") {
+  //
+  // Only the clock is throttled. The metric and the year live in state, and skipping a state
+  // change means dropping something the player just asked for: the dropdown redraws itself with
+  // the new label -- it keeps its own state, and nothing here can stop it -- while the chart goes
+  // on plotting the old metric until the clock happens to come round. That reads as a selector
+  // that does nothing, and if the clock has stopped (a scenario that has ended, a backgrounded
+  // tab) it never comes round at all.
+  public shouldComponentUpdate(nextProps: Props, nextState: State) {
+    if (nextState !== this.state || nextProps.game.speed !== "FAST") {
       return true;
     }
     return this.throttle.due(nextProps.game.date.minute, 2);
@@ -454,9 +461,10 @@ export default class Finances extends React.Component<Props, State> {
             <Typography variant="h6" style={{ flexGrow: 0 }}>
               Plotting{" "}
             </Typography>
+            {/* Controlled, so the label and the chart cannot disagree about what is plotted */}
             <Select
               id="plotMetric"
-              defaultValue={chartKey}
+              value={chartKey}
               onChange={(e: SelectChangeEvent<string>) =>
                 this.setChartKey(e.target.value as DerivedHistoryKeysType)
               }
@@ -488,14 +496,13 @@ export default class Finances extends React.Component<Props, State> {
             </Typography>
             <Select
               id="plotYear"
-              defaultValue={-1}
+              value={year}
               onChange={(e: SelectChangeEvent<number>) =>
                 this.setState({ year: e.target.value as number })
               }
             >
               <MenuItem value={0}>All time</MenuItem>
               <MenuItem value={-1}>Current year</MenuItem>
-              props.game.date.year
               {years.map((y: number) => {
                 return (
                   <MenuItem value={y} key={y}>

--- a/src/helpers/RenderThrottle.tsx
+++ b/src/helpers/RenderThrottle.tsx
@@ -11,6 +11,10 @@ import { TICK_MINUTES } from "../Constants";
  *
  * Asking how far the game clock has moved since the last render instead is independent of the
  * stride, and a clock that has gone backwards (a new game starting) always renders.
+ *
+ * This throttles the clock and nothing else. A pane that keeps its own state has to let a state
+ * change through shouldComponentUpdate regardless of what due() says, or the player's clicks go
+ * into a queue that only the clock can drain -- and the clock does stop.
  */
 export class TickThrottle {
   private lastRenderedMinute = -Infinity;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -20,6 +20,23 @@ if (!window.matchMedia) {
     }) as MediaQueryList;
 }
 
+// Every chart watches its container for a width to lay out in, and jsdom has no ResizeObserver.
+// One that never reports is the honest stub here: jsdom lays nothing out, so the width stays at
+// zero and uPlot is never built, which is exactly what the charts do in a real pane of no width.
+if (!window.ResizeObserver) {
+  window.ResizeObserver = class {
+    public observe() {
+      return undefined;
+    }
+    public unobserve() {
+      return undefined;
+    }
+    public disconnect() {
+      return undefined;
+    }
+  };
+}
+
 // jsdom has no IndexedDB, so Firebase Analytics warns loudly the first time anything logs an
 // event. Nothing under test cares what was reported, so the transport is stubbed out entirely.
 jest.mock("firebase/analytics", () => ({


### PR DESCRIPTION
## The bug

Picking a metric or a period in **"Plotting _Profit_ for _All time_"** could relabel the dropdown and leave the chart plotting the old thing.

`Finances` skips alternating frames at FAST speed, but its `shouldComponentUpdate` only inspected `nextProps`:

```ts
public shouldComponentUpdate(nextProps: Props) {
  if (nextProps.game.speed !== "FAST") { return true; }
  return this.throttle.due(nextProps.game.date.minute, 2);
}
```

Both selectors live in component state, so every change either one makes is a state-only update — and a state-only update was thrown away unless the game clock had moved two ticks since the last render.

The dropdowns don't share that fate. MUI's `Select` keeps its own value, so it redraws with the new label the moment you click, while the chart sits on the old metric waiting for the clock. The **first** change after mount always got through (the throttle starts at `-Infinity`); the second and every one after it did not.

- While the clock runs, it resolves within ~20ms — enough to read as flaky.
- While it doesn't — a scenario that has ended, a backgrounded tab whose timers are throttled — it never resolves, and the selector is simply dead.

## The fix

- The throttle now covers the game clock only; a state change always renders.
- Both `Select`s become controlled (`value=` rather than `defaultValue=`). This is what makes the failure mode *impossible* rather than merely unlikely — the label is read from the same state the chart is drawn from, so the two cannot disagree even for a frame.
- Dropped a stray `props.game.date.year` that was sitting in the year select's children as literal text.
- Noted the hazard on `TickThrottle` so the next stateful pane doesn't repeat it. (`Facilities` uses the same throttle but holds no state, so it is unaffected.)

## Testing

`src/components/views/Finances.test.tsx` drives the real selects at all four speeds and asserts against what the chart was handed, not just what the dropdown says. **Three of its thirteen cases fail before this change, all of them at FAST:**

```
× replots when the metric changes at FAST speed
× keeps the metric dropdown showing what is plotted at FAST speed
× replots when the period changes at FAST speed
```

All 13 pass after. Full suite: 274 passed, 25 suites. `typecheck`, `lint` and `format:check` are clean.

This needed a `ResizeObserver` stub in `setupTests.ts` — jsdom has none, so mounting any chart threw, which is why no pane had a test until now.

Also verified by hand in the running game: at FAST speed, in both the desktop three-column and the single-pane layouts, each pick moves the chart's series, y-range and title immediately, with the dropdown and the chart always in agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
