### PR TITLE
Stop the Finances chart tests flaking against Jest's default timeout

### DIFF
--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { produce } from "immer";
 import Finances, { parseRange, projectMonths } from "./Finances";
@@ -7,6 +7,12 @@ import { createGame } from "../../testing/Simulator";
 import { tickState } from "../../reducers/Game";
 import { MINUTES_PER_MONTH, summarizeTimeline } from "../../helpers/DateTime";
 import { GameType, MonthlyHistoryType, SpeedType } from "../../Types";
+
+// Every test in here plays a couple of game years and then renders the real pane, chart and all,
+// so the slowest of them sit close enough to Jest's 5s default to turn into a coin flip once the
+// machine is under load. Nothing here waits on anything, so a ceiling this high only ever catches
+// a genuine hang
+jest.setTimeout(30000);
 
 // The card chrome is connected to the store and hides its children until a game is running, none
 // of which this is about. A plain wrapper puts the pane's own contents straight into the document
@@ -39,10 +45,12 @@ function periodSelect(): HTMLElement {
 }
 
 // The period select doesn't reach the chart's accessible name -- it changes which months are in
-// it -- so the summary underneath, which is totalled over exactly the same months, stands in
+// it -- so the summary underneath, which is totalled over exactly the same months, stands in.
+// Found by its label cell rather than by the row's accessible name: asking for a row by name
+// makes testing-library compute one for every row in the table, which costs over a second a call
 function summarised(label: string): string {
-  const row = screen.getByRole("row", { name: new RegExp(`^${label} `) });
-  return within(row).getAllByRole("cell")[1].textContent || "";
+  const labelCell = screen.getByText(label, { selector: "td" });
+  return labelCell.nextElementSibling?.textContent || "";
 }
 
 async function choose(select: HTMLElement, option: string) {


### PR DESCRIPTION
The `the Finances chart selectors` block in `src/components/views/Finances.test.tsx` intermittently failed with `Exceeded timeout of 5000 ms for a test`. Three consecutive runs on master gave 0, 1, then 7 failures.

Not a correctness bug — all 30 tests passed under `--testTimeout=30000`. The slowest test sat at 5767ms, close enough to the default that how many failed depended on machine load.

## What was actually slow

Profiling found the cost was in a test helper, not in the component:

| operation | cost |
|---|---|
| `getByRole("row", { name: /^Revenue / })` + `getAllByRole("cell")` | **1363 ms** |
| `getByText("Revenue", { selector: "td" })` + `.nextElementSibling` | **2 ms** |
| `projectMonths(…, 60)` (five-year forecast) | 121 ms |
| first full render of the pane | 184 ms |

The `name` option makes dom-accessibility-api compute an accessible name for every row in the summary table. `summarised()` is called three times in each period test, which is why those straddled the limit while the metric tests — which never call it — never did.

## Changes

Test file only, no production code touched:

1. `summarised()` finds the label `<td>` by text and reads its sibling instead of naming the row. Same returned value, same assertions.
2. `jest.setTimeout(30000)`, matching what `src/reducers/Replay.test.tsx` already does.

## Results

- Suite: **51s → 21-24s**
- Slowest test: **5767ms → 1964ms**, under the 5000ms default even without the raised ceiling, so the timeout is now only there to catch a genuine hang
- Three consecutive runs, 30/30 passing each time; `tsc --noEmit` clean

## Not covered

The same `getByRole(…, { name })` pattern may exist in other component tests. Only this file was measured and changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
