### PR TITLE
Let the finances chart plot future ranges

### DIFF
--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -1,0 +1,106 @@
+import { parseRange, projectMonths } from "./Finances";
+import { MINUTES_PER_MONTH, summarizeTimeline } from "../../helpers/DateTime";
+import { GameType, MonthlyHistoryType } from "../../Types";
+import { createGame } from "../../testing/Simulator";
+
+function aGame(): GameType {
+  return createGame({ scenarioId: 103 });
+}
+
+describe("parseRange", () => {
+  it("should follow the clock rather than pinning the year it was chosen in", () => {
+    expect(parseRange("current", 2050)).toEqual({ mode: "year", year: 2050 });
+  });
+
+  it("should read a year the game has been to as that year", () => {
+    expect(parseRange("2032", 2050)).toEqual({ mode: "year", year: 2032 });
+  });
+
+  it("should read the forward ranges as horizons", () => {
+    expect(parseRange("next1", 2050)).toEqual({ mode: "future", years: 1 });
+    expect(parseRange("next20", 2050)).toEqual({ mode: "future", years: 20 });
+  });
+
+  it("should treat all time as its own mode", () => {
+    expect(parseRange("all", 2050)).toEqual({ mode: "all" });
+  });
+
+  /**
+   * The range is remembered in local storage, so a returning player can arrive with a value from
+   * a build that offered something this one doesn't. Falling back beats charting NaN months.
+   */
+  it("should fall back to the current year for anything it doesn't recognise", () => {
+    expect(parseRange("next7", 2050)).toEqual({ mode: "year", year: 2050 });
+    expect(parseRange("sometime", 2050)).toEqual({ mode: "year", year: 2050 });
+    expect(parseRange("", 2050)).toEqual({ mode: "year", year: 2050 });
+  });
+});
+
+describe("projectMonths", () => {
+  const monthsAhead = (game: GameType, ahead: number) =>
+    projectMonths(
+      game,
+      game.timeline[0].cash,
+      game.timeline[0].customers,
+      ahead,
+    );
+
+  it("should return the current month plus the months asked for", () => {
+    const game = aGame();
+    // A year, five years and twenty years, the horizons the dropdown offers
+    expect(monthsAhead(game, 12).length).toEqual(13);
+    expect(monthsAhead(game, 60).length).toEqual(61);
+    expect(monthsAhead(game, 240).length).toEqual(241);
+  });
+
+  it("should only project the current month when nothing is ahead of it", () => {
+    const game = aGame();
+    const months = monthsAhead(game, 0);
+    expect(months.length).toEqual(1);
+    expect(months[0]).toEqual(
+      summarizeTimeline(game.timeline, game.startingYear),
+    );
+  });
+
+  it("should run consecutive months, rolling the year over as it goes", () => {
+    const game = aGame();
+    const months = monthsAhead(game, 26);
+    const indexes = months.map(
+      (m: MonthlyHistoryType) => m.year * 12 + m.month,
+    );
+    expect(indexes).toEqual(indexes.map((_, i: number) => indexes[0] + i));
+    expect(months[months.length - 1].year - months[0].year).toEqual(2);
+  });
+
+  /**
+   * The forecast starts at the current minute, part way through a month, so its first and last
+   * buckets cover only part of one. Drawing either would put a false trough on the chart.
+   */
+  it("should drop the partial months at both ends of the forecast", () => {
+    const game = aGame();
+    const projected = monthsAhead(game, 24).slice(1);
+    const wholeMonth = summarizeTimeline(game.timeline, game.startingYear);
+
+    // Demand runs to a seasonal shape rather than a flat line, so months differ from each other
+    // -- but never by the order of magnitude a half-counted one would
+    projected.forEach((m: MonthlyHistoryType) => {
+      expect(m.demandWh).toBeGreaterThan(wholeMonth.demandWh * 0.5);
+    });
+  });
+
+  it("should carry cash forward across the horizon rather than holding it flat", () => {
+    const game = aGame();
+    const months = monthsAhead(game, 60);
+    const cash = months.map((m: MonthlyHistoryType) => m.cash);
+    expect(new Set(cash).size).toBeGreaterThan(1);
+  });
+
+  it("should start where the live timeline's own month does", () => {
+    const game = aGame();
+    const months = monthsAhead(game, 12);
+    expect(Math.floor(game.date.minute / MINUTES_PER_MONTH)).toEqual(
+      Math.floor(game.timeline[0].minute / MINUTES_PER_MONTH),
+    );
+    expect(months[0].month).toEqual(game.date.monthNumber);
+  });
+});

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -18,11 +18,11 @@ import { TickThrottle } from "../../helpers/RenderThrottle";
 import {
   deriveExpandedSummary,
   EMPTY_HISTORY,
-  getDateFromMinute,
   getTimeFromTimeline,
   reduceHistories,
   summarizeHistory,
   summarizeTimeline,
+  summarizeTimelineByMonth,
 } from "../../helpers/DateTime";
 import { customersFromMarketingSpend } from "../../helpers/Financials";
 import {
@@ -170,7 +170,7 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 interface State {
-  year: number;
+  range: string;
   expanded: boolean;
   chartKey: DerivedHistoryKeysType;
 }
@@ -180,6 +180,85 @@ interface ChartPointType {
   year: number;
   value: number;
   projected: boolean;
+}
+
+/**
+ * What the "for" dropdown is set to. A backwards range is a year the game has actually been to,
+ * so it is its own value; the rest are named, because "the current year" follows the clock and a
+ * forward range isn't a year at all. Previously all three were numbers with 0 and -1 as
+ * sentinels, which had no room left for "the next ten years".
+ */
+const ALL_TIME = "all";
+const CURRENT_YEAR = "current";
+const FUTURE_PREFIX = "next";
+// Matching the horizons the Forecasts pane offers, so the two panes look ahead the same distance
+const FUTURE_YEARS = [1, 5, 10, 20];
+
+// One shared array, so that a range with nothing ahead of it keeps handing back the same empty
+// projection and the series cache can go on comparing by identity
+const EMPTY_PROJECTION: MonthlyHistoryType[] = [];
+
+type ParsedRangeType =
+  | { mode: "all" }
+  | { mode: "year"; year: number }
+  | { mode: "future"; years: number };
+
+export function parseRange(
+  range: string,
+  currentYear: number,
+): ParsedRangeType {
+  if (range === ALL_TIME) {
+    return { mode: "all" };
+  }
+  if (range.startsWith(FUTURE_PREFIX)) {
+    const years = Number(range.slice(FUTURE_PREFIX.length));
+    if (FUTURE_YEARS.includes(years)) {
+      return { mode: "future", years };
+    }
+    return { mode: "year", year: currentYear };
+  }
+  const year = Number(range);
+  // Anything unrecognised lands here too, including a value left in local storage by a build
+  // that offered ranges this one doesn't. The emptiness check is because Number("") is 0, which
+  // is finite, and would chart the year nothing happened in
+  if (range !== "" && Number.isFinite(year)) {
+    return { mode: "year", year };
+  }
+  return { mode: "year", year: currentYear };
+}
+
+/**
+ * The current month, followed by `monthsAhead` complete simulated months.
+ *
+ * The current month comes from the live timeline, which already covers it from its start; the
+ * forecast only picks up from the current minute. Starting part way through a month is also why
+ * a whole extra month of ticks is simulated: it is what guarantees `monthsAhead` complete months
+ * after this one, since the forecast's own first bucket is only the rest of the current month
+ * and whatever trails off its end is the matching part of a later one. Both are dropped rather
+ * than drawn as months that only half happened.
+ */
+export function projectMonths(
+  game: GameType,
+  cash: number,
+  customers: number,
+  monthsAhead: number,
+): MonthlyHistoryType[] {
+  const months = [summarizeTimeline(game.timeline, game.startingYear)];
+  if (monthsAhead > 0) {
+    const forecast = generateNewTimeline(
+      game,
+      cash,
+      customers,
+      TICKS_PER_MONTH * (1 + monthsAhead),
+    );
+    months.push(
+      ...summarizeTimelineByMonth(forecast, game.startingYear).slice(
+        1,
+        1 + monthsAhead,
+      ),
+    );
+  }
+  return months;
 }
 
 // -1:0 -> 0:$100k, each tick increments the front number - when it overflows, instead add a 0 (i.e. 1->2M, 9->10M, 10->20M)
@@ -205,7 +284,7 @@ export default class Finances extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      year: -1, // current year
+      range: getStorageString("financesChartRange", CURRENT_YEAR),
       expanded: getStorageBoolean("financesTableOpened", false),
       chartKey: getStorageString(
         "financesChartKey",
@@ -214,8 +293,29 @@ export default class Finances extends React.Component<Props, State> {
     };
   }
 
-  private chartSeriesCache:
-    { key: string; series: ChartPointType[] } | undefined;
+  // Two caches rather than one, because the two halves of the work are invalidated by
+  // different things. The projection is the expensive half and doesn't care which metric is on
+  // screen, so switching metric no longer re-simulates; the series is cheap but has to stay
+  // referentially stable, because that is what lets ChartFinances memoise its canvas.
+  private projectionCache:
+    { key: string; months: MonthlyHistoryType[] } | undefined;
+  private seriesCache:
+    | {
+        chartKey: DerivedHistoryKeysType;
+        range: string;
+        historyLength: number;
+        projected: MonthlyHistoryType[];
+        series: ChartPointType[];
+      }
+    | undefined;
+
+  // Rebuilding a twenty-year projection costs ~120ms, and the marketing and rate sliders change
+  // one of its inputs on every pointer move. Drawing from the previous projection while the
+  // player is still dragging keeps the slider smooth, and the trailing timer below makes sure
+  // the chart catches up with wherever they let go.
+  private static readonly PROJECTION_THROTTLE_MS = 250;
+  private lastProjectionMs = 0;
+  private projectionCatchup: ReturnType<typeof setTimeout> | undefined;
 
   private throttle = new TickThrottle();
 
@@ -234,6 +334,12 @@ export default class Finances extends React.Component<Props, State> {
     this.throttle.rendered(this.props.game.date.minute);
   }
 
+  public componentWillUnmount() {
+    if (this.projectionCatchup) {
+      clearTimeout(this.projectionCatchup);
+    }
+  }
+
   public setExpand(expanded: boolean) {
     setStorageKeyValue("financesTableOpened", expanded);
     this.setState({ expanded });
@@ -244,87 +350,131 @@ export default class Finances extends React.Component<Props, State> {
     this.setState({ chartKey });
   }
 
+  public setRange(range: string) {
+    setStorageKeyValue("financesChartRange", range);
+    this.setState({ range });
+  }
+
   /**
-   * The chart plots monthly aggregates, and the projection behind its dashed half is a whole
-   * simulated year. Rebuilding that every frame was the single most expensive thing the game
-   * did -- at FAST it ran a year of simulation up to fifty times a second to redraw a line
-   * whose points cannot move until the month does. So it is rebuilt when something that can
-   * actually change it changes: the month rolling over, or the player touching the metric, the
-   * year, a slider or the fleet.
+   * The months the chart draws as a dashed projection: the current one, plus however far ahead
+   * the selected range looks.
+   *
+   * Simulating them is by far the most expensive thing this pane does -- at FAST it once ran a
+   * year of simulation up to fifty times a second to redraw a line whose points cannot move
+   * until the month does. So it is rebuilt only when something that can actually change it
+   * changes: the month rolling over, or the player touching the range, a slider or the fleet.
    */
-  private getChartSeries(
-    monthlyHistory: MonthlyHistoryType[],
+  private getProjectedMonths(
+    range: ParsedRangeType,
     cash: number,
     customers: number,
-  ): ChartPointType[] {
+  ): MonthlyHistoryType[] {
     const { game } = this.props;
-    const { startingYear, timeline, date } = game;
-    const { year, chartKey } = this.state;
+    const { date } = game;
+
+    // A year that is already in the books has nothing ahead of it to project
+    if (range.mode === "year" && range.year !== date.year) {
+      return EMPTY_PROJECTION;
+    }
 
     const key = [
-      chartKey,
-      year,
+      this.state.range,
       date.monthsEllapsed,
       game.monthlyHistory.length,
       game.monthlyMarketingSpend,
       game.dollarsPerkWh,
       game.facilities.map((f) => `${f.id}${f.paused ? "p" : ""}`).join(","),
     ].join("|");
-    const cached = this.chartSeriesCache;
+    const cached = this.projectionCache;
     if (cached && cached.key === key) {
+      return cached.months;
+    }
+    const sinceLast = Date.now() - this.lastProjectionMs;
+    if (
+      cached &&
+      range.mode === "future" &&
+      range.years > 1 &&
+      sinceLast < Finances.PROJECTION_THROTTLE_MS
+    ) {
+      // Mid-drag: draw the projection from before the drag started, and come back for the real
+      // one once the player has stopped moving. forceUpdate rather than setState because in FAST
+      // mode shouldComponentUpdate would otherwise swallow the catch-up render
+      if (!this.projectionCatchup) {
+        this.projectionCatchup = setTimeout(() => {
+          this.projectionCatchup = undefined;
+          this.forceUpdate();
+        }, Finances.PROJECTION_THROTTLE_MS - sinceLast);
+      }
+      return cached.months;
+    }
+
+    // A backwards range still projects the rest of the year it is looking at, which is what the
+    // chart has always drawn behind its dashed half
+    const monthsAhead =
+      range.mode === "future" ? 12 * range.years : 12 - date.monthNumber;
+    const months = projectMonths(game, cash, customers, monthsAhead);
+
+    this.lastProjectionMs = Date.now();
+    this.projectionCache = { key, months };
+    return months;
+  }
+
+  /**
+   * The chart's points for the metric on screen. Cheap next to the projection, but it has to
+   * hand back the same array when nothing has moved, because that referential stability is what
+   * lets ChartFinances memoise its canvas across the frames in between.
+   */
+  private getChartSeries(
+    monthlyHistory: MonthlyHistoryType[],
+    projected: MonthlyHistoryType[],
+  ): ChartPointType[] {
+    const { chartKey, range } = this.state;
+    const historyLength = this.props.game.monthlyHistory.length;
+    const cached = this.seriesCache;
+    if (
+      cached &&
+      cached.chartKey === chartKey &&
+      cached.range === range &&
+      cached.historyLength === historyLength &&
+      cached.projected === projected
+    ) {
       return cached.series;
     }
 
-    const monthly = [] as ChartPointType[];
+    const point = (m: MonthlyHistoryType, isProjected: boolean) => {
+      const summary = deriveExpandedSummary(m);
+      return {
+        month: summary.year * 12 + summary.month,
+        year: summary.year,
+        value: summary[chartKey],
+        projected: isProjected,
+      };
+    };
+
+    const series = [] as ChartPointType[];
+    // game.monthlyHistory is newest first, so unshifting puts the chart back in time order
     for (const m of monthlyHistory) {
-      const s = deriveExpandedSummary(m);
-      monthly.unshift({
-        month: s.year * 12 + s.month,
-        year: s.year,
-        value: s[chartKey],
-        projected: false,
-      });
+      series.unshift(point(m, false));
     }
-    if (!year || year === -1 || date.year === year) {
-      // Add projected months if current year is included in chart
-      const presentFutureMonths = [summarizeTimeline(timeline, startingYear)];
-      if (date.month !== "Dec") {
-        // Project out for the rest of the year
-        const forecastedTimeline = generateNewTimeline(
-          game,
-          cash,
-          customers,
-          TICKS_PER_MONTH * (1 + 12 - date.monthNumber),
-        ); // Current month, plus the rest of the months
-        for (let month = date.monthNumber + 1; month <= 12; month++) {
-          const m = summarizeTimeline(
-            forecastedTimeline,
-            startingYear,
-            (t) =>
-              getDateFromMinute(t.minute, startingYear).monthNumber === month,
-          );
-          presentFutureMonths.push(m);
-        }
-      }
-      presentFutureMonths.forEach((m) => {
-        const s = deriveExpandedSummary(m);
-        monthly.push({
-          month: s.year * 12 + s.month,
-          year: s.year,
-          value: s[chartKey],
-          projected: true,
-        });
-      });
+    for (const m of projected) {
+      series.push(point(m, true));
     }
 
-    this.chartSeriesCache = { key, series: monthly };
-    return monthly;
+    this.seriesCache = {
+      chartKey,
+      range,
+      historyLength,
+      projected,
+      series,
+    };
+    return series;
   }
 
   public render() {
     const { game, onDelta } = this.props;
     const { startingYear, timeline, date } = game;
-    const { year, expanded, chartKey } = this.state;
+    const { expanded, chartKey } = this.state;
+    const range = parseRange(this.state.range, date.year);
     const now = getTimeFromTimeline(date.minute, timeline);
 
     if (!now) {
@@ -338,15 +488,28 @@ export default class Finances extends React.Component<Props, State> {
       years.push(i);
     }
 
+    // A forward range still draws every month on the record behind its projection, so that the
+    // trajectory the forecast comes out of is on screen next to it
     const monthlyHistory = game.monthlyHistory.filter(
       (t: MonthlyHistoryType) =>
-        !year || t.year === year || (year === -1 && t.year === date.year),
+        range.mode === "year" ? t.year === range.year : true,
     );
-    const previousMonths = summarizeHistory(monthlyHistory);
 
-    // For the summary table
-    const summaryMonths = [previousMonths];
-    if (year === -1 || year === date.year) {
+    const projectedMonths = this.getProjectedMonths(
+      range,
+      now.cash,
+      now.customers,
+    );
+    const monthly = this.getChartSeries(monthlyHistory, projectedMonths);
+
+    // For the summary table. A backwards range totals what has happened, a forward one totals
+    // what is projected to -- which for cash and net worth means where the horizon leaves them,
+    // since reduceHistories carries those through rather than adding them up
+    const summaryMonths =
+      range.mode === "future"
+        ? [...projectedMonths]
+        : [summarizeHistory(monthlyHistory)];
+    if (range.mode === "year" && range.year === date.year) {
       summaryMonths.push(
         summarizeTimeline(
           timeline,
@@ -357,12 +520,6 @@ export default class Finances extends React.Component<Props, State> {
     }
     const summary = deriveExpandedSummary(
       summaryMonths.reduce(reduceHistories, { ...EMPTY_HISTORY }),
-    );
-
-    const monthly = this.getChartSeries(
-      monthlyHistory,
-      now.cash,
-      now.customers,
     );
 
     return (
@@ -456,7 +613,7 @@ export default class Finances extends React.Component<Props, State> {
             </Typography>
             <Select
               id="plotMetric"
-              defaultValue={chartKey}
+              value={chartKey}
               onChange={(e: SelectChangeEvent<string>) =>
                 this.setChartKey(e.target.value as DerivedHistoryKeysType)
               }
@@ -487,18 +644,27 @@ export default class Finances extends React.Component<Props, State> {
               for{" "}
             </Typography>
             <Select
-              id="plotYear"
-              defaultValue={-1}
-              onChange={(e: SelectChangeEvent<number>) =>
-                this.setState({ year: e.target.value as number })
+              id="plotRange"
+              value={this.state.range}
+              onChange={(e: SelectChangeEvent<string>) =>
+                this.setRange(e.target.value)
               }
             >
-              <MenuItem value={0}>All time</MenuItem>
-              <MenuItem value={-1}>Current year</MenuItem>
-              props.game.date.year
+              <MenuItem value={ALL_TIME}>All time</MenuItem>
+              <MenuItem value={CURRENT_YEAR}>Current year</MenuItem>
+              {FUTURE_YEARS.map((y: number) => {
+                return (
+                  <MenuItem
+                    value={`${FUTURE_PREFIX}${y}`}
+                    key={`${FUTURE_PREFIX}${y}`}
+                  >
+                    Next {y} {y === 1 ? "year" : "years"}
+                  </MenuItem>
+                );
+              })}
               {years.map((y: number) => {
                 return (
-                  <MenuItem value={y} key={y}>
+                  <MenuItem value={String(y)} key={y}>
                     {y}
                   </MenuItem>
                 );

--- a/src/helpers/DateTime.test.tsx
+++ b/src/helpers/DateTime.test.tsx
@@ -3,9 +3,15 @@ import {
   getDateFromMinute,
   getHourTicks,
   getSunriseSunset,
+  MINUTES_PER_MONTH,
+  summarizeTimeline,
+  summarizeTimelineByMonth,
 } from "./DateTime";
-import { LOCATIONS } from "../Constants";
-import { DateType } from "../Types";
+import { LOCATIONS, TICKS_PER_MONTH } from "../Constants";
+import { DateType, MonthlyHistoryType } from "../Types";
+import { SCENARIOS } from "../data/Scenarios";
+import { generateNewTimeline } from "../reducers/Game";
+import { createGame } from "../testing/Simulator";
 
 describe("formatMinuteOfDayChartAxis", () => {
   it("should render midnight as 12am", () => {
@@ -93,5 +99,82 @@ describe("getSunriseSunset", () => {
     // Guards the assertion above from passing only because the runner happens to sit in the
     // location's own zone
     expect(typeof machineOffsetMinutes).toEqual("number");
+  });
+});
+
+describe("summarizeTimelineByMonth", () => {
+  const startingYear = SCENARIOS[0].startingYear;
+
+  /**
+   * The finances chart used to build its projection by calling summarizeTimeline once per month
+   * with a filter. This has to be the same answer, or a projected month would stop reading the
+   * way a recorded one does at the point the two meet on the chart.
+   */
+  it("should match summarizing each month separately", () => {
+    const game = createGame({ scenarioId: 103 });
+    const timeline = generateNewTimeline(
+      game,
+      game.timeline[0].cash,
+      game.timeline[0].customers,
+      TICKS_PER_MONTH * 5,
+    );
+
+    const byMonth = summarizeTimelineByMonth(timeline, startingYear);
+
+    const months = new Set(
+      timeline.map((t) => Math.floor(t.minute / MINUTES_PER_MONTH)),
+    );
+    expect(byMonth.length).toEqual(months.size);
+    [...months]
+      .sort((a, b) => a - b)
+      .forEach((month: number, i: number) => {
+        expect(byMonth[i]).toEqual(
+          summarizeTimeline(
+            timeline,
+            startingYear,
+            (t) => Math.floor(t.minute / MINUTES_PER_MONTH) === month,
+          ),
+        );
+      });
+  });
+
+  it("should return the months oldest first", () => {
+    const game = createGame({ scenarioId: 103 });
+    const timeline = generateNewTimeline(
+      game,
+      game.timeline[0].cash,
+      game.timeline[0].customers,
+      TICKS_PER_MONTH * 14,
+    );
+
+    const byMonth = summarizeTimelineByMonth(timeline, startingYear);
+
+    const asMonthIndex = (m: MonthlyHistoryType) => m.year * 12 + m.month;
+    const indexes = byMonth.map(asMonthIndex);
+    expect(indexes).toEqual([...indexes].sort((a, b) => a - b));
+    expect(new Set(indexes).size).toEqual(indexes.length);
+    // Long enough to roll over a year, which the month numbers wrap on but the ordering must not
+    expect(byMonth[byMonth.length - 1].year).toBeGreaterThan(byMonth[0].year);
+  });
+
+  it("should total the same as summarizing the whole span at once", () => {
+    const game = createGame({ scenarioId: 103 });
+    const timeline = generateNewTimeline(
+      game,
+      game.timeline[0].cash,
+      game.timeline[0].customers,
+      TICKS_PER_MONTH * 6,
+    );
+
+    const byMonth = summarizeTimelineByMonth(timeline, startingYear);
+    const whole = summarizeTimeline(timeline, startingYear);
+
+    const totalRevenue = byMonth.reduce(
+      (sum: number, m: MonthlyHistoryType) => sum + m.revenue,
+      0,
+    );
+    expect(totalRevenue).toBeCloseTo(whole.revenue, 4);
+    // Ending values are carried rather than added, and belong to the oldest tick either way
+    expect(byMonth[0].cash).toEqual(whole.cash);
   });
 });

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -15,6 +15,9 @@ import {
   TickPresentFutureType,
 } from "../Types";
 
+/** A game month, in minutes -- the unit the forecast charts step their x axis in. */
+export const MINUTES_PER_MONTH = DAYS_PER_MONTH * 1440;
+
 export const EMPTY_HISTORY = {
   month: 0,
   year: 0,
@@ -74,6 +77,36 @@ export function deriveExpandedSummary(
   };
 }
 
+/**
+ * Everything reduceHistories does for a single tick, without first building the copy of it that
+ * used to be spread into a MonthlyHistoryType. A year-long forecast is over a thousand ticks and
+ * a twenty-year one over twenty thousand, so that copy was the bulk of the work.
+ */
+function accumulateTick(
+  summary: MonthlyHistoryType,
+  t: TickPresentFutureType,
+  startingYear: number,
+) {
+  const date = getMonthYearFromMinute(t.minute, startingYear);
+  // Integrate instantaneous electricity (watts) to watt hours
+  // Only electricity isn't multiplied by this during tick calculations (financials are)
+  summary.supplyWh +=
+    (Math.min(t.demandW, t.supplyW) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+  summary.demandWh += (t.demandW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+  summary.kgco2e += t.kgco2e;
+  summary.revenue += t.revenue;
+  summary.expensesFuel += t.expensesFuel;
+  summary.expensesOM += t.expensesOM;
+  summary.expensesMarketing += t.expensesMarketing;
+  summary.expensesCarbonFee += t.expensesCarbonFee;
+  summary.expensesInterest += t.expensesInterest;
+  summary.cash = t.cash;
+  summary.customers = t.customers;
+  summary.netWorth = t.netWorth;
+  summary.month = date.monthNumber;
+  summary.year = date.year;
+}
+
 // start + end inclusive - can be used to summarize a month, but also any arbitrary timeline group
 export function summarizeTimeline(
   timeline: TickPresentFutureType[],
@@ -85,23 +118,43 @@ export function summarizeTimeline(
   for (let i = timeline.length - 1; i >= 0; i--) {
     const t = timeline[i];
     if (!filter || filter(t)) {
-      // TODO perf this gets called a lot, but only need
-      const date = getMonthYearFromMinute(t.minute, startingYear);
-      // Integrate instantaneous electricity (watts) to watt hours
-      // Only electricity isn't multiplied by this during tick calculations (financials are)
-      const supplyWh =
-        (Math.min(t.demandW, t.supplyW) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
-      const demandWh = (t.demandW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
-      reduceHistories(summary, {
-        ...t,
-        supplyWh,
-        demandWh,
-        month: date.monthNumber,
-        year: date.year,
-      });
+      accumulateTick(summary, t, startingYear);
     }
   }
   return summary;
+}
+
+/**
+ * Every month a timeline spans, oldest first, in a single pass.
+ *
+ * The same answer as calling summarizeTimeline once per month with a filter, which is what the
+ * finances chart did while it only ever projected to the end of the current year. That approach
+ * is O(months x ticks): twelve scans of a year-long forecast is merely wasteful, but 240 scans of
+ * a twenty-year one takes over a second and a half -- more than ten times what simulating those
+ * twenty years costs in the first place.
+ */
+export function summarizeTimelineByMonth(
+  timeline: TickPresentFutureType[],
+  startingYear: number,
+): MonthlyHistoryType[] {
+  const byMonth = new Map<number, MonthlyHistoryType>();
+  // Reverse, with each tick overwriting the ending values, for the same reason summarizeTimeline
+  // does it -- so a month summarized here reads the same way as one recorded during play
+  for (let i = timeline.length - 1; i >= 0; i--) {
+    const t = timeline[i];
+    // DAYS_PER_MONTH is 1, so this is the same count getMonthYearFromMinute works from, and it
+    // keeps counting past 12 rather than wrapping, which makes it unique across years
+    const month = Math.floor(t.minute / MINUTES_PER_MONTH);
+    let summary = byMonth.get(month);
+    if (!summary) {
+      summary = { ...EMPTY_HISTORY };
+      byMonth.set(month, summary);
+    }
+    accumulateTick(summary, t, startingYear);
+  }
+  return [...byMonth.keys()]
+    .sort((a, b) => a - b)
+    .map((month) => byMonth.get(month) as MonthlyHistoryType);
 }
 
 export function summarizeHistory(
@@ -147,9 +200,6 @@ export function formatMonthChartAxis(t: number, multiyear: boolean) {
   }
   return MONTHS[t % 12];
 }
-
-/** A game month, in minutes -- the unit the forecast charts step their x axis in. */
-export const MINUTES_PER_MONTH = DAYS_PER_MONTH * 1440;
 
 /**
  * The month label for a point on a forecast chart, whose x is a minute of the game rather than


### PR DESCRIPTION
The finances chart's "for" dropdown could only look backwards — all time, the current year, or a year the game had already been to. It now also offers **Next 1 / 5 / 10 / 20 years**, the same horizons the Forecasts pane looks ahead over.

The dropdown now reads: All time · Current year · Next 1 year · Next 5 years · Next 10 years · Next 20 years · then each year the game has been to.

## Why it wasn't just a dropdown change

The pane already knew how to forecast — it simulates the rest of the current year to draw the dashed half of its chart. What it couldn't do was *aggregate* one cheaply.

It summarized the forecast by calling `summarizeTimeline` once per month with a `monthNumber === month` filter. Each call is a full scan, so the whole thing is O(months × ticks) with a `getDateFromMinute` per tick per month. Measured on `createGame({scenarioId: 103})`:

| Horizon | Ticks | Simulate | Aggregate (before) | Aggregate (after) |
|---|---|---|---|---|
| 1 yr | 1,152 | 7 ms | 20 ms | 1 ms |
| 5 yr | 5,760 | 26 ms | 102 ms | 3 ms |
| 10 yr | 11,520 | 54 ms | 452 ms | 6 ms |
| 20 yr | 23,040 | 122 ms | **1,766 ms** | **14 ms** |

Twelve scans of a year is merely wasteful. 240 scans of twenty years costs more than ten times what simulating those twenty years costs in the first place. `summarizeTimelineByMonth` buckets the whole span in one pass instead, and drops the per-tick object copy that `reduceHistories` needed. The existing one-year path gets faster too, 20 ms → 1 ms.

## Keeping the sliders usable

The marketing and rate sliders change an input to the projection on **every pointer move**, so a 20-year rebuild per drag event would lock the UI. A long projection now redraws from the previous one while the player is still dragging, with a trailing timer to catch up once they stop.

Measured in the browser over a 24-event drag at the 20-year horizon: **median 6 ms per event, with 2 of 24 paying the full ~122 ms rebuild** rather than all 24.

The cache also split in two, because the two halves are invalidated by different things — switching metric no longer re-simulates, and the series stays referentially stable so `ChartFinances` can keep memoising its canvas.

## Decisions worth a look

- **A forward range still draws the recorded history behind its projection**, using the solid/dashed split the chart already has, so the trajectory the forecast comes out of is on screen next to it. The table underneath totals only the forward window, since that's what "Next 20 years" is asking about.
- **Partial months at both ends of the forecast are dropped.** The forecast starts at the current minute, part way through a month, so an extra month of ticks is simulated and the two partial buckets are discarded — drawing them would put a false trough at each end of the line.
- **Projected months are summarized exactly the way recorded ones are**, including the quirk that `summarizeTimeline`'s carried values (cash, net worth, customers) come from the *earliest* tick of a span rather than the latest. That's pre-existing and left alone deliberately: matching it is what keeps a projected month reading the same as a recorded one at the point the two meet.
- **The projection holds the fleet, the rate and the marketing spend fixed** — cash, customers and net worth do compound across the horizon, and loans amortize, but nothing new gets built. Same promise the Forecasts pane already makes.

## Also in here

- Drops a stray `props.game.date.year` text node that was rendering as literal text inside the dropdown.
- Both selects are controlled rather than uncontrolled, and the range is remembered across sessions like the metric already was. The year sentinels (`0` = all time, `-1` = current year) had no room left for a forward range, so the selection is a named string now, with a fallback for a value left behind by a build that offered different ranges.

## Testing

`npm run check` clean; 275 tests pass. New coverage for `summarizeTimelineByMonth` (equivalence with the per-month approach it replaces, ordering, totals) and for `parseRange` / `projectMonths` (month counts per horizon, consecutive months across a year rollover, no partial months, cash compounding).

Verified in the running app: all seven options render, selection persists across a reload and a new game, and no new console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Merged with master (#162, #164)

Both landed on this same pane while this was open, and both were better than what this branch had done in passing:

- **`getStorageChoice`** restores a stored selection only while it's still one of the options on offer. This branch had hand-rolled a weaker version inside `parseRange`; the selection now goes through the shared helper, and `parseRange`'s fallback is a last line of defence rather than the only one.
- **`shouldComponentUpdate` taking `nextState`** — every change either dropdown makes is state-only, so this branch's version would have reintroduced a selector that ignores the player at FAST speed.

Master kept the numeric year sentinels (`0` all time, `-1` current year) that this branch replaced with named strings to make room for forward ranges. The storage key stays `financesChartYear` so a stored *year* still reads back on upgrade; the two sentinels simply aren't options any more and `getStorageChoice` drops them. There are tests for both.

The two `Finances.test.tsx` files arrived as an add/add conflict and test different things — master's drives the real selects at every speed, this branch's covers range parsing and projection arithmetic — so the combined file keeps both suites, and master's harness now also drives the new forward ranges.

**That new coverage caught a bug in this branch.** The projection throttle was deferring on *range changes*, not just slider drags, so picking a long horizon drew the previous range's months for up to 250ms before correcting itself. It now defers only when the game's own inputs move under a range the player already had. 315 tests pass.
