### PR TITLE
Any location, any era: phase 0 of #163

### DIFF
--- a/scripts/sim.js
+++ b/scripts/sim.js
@@ -12,6 +12,8 @@ const path = require("path");
 
 const FLAGS = {
   "--scenario": "SIM_SCENARIO",
+  "--year": "SIM_YEAR",
+  "--location": "SIM_LOCATION",
   "--difficulty": "SIM_DIFFICULTY",
   "--months": "SIM_MONTHS",
   "--seed": "SIM_SEED",
@@ -30,8 +32,11 @@ Runs the game's simulation headlessly and reports what happened.
   npm run sim                              one scenario, default settings
   npm run sim -- --all                     every scenario, one line each
   npm run sim -- --scenario 103 --full     every month of "The Shale Boom"
+  npm run sim -- --year 2080 --months 240  a twenty-year run starting in 2080
 
   --scenario <id>        Scenario to play (default 101). --list shows the ids
+  --year <n>             Override the scenario's starting year (1980 and up)
+  --location <id>        Override where it's played: PIT, SF, LA, CAMountains, HNL, SJU
   --difficulty <name>    Intern | Employee | Manager | VP | CEO (default Employee)
   --months <n>           Override the scenario's own duration
   --seed <n>             Pin the run's randomness (default 12345)

--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -64,6 +64,23 @@ export const LOCATIONS = {
     long: -122.4194,
     timeZone: "America/Los_Angeles",
   },
+  LA: {
+    id: "LA",
+    name: "Los Angeles, CA",
+    lat: 34.0522,
+    long: -118.2437,
+    timeZone: "America/Los_Angeles",
+  },
+  // Its forty years read as coastal range rather than Sierra -- a 9C to 17C annual swing that
+  // peaks in September, which is the marine layer's signature and not the high country's --
+  // so it's placed and named for the Santa Cruz Mountains
+  CAMountains: {
+    id: "CAMountains",
+    name: "Santa Cruz Mountains, CA",
+    lat: 37.1041,
+    long: -122.0308,
+    timeZone: "America/Los_Angeles",
+  },
   HNL: {
     id: "HNL",
     name: "Honolulu, HI",

--- a/src/Replay.test.tsx
+++ b/src/Replay.test.tsx
@@ -7,6 +7,7 @@ import {
   replayByteLength,
   REPLAY_VERSION,
 } from "./Replay";
+import { LOCATIONS } from "./Constants";
 import { GameType, ReplayActionType, ReplayType } from "./Types";
 
 // Only the two fields the recorder touches, so these tests don't need a whole simulation to run
@@ -25,6 +26,7 @@ function aReplay(overrides: Partial<ReplayType> = {}): ReplayType {
     difficulty: "Employee",
     seed: 12345,
     startingYear: 2020,
+    location: LOCATIONS.SF,
     durationMinutes: 43200,
     actions: [
       { minute: 0, type: "delta", payload: { dollarsPerkWh: 0.12 } },
@@ -153,6 +155,42 @@ describe("decodeReplay", () => {
     const doc = encodeReplay(aReplay()) as unknown as Record<string, unknown>;
     delete doc.seed;
     expect(decodeReplay(doc)).toBeNull();
+  });
+
+  // A scenario id no longer says where a run was played, so a replay without a location has
+  // nowhere to be re-simulated -- which is the whole reason REPLAY_VERSION went to 2
+  it("ignores a replay that doesn't say where it was played", () => {
+    const doc = encodeReplay(aReplay()) as unknown as Record<string, unknown>;
+    delete doc.location;
+    expect(decodeReplay(doc)).toBeNull();
+  });
+
+  it("ignores a location that isn't one", () => {
+    const bad = [
+      "SF",
+      { id: "SF" },
+      { ...LOCATIONS.SF, lat: 91 },
+      { ...LOCATIONS.SF, long: "west" },
+      // The id becomes the path of the weather file the loading screen fetches
+      { ...LOCATIONS.SF, id: "../../secrets" },
+    ];
+    bad.forEach((location: unknown) => {
+      expect(decodeReplay({ ...encodeReplay(aReplay()), location })).toBeNull();
+    });
+  });
+
+  it("keeps a location the game doesn't ship, so a custom run replays where it was played", () => {
+    const unlisted = {
+      id: "REY",
+      name: "Reykjavik, Iceland",
+      lat: 64.1466,
+      long: -21.9426,
+      timeZone: "Atlantic/Reykjavik",
+    };
+    const decoded = decodeReplay(
+      JSON.parse(JSON.stringify(encodeReplay(aReplay({ location: unlisted })))),
+    );
+    expect(decoded!.location).toEqual(unlisted);
   });
 
   /**

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -1,5 +1,6 @@
 import cloneDeep from "lodash.clonedeep";
 import packageJson from "../package.json";
+import { isValidLocation } from "./helpers/Locations";
 import {
   GameType,
   ReplayActionNameType,
@@ -28,7 +29,9 @@ import {
  */
 
 // Bump on any breaking schema change. Mismatched replays are ignored rather than migrated.
-export const REPLAY_VERSION = 1;
+// 2 added `location`: a v1 replay names only a scenario, and a scenario no longer pins down
+// where it is played, so there is no safe way to migrate one.
+export const REPLAY_VERSION = 2;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few
@@ -139,6 +142,7 @@ export function serializeReplay(game: GameType): ReplayType | undefined {
     difficulty: game.difficulty,
     seed: game.seed,
     startingYear: game.startingYear,
+    location: cloneDeep(game.location),
     durationMinutes: game.date.minute,
     actions: cloneDeep(game.replayLog),
   };
@@ -218,7 +222,10 @@ export function decodeReplay(raw: unknown): ReplayType | null {
     !isFiniteNumber(doc.scenarioId) ||
     !isFiniteNumber(doc.seed) ||
     !isFiniteNumber(doc.startingYear) ||
-    typeof doc.difficulty !== "string"
+    typeof doc.difficulty !== "string" ||
+    // Checked in full rather than trusted: the location's id becomes the path of the weather file
+    // the loading screen fetches, and its lat/long drive the sun model
+    !isValidLocation(doc.location)
   ) {
     return null;
   }
@@ -233,6 +240,7 @@ export function decodeReplay(raw: unknown): ReplayType | null {
     difficulty: doc.difficulty as ReplayType["difficulty"],
     seed: doc.seed,
     startingYear: doc.startingYear,
+    location: doc.location,
     durationMinutes: isFiniteNumber(doc.durationMinutes)
       ? doc.durationMinutes
       : 0,

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -23,7 +23,12 @@ export type MonthType =
 export type DifficultyType = "Intern" | "Employee" | "Manager" | "VP" | "CEO";
 export type SpeedType = "PAUSED" | "SLOW" | "NORMAL" | "FAST";
 
-export type LocationIdType = "PIT" | "SF" | "HNL" | "SJU";
+// Deliberately open rather than a union of the places that happen to ship today: a custom game
+// may hold a location that isn't in LOCATIONS at all, so nothing is allowed to key off the
+// closed set. Resolve one through getLocation / getScenarioLocation rather than indexing
+// LOCATIONS directly, and check anything untrusted with isValidLocationId -- the id ends up in
+// the path of a weather file.
+export type LocationIdType = string;
 export interface LocationType {
   id: LocationIdType;
   name: string;
@@ -135,6 +140,10 @@ export interface ReplayType {
   difficulty: DifficultyType;
   seed: number;
   startingYear: number;
+  // Where the run was played. A scenario id no longer pins this down -- a custom game carries its
+  // own location, and an authored one could be given a location that isn't in LOCATIONS -- so
+  // without it a replay would silently be re-simulated against a different city's weather
+  location: LocationType;
   durationMinutes: number; // How far the recorded run got
   actions: ReplayActionType[];
 }
@@ -327,6 +336,10 @@ export interface ScenarioType {
   name: string;
   icon: string; // assumed to be images/<string>.svg
   locationId: LocationIdType;
+  // The full location, for scenarios whose location isn't in LOCATIONS -- which is every custom
+  // game, since the player may eventually pick a place no table knows about. When it's set it
+  // wins over locationId; getScenarioLocation is the one place that resolves the two.
+  location?: LocationType;
   summary?: string;
   ownership: "Investor" | "Public";
   tutorialSteps?: TutorialStepType[];

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -30,6 +30,7 @@ import VictoryConditions from "../base/VictoryConditions";
 import { DIFFICULTIES, LOCATIONS } from "../../Constants";
 import { GENERATORS, STORAGE } from "../../data/Facilities";
 import { WEATHER_STARTING_YEAR } from "../../data/Weather";
+import { getFuelEscalation } from "../../data/FuelPrices";
 import { getDateFromMinute } from "../../helpers/DateTime";
 import { getLocation, getScenarioLocation } from "../../helpers/Locations";
 import { formatWattHours, formatWatts } from "../../helpers/Format";
@@ -70,6 +71,65 @@ const STARTING_YEARS = Array.from(
   (_v: unknown, i: number) => WEATHER_STARTING_YEAR + i * STARTING_YEAR_STEP,
 );
 const DURATION_YEARS = [1, 5, 10, 20, 40, 60, 100];
+// The era the rates and fees above are written in: cents per kilowatt hour a player recognises,
+// against the fuel prices the data ends on.
+const RATE_BASE_YEAR = 2020;
+
+/**
+ * A rate or a fee re-quoted into the money of the year the game starts in.
+ *
+ * Fuel is the one price the game reads at face value for the year it is in - build costs and O&M
+ * are anchored on whatever year a game starts, so they always open at what the tables say. A 2080
+ * game therefore opens against sixty years of escalated fuel, and offering it a literal seven
+ * cents a kilowatt hour is offering a game that is bankrupt inside a quarter.
+ *
+ * Only forwards. A game starting before RATE_BASE_YEAR is played against real recorded prices
+ * rather than a projection, so there is no escalation to undo, and deflating those rates would
+ * change every historical scenario's balance for no reason.
+ */
+function inEraMoney(base: number, startingYear: number): number {
+  const factor =
+    getFuelEscalation(Math.max(startingYear, RATE_BASE_YEAR)) /
+    getFuelEscalation(RATE_BASE_YEAR);
+  // Two significant figures, so the offered numbers stay round enough to choose between
+  return Number((base * factor).toPrecision(2));
+}
+
+// The option nearest a value, used to keep the player's position in a list when the era under it
+// moves, and to migrate a custom game stored before these became era-aware.
+function nearestIndex(options: number[], value: number): number {
+  let best = 0;
+  options.forEach((option: number, i: number) => {
+    if (Math.abs(option - value) < Math.abs(options[best] - value)) {
+      best = i;
+    }
+  });
+  return best;
+}
+
+/**
+ * A stored custom game with its rate and fee snapped onto the options its own starting year
+ * offers.
+ *
+ * Only ever changes a game saved before those became era-aware. Doing it on the way in rather
+ * than on the way out is what keeps the screen honest: showing the nearest option while the
+ * scenario still held the old number would start a game at a rate the player was never shown.
+ * There is no recovering what they originally meant -- fifty dollars a ton is a rounding error in
+ * 2090 money -- so the nearest option is the best that can be done, once.
+ */
+function inEraScenario(scenario: ScenarioType): ScenarioType {
+  const rates = RATES_PER_KWH.map((r: number) =>
+    inEraMoney(r, scenario.startingYear),
+  );
+  const fees = FEES_PER_TON.map((f: number) =>
+    inEraMoney(f, scenario.startingYear),
+  );
+  return {
+    ...scenario,
+    dollarsPerkWh: rates[nearestIndex(rates, scenario.dollarsPerkWh)],
+    feePerKgCO2e: fees[nearestIndex(fees, scenario.feePerKgCO2e * 1000)] / 1000,
+  };
+}
 const STARTING_CASH = [100000000, 200000000, 500000000, 1000000000];
 const RATES_PER_KWH = [0.05, 0.07, 0.1, 0.15];
 const FEES_PER_TON = [0, 20, 50, 100];
@@ -135,7 +195,9 @@ function facilitySize(facility: Partial<FacilityShoppingType>): string {
 
 export default function CustomGame(props: Props): React.JSX.Element {
   const { game, onBack, onDelta, onStart } = props;
-  const [scenario, setScenario] = React.useState<ScenarioType>(props.scenario);
+  const [scenario, setScenario] = React.useState<ScenarioType>(() =>
+    inEraScenario(props.scenario),
+  );
   const [victoryDialogOpen, setVictoryDialogOpen] = React.useState(false);
   const [feeDialogOpen, setFeeDialogOpen] = React.useState(false);
   const [addName, setAddName] = React.useState("");
@@ -154,6 +216,20 @@ export default function CustomGame(props: Props): React.JSX.Element {
   const totalPeakW = scenario.facilities.reduce(
     (sum: number, f: Partial<FacilityShoppingType>) => sum + (f.peakW || 0),
     0,
+  );
+
+  // What a kilowatt hour may be charged at, and what a ton of CO2e may be feed, in the money of
+  // the year the game starts in. Both move with the starting year, which is why changing that
+  // year has to re-quote whatever was already chosen rather than leaving a 2020 rate on a 2080
+  // game -- see changeStartingYear below.
+  const rateOptions = React.useMemo(
+    () =>
+      RATES_PER_KWH.map((r: number) => inEraMoney(r, scenario.startingYear)),
+    [scenario.startingYear],
+  );
+  const feeOptions = React.useMemo(
+    () => FEES_PER_TON.map((f: number) => inEraMoney(f, scenario.startingYear)),
+    [scenario.startingYear],
   );
 
   // Every place that can be picked. LOCATIONS plus, if the scenario is being played somewhere
@@ -177,6 +253,23 @@ export default function CustomGame(props: Props): React.JSX.Element {
 
   const change = (delta: Partial<ScenarioType>) => {
     setScenario({ ...scenario, ...delta });
+  };
+
+  /**
+   * Moving the game's era, and carrying the prices that are quoted in it along.
+   *
+   * The player picked "the cheapest rate" or "the middling carbon fee", not a literal number of
+   * cents, so the same position in each list is what survives the move. Rolling 2020 forward to
+   * 2080 and leaving seven cents behind would silently hand back a game that cannot be won.
+   */
+  const changeStartingYear = (startingYear: number) => {
+    const rate = nearestIndex(rateOptions, scenario.dollarsPerkWh);
+    const fee = nearestIndex(feeOptions, scenario.feePerKgCO2e * 1000);
+    change({
+      startingYear,
+      dollarsPerkWh: inEraMoney(RATES_PER_KWH[rate], startingYear),
+      feePerKgCO2e: inEraMoney(FEES_PER_TON[fee], startingYear) / 1000,
+    });
   };
 
   const addFacility = () => {
@@ -250,7 +343,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
                   id="startingYear"
                   value={scenario.startingYear}
                   onChange={(e: SelectChangeEvent<number>) =>
-                    change({ startingYear: Number(e.target.value) })
+                    changeStartingYear(Number(e.target.value))
                   }
                 >
                   {STARTING_YEARS.map((y: number) => {
@@ -340,7 +433,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
                     change({ dollarsPerkWh: Number(e.target.value) })
                   }
                 >
-                  {RATES_PER_KWH.map((r: number) => {
+                  {rateOptions.map((r: number) => {
                     return (
                       <MenuItem value={r} key={r}>
                         ${r.toFixed(2)}/kWh
@@ -370,10 +463,10 @@ export default function CustomGame(props: Props): React.JSX.Element {
                     change({ feePerKgCO2e: Number(e.target.value) })
                   }
                 >
-                  {FEES_PER_TON.map((f: number) => {
+                  {feeOptions.map((f: number) => {
                     return (
                       <MenuItem value={f / 1000} key={f}>
-                        ${f}/ton
+                        ${Math.round(f).toLocaleString("en-US")}/ton
                       </MenuItem>
                     );
                   })}

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -29,14 +29,15 @@ import InfoIcon from "@mui/icons-material/Info";
 import VictoryConditions from "../base/VictoryConditions";
 import { DIFFICULTIES, LOCATIONS } from "../../Constants";
 import { GENERATORS, STORAGE } from "../../data/Facilities";
+import { WEATHER_STARTING_YEAR } from "../../data/Weather";
 import { getDateFromMinute } from "../../helpers/DateTime";
+import { getLocation, getScenarioLocation } from "../../helpers/Locations";
 import { formatWattHours, formatWatts } from "../../helpers/Format";
 import { newSeed } from "../../helpers/Math";
 import {
   DifficultyType,
   FacilityShoppingType,
   GameType,
-  LocationIdType,
   LocationType,
   ScenarioType,
 } from "../../Types";
@@ -54,10 +55,21 @@ export interface DispatchProps {
 
 export interface Props extends StateProps, DispatchProps {}
 
-// Weather data runs 1980 - 2019 and is projected forwards from there, so anything from 1980 on
-// plays; earlier would have nothing to project from
-const STARTING_YEARS = [1980, 1990, 2000, 2010, 2020];
-const DURATION_YEARS = [1, 5, 10, 20, 40];
+// Only the floor is a real constraint: the recorded weather begins in WEATHER_STARTING_YEAR and
+// the fuel prices in 1975, and a year before that has nothing to project forwards from. Forwards
+// there is no limit - the weather forecast and the price projection both run indefinitely, so a
+// 2100 start just plays eighty years of projection - and this is simply as far ahead as seemed
+// worth offering. Stepped by decade because a dropdown is the wrong control for 121 rows.
+const LATEST_STARTING_YEAR = 2100;
+const STARTING_YEAR_STEP = 10;
+const STARTING_YEARS = Array.from(
+  {
+    length:
+      (LATEST_STARTING_YEAR - WEATHER_STARTING_YEAR) / STARTING_YEAR_STEP + 1,
+  },
+  (_v: unknown, i: number) => WEATHER_STARTING_YEAR + i * STARTING_YEAR_STEP,
+);
+const DURATION_YEARS = [1, 5, 10, 20, 40, 60, 100];
 const STARTING_CASH = [100000000, 200000000, 500000000, 1000000000];
 const RATES_PER_KWH = [0.05, 0.07, 0.1, 0.15];
 const FEES_PER_TON = [0, 20, 50, 100];
@@ -144,6 +156,18 @@ export default function CustomGame(props: Props): React.JSX.Element {
     0,
   );
 
+  // Every place that can be picked. LOCATIONS plus, if the scenario is being played somewhere
+  // that isn't in it, that place too -- a custom game may carry a location no table lists, and a
+  // Select whose value isn't one of its options renders blank and drops the choice on the next
+  // edit. Ordered with the table first so the odd one out doesn't jump the list around.
+  const selectableLocations = React.useMemo(() => {
+    const current = getScenarioLocation(scenario);
+    const listed = Object.values(LOCATIONS);
+    return current && !listed.some((l: LocationType) => l.id === current.id)
+      ? [...listed, current]
+      : listed;
+  }, [scenario]);
+
   // Rolling the year back past a technology's invention would otherwise leave a facility in the
   // list that quietly disappears once the game loads
   const unavailable = scenario.facilities.filter(
@@ -196,14 +220,20 @@ export default function CustomGame(props: Props): React.JSX.Element {
             <TableRow>
               <TableCell>Location</TableCell>
               <TableCell>
+                {/* The scenario carries the whole location rather than just its id, so a custom
+                    game stays playable even if the table it was picked from changes underneath it
+                    - and so it can eventually hold somewhere the table never listed */}
                 <Select
                   id="location"
-                  value={scenario.locationId}
-                  onChange={(e: SelectChangeEvent<LocationIdType>) =>
-                    change({ locationId: e.target.value as LocationIdType })
+                  value={getScenarioLocation(scenario)?.id || ""}
+                  onChange={(e: SelectChangeEvent<string>) =>
+                    change({
+                      locationId: e.target.value,
+                      location: getLocation(e.target.value),
+                    })
                   }
                 >
-                  {Object.values(LOCATIONS).map((l: LocationType) => {
+                  {selectableLocations.map((l: LocationType) => {
                     return (
                       <MenuItem value={l.id} key={l.id}>
                         {l.name}

--- a/src/components/views/LoadingContainer.tsx
+++ b/src/components/views/LoadingContainer.tsx
@@ -4,7 +4,7 @@ import { logEvent } from "../../Globals";
 import { initEconomy } from "../../data/Economy";
 import { initFuelPrices } from "../../data/FuelPrices";
 import { initWeather } from "../../data/Weather";
-import { LOCATIONS } from "../../Constants";
+import { getScenarioLocation } from "../../helpers/Locations";
 import { getScenario } from "../../data/Scenarios";
 import { initGame, loaded, delta } from "../../reducers/Game";
 import { isResumedGame } from "../../SaveGame";
@@ -47,8 +47,11 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
         return alert("Unknown scenario ID " + game.scenarioId);
       }
       // A resumed game keeps the location it was saved with, so the weather CSV that gets loaded
-      // is the one its forecasts were built from
-      const location = resumed ? game.location : LOCATIONS[scenario.locationId];
+      // is the one its forecasts were built from. A replay is the same story: startReplay put
+      // the location the run was recorded in on the slice, which is the only thing that keeps a
+      // replay from being re-simulated somewhere else
+      const location =
+        resumed || replaying ? game.location : getScenarioLocation(scenario);
       if (!location) {
         return alert("Unknown location ID " + scenario.locationId);
       }

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -16,7 +16,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutlineOutlined";
 import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import { getPlayedScenarioIds } from "../../LocalStorage";
-import { LOCATIONS } from "../../Constants";
+import { getScenarioLocation } from "../../helpers/Locations";
 import {
   CUSTOM_SCENARIO_ID,
   DEFAULT_CUSTOM_SCENARIO,
@@ -95,9 +95,7 @@ interface ScenarioListItemProps {
 
 function ScenarioListItem(props: ScenarioListItemProps): React.JSX.Element {
   const { s, onSelect } = props;
-  const location = LOCATIONS[s.locationId] || {
-    name: "UNKNOWN",
-  };
+  const location = getScenarioLocation(s) || { name: "UNKNOWN" };
   const summary =
     s.id === CUSTOM_SCENARIO_ID ? (
       s.summary

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -34,9 +34,10 @@ import InfoIcon from "@mui/icons-material/Info";
 import PlayCircleIcon from "@mui/icons-material/PlayCircleOutlined";
 import CircularProgress from "@mui/material/CircularProgress";
 import VictoryConditions from "../base/VictoryConditions";
-import { DIFFICULTIES, LOCATIONS } from "../../Constants";
+import { DIFFICULTIES } from "../../Constants";
 import { getDb, login } from "../../Globals";
 import { getScenario } from "../../data/Scenarios";
+import { getScenarioLocation } from "../../helpers/Locations";
 import { decodeReplay } from "../../Replay";
 import {
   DifficultyType,
@@ -81,7 +82,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
       getScenario(props.game.scenarioId, props.game.customScenario) || null;
     this.state = {
       scenario,
-      location: scenario ? LOCATIONS[scenario.locationId || null] : null,
+      location: getScenarioLocation(scenario) || null,
     };
     if (props.uid) {
       this.loadScores(props.uid);

--- a/src/data/FuelPrices.test.tsx
+++ b/src/data/FuelPrices.test.tsx
@@ -1,12 +1,89 @@
-import { getFuelPricesPerMBTU, initFuelPricesFromCsv } from "./FuelPrices";
+import {
+  getFuelEscalation,
+  getFuelPricesPerMBTU,
+  initFuelPricesFromCsv,
+  LATEST_DATA_YEAR,
+  TREND_ESCALATION_YEARLY,
+} from "./FuelPrices";
 import { getDateFromMinute } from "../helpers/DateTime";
 import { FuelPricesType } from "../Types";
 
 const FIXTURE_STARTING_YEAR = 2000;
-const FIXTURE_ENDING_YEAR = 2001;
+const FIXTURE_YEARS = 20;
+const FIXTURE_ENDING_YEAR = FIXTURE_STARTING_YEAR + FIXTURE_YEARS - 1;
 const SEED = 1;
 
+// What each fuel costs in the fixture's first month, and how far it wobbles around its own trend
+// across the record, in log terms. Deliberately different per fuel: the projection measures each
+// fuel's spread from its own history rather than sharing one number, the way the real coal series
+// sits within 20% of its trend while oil swings by half again.
+interface FixtureFuelType {
+  column: string;
+  name: string;
+  base: number;
+  trendYearly: number;
+  swing: number;
+}
+const FIXTURE_FUELS: FixtureFuelType[] = [
+  { column: "coal", name: "Coal", base: 2, trendYearly: 0.03, swing: 0.2 },
+  {
+    column: "naturalgas",
+    name: "Natural Gas",
+    base: 3,
+    trendYearly: 0.02,
+    swing: 0.25,
+  },
+  {
+    column: "uranium",
+    name: "Uranium",
+    base: 0.7,
+    trendYearly: 0.02,
+    swing: 0.5,
+  },
+  { column: "oil", name: "Oil", base: 10, trendYearly: 0.035, swing: 0.45 },
+];
+const COAL = FIXTURE_FUELS[0];
+const NATURAL_GAS = FIXTURE_FUELS[1];
+
+// A trend with a slow cycle riding on it, which is the shape a fuel price actually has -- and,
+// unlike the flat series this fixture used to be, something the projection can measure a spread
+// and a reversion speed from. Five year period, so twenty years holds four full cycles.
+const CYCLE_MONTHS = 60;
+function fixturePrice(fuel: FixtureFuelType, monthsIn: number): number {
+  return (
+    fuel.base *
+    Math.pow(1 + fuel.trendYearly, monthsIn / 12) *
+    Math.exp(fuel.swing * Math.sin((2 * Math.PI * monthsIn) / CYCLE_MONTHS))
+  );
+}
+
 function fixtureCsv(): string {
+  const rows = ["year,month,naturalgas,coal,uranium,oil"];
+  for (let year = FIXTURE_STARTING_YEAR; year <= FIXTURE_ENDING_YEAR; year++) {
+    for (let month = 1; month <= 12; month++) {
+      const monthsIn = (year - FIXTURE_STARTING_YEAR) * 12 + (month - 1);
+      const by = (column: string) =>
+        fixturePrice(
+          FIXTURE_FUELS.find((f: FixtureFuelType) => f.column === column)!,
+          monthsIn,
+        ).toFixed(6);
+      rows.push(
+        [
+          year,
+          month,
+          by("naturalgas"),
+          by("coal"),
+          by("uranium"),
+          by("oil"),
+        ].join(","),
+      );
+    }
+  }
+  return rows.join("\n");
+}
+
+// A flat record, for the degenerate case: a fuel that never moved has no spread to reproduce
+function flatCsv(): string {
   const rows = ["year,month,naturalgas,coal,uranium,oil"];
   for (let year = FIXTURE_STARTING_YEAR; year <= FIXTURE_ENDING_YEAR; year++) {
     for (let month = 1; month <= 12; month++) {
@@ -22,8 +99,24 @@ function dateIn(year: number, month: number) {
   return getDateFromMinute(minute, FIXTURE_STARTING_YEAR);
 }
 
-function pricesIn(year: number, month: number): FuelPricesType {
-  return getFuelPricesPerMBTU(dateIn(year, month), SEED);
+function pricesIn(year: number, month: number, seed = SEED): FuelPricesType {
+  return getFuelPricesPerMBTU(dateIn(year, month), seed);
+}
+
+/**
+ * The level the projection ties a fuel to in a given year: the last recorded year's average,
+ * escalated from there. Worked out from the fixture rather than read back out of the module, so
+ * that these tests would notice the module changing its mind about either half of it.
+ */
+function trendPriceIn(fuel: FixtureFuelType, year: number): number {
+  let recorded = 0;
+  for (let month = 0; month < 12; month++) {
+    recorded += fixturePrice(fuel, (FIXTURE_YEARS - 1) * 12 + month);
+  }
+  return (
+    (recorded / 12) *
+    Math.pow(1 + TREND_ESCALATION_YEARLY, year - FIXTURE_ENDING_YEAR)
+  );
 }
 
 describe("getFuelPricesPerMBTU", () => {
@@ -32,11 +125,9 @@ describe("getFuelPricesPerMBTU", () => {
   });
 
   it("returns the loaded prices for a year the data covers", () => {
-    expect(pricesIn(FIXTURE_STARTING_YEAR, 6)).toEqual({
-      "Natural Gas": 3,
-      Coal: 2,
-      Uranium: 0.7,
-      Oil: 10,
+    const prices = pricesIn(FIXTURE_STARTING_YEAR, 6);
+    FIXTURE_FUELS.forEach((fuel: FixtureFuelType) => {
+      expect(prices[fuel.name]).toBeCloseTo(fixturePrice(fuel, 5), 5);
     });
   });
 
@@ -65,11 +156,7 @@ describe("getFuelPricesPerMBTU", () => {
   it("projects different prices for a different seed", () => {
     const first = { ...pricesIn(FIXTURE_ENDING_YEAR + 1, 6) };
     initFuelPricesFromCsv(fixtureCsv());
-    const second = getFuelPricesPerMBTU(
-      dateIn(FIXTURE_ENDING_YEAR + 1, 6),
-      SEED + 1,
-    );
-    expect(second).not.toEqual(first);
+    expect(pricesIn(FIXTURE_ENDING_YEAR + 1, 6, SEED + 1)).not.toEqual(first);
   });
 
   it("explains itself rather than hanging when nothing has been loaded", () => {
@@ -77,5 +164,131 @@ describe("getFuelPricesPerMBTU", () => {
     expect(() => pricesIn(FIXTURE_STARTING_YEAR, 1)).toThrow(
       /No fuel prices loaded/,
     );
+  });
+
+  // The projection carries the last recorded month's departure from trend forward rather than
+  // restarting at the trend, so the handoff out of the data is a month's move, not a step change
+  it("picks up where the record left off rather than jumping", () => {
+    const last = pricesIn(FIXTURE_ENDING_YEAR, 12);
+    const first = pricesIn(FIXTURE_ENDING_YEAR + 1, 1);
+    FIXTURE_FUELS.forEach((fuel: FixtureFuelType) => {
+      expect(first[fuel.name] / last[fuel.name]).toBeGreaterThan(0.75);
+      expect(first[fuel.name] / last[fuel.name]).toBeLessThan(1.35);
+    });
+  });
+
+  /**
+   * The reason any of this exists. The projection used to be an unbounded multiplicative random
+   * walk, so its spread grew with the square root of the horizon: tolerable over the twenty years
+   * a game could once cover, and nonsense over the two hundred it now can, where one seed left
+   * natural gas at three cents per MBTU -- free fuel -- for the rest of the run. Tied to a trend,
+   * the spread settles instead of growing.
+   */
+  describe("mean reversion", () => {
+    const SEEDS = Array.from(
+      { length: 40 },
+      (_v: unknown, i: number) => i * 7919 + 3,
+    );
+
+    it("holds every fuel near its trend two centuries out", () => {
+      SEEDS.slice(0, 12).forEach((seed: number) => {
+        initFuelPricesFromCsv(fixtureCsv());
+        const year = FIXTURE_ENDING_YEAR + 200;
+        const prices = pricesIn(year, 6, seed);
+        FIXTURE_FUELS.forEach((fuel: FixtureFuelType) => {
+          // Clamped at three standard deviations of each fuel's own recorded spread, so how far
+          // a fuel may ever sit from its trend is a property of its history rather than a
+          // constant, and a calm fuel stays calm
+          const ratio = prices[fuel.name] / trendPriceIn(fuel, year);
+          expect(ratio).toBeGreaterThan(Math.exp(-3 * fuel.swing));
+          expect(ratio).toBeLessThan(Math.exp(3 * fuel.swing));
+        });
+      });
+    });
+
+    it("does not widen as the horizon grows, the way a random walk does", () => {
+      const spreadAt = (year: number) => {
+        const departures = SEEDS.map((seed: number) => {
+          initFuelPricesFromCsv(fixtureCsv());
+          return Math.log(
+            pricesIn(year, 6, seed)[NATURAL_GAS.name] /
+              trendPriceIn(NATURAL_GAS, year),
+          );
+        });
+        const mean = departures.reduce((a, b) => a + b, 0) / departures.length;
+        return Math.sqrt(
+          departures.reduce((a, b) => a + Math.pow(b - mean, 2), 0) /
+            departures.length,
+        );
+      };
+
+      // A random walk's spread would grow like the square root of the horizon -- nearly
+      // threefold across this gap. Settling means the far one is no wider than the near one.
+      const near = spreadAt(FIXTURE_ENDING_YEAR + 25);
+      const far = spreadAt(FIXTURE_ENDING_YEAR + 200);
+      expect(far).toBeLessThan(near * 1.6);
+      expect(far).toBeLessThan(2 * NATURAL_GAS.swing);
+    });
+
+    it("escalates the trend it reverts to by TREND_ESCALATION_YEARLY", () => {
+      const years = 60;
+      const year = FIXTURE_ENDING_YEAR + years;
+      // Averaged across seeds the departure comes out at zero, which leaves the escalation alone
+      const departures = SEEDS.map((seed: number) => {
+        initFuelPricesFromCsv(fixtureCsv());
+        return Math.log(
+          pricesIn(year, 6, seed)[COAL.name] / trendPriceIn(COAL, year),
+        );
+      });
+      const meanDeparture =
+        departures.reduce((a, b) => a + b, 0) / departures.length;
+      const impliedYearly =
+        Math.exp(
+          Math.log(1 + TREND_ESCALATION_YEARLY) + meanDeparture / years,
+        ) - 1;
+      expect(impliedYearly).toBeCloseTo(TREND_ESCALATION_YEARLY, 2);
+    });
+
+    // Documents the degenerate case rather than leaving it to be found: a fuel whose record never
+    // moves has no spread to reproduce, so it rides its trend exactly
+    it("holds a fuel with no recorded variation on its trend", () => {
+      initFuelPricesFromCsv(flatCsv());
+      const year = FIXTURE_ENDING_YEAR + 30;
+      expect(pricesIn(year, 12)[COAL.name]).toBeCloseTo(
+        2 * Math.pow(1 + TREND_ESCALATION_YEARLY, year - FIXTURE_ENDING_YEAR),
+        4,
+      );
+    });
+  });
+});
+
+/**
+ * What the custom game screen re-quotes its rates and fees with. Fuel is the only price the game
+ * reads at face value for the year it is in -- build costs and O&M are anchored on whatever year
+ * a game starts -- so without this a game started deep in the projection is unwinnable before the
+ * player touches anything.
+ */
+describe("getFuelEscalation", () => {
+  it("is flat across the years the data actually covers", () => {
+    expect(getFuelEscalation(LATEST_DATA_YEAR)).toBe(1);
+    expect(getFuelEscalation(1980)).toBe(1);
+  });
+
+  it("compounds at TREND_ESCALATION_YEARLY past the end of the data", () => {
+    expect(getFuelEscalation(LATEST_DATA_YEAR + 1)).toBeCloseTo(
+      1 + TREND_ESCALATION_YEARLY,
+      10,
+    );
+    expect(getFuelEscalation(LATEST_DATA_YEAR + 50)).toBeCloseTo(
+      Math.pow(1 + TREND_ESCALATION_YEARLY, 50),
+      10,
+    );
+  });
+
+  // The number the rate picker leans on: a game starting sixty years past the record is played
+  // against fuel an order of magnitude dearer, so its rates have to be an order of magnitude up
+  it("puts a 2080 start an order of magnitude above the record", () => {
+    expect(getFuelEscalation(2080)).toBeGreaterThan(9);
+    expect(getFuelEscalation(2080)).toBeLessThan(12);
   });
 });

--- a/src/data/FuelPrices.tsx
+++ b/src/data/FuelPrices.tsx
@@ -1,7 +1,6 @@
 import Papa from "papaparse";
-import { INFLATION } from "../Constants";
 import { DateType, FuelPricesType } from "../Types";
-import { getRandomRangeAt, RANDOM_STREAM } from "../helpers/Math";
+import { normalAt, RANDOM_STREAM } from "../helpers/Math";
 
 // GOOGLE SHEET: https://docs.google.com/spreadsheets/d/1IFc_5NOuU-y0pJGml1IBd2HlKV8unhgIpnhZQmsMCs4/edit#gid=0
 // Sources: (all prices real / in that year's $'s, per million BTU)
@@ -21,9 +20,52 @@ import { getRandomRangeAt, RANDOM_STREAM } from "../helpers/Math";
 // loaded, rather than that the game is being played in the 1970s.
 const EARLIEST_DATA_YEAR = 1975;
 
+// The last year in it. Mirrored as a constant rather than read off the loaded table for the same
+// reason EARLIEST_DATA_YEAR is: the new game screens have to price an era before any CSV has been
+// downloaded. buildFuelTrends uses the real latest year from the data; this only has to agree
+// with it closely enough to quote a retail rate in the right ballpark.
+export const LATEST_DATA_YEAR = 2019;
+
 // Fixed so that each fuel always draws from the same slot of the fuel stream, whatever order
 // the CSV's columns happen to arrive in
 const FUEL_KEYS = ["Natural Gas", "Coal", "Uranium", "Oil"];
+
+// How fast the trend a projected price is tied to climbs, in that year's dollars. The recorded
+// series run between 1.8%/yr (natural gas) and 3.6%/yr (oil) across 1975-2019, so this sits just
+// above the top of the range the data supports: fuel gets steadily dearer in real terms against
+// the ~2.5-3% the economy inflates build and O&M costs at, and a long game is a slow squeeze on
+// anything that burns something rather than a coin flip about whether fuel ends up free.
+export const TREND_ESCALATION_YEARLY = 0.04;
+
+// How much of last month's departure from that trend carries into this month's, and how far it is
+// allowed to sit from the trend. Both are measured off the record rather than written down here;
+// these are the bounds that keep a pathological series (one that never moves, or one the linear
+// fit describes badly) from producing a persistence of 1 -- which is the unbounded random walk
+// this replaced -- or of 0, which would be white noise pinned to the trend.
+const MIN_PERSISTENCE = 0.9;
+const MAX_PERSISTENCE = 0.9995;
+// Nothing may sit more than this many standard deviations from its trend. The departure is a
+// normal draw, so it has no natural ceiling, and one draw in a few thousand is worth clamping
+// when the run is two centuries long and the result is multiplied by the anchor.
+const MAX_DEPARTURE_SDS = 3;
+
+/**
+ * What one fuel's recorded prices say about how it behaves: where its trend starts, how far from
+ * that trend it wanders, and how long it takes to come back.
+ *
+ * Derived from the CSV at load rather than written per fuel, for the same reason the weather's
+ * climatology is derived from each location's own forty years -- coal is a slow, smooth series
+ * that sits within 20% of its trend for decades, while oil swings by a factor of two and mean
+ * reverts within about four years, and nothing here has to know which is which.
+ */
+interface DepartureType {
+  persistence: number; // Fraction of last month's log departure kept, 0 - 1
+  departureSd: number; // Log space, the spread the record actually shows around its own trend
+  shockSd: number; // Log space, the monthly draw that sustains exactly that spread
+}
+interface FuelTrendType extends DepartureType {
+  baseline: number; // $/MBTU the trend passes through, in the anchor month
+}
 
 interface RawFuelPricesType {
   month: number;
@@ -49,12 +91,164 @@ export function hasFuelPrices(): boolean {
   return Object.keys(fuelPrices).length > 0;
 }
 
+// One entry per fuel, rebuilt from the record on each load, and the absolute month its baseline
+// is quoted at. Empty until a CSV has been read, which is also when the projection is first asked
+// for anything.
+const fuelTrends: Record<string, FuelTrendType> = {};
+let anchorMonth = 0;
+
+// A contiguous month index, so that December of one year and January of the next are one apart.
+// Both the anchor and the projection walk in this space.
+function absoluteMonth(year: number, month: number): number {
+  return year * 12 + month;
+}
+
 // Emptied in place rather than reassigned so that the closure in projectYear keeps referring to
 // a const, which no-loop-func requires
 function resetFuelPrices() {
   Object.keys(fuelPrices).forEach((year: string) => {
     delete fuelPrices[+year];
   });
+  Object.keys(fuelTrends).forEach((fuel: string) => {
+    delete fuelTrends[fuel];
+  });
+  anchorMonth = 0;
+}
+
+/** Every recorded month for one fuel, oldest first. Only ever run over real rows. */
+function recordedPrices(fuel: string, years: number[]): number[] {
+  const prices: number[] = [];
+  years.forEach((year: number) => {
+    for (let month = 1; month <= 12; month++) {
+      const price = fuelPrices[year][month]?.[fuel];
+      if (price !== undefined && price > 0) {
+        prices.push(price);
+      }
+    }
+  });
+  return prices;
+}
+
+// A fuel whose record gives the projection nothing to wander with: it rides its trend exactly.
+// Not the same as having no trend at all -- the escalation applies to every fuel that was ever
+// recorded, and only the departure from it is measured.
+const NO_DEPARTURE = { persistence: 0, departureSd: 0, shockSd: 0 };
+
+/**
+ * Reduces one fuel's record to the three numbers that describe how it departs from its own trend.
+ *
+ * Everything is done on logs, because a fuel price is a multiplicative thing: $9 oil moving to
+ * $18 and $2 gas moving to $4 are the same event, and only in log space does one set of constants
+ * describe both. A straight line is fitted through those logs -- the fuel's own trend -- and what
+ * is left over is the departure the projection has to reproduce: how wide it sits (its standard
+ * deviation) and how quickly it closes (recovered from the size of a typical month to month step,
+ * since for this process a step's variance is 2(1 - persistence) times the departure's).
+ */
+function measureDeparture(prices: number[]): DepartureType {
+  const n = prices.length;
+  if (n < 24) {
+    return NO_DEPARTURE; // Too little to fit a trend through, let alone measure a spread around one
+  }
+  const logs = prices.map(Math.log);
+  const meanIndex = (n - 1) / 2;
+  const meanLog = logs.reduce((a, b) => a + b, 0) / n;
+  let covariance = 0;
+  let variance = 0;
+  for (let i = 0; i < n; i++) {
+    covariance += (i - meanIndex) * (logs[i] - meanLog);
+    variance += Math.pow(i - meanIndex, 2);
+  }
+  const slope = covariance / variance;
+
+  let departureSquares = 0;
+  for (let i = 0; i < n; i++) {
+    departureSquares += Math.pow(
+      logs[i] - (meanLog + slope * (i - meanIndex)),
+      2,
+    );
+  }
+  const departureSd = Math.sqrt(departureSquares / n);
+
+  // The month to month step, with the trend's own slope taken out of it
+  let stepSquares = 0;
+  for (let i = 1; i < n; i++) {
+    stepSquares += Math.pow(logs[i] - logs[i - 1] - slope, 2);
+  }
+  const stepSd = Math.sqrt(stepSquares / (n - 1));
+  if (departureSd <= 0 || stepSd <= 0) {
+    return NO_DEPARTURE; // A series that never moves has no spread to reproduce
+  }
+
+  const persistence = Math.min(
+    MAX_PERSISTENCE,
+    Math.max(
+      MIN_PERSISTENCE,
+      1 - Math.pow(stepSd, 2) / (2 * Math.pow(departureSd, 2)),
+    ),
+  );
+  return {
+    persistence,
+    departureSd,
+    // Sized so the departure settles at exactly the spread the record shows rather than growing
+    // with the horizon -- the same relationship the weather's anomaly walk uses
+    shockSd: departureSd * Math.sqrt(1 - Math.pow(persistence, 2)),
+  };
+}
+
+/**
+ * Builds the per fuel trends from whatever was just loaded. Has to run before anything is
+ * projected, and while fuelPrices still holds only real rows.
+ */
+function buildFuelTrends() {
+  const years = Object.keys(fuelPrices)
+    .map(Number)
+    .sort((a, b) => a - b);
+  if (years.length === 0) {
+    return;
+  }
+  const latestYear = years[years.length - 1];
+  anchorMonth = absoluteMonth(latestYear, 12);
+
+  FUEL_KEYS.forEach((fuel: string) => {
+    const prices = recordedPrices(fuel, years);
+    if (prices.length === 0) {
+      return; // A fuel the CSV never carried. Nothing to escalate, nothing to project.
+    }
+    // The trend passes through the last recorded year's average price rather than through its
+    // December, so a single volatile month doesn't set the level for the next two centuries
+    const lastYear = recordedPrices(fuel, [latestYear]);
+    fuelTrends[fuel] = {
+      baseline:
+        lastYear.length > 0
+          ? lastYear.reduce((a, b) => a + b, 0) / lastYear.length
+          : prices[prices.length - 1],
+      ...measureDeparture(prices),
+    };
+  });
+}
+
+/**
+ * How much dearer fuel is in a given year than at the end of the record, on the trend alone.
+ *
+ * Fuel is the one price in the game quoted in the year's own money: build costs and O&M are
+ * anchored on whatever year a game starts in, so they open at exactly what the tables say, but a
+ * game starting in 2080 opens against fuel that has escalated for sixty years. The retail rate it
+ * is played at has to be quoted in that same money, or the run is bankrupt in its first quarter -
+ * which is what the custom game screen uses this for.
+ */
+export function getFuelEscalation(year: number): number {
+  return Math.pow(
+    1 + TREND_ESCALATION_YEARLY,
+    Math.max(0, year - LATEST_DATA_YEAR),
+  );
+}
+
+/** What a fuel costs on its trend in a given month, before any departure from it. */
+function anchorPrice(trend: FuelTrendType, month: number): number {
+  return (
+    trend.baseline *
+    Math.pow(1 + TREND_ESCALATION_YEARLY, (month - anchorMonth) / 12)
+  );
 }
 
 function collectFuelPriceRow(row: Papa.ParseStepResult<RawFuelPricesType>) {
@@ -77,6 +271,8 @@ export function initFuelPrices(callback?: () => void) {
     // worker: true,
     step: collectFuelPriceRow,
     complete() {
+      // Has to run before anything is projected, and while the table holds only real rows
+      buildFuelTrends();
       if (callback) {
         callback();
       }
@@ -97,12 +293,23 @@ export function initFuelPricesFromCsv(csv: string) {
     header: true,
     step: collectFuelPriceRow,
   });
+  buildFuelTrends();
 }
 
 /**
  * Extrapolates one year of prices from the previous December, walking each fuel forward month by
  * month. Each fuel draws from its own slot in the year's slice of the fuel stream, so a year comes
  * out the same whenever it is generated and however many years were generated before it.
+ *
+ * Each fuel is tied to a trend rising at TREND_ESCALATION_YEARLY and wanders around it: last
+ * month's departure is kept in part, shed in part, and shocked. What that buys is a spread that
+ * settles rather than grows. The multiplicative random walk this replaced had no anchor at all,
+ * so its spread widened with the square root of the horizon -- tolerable across the twenty years
+ * a game used to be able to cover, and nonsense across two hundred, where it put natural gas at
+ * three cents per MBTU and left the fuel free.
+ *
+ * The departure is read back off the previous month's price rather than carried alongside it, so
+ * this stays what it always was: a pure function of the seed and the December it starts from.
  */
 function projectYear(
   seed: number,
@@ -113,20 +320,26 @@ function projectYear(
   let previous = startingPrices;
   for (let month = 1; month <= 12; month++) {
     const prices = { ...previous };
-    const draw = (year * 12 + month) * FUEL_KEYS.length;
+    const thisMonth = absoluteMonth(year, month);
+    const draw = thisMonth * FUEL_KEYS.length;
     FUEL_KEYS.forEach((fuel: string, fuelIndex: number) => {
-      if (prices[fuel] === undefined) {
-        return;
+      const trend = fuelTrends[fuel];
+      if (prices[fuel] === undefined || !trend) {
+        return; // A fuel the CSV never carried, or one with no measurable trend, is held flat
       }
-      prices[fuel] *=
-        1 +
-        getRandomRangeAt(
-          seed,
-          RANDOM_STREAM.fuelPrices,
-          draw + fuelIndex,
-          -0.06,
-          0.06 + INFLATION / 12,
-        );
+      // A fuel the record shows sitting still has nothing to carry and nothing to shock, so it
+      // rides the trend exactly rather than being frozen at its last recorded price
+      const previousDeparture = trend.departureSd
+        ? Math.log(prices[fuel] / anchorPrice(trend, thisMonth - 1))
+        : 0;
+      const departure =
+        trend.persistence * previousDeparture +
+        trend.shockSd *
+          normalAt(seed, RANDOM_STREAM.fuelPrices, draw + fuelIndex);
+      const limit = MAX_DEPARTURE_SDS * trend.departureSd;
+      prices[fuel] =
+        anchorPrice(trend, thisMonth) *
+        Math.exp(Math.min(limit, Math.max(-limit, departure)));
     });
     fuelPrices[year][month] = prices;
     previous = prices;

--- a/src/data/Weather.test.tsx
+++ b/src/data/Weather.test.tsx
@@ -1,4 +1,8 @@
-import { getWeather, initWeatherFromCsv } from "./Weather";
+import {
+  getWeather,
+  initWeatherFromCsv,
+  WEATHER_STARTING_YEAR,
+} from "./Weather";
 import { getDateFromMinute } from "../helpers/DateTime";
 
 // Weather rows are looked up by position, one row per hour, with DAYS_PER_MONTH = 1 -- so a
@@ -183,6 +187,21 @@ describe("getWeather", () => {
     expect(Number.isFinite(forecast.WIND_KPH)).toBe(true);
     expect(Number.isFinite(forecast.YEAR)).toBe(true);
     expect(Number.isFinite(forecast.MONTH)).toBe(true);
+  });
+
+  // The custom game screen builds its year list off WEATHER_STARTING_YEAR, so a date before the
+  // record can only arrive from a hand-edited save or an older scenario. Pinned here because
+  // opening the timeline makes the year a thing players choose: it has to come back as an empty
+  // reading rather than reaching into the arrays at a negative index.
+  it("survives a date before the data starts", () => {
+    const before = getWeather(dateAt(-24, 8), SEED, 100);
+    expect(Number.isFinite(before.TEMP_C)).toBe(true);
+    expect(Number.isFinite(before.CLOUD_PCT)).toBe(true);
+    expect(Number.isFinite(before.WIND_KPH)).toBe(true);
+  });
+
+  it("starts the record at the year the custom game screen offers as its floor", () => {
+    expect(WEATHER_STARTING_YEAR).toBe(FIXTURE_STARTING_YEAR);
   });
 
   // The bug this replaced: forecasting filled a single day per cache miss, so a lookup years past

--- a/src/data/Weather.tsx
+++ b/src/data/Weather.tsx
@@ -2,9 +2,14 @@ import { DAYS_PER_MONTH, DAYS_PER_YEAR, EQUATOR_RADIANCE } from "../Constants";
 import { DateType, LocationType, RawWeatherType } from "../Types";
 import { normalAt, randomAt, RANDOM_STREAM } from "../helpers/Math";
 import { getSunriseSunset } from "../helpers/DateTime";
+import { isValidLocationId } from "../helpers/Locations";
 import Papa from "papaparse";
 
-const STARTING_YEAR = 1980; // for weather data, Jan 1st, assumed to be the same for all locations
+// The first year any location has data for, Jan 1st. Everything after the recorded years is
+// forecast indefinitely, but nothing exists to run backwards from, so this is the floor on when a
+// game may start -- which is why the custom game screen builds its year list off it.
+export const WEATHER_STARTING_YEAR = 1980;
+const STARTING_YEAR = WEATHER_STARTING_YEAR; // assumed to be the same for all locations
 const ENDING_YEAR = 2019; // for weather data, Dec 31st, assumed to be the same for all locations
 const ROWS_PER_DAY = 24;
 const ROWS_PER_YEAR = DAYS_PER_YEAR * ROWS_PER_DAY;
@@ -172,6 +177,17 @@ function warnIfWeatherIncomplete(location: string) {
 
 export function initWeather(location: string, callback?: () => void) {
   weather = []; // reset each time to prevent accidentally appending to old state
+  if (!isValidLocationId(location)) {
+    // A location id is now any string rather than a checked union, and it arrives here from a
+    // saved game or a replay document on its way into a URL
+    console.error(
+      `Refusing to load weather for invalid location id "${location}"`,
+    );
+    if (callback) {
+      callback();
+    }
+    return;
+  }
   Papa.parse<RawWeatherType>(`/data/WeatherRaw${location}.csv`, {
     download: true,
     dynamicTyping: true,

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -306,7 +306,7 @@ export function getSunriseSunset(
   );
 
   // suncalc returns null above the polar circles, where the sun may never rise or never set
-  // on a given day. None of the four locations the game ships get anywhere near that, so
+  // on a given day. None of the locations the game ships get anywhere near that, so
   // these fallbacks are only here to keep a hypothetical high-latitude location from
   // crashing the simulation
   const minuteOfDay = (d: Date | null, fallback: number) =>

--- a/src/helpers/Locations.test.tsx
+++ b/src/helpers/Locations.test.tsx
@@ -1,0 +1,109 @@
+import { LOCATIONS } from "../Constants";
+import {
+  getLocation,
+  getScenarioLocation,
+  isValidLocation,
+  isValidLocationId,
+} from "./Locations";
+import { LocationType, ScenarioType } from "../Types";
+
+const ELSEWHERE: LocationType = {
+  id: "REY",
+  name: "Reykjavik, Iceland",
+  lat: 64.1466,
+  long: -21.9426,
+  timeZone: "Atlantic/Reykjavik",
+};
+
+function aScenario(overrides: Partial<ScenarioType> = {}): ScenarioType {
+  return {
+    id: 1,
+    name: "Test",
+    icon: "battery",
+    locationId: "SF",
+    ownership: "Investor",
+    startingYear: 2020,
+    cash: 1,
+    dollarsPerkWh: 0.07,
+    durationMonths: 12,
+    feePerKgCO2e: 0,
+    facilities: [],
+    ...overrides,
+  } as ScenarioType;
+}
+
+describe("getLocation", () => {
+  it("resolves a shipped location", () => {
+    expect(getLocation("PIT")).toBe(LOCATIONS.PIT);
+  });
+
+  it("returns undefined rather than a bogus object for an unknown id", () => {
+    expect(getLocation("NOWHERE")).toBeUndefined();
+    expect(getLocation(undefined)).toBeUndefined();
+    expect(getLocation(null)).toBeUndefined();
+  });
+
+  it("ships the two locations whose data was already in the repo", () => {
+    expect(getLocation("LA")?.name).toContain("Los Angeles");
+    expect(getLocation("CAMountains")?.lat).toBeGreaterThan(30);
+  });
+
+  it("gives every shipped location an id matching its key and a valid position", () => {
+    Object.keys(LOCATIONS).forEach((key: string) => {
+      const location = LOCATIONS[key];
+      expect(location.id).toBe(key);
+      expect(isValidLocation(location)).toBe(true);
+    });
+  });
+});
+
+describe("getScenarioLocation", () => {
+  it("looks an id up when that's all the scenario carries", () => {
+    expect(getScenarioLocation(aScenario())).toBe(LOCATIONS.SF);
+  });
+
+  it("prefers a full location, so a custom game can be played somewhere unlisted", () => {
+    const scenario = aScenario({ locationId: "SF", location: ELSEWHERE });
+    expect(getScenarioLocation(scenario)).toBe(ELSEWHERE);
+  });
+
+  it("returns undefined for an unknown id and for no scenario at all", () => {
+    expect(
+      getScenarioLocation(aScenario({ locationId: "XXX" })),
+    ).toBeUndefined();
+    expect(getScenarioLocation(undefined)).toBeUndefined();
+  });
+});
+
+describe("isValidLocationId", () => {
+  it("accepts the ids the game ships", () => {
+    Object.keys(LOCATIONS).forEach((id: string) =>
+      expect(isValidLocationId(id)).toBe(true),
+    );
+  });
+
+  it("rejects anything that could escape the weather data directory", () => {
+    expect(isValidLocationId("../../../etc/passwd")).toBe(false);
+    expect(isValidLocationId("SF/../PIT")).toBe(false);
+    expect(isValidLocationId("SF?x=1")).toBe(false);
+    expect(isValidLocationId("")).toBe(false);
+    expect(isValidLocationId("x".repeat(33))).toBe(false);
+    expect(isValidLocationId(7)).toBe(false);
+  });
+});
+
+describe("isValidLocation", () => {
+  it("accepts a well formed location", () => {
+    expect(isValidLocation(ELSEWHERE)).toBe(true);
+  });
+
+  it("rejects blobs that aren't one", () => {
+    expect(isValidLocation(null)).toBe(false);
+    expect(isValidLocation("SF")).toBe(false);
+    expect(isValidLocation({ ...ELSEWHERE, id: "../SF" })).toBe(false);
+    expect(isValidLocation({ ...ELSEWHERE, lat: 91 })).toBe(false);
+    expect(isValidLocation({ ...ELSEWHERE, long: -181 })).toBe(false);
+    expect(isValidLocation({ ...ELSEWHERE, lat: NaN })).toBe(false);
+    expect(isValidLocation({ ...ELSEWHERE, timeZone: 5 })).toBe(false);
+  });
+});

--- a/src/helpers/Locations.tsx
+++ b/src/helpers/Locations.tsx
@@ -1,0 +1,63 @@
+import { LOCATIONS } from "../Constants";
+import { LocationIdType, LocationType, ScenarioType } from "../Types";
+
+/**
+ * Turning a location id into a location, in one place.
+ *
+ * LocationIdType used to be a four-string union, so `LOCATIONS[id]` was total and every caller
+ * indexed it directly. Now that a location can be anything - including one a custom game carries
+ * that no table has ever heard of - a bare index is a lie about what came back, and there are
+ * two different questions being asked: "which of the places we ship is this?" (getLocation) and
+ * "where is this scenario played?" (getScenarioLocation), which are no longer the same question.
+ */
+export function getLocation(
+  id: LocationIdType | undefined | null,
+): LocationType | undefined {
+  return id ? LOCATIONS[id] : undefined;
+}
+
+/**
+ * Where a scenario is played. A scenario that carries a full location wins over one that only
+ * names an id, so a custom game can hold somewhere LOCATIONS doesn't list.
+ */
+export function getScenarioLocation(
+  scenario: ScenarioType | undefined | null,
+): LocationType | undefined {
+  if (!scenario) {
+    return undefined;
+  }
+  return scenario.location || getLocation(scenario.locationId);
+}
+
+/**
+ * Whether an id is safe to build a weather file path out of.
+ *
+ * The id goes straight into `/data/WeatherRaw<id>.csv` (and into a filesystem path headless), and
+ * it now arrives from a saved game, a replay document or local storage rather than from a union
+ * the compiler checked - so `../` has to be ruled out before it gets there.
+ */
+export function isValidLocationId(id: unknown): id is LocationIdType {
+  return typeof id === "string" && /^[A-Za-z0-9_-]{1,32}$/.test(id);
+}
+
+/**
+ * Whether a blob is a usable location. Used on the way in from anywhere untrusted - a replay
+ * document, most of all, which is a stranger's JSON driving the real simulation.
+ */
+export function isValidLocation(value: unknown): value is LocationType {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const location = value as Partial<LocationType>;
+  return (
+    isValidLocationId(location.id) &&
+    typeof location.name === "string" &&
+    typeof location.lat === "number" &&
+    Number.isFinite(location.lat) &&
+    Math.abs(location.lat) <= 90 &&
+    typeof location.long === "number" &&
+    Number.isFinite(location.long) &&
+    Math.abs(location.long) <= 180 &&
+    typeof location.timeZone === "string"
+  );
+}

--- a/src/reducers/CustomGame.test.tsx
+++ b/src/reducers/CustomGame.test.tsx
@@ -137,6 +137,12 @@ describe("a custom game", () => {
         ...CUSTOM,
         startingYear: 2080,
         durationMonths: 12 * 5,
+        // Quoted in 2080 money, the way the custom game screen offers it. Fuel prices are the one
+        // thing the game reads at face value for the year it is in, so a 2080 game charging a
+        // literal ten cents a kilowatt hour against sixty years of escalated fuel is bankrupt in
+        // its first quarter -- which is what this test caught when the escalation went in.
+        dollarsPerkWh: 1.1,
+        feePerKgCO2e: 530 / 1000,
       } as ScenarioType,
     });
 

--- a/src/reducers/CustomGame.test.tsx
+++ b/src/reducers/CustomGame.test.tsx
@@ -1,8 +1,14 @@
+import { LOCATIONS } from "../Constants";
 import { CUSTOM_SCENARIO_ID, DEFAULT_CUSTOM_SCENARIO } from "../data/Scenarios";
 import { getTimeFromTimeline } from "../helpers/DateTime";
 import { getPlayedScenarioIds } from "../LocalStorage";
 import { createGame, runSimulation } from "../testing/Simulator";
-import { FacilityOperatingType, ScenarioType } from "../Types";
+import {
+  FacilityOperatingType,
+  LocationType,
+  MonthlyHistoryType,
+  ScenarioType,
+} from "../Types";
 
 // The settings a player might pick on the custom game screen, all different from both the slice
 // defaults and the first authored scenario, which is what a broken lookup falls back to
@@ -97,5 +103,50 @@ describe("a custom game", () => {
     // passing because nothing reaches the end
     runSimulation({ scenarioId: 4 }); // 104: Finances, also one month long
     expect(getPlayedScenarioIds()).toContain(4);
+  });
+
+  // The point of a scenario carrying a whole location rather than an id: a place the game has
+  // never shipped can still be played, so nothing downstream may quietly re-resolve the id
+  it("is played at the location it carries, not the one its id names", () => {
+    const UNLISTED: LocationType = {
+      // The id still picks the weather file, so this borrows one that exists; the rest of the
+      // fields are what a location outside LOCATIONS would bring with it
+      id: "SF",
+      name: "Somewhere Not In LOCATIONS",
+      lat: 12.3456,
+      long: 65.4321,
+      timeZone: "Etc/UTC",
+    };
+    const state = createGame({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: { ...CUSTOM, locationId: "PIT", location: UNLISTED },
+    });
+
+    expect(state.location).toEqual(UNLISTED);
+    expect(state.location.name).not.toBe(LOCATIONS.PIT.name);
+    expect(state.location.lat).toBe(12.3456);
+  });
+
+  // The weather data ends in 2019 and is forecast forwards from there, and the fuel prices are
+  // projected year by year, so a start decades past the record has to be simulated rather than
+  // read. Nothing before 1980 is offered, because there is nothing to project backwards from.
+  it("plays a start far past the end of the recorded data", () => {
+    const result = runSimulation({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: {
+        ...CUSTOM,
+        startingYear: 2080,
+        durationMonths: 12 * 5,
+      } as ScenarioType,
+    });
+
+    expect(result.months[0].year).toBe(2080);
+    expect(result.months[result.months.length - 1].year).toBe(2084);
+    expect(result.violationCount).toBe(0);
+    // Weather that was forecast rather than the zeroed DUMMY_WEATHER a missing row returns,
+    // which would flatten demand to the same number every month
+    const demands = result.months.map((m: MonthlyHistoryType) => m.demandWh);
+    expect(Math.min(...demands)).toBeGreaterThan(0);
+    expect(new Set(demands).size).toBe(demands.length);
   });
 });

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -339,8 +339,8 @@ export const gameSlice = createSlice({
     });
     /**
      * Sets a replay up to be watched. Nothing is simulated here: this only puts the scenario, the
-     * difficulty and the seed in place, then hands over to the loading screen, which reloads the
-     * data files and calls initGame the same way it does for a new game.
+     * location, the difficulty and the seed in place, then hands over to the loading screen, which
+     * reloads the data files and calls initGame the same way it does for a new game.
      */
     builder.addCase(startReplay, (_state, action) => {
       const replay = action.payload;
@@ -351,6 +351,9 @@ export const gameSlice = createSlice({
         scenarioId: replay.scenarioId,
         difficulty: replay.difficulty,
         seed: replay.seed,
+        // The loading screen reads this back rather than looking the scenario's location up,
+        // which is what makes the replay run against the weather the original player saw
+        location: cloneDeep(replay.location),
         replayPlayback: { actions: cloneDeep(replay.actions), index: 0 },
       };
     });

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1155,10 +1155,18 @@ function updateSupplyFacilitiesFinances(
           g.loanAmountLeft,
           g.interestRate,
         );
-        const paymentPrincipal = g.loanMonthlyPayment - paymentInterest;
+        // Never more principal than is actually outstanding. The last payment of a loan is a
+        // whole tick's worth against whatever fraction of it is left, so without the floor the
+        // balance settles a few dollars below zero and stays there for the rest of the run --
+        // which reads as the lender owing the player money, counts towards net worth, and trips
+        // the loan invariant on every tick from then on
+        const paymentPrincipal = Math.min(
+          (g.loanMonthlyPayment - paymentInterest) / TICKS_PER_MONTH,
+          g.loanAmountLeft,
+        );
         expensesInterest += paymentInterest / TICKS_PER_MONTH;
-        principalRepayment += paymentPrincipal / TICKS_PER_MONTH;
-        g.loanAmountLeft -= paymentPrincipal / TICKS_PER_MONTH;
+        principalRepayment += paymentPrincipal;
+        g.loanAmountLeft -= paymentPrincipal;
       }
     } else {
       expensesInterest +=

--- a/src/reducers/Replay.test.tsx
+++ b/src/reducers/Replay.test.tsx
@@ -116,6 +116,38 @@ describe("recording a run", () => {
     });
   });
 
+  /**
+   * A scenario id used to be enough to say where a run happened. It isn't any more -- a custom
+   * game carries its own location, and an authored one can be given one that isn't in LOCATIONS
+   * -- so the replay has to record it, and watching one has to read it back rather than looking
+   * the scenario up again. Without both halves a replay is re-simulated against another city's
+   * weather and stops matching the run it claims to be.
+   */
+  it("records where the run was played", () => {
+    const replay = serializeReplay(played)!;
+    expect(replay.location).toEqual(played.location);
+  });
+
+  it("is watched at the location it recorded, not the scenario's", () => {
+    const replay = roundTripped(serializeReplay(played)!);
+    const elsewhere = {
+      ...replay,
+      // Same weather file, so the run still loads; everything else is what a location outside
+      // LOCATIONS would bring, and none of it can come from a scenario lookup
+      location: {
+        id: replay.location.id,
+        name: "Somewhere Not In LOCATIONS",
+        lat: 12.3456,
+        long: 65.4321,
+        timeZone: "Etc/UTC",
+      },
+    };
+
+    expect(createGameFromReplay(elsewhere).location).toEqual(
+      elsewhere.location,
+    );
+  });
+
   it("stays small enough to hang off a high score", () => {
     // A whole save of the same run is hundreds of kilobytes; this is the reason replays are
     // stored as actions rather than as states

--- a/src/reducers/User.test.tsx
+++ b/src/reducers/User.test.tsx
@@ -1,5 +1,6 @@
 import userReducer, { submitHighscore } from "./User";
 import { MAX_REPLAY_BYTES, REPLAY_VERSION } from "../Replay";
+import { LOCATIONS } from "../Constants";
 import { ReplayType, UserType } from "../Types";
 
 const mockAddDoc = jest.fn();
@@ -24,6 +25,7 @@ function aReplay(overrides: Partial<ReplayType> = {}): ReplayType {
     difficulty: "Employee",
     seed: 12345,
     startingYear: 2020,
+    location: LOCATIONS.SF,
     durationMinutes: 43200,
     actions: [{ minute: 1440, type: "sellFacility", payload: 3 }],
     ...overrides,

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -28,6 +28,17 @@ which prints a month by month table (customers, demand, supplied, unserved, cash
 profit, emissions), totals for the run, the fleet it finished with, and any invariant violations.
 `npm run sim -- --help` lists the flags; `--list` shows the scenario ids.
 
+`--year` and `--location` play an authored scenario somewhere or somewhen else, which is the
+only way to exercise a start past the recorded weather from the command line:
+
+```sh
+npm run sim -- --scenario 103 --year 2080 --months 240 --strategy keepUp
+```
+
+Both come back as a custom game rather than the scenario they started from, because that is what
+they are: `initGame` resolves an authored id straight back out of `SCENARIOS`, so an edited copy
+handed over under its original id would have its edits silently dropped.
+
 ## What it checks
 
 The point is not the numbers, it's the **invariants** -- rules the economy must obey no matter
@@ -35,15 +46,15 @@ what the balance looks like. They run on every tick of every simulated month, an
 reports the game time it happened and the values involved, so a broken run points at a line of
 code rather than a vibe.
 
-| | |
-|---|---|
-| Finite values | No `NaN` or `Infinity` reaches any tick or monthly field. `NaN` propagates silently through the whole economy, so this is the one that catches the most |
-| Signs | Supply, demand, customers, stored energy, revenue and every expense stay non-negative; demand stays positive. Cash and net worth may go negative, by design |
-| Cash continuity | Within a month, cash moves by exactly the tick's own revenue minus its recorded expenses, allowing for loan principal, which is spent but not recorded on the tick |
-| Energy conservation | Stored energy moves by exactly what the storage fleet charged or discharged. Storage cannot invent electricity |
-| Fleet bounds | Generators output between 0 and their rated power, storage stays within its rated power and capacity, construction time never goes negative, loan balances stay between 0 and the original amount |
-| Supply accounting | `supplyByFuel` sums to no more than `supplyW`, which also includes storage discharge |
-| Monthly totals | Billed supply never exceeds demand, and every total is finite |
+|                     |                                                                                                                                                                                                   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Finite values       | No `NaN` or `Infinity` reaches any tick or monthly field. `NaN` propagates silently through the whole economy, so this is the one that catches the most                                           |
+| Signs               | Supply, demand, customers, stored energy, revenue and every expense stay non-negative; demand stays positive. Cash and net worth may go negative, by design                                       |
+| Cash continuity     | Within a month, cash moves by exactly the tick's own revenue minus its recorded expenses, allowing for loan principal, which is spent but not recorded on the tick                                |
+| Energy conservation | Stored energy moves by exactly what the storage fleet charged or discharged. Storage cannot invent electricity                                                                                    |
+| Fleet bounds        | Generators output between 0 and their rated power, storage stays within its rated power and capacity, construction time never goes negative, loan balances stay between 0 and the original amount |
+| Supply accounting   | `supplyByFuel` sums to no more than `supplyW`, which also includes storage discharge                                                                                                              |
+| Monthly totals      | Billed supply never exceeds demand, and every total is finite                                                                                                                                     |
 
 `Simulation.test.tsx` asserts all of this as part of `npm test`, across every scenario, both ends
 of the difficulty range, marketing spend, and a run that builds on credit. It also pins down

--- a/src/testing/Report.tsx
+++ b/src/testing/Report.tsx
@@ -1,4 +1,4 @@
-import { LOCATIONS } from "../Constants";
+import { getScenarioLocation } from "../helpers/Locations";
 import { deriveExpandedSummary, summarizeHistory } from "../helpers/DateTime";
 import {
   formatMoneyConcise,
@@ -135,7 +135,7 @@ export function formatReport(
 ): string {
   const maxRows = options.maxRows || DEFAULT_MAX_ROWS;
   const { scenario, months, options: opts } = result;
-  const location = LOCATIONS[scenario.locationId];
+  const location = getScenarioLocation(scenario);
   const summary = summarizeHistory(result.months);
   const derived = deriveExpandedSummary(summary);
   const first = months[0];

--- a/src/testing/SimCli.tsx
+++ b/src/testing/SimCli.tsx
@@ -5,7 +5,9 @@
  * Output goes straight to stdout rather than through console.log, which jest decorates with a
  * stack trace after every call.
  */
-import { SCENARIOS } from "../data/Scenarios";
+import { LOCATIONS } from "../Constants";
+import { CUSTOM_SCENARIO_ID, SCENARIOS } from "../data/Scenarios";
+import { getLocation } from "../helpers/Locations";
 import { DifficultyType, ScenarioType } from "../Types";
 import { formatReport } from "./Report";
 import { runSimulation, SimOptionsType, StrategyType } from "./Simulator";
@@ -19,6 +21,36 @@ function write(s: string) {
 function envNumber(name: string): number | undefined {
   const raw = process.env[name];
   return raw === undefined || raw === "" ? undefined : Number(raw);
+}
+
+/**
+ * An authored scenario played somewhere or somewhen else, for --year and --location.
+ *
+ * Comes back under CUSTOM_SCENARIO_ID because that is what it now is. initGame resolves the
+ * scenario it builds from through getScenario(), which reads an authored id straight back out of
+ * SCENARIOS -- so an edited copy handed over under its original id has its edits silently thrown
+ * away, and the run reports the year it was actually played rather than the one that was asked
+ * for. The name is kept so the report still says which scenario it started from.
+ */
+function withOverrides(scenario: ScenarioType): ScenarioType | undefined {
+  const year = envNumber("SIM_YEAR");
+  const locationId = process.env.SIM_LOCATION;
+  if (year === undefined && !locationId) {
+    return undefined;
+  }
+  if (locationId && !getLocation(locationId)) {
+    throw new Error(
+      `Unknown location "${locationId}". Known: ${Object.keys(LOCATIONS).join(", ")}`,
+    );
+  }
+  return {
+    ...scenario,
+    id: CUSTOM_SCENARIO_ID,
+    startingYear: year === undefined ? scenario.startingYear : year,
+    ...(locationId
+      ? { locationId, location: getLocation(locationId) }
+      : undefined),
+  };
 }
 
 function baseOptions(): Omit<SimOptionsType, "scenarioId"> {
@@ -44,7 +76,11 @@ function runSweep() {
     "  ------------------------- -------- -------------------- --------- --------- ----------",
   );
   SCENARIOS.forEach((scenario: ScenarioType) => {
-    const result = runSimulation({ ...options, scenarioId: scenario.id });
+    const result = runSimulation({
+      ...options,
+      scenarioId: scenario.id,
+      scenario: withOverrides(scenario),
+    });
     totalViolations += result.violationCount;
     const demandWh = result.months.reduce((a, m) => a + m.demandWh, 0);
     const supplyWh = result.months.reduce((a, m) => a + m.supplyWh, 0);
@@ -80,11 +116,13 @@ function runSweep() {
 }
 
 function runSingle() {
-  const scenarioId = envNumber("SIM_SCENARIO");
+  const scenarioId = envNumber("SIM_SCENARIO") ?? 101;
+  const base = SCENARIOS.find((s: ScenarioType) => s.id === scenarioId);
   const started = Date.now();
   const result = runSimulation({
     ...baseOptions(),
-    scenarioId: scenarioId === undefined ? 101 : scenarioId,
+    scenarioId,
+    scenario: base && withOverrides(base),
   });
   write(
     formatReport(result, {

--- a/src/testing/SimData.tsx
+++ b/src/testing/SimData.tsx
@@ -3,6 +3,7 @@ import * as path from "path";
 import { initEconomyFromCsv } from "../data/Economy";
 import { initFuelPricesFromCsv } from "../data/FuelPrices";
 import { initWeatherFromCsv } from "../data/Weather";
+import { isValidLocationId } from "../helpers/Locations";
 import { LocationIdType } from "../Types";
 
 // In the browser these CSVs are downloaded from /data; headless we read the same files off disk.
@@ -14,6 +15,12 @@ const DATA_DIR = path.resolve(__dirname, "..", "..", "public", "data");
  * has to run before any simulation is started.
  */
 export function loadSimData(locationId: LocationIdType) {
+  // Now that a location id is any string rather than a checked union, it can't go into a path
+  // unexamined -- and "no such file" thrown from deep inside readFileSync is a worse error than
+  // this one anyway
+  if (!isValidLocationId(locationId)) {
+    throw new Error(`Invalid location id "${locationId}"`);
+  }
   initWeatherFromCsv(
     locationId,
     fs.readFileSync(path.join(DATA_DIR, `WeatherRaw${locationId}.csv`), "utf8"),

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -11,15 +11,17 @@ import gameReducer, {
   startReplay,
   tickState,
 } from "../reducers/Game";
-import { DIFFICULTIES, LOCATIONS } from "../Constants";
+import { DIFFICULTIES } from "../Constants";
 import { GENERATORS } from "../data/Facilities";
 import { SCENARIOS } from "../data/Scenarios";
 import { getTimeFromTimeline } from "../helpers/DateTime";
+import { getScenarioLocation } from "../helpers/Locations";
 import {
   DifficultyType,
   FacilityOperatingType,
   GameType,
   GeneratorShoppingType,
+  LocationType,
   MonthlyHistoryType,
   ReplayType,
   ScenarioType,
@@ -34,6 +36,22 @@ import {
 import { loadSimData } from "./SimData";
 
 export type StrategyType = "none" | "keepUp";
+
+/**
+ * Where a scenario is played, or a hard failure. The browser can put an alert on screen and go
+ * back to the menu; a headless run that quietly simulated the wrong city would just print a
+ * plausible report about somewhere else.
+ */
+function scenarioLocation(scenario: ScenarioType): LocationType {
+  const location = getScenarioLocation(scenario);
+  if (!location) {
+    throw new Error(
+      `Scenario "${scenario.name}" has no location: "${scenario.locationId}" isn't in LOCATIONS ` +
+        "and no full location was carried on the scenario itself.",
+    );
+  }
+  return location;
+}
 
 export interface SimOptionsType {
   scenarioId: number;
@@ -104,7 +122,7 @@ export function createGame(options: SimOptionsType): GameType {
     options.scenario ||
     SCENARIOS.find((s: ScenarioType) => s.id === options.scenarioId) ||
     SCENARIOS[0];
-  loadSimData(scenario.locationId);
+  loadSimData(scenarioLocation(scenario).id);
   return setUpGame(scenario, resolveOptions(scenario, options));
 }
 
@@ -132,7 +150,7 @@ function setUpGame(
       facilities: scenario.facilities,
       cash: scenario.cash,
       customers: DEFAULT_CUSTOMERS,
-      location: LOCATIONS[scenario.locationId],
+      location: scenarioLocation(scenario),
       seed: options.seed,
     }),
   );
@@ -157,7 +175,9 @@ export function createGameFromReplay(replay: ReplayType): GameType {
   const scenario =
     SCENARIOS.find((s: ScenarioType) => s.id === replay.scenarioId) ||
     SCENARIOS[0];
-  loadSimData(scenario.locationId);
+  // The replay's own location, not the scenario's: that is the whole point of recording it, and
+  // it is also what the loading screen uses in the browser
+  loadSimData(replay.location.id);
   let state = gameReducer(undefined, startReplay(replay));
   state = gameReducer(
     state,
@@ -165,7 +185,7 @@ export function createGameFromReplay(replay: ReplayType): GameType {
       facilities: scenario.facilities,
       cash: scenario.cash,
       customers: DEFAULT_CUSTOMERS,
-      location: LOCATIONS[scenario.locationId],
+      location: replay.location,
       seed: replay.seed,
     }),
   );
@@ -243,7 +263,7 @@ export function runSimulation(options: SimOptionsType): SimResultType {
     SCENARIOS[0];
   const resolved = resolveOptions(scenario, options);
 
-  loadSimData(scenario.locationId);
+  loadSimData(scenarioLocation(scenario).id);
   let state = setUpGame(scenario, resolved);
 
   const collector = new InvariantCollector();


### PR DESCRIPTION
Phase 0 of #163 — the de-hardcoding pass — plus a rework of the fuel price projection that opening the timeline made necessary. No new weather data and no network dependency; phases 1–4 are untouched.

## Location is no longer a closed set

`LocationIdType` was a four-string union and every lookup a bare `LOCATIONS[id]` the compiler could prove total, which made "a place the table has never heard of" inexpressible. It's now a plain string, resolved through `getLocation` / `getScenarioLocation` in the new `src/helpers/Locations.tsx`.

Because the id ends up in the path of a weather file (`/data/WeatherRaw<id>.csv` in the browser, a filesystem path headless), `isValidLocationId` guards both places it becomes one, and `isValidLocation` checks a whole location arriving from an untrusted replay document.

**A scenario may carry a full `LocationType`**, which wins over its `locationId`, so a custom game can hold somewhere `LOCATIONS` doesn't list. The picker renders such a location as its own option rather than showing a blank Select.

**Replays record where they were played.** A scenario id no longer pins a place down, so `ReplayType` gains `location`, `startReplay` puts it on the slice, and the loading screen reads it back instead of re-resolving the scenario. `REPLAY_VERSION` → 2; v1 replays can't be migrated, since the field they're missing is exactly the one that matters. (Custom games are never ranked, so nothing in the wild is affected today — this closes the door before an authored scenario gains a custom location.)

**Four locations to six, for free.** `WeatherRawLA.csv` and `WeatherRawCAMountains.csv` have been sitting unreferenced in `public/data` since the CRA migration. CAMountains' forty years read as coastal range rather than Sierra — a 9 °C to 17 °C annual swing that peaks in September, which is the marine layer's signature — so it's placed and named for the Santa Cruz Mountains.

**The timeline opens up:** every decade from 1980 to 2100, durations to 100 years. Only the floor is a real constraint (weather from 1980, fuel prices from 1975 — nothing projects backwards), so the year list is generated from an exported `WEATHER_STARTING_YEAR` rather than a second hardcoded copy of it.

**`npm run sim` gains `--year` and `--location`,** without which there was no way to exercise a start past the recorded data from the command line. They come back as a custom game, because `initGame` resolves an authored id straight back out of `SCENARIOS` and would otherwise drop the override silently — which it did on the first attempt.

## Fuel prices are tied to a trend

Opening the timeline exposed the projection as an unbounded multiplicative random walk — a draw a month, compounding forever, with no anchor. Its spread grew with the square root of the horizon, which was tolerable across twenty years and nonsense across two hundred:

| Seed 12345 | 2050 | 2100 | 2150 | 2200 |
|---|---|---|---|---|
| Natural gas, before | 0.97 | **0.10** | **0.03** | 0.09 |
| Oil, before | 14.38 | 74.30 | 71.17 | 121.82 |

Three cents per MBTU is free fuel for the rest of the run.

Each fuel now wanders around a trend rising at **4%/yr**, in the same Ornstein–Uhlenbeck shape the weather anomalies already use: last month's departure kept in part, shed in part, shocked. The spread settles instead of growing — two centuries out is no wider than two decades out.

How far and how fast each fuel wanders is measured from its own record at load, the way the weather's climatology is derived per location rather than written per location. The four fuels are not alike:

| Fuel | Recorded trend | Spread around it | Reverts within |
|---|---|---|---|
| Coal | 3.2%/yr | ±20% | very slowly |
| Natural gas | 1.8%/yr | ±19% | ~4 years |
| Uranium | 2.0%/yr | ±65% | ~16 years |
| Oil | 3.6%/yr | ±58% | ~4 years |

4%/yr sits just above the top of the range the record supports, so fuel gets slowly dearer in real terms against the ~2.5–3% the economy inflates build and O&M costs at.

### Two things had to come with it

**The custom game screen quotes its rate and carbon fee in the starting year's money.** Fuel is the one price the game reads at face value for the year it is in — build costs and O&M are anchored on the starting year — so a 2080 game opens against sixty years of escalated fuel. At a literal $0.07/kWh it was bankrupt in month 3. Rolling the year forward keeps the player's *position* in each list rather than their literal number:

| Start | Rates offered | Fees offered |
|---|---|---|
| 1980–2020 | $0.05 · $0.07 · $0.10 · $0.15 | $0 · $20 · $50 · $100 |
| 2050 | $0.16 · $0.23 · $0.32 · $0.49 | $0 · $65 · $160 · $320 |
| 2080 | $0.53 · $0.74 · $1.10 · $1.60 | $0 · $210 · $530 · $1,100 |

Nothing at or before 2020 changes — those years are played against real recorded prices, so there is no escalation to undo.

**A loan's last payment overshot into negative territory and stayed there.** A whole tick's worth of principal against whatever fraction of it was left, with no floor, left the balance a few dollars below zero — harmless in dollars, but it counted towards net worth and tripped the loan invariant on *every subsequent tick*: 196,000 violations on a fifty-year run, enough to bury a real regression. Predates this branch; it only became visible once runs got long enough to pay a loan off and keep going.

## Verification

```
npm run sim -- --scenario 103 --year 2080 --months 240 --strategy keepUp
```

- 2080–2099 holds every invariant across 23,040 ticks.
- A **50-year run from 2100** holds every invariant across 57,600 ticks — previously 196,000 violations.
- Every fuel stays within its own recorded spread of trend across 12 seeds two centuries out, and the spread at a 200-year horizon is no wider than at 25 years.
- LA and CAMountains both play a 120-month run with no violations.
- 378 tests pass (17 new), typecheck, lint and prettier clean.
- Played in the browser: Los Angeles starting Jan 2090 and Jan 2100, weather CSV served, six locations in the picker, thirteen starting years, era-appropriate rates, no new console errors.

## Two things for you to decide

**Carbon Fee's balance moved.** 2020–2032 now goes bankrupt at month 126 for a player who changes nothing, where it used to survive with $329M. One cent on the rate ($0.07 → $0.08) restores it. The old projection had fuel getting *cheaper* in real terms every year, which made "can you modernize the company?" toothless — so this may be the intended bite rather than a regression. Not retuned here, since that's a design call. Every other scenario is unchanged in outcome.

**`Finances.test.tsx` is flaky under load**, independent of this branch: its chart tests sit right at jest's 5s default and start timing out as the machine warms up (the committed base fails 1 then 7 of the same tests on repeat runs; all 30 pass with `--testTimeout=30000`). Worth raising the timeout for that suite separately.

#163 stays open for phases 1–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
