### PR TITLE
Draw the chart decorations where they were meant to go

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -57,6 +57,9 @@ export const blackoutColor = red[800]; // darker than red[500] so the translucen
 export const demandColor = grey[900];
 export const supplyColor = blue[600];
 export const temperatureColor = red[500];
+// The temperature line wants red500's punch against white, but 3.7:1 is too thin for the axis
+// labels that name it, so the axis carrying it takes the darker shade instead
+export const temperatureAxisColor = red[800];
 export const cursorColor = grey[600]; // hover crosshair, lighter than the data it crosses
 export const windColor = fuelColors.Wind; // for weather forecasts
 

--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -76,7 +76,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         spanGaps: false,
       },
     ],
-    plugins: [titlePlugin(() => getState().title, 200, 7)],
+    plugins: [titlePlugin(() => getState().title, 7)],
   };
 }
 

--- a/src/components/base/ChartForecastWeather.tsx
+++ b/src/components/base/ChartForecastWeather.tsx
@@ -1,21 +1,14 @@
 import * as React from "react";
 import uPlot from "uplot";
 import UPlotChart, { BuildContext } from "./UPlotChart";
-import {
-  legendPlugin,
-  padRange,
-  SPLINE,
-  stepTicks,
-  xAxis,
-  yAxis,
-} from "./UPlotHelpers";
+import { padRange, SPLINE, stepTicks, xAxis, yAxis } from "./UPlotHelpers";
 import { TICK_MINUTES } from "../../Constants";
 import { TickPresentFutureType } from "../../Types";
 import {
   formatMinuteAsMonthAxis,
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
-import { temperatureColor, windColor } from "../../Theme";
+import { temperatureAxisColor, temperatureColor, windColor } from "../../Theme";
 
 export interface Props {
   height?: number;
@@ -32,12 +25,10 @@ interface State {
   multiyear: boolean;
 }
 
-// Temperature and wind share one axis, as they did on Victory: the numbers are close enough in
-// range that a second scale would only add a second set of labels to read
-const LEGEND = [
-  { name: "Heat (°C)", fill: temperatureColor },
-  { name: "Wind (km/h)", fill: windColor },
-];
+// A scale each, labelled on its own side and coloured to match its line: degrees and km/h only
+// looked like one axis because the numbers happened to overlap, and sharing it flattened whichever
+// of the two had the narrower spread.
+const WIND_SCALE = "wind";
 
 function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
   return {
@@ -54,6 +45,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
     scales: {
       x: { time: false, range: () => getState().domain.x },
       y: { range: (_u, min, max) => padRange(min, max) },
+      [WIND_SCALE]: { range: (_u, min, max) => padRange(min, max) },
     },
     axes: [
       xAxis(scale, {
@@ -70,6 +62,15 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
       }),
       yAxis(scale, {
         grid: true,
+        label: "Heat (°C)",
+        stroke: temperatureAxisColor,
+        values: (_u, splits) => splits.map((t) => String(Math.round(t))),
+      }),
+      yAxis(scale, {
+        scale: WIND_SCALE,
+        side: 1,
+        label: "Wind (km/h)",
+        stroke: windColor,
         values: (_u, splits) => splits.map((t) => String(Math.round(t))),
       }),
     ],
@@ -81,9 +82,14 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         points: { show: false },
         paths: SPLINE,
       },
-      { stroke: windColor, width: 1, points: { show: false }, paths: SPLINE },
+      {
+        scale: WIND_SCALE,
+        stroke: windColor,
+        width: 1,
+        points: { show: false },
+        paths: SPLINE,
+      },
     ],
-    plugins: [legendPlugin(() => LEGEND, 270, 20)],
   };
 }
 

--- a/src/components/base/UPlotHelpers.ts
+++ b/src/components/base/UPlotHelpers.ts
@@ -21,12 +21,50 @@ export const TICK_LABEL_FILL = chartTheme.tickLabels.fill;
 // VictoryTheme.material's colours for the parts of an axis that aren't the baseline
 const GRID_STROKE = "#ECEFF1";
 const TICK_STROKE = "#90A4AE";
+// How far a tick pokes out of the axis, and how far the label then sits from it, in design units
+const TICK_SIZE = 5;
+const LABEL_GAP = 4;
 // Victory drew legend text in its material theme's near-black rather than the axes' grey
 const LEGEND_TEXT = "#252525";
 
-/** A font string at the chart's current scale. */
+/**
+ * A font string at the chart's current scale.
+ *
+ * Whole pixels on purpose: uPlot rescales axis fonts for the device by rewriting the `<n>px` in
+ * this string, and its pattern only matches digits, so a fractional size would leave it
+ * rewriting the ".9" of "43.9px" and handing the canvas a font it can't parse.
+ */
 export function chartFont(scale: number, sizePx = 12): string {
-  return `${(sizePx * scale).toFixed(1)}px ${CHART_FONT_FAMILY}`;
+  return `${Math.max(1, Math.round(sizePx * scale))}px ${CHART_FONT_FAMILY}`;
+}
+
+/**
+ * Design units to canvas pixels, for the plugins below that paint on the canvas themselves.
+ *
+ * uPlot works in CSS pixels but never scales the context, multiplying every coordinate it draws
+ * by the device ratio instead -- so `u.bbox` and anything else reaching the canvas is in device
+ * pixels, and a plugin that positions itself in CSS pixels lands short of where it means to on
+ * any display that isn't at 100%.
+ */
+function canvasScale(u: uPlot): number {
+  return (u.width / DESIGN_WIDTH) * uPlot.pxRatio;
+}
+
+// A context of our own to ask how wide a label will be, since axis sizes have to be settled
+// before there is a plot to measure with
+let measureCtx: CanvasRenderingContext2D | null | undefined;
+
+/** Width of `text` in CSS pixels at `font`, whose size is `sizePx`. */
+function textWidth(text: string, font: string, sizePx: number): number {
+  if (measureCtx === undefined) {
+    measureCtx = document.createElement("canvas").getContext("2d");
+  }
+  if (!measureCtx) {
+    // No canvas to measure with (jsdom); a half-em per character is close enough for digits
+    return text.length * sizePx * 0.55;
+  }
+  measureCtx.font = font;
+  return measureCtx.measureText(text).width;
 }
 
 export interface LegendItem {
@@ -38,11 +76,17 @@ interface AxisOptions {
   /** Which tick values to draw; omitted lets uPlot choose */
   splits?: uPlot.Axis.Splits;
   values: uPlot.Axis.Values;
-  /** Space reserved for the axis, in design units */
+  /** Space reserved for the axis, in design units; omitted fits it to the labels */
   size?: number;
   label?: string;
   /** Only the charts that showed Victory's default grid ask for one */
   grid?: boolean;
+  /** Which y scale the axis reads, for the charts that carry two */
+  scale?: string;
+  /** uPlot's sides: 1 is right, 3 is left */
+  side?: 1 | 3;
+  /** Ticks, labels and axis label in one colour, to tie an axis to its series */
+  stroke?: string;
 }
 
 /**
@@ -72,7 +116,7 @@ export function niceSplits(min: number, max: number, target = 5): number[] {
 
 function axisCommon(scale: number, o: AxisOptions) {
   return {
-    stroke: TICK_LABEL_FILL,
+    stroke: o.stroke ?? TICK_LABEL_FILL,
     font: chartFont(scale),
     grid: o.grid
       ? {
@@ -82,7 +126,12 @@ function axisCommon(scale: number, o: AxisOptions) {
           dash: [10 * scale, 5 * scale],
         }
       : { show: false },
-    ticks: { show: true, stroke: TICK_STROKE, width: 1, size: 5 * scale },
+    ticks: {
+      show: true,
+      stroke: TICK_STROKE,
+      width: 1,
+      size: TICK_SIZE * scale,
+    },
     border: { show: true, stroke: chartTheme.axis.stroke, width: 1 },
     label: o.label,
     labelFont: chartFont(scale),
@@ -102,14 +151,37 @@ export function xAxis(scale: number, o: AxisOptions): uPlot.Axis {
   };
 }
 
-/** The y axis every chart shares. Wider than x because the labels sit beside it. */
+/**
+ * The y axis every chart shares.
+ *
+ * Its width follows the labels rather than a fixed reserve: uPlot draws them right up against
+ * the plot, so anything left over opens as a gap on the far side -- between "Per MMBTU" and
+ * "$12" on the fuel chart, which is what gave the reserve away.
+ */
 export function yAxis(scale: number, o: AxisOptions): uPlot.Axis {
+  const font = chartFont(scale);
+  const fontSize = 12 * scale;
+  const fixed = TICK_SIZE * scale + LABEL_GAP * scale;
   return {
     ...axisCommon(scale, o),
-    scale: "y",
-    side: 3,
-    size: (o.size ?? 55) * scale,
-    gap: 4 * scale,
+    scale: o.scale ?? "y",
+    side: o.side ?? 3,
+    size:
+      o.size != null
+        ? o.size * scale
+        : (_u, values) => {
+            let widest = 0;
+            for (const value of values || []) {
+              if (value != null) {
+                widest = Math.max(
+                  widest,
+                  textWidth(String(value), font, fontSize),
+                );
+              }
+            }
+            return Math.ceil(fixed + widest);
+          },
+    gap: LABEL_GAP * scale,
     splits: o.splits ?? ((_u, _i, min, max) => niceSplits(min, max)),
   };
 }
@@ -219,7 +291,7 @@ export function legendPlugin(
         if (items.length === 0) {
           return;
         }
-        const scale = u.width / DESIGN_WIDTH;
+        const scale = canvasScale(u);
         const radius = 3.5 * scale;
         const gap = 5 * scale;
         const lineHeight = 16 * scale;
@@ -252,10 +324,13 @@ export function legendPlugin(
   };
 }
 
-/** A caption over the plot, which the finance charts carry instead of a legend. */
+/**
+ * A caption over the plot, which the finance charts carry instead of a legend. Centred on the
+ * plot rather than on a fixed offset, since the y axis is only as wide as its labels and so a
+ * chart of percentages and a chart of dollars no longer start in the same place.
+ */
 export function titlePlugin(
   getTitle: () => string,
-  designX: number,
   designY: number,
 ): uPlot.Plugin {
   return {
@@ -265,13 +340,13 @@ export function titlePlugin(
         if (!title) {
           return;
         }
-        const scale = u.width / DESIGN_WIDTH;
+        const scale = canvasScale(u);
         u.ctx.save();
         u.ctx.font = chartFont(scale, 14);
         u.ctx.fillStyle = chartTheme.axis.stroke;
         u.ctx.textAlign = "center";
         u.ctx.textBaseline = "middle";
-        u.ctx.fillText(title, designX * scale, designY * scale);
+        u.ctx.fillText(title, u.bbox.left + u.bbox.width / 2, designY * scale);
         u.ctx.restore();
       },
     },


### PR DESCRIPTION
Three reported chart bugs, two of which turn out to share a root cause.

## The legend was never actually right-aligned

The right-align commit was already on the branch — it just wasn't taking effect. uPlot works in CSS pixels but never scales the canvas context; it multiplies every coordinate by the device ratio as it draws. `legendPlugin` and `titlePlugin` were positioning themselves in CSS pixels, so on a display at 125% scaling the supply/demand legend landed at `98.6% / 1.25 ≈ 79%` of the width instead of flush with the plot's right edge.

Verified live at dpr 1.25: legend text now ends at device px 1573 with the plot edge at 1577. Before the fix it landed at 1261.

The same slip reached the fonts. `chartFont` emitted fractional sizes like `43.9px`, and uPlot's rescale pattern (`/(\d+)px/`) matches only digits — so it rewrote the `9px` and handed the canvas `43.11px`, which won't parse. Whole pixels now.

## The gap on the fuel prices chart

The y axis reserved a flat 55 design units regardless of what the labels needed. uPlot draws tick labels flush against the plot, so the surplus opened as a gap on the *far* side — between "Per MMBTU" and "$12". `yAxis` now measures the widest label and fits to it, taking that chart's left inset from 260px to 165px and the label-to-numbers gap down to ~12px.

Axis widths vary per chart as a result, so the finance chart title now centres on the actual plot rather than on a fixed offset.

## Separate axes for temperature and wind

The two shared one scale on the assumption that degrees and km/h were close enough in range to read off a single set of labels; in practice it flattened whichever series had the narrower spread. Each gets its own axis now — temperature left in red, wind right in dark blue — labelled on its own side with its units, which lets the floating in-plot legend go.

One judgment call: the line keeps `red500`'s punch against white, but 3.7:1 is too thin for the small axis text naming it, so that axis uses a darker red (`temperatureAxisColor`, 5.9:1).

## Testing

406 tests passing. Chart geometry verified by reading pixel positions off the live canvases — the Browser pane wasn't compositing frames in this session, so I couldn't attach screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
