### PR TITLE
Remember the chart selectors across page changes

### DIFF
--- a/src/LocalStorage.test.tsx
+++ b/src/LocalStorage.test.tsx
@@ -1,0 +1,38 @@
+import { getStorageChoice, setStorageKeyValue } from "./LocalStorage";
+import { getLocalStorage } from "./Globals";
+
+const KEY = "testChoice";
+
+describe("getStorageChoice", () => {
+  beforeEach(() => {
+    getLocalStorage().removeItem(KEY);
+  });
+
+  it("falls back when nothing has been stored yet", () => {
+    expect(getStorageChoice(KEY, [1, 5, 10, 20], 1)).toBe(1);
+  });
+
+  it("round trips a number through storage", () => {
+    setStorageKeyValue(KEY, 20);
+    expect(getStorageChoice(KEY, [1, 5, 10, 20], 1)).toBe(20);
+  });
+
+  it("round trips a string through storage", () => {
+    setStorageKeyValue(KEY, "revenue");
+    expect(getStorageChoice(KEY, ["profit", "revenue"], "profit")).toBe(
+      "revenue",
+    );
+  });
+
+  // The finances year dropdown only offers the years a given game has reached, so a value left
+  // by a longer game has to be dropped rather than left selected with nothing to plot
+  it("falls back when the stored value is no longer on offer", () => {
+    setStorageKeyValue(KEY, 2035);
+    expect(getStorageChoice(KEY, [0, -1, 2020], -1)).toBe(-1);
+  });
+
+  it("keeps negative and zero choices distinct from the fallback", () => {
+    setStorageKeyValue(KEY, 0);
+    expect(getStorageChoice(KEY, [0, -1, 2020], -1)).toBe(0);
+  });
+});

--- a/src/LocalStorage.tsx
+++ b/src/LocalStorage.tsx
@@ -35,6 +35,23 @@ export function getStorageString(key: string, fallback: string): string {
   return val !== null ? val : fallback;
 }
 
+// Restores a dropdown's last choice. The stored value is only honoured while it's still one of
+// the options on offer - a metric that has since been renamed, or a year belonging to a game
+// that's been replaced, falls back rather than leaving the control showing something it can't
+// plot. Works for numeric and string valued selects alike, since storage only holds strings.
+export function getStorageChoice<T extends number | string>(
+  key: string,
+  options: readonly T[],
+  fallback: T,
+): T {
+  const val = getLocalStorage().getItem(key);
+  if (val === null) {
+    return fallback;
+  }
+  const match = options.find((option) => String(option) === val);
+  return match !== undefined ? match : fallback;
+}
+
 // Value can be boolean, number, string or stringifiable JSON.
 // Writes throw when storage is full or the browser blocks it, and no caller has anything useful
 // to do about that, so by default the write is best effort. Pass ignoreErrors: false where the

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -32,7 +32,7 @@ import {
 } from "../../helpers/Format";
 import {
   getStorageBoolean,
-  getStorageString,
+  getStorageChoice,
   setStorageKeyValue,
 } from "../../LocalStorage";
 import { isDesktopScreen } from "../../Globals";
@@ -159,6 +159,26 @@ const CHART_KEYS = {
   },
 } as { [index: string]: ChartKeyMetadataType };
 
+const CHART_KEY_STORAGE_KEY = "financesChartKey";
+const CHART_YEAR_STORAGE_KEY = "financesChartYear";
+
+// The two entries of the year dropdown that aren't a year, and so stay valid in any game
+const ALL_TIME = 0;
+const CURRENT_YEAR = -1;
+
+// Newest first, so that the year being played is at the top of the dropdown
+function getPlayedYears(game: GameType): number[] {
+  const years = [];
+  for (let i = game.date.year; i >= game.startingYear; i--) {
+    years.push(i);
+  }
+  return years;
+}
+
+function getPlotYearOptions(game: GameType): number[] {
+  return [ALL_TIME, CURRENT_YEAR, ...getPlayedYears(game)];
+}
+
 export interface StateProps {
   game: GameType;
 }
@@ -204,11 +224,18 @@ function getTickFromValue(v: number) {
 export default class Finances extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
+    // Building a facility unmounts this pane, so both dropdowns have to be remembered outside
+    // the component or the player lands back on this year's profit every time they return
     this.state = {
-      year: -1, // current year
+      year: getStorageChoice(
+        CHART_YEAR_STORAGE_KEY,
+        getPlotYearOptions(props.game),
+        CURRENT_YEAR,
+      ),
       expanded: getStorageBoolean("financesTableOpened", false),
-      chartKey: getStorageString(
-        "financesChartKey",
+      chartKey: getStorageChoice(
+        CHART_KEY_STORAGE_KEY,
+        Object.keys(CHART_KEYS),
         "profit",
       ) as DerivedHistoryKeysType,
     };
@@ -240,8 +267,13 @@ export default class Finances extends React.Component<Props, State> {
   }
 
   public setChartKey(chartKey: DerivedHistoryKeysType) {
-    setStorageKeyValue("financesChartKey", chartKey);
+    setStorageKeyValue(CHART_KEY_STORAGE_KEY, chartKey);
     this.setState({ chartKey });
+  }
+
+  public setYear(year: number) {
+    setStorageKeyValue(CHART_YEAR_STORAGE_KEY, year);
+    this.setState({ year });
   }
 
   /**
@@ -333,10 +365,7 @@ export default class Finances extends React.Component<Props, State> {
 
     const scenario =
       getScenario(game.scenarioId, game.customScenario) || SCENARIOS[0];
-    const years = []; // Go in reverse so that newest value (current year) is on top
-    for (let i = date.year; i >= startingYear; i--) {
-      years.push(i);
-    }
+    const years = getPlayedYears(game);
 
     const monthlyHistory = game.monthlyHistory.filter(
       (t: MonthlyHistoryType) =>
@@ -456,7 +485,7 @@ export default class Finances extends React.Component<Props, State> {
             </Typography>
             <Select
               id="plotMetric"
-              defaultValue={chartKey}
+              value={chartKey}
               onChange={(e: SelectChangeEvent<string>) =>
                 this.setChartKey(e.target.value as DerivedHistoryKeysType)
               }
@@ -488,14 +517,13 @@ export default class Finances extends React.Component<Props, State> {
             </Typography>
             <Select
               id="plotYear"
-              defaultValue={-1}
+              value={year}
               onChange={(e: SelectChangeEvent<number>) =>
-                this.setState({ year: e.target.value as number })
+                this.setYear(e.target.value as number)
               }
             >
-              <MenuItem value={0}>All time</MenuItem>
-              <MenuItem value={-1}>Current year</MenuItem>
-              props.game.date.year
+              <MenuItem value={ALL_TIME}>All time</MenuItem>
+              <MenuItem value={CURRENT_YEAR}>Current year</MenuItem>
               {years.map((y: number) => {
                 return (
                   <MenuItem value={y} key={y}>

--- a/src/components/views/Forecasts.tsx
+++ b/src/components/views/Forecasts.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../helpers/DateTime";
 import { formatWattHours, formatWatts } from "../../helpers/Format";
 import { getDispatchOrderedFuels } from "../../helpers/Energy";
+import { getStorageChoice, setStorageKeyValue } from "../../LocalStorage";
 import { generateNewTimeline } from "../../reducers/Game";
 import ChartForecastFuelPrices from "../base/ChartForecastFuelPrices";
 import ChartForecastSupplyDemand from "../base/ChartForecastSupplyDemand";
@@ -28,6 +29,9 @@ import ChartForecastStorage from "../base/ChartForecastStorage";
 import GameCard from "../base/GameCard";
 import { TICK_MINUTES } from "../../Constants";
 import { isDesktopScreen } from "../../Globals";
+
+const FORECAST_YEARS_KEY = "forecastYears";
+const FORECAST_YEARS_OPTIONS = [1, 5, 10, 20];
 
 interface BlackoutEdges {
   minute: number;
@@ -42,16 +46,23 @@ export interface DispatchProps {}
 
 export interface Props extends StateProps, DispatchProps {}
 
-// TODO move forecast years to UI reducer, so that it's preserved across page changes
 interface State {
-  year: number;
   years: number;
 }
 
 export default class Forecasts extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { year: 0, years: 1 };
+    // Building a facility unmounts this pane, so the horizon has to be remembered outside the
+    // component or every trip to the build screen drops the player back to a one year forecast
+    this.state = {
+      years: getStorageChoice(FORECAST_YEARS_KEY, FORECAST_YEARS_OPTIONS, 1),
+    };
+  }
+
+  public setYears(years: number) {
+    setStorageKeyValue(FORECAST_YEARS_KEY, years);
+    this.setState({ years });
   }
 
   public shouldComponentUpdate(nextProps: Props, nextState: State) {
@@ -193,16 +204,17 @@ export default class Forecasts extends React.Component<Props, State> {
               Supply & Demand
               <Select
                 id="forecastYears"
-                defaultValue={1}
+                value={years}
                 onChange={(e: SelectChangeEvent<number>) =>
-                  this.setState({ years: e.target.value as number })
+                  this.setYears(e.target.value as number)
                 }
                 sx={{ float: "right" }}
               >
-                <MenuItem value={1}>1 year</MenuItem>
-                <MenuItem value={5}>5 years</MenuItem>
-                <MenuItem value={10}>10 years</MenuItem>
-                <MenuItem value={20}>20 years</MenuItem>
+                {FORECAST_YEARS_OPTIONS.map((y: number) => (
+                  <MenuItem value={y} key={y}>
+                    {y} year{y > 1 ? "s" : ""}
+                  </MenuItem>
+                ))}
               </Select>
             </Typography>
           </Toolbar>


### PR DESCRIPTION
## The bug

Navigating to a build screen unmounts the Finances and Forecasts panes, so every dropdown on them reset on the way back:

| Selector | Before | Now |
| --- | --- | --- |
| Forecasts — supply & demand horizon | back to **1 year** | keeps 1 / 5 / 10 / 20 |
| Finances — plotted metric | kept (already stored) | kept |
| Finances — plotted year | back to **Current year** | keeps the chosen year |

Building a facility is exactly what a player does while studying a 20 year forecast, so the selection was being thrown away at the worst possible moment. `Forecasts` even carried a TODO about it.

## The fix

A shared `getStorageChoice(key, options, fallback)` in [LocalStorage.tsx](src/LocalStorage.tsx) restores a stored choice *only while it's still one of the options on offer* — a metric that has since been renamed, or a year belonging to a longer game that's been replaced, falls back rather than leaving a dropdown selected on something it can't plot.

That matches how the finances table's expanded state has always been kept, and means the selections survive a page reload too, not just a trip to the build screen.

Both selects were uncontrolled (`defaultValue`), which would have ignored the restored state, so they're now driven by it.

## Drive-by fixes in the code being touched

- A stray `props.game.date.year` was sitting between two `<MenuItem>`s in the year dropdown, rendering as literal text in the menu.
- `Forecasts` had an unused `year` field on its state.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean; 266 tests across 25 suites pass, including 5 new ones for `getStorageChoice`.
- Drove it in the browser: set the forecast to 5 years and the finances chart to Net Worth / 2015, built a natural gas plant, came back — all three selections intact. Then seeded storage with a bogus metric, a year outside the game's range and a horizon that isn't offered; all three fell back cleanly with no MUI out-of-range warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
