### PR TITLE
Metric/Imperial display units setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { Provider } from "react-redux";
 import type { User } from "firebase/auth";
 import CompositorContainer from "./components/CompositorContainer";
+import UnitsProvider from "./components/base/UnitsContext";
 import { navigateBack } from "./reducers/Card";
 import { pauseAudio, resumeAudio } from "./reducers/Settings";
 import { snackbarOpen } from "./reducers/UI";
@@ -124,7 +125,11 @@ export default function App() {
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>
         <Provider store={store}>
-          <CompositorContainer store={store} />
+          {/* Above the compositor, whose shouldComponentUpdate would otherwise swallow a
+              settings change that did not also change the card */}
+          <UnitsProvider>
+            <CompositorContainer store={store} />
+          </UnitsProvider>
         </Provider>
       </ThemeProvider>
     </StyledEngineProvider>

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -394,8 +394,13 @@ export interface GameType {
   replayPlayback?: ReplayPlaybackType;
 }
 
+// Which units the player reads. Only ever affects display: everything the game stores and
+// simulates is metric, and helpers/Units converts on the way out. See base/UnitsContext.
+export type UnitSystemType = "metric" | "imperial";
+
 export interface SettingsType {
   audioEnabled?: boolean;
+  units: UnitSystemType;
 }
 
 export interface DialogType {

--- a/src/components/base/ChartForecastWeather.tsx
+++ b/src/components/base/ChartForecastWeather.tsx
@@ -3,12 +3,21 @@ import uPlot from "uplot";
 import UPlotChart, { BuildContext } from "./UPlotChart";
 import { padRange, SPLINE, stepTicks, xAxis, yAxis } from "./UPlotHelpers";
 import { TICK_MINUTES } from "../../Constants";
-import { TickPresentFutureType } from "../../Types";
+import { TickPresentFutureType, UnitSystemType } from "../../Types";
 import {
   formatMinuteAsMonthAxis,
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
 import { temperatureAxisColor, temperatureColor, windColor } from "../../Theme";
+import {
+  formatSpeed,
+  formatTemperature,
+  speedUnit,
+  temperatureUnit,
+  toDisplaySpeed,
+  toDisplayTemperature,
+} from "../../helpers/Units";
+import { UnitsContext } from "./UnitsContext";
 
 export interface Props {
   height?: number;
@@ -23,6 +32,7 @@ interface State {
   domain: Props["domain"];
   startingYear: number;
   multiyear: boolean;
+  units: UnitSystemType;
 }
 
 // A scale each, labelled on its own side and coloured to match its line: degrees and km/h only
@@ -62,14 +72,14 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
       }),
       yAxis(scale, {
         grid: true,
-        label: "Heat (°C)",
+        label: `Heat (${temperatureUnit(getState().units)})`,
         stroke: temperatureAxisColor,
         values: (_u, splits) => splits.map((t) => String(Math.round(t))),
       }),
       yAxis(scale, {
         scale: WIND_SCALE,
         side: 1,
-        label: "Wind (km/h)",
+        label: `Wind (${speedUnit(getState().units)})`,
         stroke: windColor,
         values: (_u, splits) => splits.map((t) => String(Math.round(t))),
       }),
@@ -95,15 +105,21 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
 
 function tooltip(idx: number, state: State): string {
   const d = state.data[idx];
-  return `Temperature: ${Math.round(d.temperatureC)}°C\nWind: ${Math.round(d.windKph)} km/h`;
+  return `Temperature: ${formatTemperature(d.temperatureC, state.units)}\nWind: ${formatSpeed(d.windKph, state.units)}`;
 }
 
-// This is a pureComponent because its props should change much less frequently than it renders
+// This is a pureComponent because its props should change much less frequently than it renders.
+// The lines themselves are plotted in the display unit, so the axis a line is labelled with is
+// the one it is drawn against - converting only the labels would leave 20°F sitting where -7 is.
 export default class ChartForecastWeather extends React.PureComponent<
   Props,
   {}
 > {
+  // A PureComponent would block a prop change here, but a context change is delivered anyway
+  static contextType = UnitsContext;
+
   public render() {
+    const units = this.context as UnitSystemType;
     const { domain, height, timeline, startingYear, multiyear } = this.props;
     // Downsample the data to 6 per day to make it more vague / forecast-y
     const data = timeline.filter(
@@ -118,8 +134,8 @@ export default class ChartForecastWeather extends React.PureComponent<
     const wind = new Array<number>(data.length);
     data.forEach((t: TickPresentFutureType, i: number) => {
       minutes[i] = t.minute;
-      temperature[i] = t.temperatureC;
-      wind[i] = t.windKph;
+      temperature[i] = toDisplayTemperature(t.temperatureC, units);
+      wind[i] = toDisplaySpeed(t.windKph, units);
     });
 
     return (
@@ -127,9 +143,11 @@ export default class ChartForecastWeather extends React.PureComponent<
         id="chartForecastWeather"
         ariaLabel="Chart of forecasted temperature and wind"
         height={height}
-        state={{ data, domain, startingYear, multiyear }}
+        state={{ data, domain, startingYear, multiyear, units }}
         data={[minutes, temperature, wind]}
         buildOptions={buildOptions}
+        // The axis labels are baked into the options, so a change of system rebuilds the plot
+        structureKey={units}
         tooltip={tooltip}
       />
     );

--- a/src/components/base/UnitsContext.tsx
+++ b/src/components/base/UnitsContext.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { useAppSelector } from "../../Store";
+import { UnitSystemType } from "../../Types";
+import { DEFAULT_UNIT_SYSTEM } from "../../helpers/Units";
+
+/**
+ * The unit system every label in the game reads itself out in.
+ *
+ * A context rather than a prop, because the things that show a unit are leaves - a chart axis,
+ * a row in the build list, a paragraph of the manual - sitting under components that block
+ * re-renders on purpose (Compositor, Finances and Forecasts all have a shouldComponentUpdate
+ * that ignores everything but the clock and the card). Context updates go through those
+ * regardless, so changing the setting repaints the labels without loosening any of them.
+ *
+ * Defaulting to metric rather than throwing also means a component can be rendered on its own,
+ * outside the store, and still read in the units it would have started in.
+ */
+export const UnitsContext =
+  React.createContext<UnitSystemType>(DEFAULT_UNIT_SYSTEM);
+
+export function useUnits(): UnitSystemType {
+  return React.useContext(UnitsContext);
+}
+
+export default function UnitsProvider(props: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  const units = useAppSelector((state) => state.settings.units);
+  return (
+    <UnitsContext.Provider value={units}>
+      {props.children}
+    </UnitsContext.Provider>
+  );
+}

--- a/src/components/base/VictoryConditions.tsx
+++ b/src/components/base/VictoryConditions.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { ScenarioType } from "../../Types";
+import { formatLargeMassApprox, KG_PER_MEGATONNE } from "../../helpers/Units";
+import { useUnits } from "./UnitsContext";
 
 export interface Props {
   ownership: ScenarioType["ownership"];
@@ -14,13 +16,15 @@ export interface Props {
  */
 export default function VictoryConditions(props: Props): React.JSX.Element {
   const { ownership, dollarsPerkWh } = props;
+  const units = useUnits();
+  const perEmissions = formatLargeMassApprox(KG_PER_MEGATONNE, units);
   if (ownership === "Investor") {
     return (
       <div>
         <p>+40 pts per $1B of net worth at the end</p>
         <p>+2 pts per 100k customers at the end</p>
         <p>+1 pt per TWh of electricity supplied</p>
-        <p>-2 pts per megaton (1M tons) of greenhouse gas emissions</p>
+        <p>-2 pts per {perEmissions} of greenhouse gas emissions</p>
         <p>-8 pts per TWh of blackouts</p>
       </div>
     );
@@ -32,7 +36,7 @@ export default function VictoryConditions(props: Props): React.JSX.Element {
         {dollarsPerkWh}/kWh
       </p>
       <p>+10 pts per TWh of electricity supplied</p>
-      <p>-5 pts per megaton (1M tons) of greenhouse gas emissions</p>
+      <p>-5 pts per {perEmissions} of greenhouse gas emissions</p>
       <p>-10 pts per TWh of blackouts</p>
     </div>
   );

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -50,7 +50,9 @@ import {
 } from "../../Types";
 import { generateNewTimeline } from "../../reducers/Game";
 import { MANUAL_ENTRY } from "../../data/Manual";
+import { formatMass } from "../../helpers/Units";
 import ManualLink from "../base/ManualLink";
+import { useUnits } from "../base/UnitsContext";
 
 interface GeneratorBuildItemProps {
   cash: number;
@@ -64,6 +66,7 @@ interface GeneratorBuildItemProps {
 
 function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
   const { generator, cash } = props;
+  const units = useUnits();
   const fuel = FUELS[generator.fuel] || {};
   const fuelPrices = getFuelPricesPerMBTU(props.date, props.seed);
   const [expanded, setExpanded] = React.useState(false);
@@ -138,7 +141,7 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
               {formatMoneyConcise(generator.lcWh * 1000000)}/MWh
               <br />
               {kgCO2ePerMWh > 0
-                ? `${kgCO2ePerMWh.toLocaleString()}kg CO2e/MWh`
+                ? `${formatMass(kgCO2ePerMWh, units)} CO2e/MWh`
                 : "No CO2e"}
             </Typography>
           </span>
@@ -257,7 +260,7 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
                   </Typography>
                 </TableCell>
                 <TableCell align="right">
-                  {kgCO2ePerMWh.toLocaleString()}kg CO2e/MWh
+                  {formatMass(kgCO2ePerMWh, units)} CO2e/MWh
                 </TableCell>
               </TableRow>
             </TableBody>

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -36,6 +36,8 @@ import { getFuelEscalation } from "../../data/FuelPrices";
 import { getDateFromMinute } from "../../helpers/DateTime";
 import { getScenarioLocation } from "../../helpers/Locations";
 import { formatWattHours, formatWatts } from "../../helpers/Format";
+import { formatPricePerLargeMass, largeMassUnit } from "../../helpers/Units";
+import { useUnits } from "../base/UnitsContext";
 import { newSeed } from "../../helpers/Math";
 import {
   DifficultyType,
@@ -196,6 +198,7 @@ function facilitySize(facility: Partial<FacilityShoppingType>): string {
 
 export default function CustomGame(props: Props): React.JSX.Element {
   const { game, onBack, onDelta, onStart } = props;
+  const units = useUnits();
   const [scenario, setScenario] = React.useState<ScenarioType>(() =>
     inEraScenario(props.scenario),
   );
@@ -496,7 +499,9 @@ export default function CustomGame(props: Props): React.JSX.Element {
                   {feeOptions.map((f: number) => {
                     return (
                       <MenuItem value={f / 1000} key={f}>
-                        ${Math.round(f).toLocaleString("en-US")}/ton
+                        {/* The options are set per tonne, and the value stays per kilogram
+                            whichever way it is quoted - only the label moves */}
+                        {formatPricePerLargeMass(f / 1000, units)}
                       </MenuItem>
                     );
                   })}
@@ -713,8 +718,8 @@ export default function CustomGame(props: Props): React.JSX.Element {
         <DialogTitle>Carbon fee</DialogTitle>
         <DialogContent>
           A fee placed on pollution to cover its damage to society. Charged by
-          the amount of greenhouse gas emitted, generally measured in "tons of
-          CO2 equivalent".
+          the amount of greenhouse gas emitted, measured in{" "}
+          {largeMassUnit(units)} of CO2 equivalent.
         </DialogContent>
         <DialogActions>
           <Button

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -43,7 +43,15 @@ import {
   DerivedHistoryKeysType,
   GameType,
   MonthlyHistoryType,
+  UnitSystemType,
 } from "../../Types";
+import {
+  formatLargeMassValue,
+  largeMassUnit,
+  massUnit,
+  toDisplayMass,
+} from "../../helpers/Units";
+import { UnitsContext } from "../base/UnitsContext";
 import ChartFinances from "../base/ChartFinances";
 import GameCard from "../base/GameCard";
 import { getScenario, SCENARIOS } from "../../data/Scenarios";
@@ -58,115 +66,133 @@ interface ChartKeyMetadataType {
   nesting?: number; // default 0 / unnested
 }
 
-const CHART_KEYS = {
-  profit: {
-    label: "Profit",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-  },
-  profitPerkWh: {
-    label: "Unit profit",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-    suffix: "/kWh",
-    nesting: 1,
-  },
-  revenue: {
-    label: "Revenue",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-  },
-  revenuePerkWh: {
-    label: "Unit revenue",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-    suffix: "/kWh",
-    nesting: 1,
-  },
-  supplyWh: {
-    label: "Power sold",
-    format: (n: number) => `${formatWatts(n, 0)}h`,
-    nesting: 1,
-  },
-  demandWh: {
-    label: "Demand",
-    format: (n: number) => `${formatWatts(n, 0)}h`,
-  },
-  customers: {
-    label: "Customers",
-    format: (n: number) => numbro(n).format({ average: true }),
-    nesting: 1,
-  },
-  expenses: {
-    label: "Expenses",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-  },
-  expensesFuel: {
-    label: "Fuel",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-    nesting: 1,
-  },
-  expensesOM: {
-    label: "Operations",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-    nesting: 1,
-  },
-  expensesMarketing: {
-    label: "Marketing",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-    nesting: 1,
-  },
-  expensesInterest: {
-    label: "Loan interest",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-    nesting: 1,
-  },
-  interestRate: {
-    label: "Interest rate",
-    format: (n: number) => `${(n * 100).toFixed(2)}%`,
-    nesting: 2,
-  },
-  expensesCarbonFee: {
-    label: "Carbon fees",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-    nesting: 1,
-  },
-  kgco2e: {
-    label: "CO2e emitted",
-    format: (n: number) =>
-      `${numbro(n / 1000).format({ thousandSeparated: true, mantissa: 0 })}`,
-    suffix: "tons",
-    nesting: 2,
-  },
-  kgco2ePerMWh: {
-    label: "Emissions factor",
-    format: (n: number) =>
-      `${numbro(n).format({ thousandSeparated: true, mantissa: 0 })}`,
-    suffix: "kg/MWh",
-    nesting: 2,
-  },
-  netWorth: {
-    label: "Net Worth",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-  },
-  cash: {
-    label: "Cash",
-    format: formatMoneyConcise,
-    formatTable: formatMoneyStable,
-    nesting: 1,
-  },
-  inflationRate: {
-    label: "Inflation",
-    format: (n: number) => `${(n * 100).toFixed(1)}%`,
-  },
-} as { [index: string]: ChartKeyMetadataType };
+// Two tables rather than one built per render: the labels are the same either way, and only
+// the two emissions rows care which system they are read in
+function buildChartKeys(units: UnitSystemType): {
+  [index: string]: ChartKeyMetadataType;
+} {
+  return {
+    profit: {
+      label: "Profit",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+    },
+    profitPerkWh: {
+      label: "Unit profit",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+      suffix: "/kWh",
+      nesting: 1,
+    },
+    revenue: {
+      label: "Revenue",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+    },
+    revenuePerkWh: {
+      label: "Unit revenue",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+      suffix: "/kWh",
+      nesting: 1,
+    },
+    supplyWh: {
+      label: "Power sold",
+      format: (n: number) => `${formatWatts(n, 0)}h`,
+      nesting: 1,
+    },
+    demandWh: {
+      label: "Demand",
+      format: (n: number) => `${formatWatts(n, 0)}h`,
+    },
+    customers: {
+      label: "Customers",
+      format: (n: number) => numbro(n).format({ average: true }),
+      nesting: 1,
+    },
+    expenses: {
+      label: "Expenses",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+    },
+    expensesFuel: {
+      label: "Fuel",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+      nesting: 1,
+    },
+    expensesOM: {
+      label: "Operations",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+      nesting: 1,
+    },
+    expensesMarketing: {
+      label: "Marketing",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+      nesting: 1,
+    },
+    expensesInterest: {
+      label: "Loan interest",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+      nesting: 1,
+    },
+    interestRate: {
+      label: "Interest rate",
+      format: (n: number) => `${(n * 100).toFixed(2)}%`,
+      nesting: 2,
+    },
+    expensesCarbonFee: {
+      label: "Carbon fees",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+      nesting: 1,
+    },
+    kgco2e: {
+      label: "CO2e emitted",
+      format: (n: number) => formatLargeMassValue(n, units),
+      suffix: largeMassUnit(units),
+      nesting: 2,
+    },
+    kgco2ePerMWh: {
+      label: "Emissions factor",
+      format: (n: number) =>
+        numbro(toDisplayMass(n, units)).format({
+          thousandSeparated: true,
+          mantissa: 0,
+        }),
+      suffix: `${massUnit(units)}/MWh`,
+      nesting: 2,
+    },
+    netWorth: {
+      label: "Net Worth",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+    },
+    cash: {
+      label: "Cash",
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+      nesting: 1,
+    },
+    inflationRate: {
+      label: "Inflation",
+      format: (n: number) => `${(n * 100).toFixed(1)}%`,
+    },
+  };
+}
+
+const CHART_KEYS_BY_SYSTEM: {
+  [system in UnitSystemType]: { [index: string]: ChartKeyMetadataType };
+} = {
+  metric: buildChartKeys("metric"),
+  imperial: buildChartKeys("imperial"),
+};
+
+// The metrics on offer, which no system changes - the stored choice is checked against these
+const CHART_KEY_NAMES = Object.keys(CHART_KEYS_BY_SYSTEM.metric);
 
 const CHART_KEY_STORAGE_KEY = "financesChartKey";
 // Still says year, because a stored year is still one of the options and reading it back is
@@ -316,6 +342,11 @@ function getTickFromValue(v: number) {
 }
 
 export default class Finances extends React.Component<Props, State> {
+  // Context rather than a prop: shouldComponentUpdate below throttles renders against the game
+  // clock, which a prop change would have to be excepted from - a context change is delivered
+  // whatever it says
+  static contextType = UnitsContext;
+
   constructor(props: Props) {
     super(props);
     // Building a facility unmounts this pane, so both dropdowns have to be remembered outside
@@ -329,7 +360,7 @@ export default class Finances extends React.Component<Props, State> {
       expanded: getStorageBoolean("financesTableOpened", false),
       chartKey: getStorageChoice(
         CHART_KEY_STORAGE_KEY,
-        Object.keys(CHART_KEYS),
+        CHART_KEY_NAMES,
         "profit",
       ) as DerivedHistoryKeysType,
     };
@@ -525,6 +556,7 @@ export default class Finances extends React.Component<Props, State> {
 
   public render() {
     const { game, onDelta } = this.props;
+    const chartKeys = CHART_KEYS_BY_SYSTEM[this.context as UnitSystemType];
     const { startingYear, timeline, date } = game;
     const { expanded, chartKey } = this.state;
     const range = parseRange(this.state.range, date.year);
@@ -669,13 +701,13 @@ export default class Finances extends React.Component<Props, State> {
                 this.setChartKey(e.target.value as DerivedHistoryKeysType)
               }
             >
-              {Object.keys(CHART_KEYS).map((key: string) => {
-                const k = CHART_KEYS[key];
+              {CHART_KEY_NAMES.map((key: string) => {
+                const k = chartKeys[key];
                 let label = k.label;
-                if (chartKey !== key && CHART_KEYS[key].nesting) {
+                if (chartKey !== key && chartKeys[key].nesting) {
                   // https://stackoverflow.com/questions/14343844/create-a-string-of-variable-length-filled-with-a-repeated-character
                   label =
-                    new Array((CHART_KEYS[key].nesting || 0) + 1).join(" -") +
+                    new Array((chartKeys[key].nesting || 0) + 1).join(" -") +
                     " " +
                     label;
                 }
@@ -724,12 +756,12 @@ export default class Finances extends React.Component<Props, State> {
               height={140}
               timeline={monthly}
               title={
-                CHART_KEYS[chartKey].label +
-                (CHART_KEYS[chartKey].suffix
-                  ? ` (${CHART_KEYS[chartKey].suffix})`
+                chartKeys[chartKey].label +
+                (chartKeys[chartKey].suffix
+                  ? ` (${chartKeys[chartKey].suffix})`
                   : "")
               }
-              format={CHART_KEYS[chartKey].format}
+              format={chartKeys[chartKey].format}
             />
           ) : (
             <span />
@@ -740,8 +772,8 @@ export default class Finances extends React.Component<Props, State> {
           >
             <Table size="small">
               <TableBody>
-                {Object.keys(CHART_KEYS).map((key: string) => {
-                  const k = CHART_KEYS[key];
+                {CHART_KEY_NAMES.map((key: string) => {
+                  const k = chartKeys[key];
                   const format = k.formatTable || k.format;
                   return (
                     <TableRow

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -1,7 +1,16 @@
 import * as React from "react";
-import { Checkbox, IconButton, Toolbar, Typography } from "@mui/material";
+import {
+  Checkbox,
+  IconButton,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Toolbar,
+  Typography,
+} from "@mui/material";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
-import { SettingsType } from "../../Types";
+import { SettingsType, UnitSystemType } from "../../Types";
+import { UNIT_SYSTEMS, UNIT_SYSTEM_LABELS } from "../../helpers/Units";
 import KeyboardShortcuts from "../base/KeyboardShortcuts";
 import packageJson from "../../../package.json";
 
@@ -11,6 +20,7 @@ export interface StateProps {
 
 export interface DispatchProps {
   onAudioChange: (change: boolean) => void;
+  onUnitsChange: (change: UnitSystemType) => void;
   onBack: () => void;
 }
 
@@ -66,6 +76,27 @@ export default function Settings(props: Props): React.JSX.Element {
         {props.settings.audioEnabled
           ? "Music and sound effects enabled."
           : "Music and sound effects disabled."}
+        <Typography variant="h6" style={{ marginTop: 24 }}>
+          Units
+        </Typography>
+        <Select
+          id="units"
+          value={props.settings.units}
+          onChange={(e: SelectChangeEvent<UnitSystemType>) =>
+            props.onUnitsChange(e.target.value as UnitSystemType)
+          }
+        >
+          {UNIT_SYSTEMS.map((system: UnitSystemType) => (
+            <MenuItem value={system} key={system}>
+              {UNIT_SYSTEM_LABELS[system]}
+            </MenuItem>
+          ))}
+        </Select>
+        <Typography variant="body2" color="textSecondary">
+          {props.settings.units === "imperial"
+            ? "Temperatures in °F, wind in mph, emissions in pounds and tons."
+            : "Temperatures in °C, wind in km/h, emissions in kilograms and tonnes."}
+        </Typography>
         <Typography variant="h6" style={{ marginTop: 24 }}>
           Keyboard Shortcuts
         </Typography>

--- a/src/components/views/SettingsContainer.tsx
+++ b/src/components/views/SettingsContainer.tsx
@@ -2,7 +2,7 @@ import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigate } from "../../reducers/Card";
 import { change as changeSettings } from "../../reducers/Settings";
-import { AppStateType } from "../../Types";
+import { AppStateType, UnitSystemType } from "../../Types";
 import Settings, { DispatchProps, StateProps } from "./Settings";
 
 const mapStateToProps = (state: AppStateType): StateProps => {
@@ -15,6 +15,9 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onAudioChange: (v: boolean) => {
       dispatch(changeSettings({ audioEnabled: v }));
+    },
+    onUnitsChange: (v: UnitSystemType) => {
+      dispatch(changeSettings({ units: v }));
     },
     onBack: () => {
       dispatch(navigate("MAIN_MENU"));

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -2,6 +2,37 @@ import * as React from "react";
 import KeyboardShortcuts, {
   SHORTCUTS_SEARCH_TEXT,
 } from "../components/base/KeyboardShortcuts";
+import { useUnits } from "../components/base/UnitsContext";
+import {
+  formatLargeMassApprox,
+  formatPricePerLargeMass,
+  KG_PER_MEGATONNE,
+  largeMassUnit,
+  massUnitName,
+} from "../helpers/Units";
+
+// The entries are static markup, so the handful of places that name a unit read the setting
+// through a component of their own rather than the array becoming a function of it. Their text
+// is not walked by the search (see manualEntryText), which is what the keywords are for.
+function MassUnitName(): React.JSX.Element {
+  return <>{massUnitName(useUnits())}</>;
+}
+
+function LargeMassUnit(): React.JSX.Element {
+  return <>{largeMassUnit(useUnits())}</>;
+}
+
+// The illustrative fee in the carbon fee entry, quoted per whichever ton the player reads in -
+// $50 a tonne is $45 a ton
+const EXAMPLE_FEE_PER_KG = 0.05;
+
+function ExampleCarbonFee(): React.JSX.Element {
+  return <>{formatPricePerLargeMass(EXAMPLE_FEE_PER_KG, useUnits())}</>;
+}
+
+function EmissionsPerPoint(): React.JSX.Element {
+  return <>{formatLargeMassApprox(KG_PER_MEGATONNE, useUnits())}</>;
+}
 
 // Groups the entries into sections, so the list doesn't open on "Blackouts" and "BTU" purely
 // because the alphabet says so. Ordered the way they're shown.
@@ -232,22 +263,24 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
   {
     title: MANUAL_ENTRY.CARBON_FEE,
     group: "Money",
-    keywords: "carbon tax carbon price pollution fee co2 per ton",
+    keywords: "carbon tax carbon price pollution fee co2 per ton tonne",
     entry: (
       <div>
         <p>
           A carbon fee is a charge on pollution, meant to cover the damage it
           does to everyone else. It's billed by the amount of greenhouse gas
-          emitted, measured in tons of CO2 equivalent, and it shows up in your
-          P&amp;L as an operating expense on every dirty MWh you generate.
+          emitted, measured in <LargeMassUnit /> of CO2 equivalent, and it shows
+          up in your P&amp;L as an operating expense on every dirty MWh you
+          generate.
         </p>
         <p>
           Electricity generation is the 2nd largest source of greenhouse gas in
           the United States, and without a fee a utility has no financial reason
           to cut its emissions - the cheapest plant to run wins no matter what
-          comes out of the stack. A fee changes the merit order itself: at $50
-          per ton a coal plant can become more expensive to run than the gas
-          plant beside it, without a single rule telling you to shut it down.
+          comes out of the stack. A fee changes the merit order itself: at{" "}
+          <ExampleCarbonFee /> a coal plant can become more expensive to run
+          than the gas plant beside it, without a single rule telling you to
+          shut it down.
         </p>
         <p>
           Scenarios set their own fee, and custom games let you dial it from $0
@@ -308,14 +341,15 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
   {
     title: MANUAL_ENTRY.EMISSIONS,
     group: "Physics & Units",
-    keywords: "greenhouse gas pollution carbon dioxide equivalent tons",
+    keywords:
+      "greenhouse gas pollution carbon dioxide equivalent tons tonnes kilograms pounds",
     entry: (
       <div>
         <p>
           CO2e stands for Carbon Dioxide equivalent, a measure of the greenhouse
-          warming impact of various pollutants. Each generator lists the
-          kilograms of CO2e it releases per MWh, which is what makes a coal
-          plant and a gas plant of the same size comparable.
+          warming impact of various pollutants. Each generator lists the{" "}
+          <MassUnitName /> of CO2e it releases per MWh, which is what makes a
+          coal plant and a gas plant of the same size comparable.
         </p>
         <p>
           Electricity generation is the 2nd largest source of greenhouse gas in
@@ -592,7 +626,9 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
             </tr>
             <tr>
               <td>-2</td>
-              <td>per megaton (1M tons) of CO2e emitted</td>
+              <td>
+                per <EmissionsPerPoint /> of CO2e emitted
+              </td>
             </tr>
             <tr>
               <td>-8</td>
@@ -616,7 +652,9 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
             </tr>
             <tr>
               <td>-5</td>
-              <td>per megaton (1M tons) of CO2e emitted</td>
+              <td>
+                per <EmissionsPerPoint /> of CO2e emitted
+              </td>
             </tr>
             <tr>
               <td>-10</td>

--- a/src/helpers/Units.test.tsx
+++ b/src/helpers/Units.test.tsx
@@ -1,0 +1,72 @@
+import {
+  formatLargeMass,
+  formatLargeMassApprox,
+  formatMass,
+  formatPricePerLargeMass,
+  formatSpeed,
+  formatTemperature,
+  toDisplayLargeMass,
+  toDisplayMass,
+  toDisplaySpeed,
+  toDisplayTemperature,
+} from "./Units";
+
+describe("Units", () => {
+  describe("metric", () => {
+    // Metric is what everything upstream is already in, so it has to come back untouched -
+    // a rounding factor of 1.0000001 here would drift every number in the game
+    it("hands metric values back unchanged", () => {
+      expect(toDisplayTemperature(21.5, "metric")).toBe(21.5);
+      expect(toDisplaySpeed(30, "metric")).toBe(30);
+      expect(toDisplayMass(450, "metric")).toBe(450);
+      expect(toDisplayLargeMass(2500, "metric")).toBe(2.5);
+    });
+
+    it("labels them in metric", () => {
+      expect(formatTemperature(21.5, "metric")).toBe("22°C");
+      expect(formatSpeed(30, "metric")).toBe("30 km/h");
+      expect(formatMass(450, "metric")).toBe("450kg");
+      expect(formatLargeMass(2500000, "metric")).toBe("2,500 tonnes");
+    });
+  });
+
+  describe("imperial", () => {
+    it("converts temperature, including below freezing", () => {
+      expect(formatTemperature(0, "imperial")).toBe("32°F");
+      expect(formatTemperature(100, "imperial")).toBe("212°F");
+      expect(formatTemperature(-40, "imperial")).toBe("-40°F");
+    });
+
+    it("converts wind speed", () => {
+      expect(toDisplaySpeed(160.9344, "imperial")).toBeCloseTo(100, 6);
+      expect(formatSpeed(50, "imperial")).toBe("31 mph");
+    });
+
+    it("converts mass and quotes it in pounds", () => {
+      expect(toDisplayMass(0.45359237, "imperial")).toBeCloseTo(1, 9);
+      expect(formatMass(450, "imperial")).toBe("992lb");
+    });
+
+    // Short tons, not tonnes: 10% apart, which is why the metric one is spelled "tonnes"
+    it("converts large mass into short tons", () => {
+      expect(toDisplayLargeMass(907.18474, "imperial")).toBeCloseTo(1, 9);
+      expect(formatLargeMass(907184.74, "imperial")).toBe("1,000 tons");
+    });
+  });
+
+  // A round number of one is a lopsided number of the other, and the score's megatonne is
+  // exactly that: a yardstick, not a measurement
+  it("rounds a yardstick quantity to something readable", () => {
+    expect(formatLargeMassApprox(1000000000, "metric")).toBe("1M tonnes");
+    expect(formatLargeMassApprox(1000000000, "imperial")).toBe("1.1M tons");
+  });
+
+  // The scenario stores a fee per kilogram whichever system it's quoted in, so only the
+  // quoted number moves
+  it("restates a per-ton price without touching the stored one", () => {
+    expect(formatPricePerLargeMass(0.05, "metric")).toBe("$50/tonne");
+    expect(formatPricePerLargeMass(0.05, "imperial")).toBe("$45/ton");
+    expect(formatPricePerLargeMass(0, "metric")).toBe("$0/tonne");
+    expect(formatPricePerLargeMass(0, "imperial")).toBe("$0/ton");
+  });
+});

--- a/src/helpers/Units.tsx
+++ b/src/helpers/Units.tsx
@@ -1,0 +1,138 @@
+import numbro from "numbro";
+import { UnitSystemType } from "../Types";
+
+/**
+ * Everything the player reads is converted from metric at the last moment; nothing upstream of
+ * these functions ever holds an imperial number. The simulation, the saves and the weather data
+ * are all metric, so switching systems can only ever change what a label says, never what the
+ * game does - which is also why every conversion here is one way, out of metric.
+ */
+
+// The order the setting offers them in, and what a stored choice is checked against
+export const UNIT_SYSTEMS: readonly UnitSystemType[] = ["metric", "imperial"];
+export const DEFAULT_UNIT_SYSTEM: UnitSystemType = "metric";
+
+export const UNIT_SYSTEM_LABELS: { [system in UnitSystemType]: string } = {
+  metric: "Metric",
+  imperial: "Imperial",
+};
+
+// Exact definitions rather than the rounded constants they're usually quoted as
+const KM_PER_MILE = 1.609344;
+const KG_PER_POUND = 0.45359237;
+const KG_PER_SHORT_TON = 907.18474;
+const KG_PER_TONNE = 1000;
+
+// The yardstick the score deducts emissions per. A round megatonne, and a lopsided 1.1M tons
+export const KG_PER_MEGATONNE = 1000000000;
+
+export function isImperial(units: UnitSystemType): boolean {
+  return units === "imperial";
+}
+
+export function temperatureUnit(units: UnitSystemType): string {
+  return isImperial(units) ? "°F" : "°C";
+}
+
+export function toDisplayTemperature(
+  celsius: number,
+  units: UnitSystemType,
+): number {
+  return isImperial(units) ? celsius * 1.8 + 32 : celsius;
+}
+
+export function formatTemperature(
+  celsius: number,
+  units: UnitSystemType,
+): string {
+  return `${Math.round(toDisplayTemperature(celsius, units))}${temperatureUnit(units)}`;
+}
+
+export function speedUnit(units: UnitSystemType): string {
+  return isImperial(units) ? "mph" : "km/h";
+}
+
+export function toDisplaySpeed(kph: number, units: UnitSystemType): number {
+  return isImperial(units) ? kph / KM_PER_MILE : kph;
+}
+
+export function formatSpeed(kph: number, units: UnitSystemType): string {
+  return `${Math.round(toDisplaySpeed(kph, units))} ${speedUnit(units)}`;
+}
+
+/** The unit a generator's emissions per MWh are quoted in - small enough to read in whole units */
+export function massUnit(units: UnitSystemType): string {
+  return isImperial(units) ? "lb" : "kg";
+}
+
+/** Spelled out, for prose rather than a table cell */
+export function massUnitName(units: UnitSystemType): string {
+  return isImperial(units) ? "pounds" : "kilograms";
+}
+
+export function toDisplayMass(kg: number, units: UnitSystemType): number {
+  return isImperial(units) ? kg / KG_PER_POUND : kg;
+}
+
+export function formatMass(kg: number, units: UnitSystemType): string {
+  return `${Math.round(toDisplayMass(kg, units)).toLocaleString()}${massUnit(units)}`;
+}
+
+/**
+ * Metric tons are spelled "tonnes" so that the two systems' tons can't be mistaken for each
+ * other - they're 10% apart, which is exactly the size of difference that reads as a bug.
+ */
+export function largeMassUnit(units: UnitSystemType): string {
+  return isImperial(units) ? "tons" : "tonnes";
+}
+
+export function toDisplayLargeMass(kg: number, units: UnitSystemType): number {
+  return kg / (isImperial(units) ? KG_PER_SHORT_TON : KG_PER_TONNE);
+}
+
+/** Just the number, for a table that puts the unit in its own column or suffix */
+export function formatLargeMassValue(
+  kg: number,
+  units: UnitSystemType,
+  mantissa = 0,
+): string {
+  return numbro(toDisplayLargeMass(kg, units)).format({
+    thousandSeparated: true,
+    mantissa,
+  });
+}
+
+export function formatLargeMass(kg: number, units: UnitSystemType): string {
+  return `${formatLargeMassValue(kg, units)} ${largeMassUnit(units)}`;
+}
+
+/**
+ * A round number of tons in one system is a lopsided one in the other, so a quantity used as a
+ * yardstick - the megatonne the score deducts per, the fee quoted per ton - is rounded to
+ * something a player can hold onto rather than shown to the digit.
+ */
+export function formatLargeMassApprox(
+  kg: number,
+  units: UnitSystemType,
+): string {
+  const value = toDisplayLargeMass(kg, units);
+  return `${numbro(value).format({ average: true, totalLength: 2, trimMantissa: true }).toUpperCase()} ${largeMassUnit(units)}`;
+}
+
+/**
+ * A price quoted per metric ton, restated per whatever ton the player is reading in. The stored
+ * value stays per kilogram either way - see feePerKgCO2e on the scenario.
+ */
+export function toDisplayPricePerLargeMass(
+  dollarsPerKg: number,
+  units: UnitSystemType,
+): number {
+  return dollarsPerKg * (isImperial(units) ? KG_PER_SHORT_TON : KG_PER_TONNE);
+}
+
+export function formatPricePerLargeMass(
+  dollarsPerKg: number,
+  units: UnitSystemType,
+): string {
+  return `$${Math.round(toDisplayPricePerLargeMass(dollarsPerKg, units)).toLocaleString("en-US")}/${isImperial(units) ? "ton" : "tonne"}`;
+}

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1,7 +1,6 @@
 import type { AppDispatch } from "../Store";
 import cloneDeep from "lodash.clonedeep";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import numbro from "numbro";
 import { submitHighscore } from "./User";
 import {
   getDateFromMinute,
@@ -26,6 +25,7 @@ import {
   formatWattHours,
 } from "../helpers/Format";
 import { arrayMove, newSeed } from "../helpers/Math";
+import { formatLargeMass } from "../helpers/Units";
 import { getSolarOutputFactor, getWindOutputFactor } from "../helpers/Energy";
 import { getFuelPricesPerMBTU } from "../data/FuelPrices";
 import { getWeather, getRawSolarIrradianceWM2 } from "../data/Weather";
@@ -693,7 +693,7 @@ export function tickState(state: GameType) {
               message: `You've run out of money.
                 You survived for ${finished.date.year - finished.startingYear} years,
                 earned ${formatMoneyConcise(summary.revenue)} in revenue
-                and emitted ${numbro(summary.kgco2e / 1000).format({ thousandSeparated: true, mantissa: 0 })} tons of pollution.`,
+                and emitted ${formatLargeMass(summary.kgco2e, getStore().getState().settings.units)} of pollution.`,
               open: true,
               notCancellable: true,
               actionLabel: "Try again",
@@ -731,7 +731,7 @@ export function tickState(state: GameType) {
               message: `You've allowed chronic blackouts for 3 months, causing shareholders to remove you from office.
                 You survived for ${finished.date.year - finished.startingYear} years,
                 earned ${formatMoneyConcise(summary.revenue)} in revenue
-                and emitted ${numbro(summary.kgco2e / 1000).format({ thousandSeparated: true, mantissa: 0 })} tons of pollution.`,
+                and emitted ${formatLargeMass(summary.kgco2e, getStore().getState().settings.units)} of pollution.`,
               open: true,
               notCancellable: true,
               actionLabel: "Try again",

--- a/src/reducers/Settings.tsx
+++ b/src/reducers/Settings.tsx
@@ -1,13 +1,18 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import {
   getStorageBooleanOrUndefined,
+  getStorageChoice,
   setStorageKeyValue,
 } from "../LocalStorage";
 import { SettingsType } from "../Types";
 import { pause, resume } from "../data/Audio";
+import { DEFAULT_UNIT_SYSTEM, UNIT_SYSTEMS } from "../helpers/Units";
 
 export const initialSettings: SettingsType = {
   audioEnabled: getStorageBooleanOrUndefined("audioEnabled"),
+  // getStorageChoice rather than getStorageString so a hand-edited or outdated value falls back
+  // to metric instead of reaching the formatters as a system that does not exist
+  units: getStorageChoice("units", UNIT_SYSTEMS, DEFAULT_UNIT_SYSTEM),
 };
 
 export const settingsSlice = createSlice({


### PR DESCRIPTION
Adds a **Units** setting (Metric by default) that changes every unit the game shows, while everything it stores and simulates stays metric.

### What changes on screen

| | Metric | Imperial |
|---|---|---|
| Weather chart axes + tooltip | `Heat (°C)`, `Wind (km/h)` | `Heat (°F)`, `Wind (mph)` |
| Build generator emissions | `1,176kg CO2e/MWh` | `2,593lb CO2e/MWh` |
| P&L emissions rows | `9,260 tonnes`, `kg/MWh` | `10,208 tons`, `lb/MWh` |
| Custom game carbon fee | `$50/tonne` | `$45/ton` |
| Score summaries + manual | `per 1M tonnes` | `per 1.1M tons` |
| End-of-run summary | `… tonnes of pollution` | `… tons of pollution` |

The weather chart plots in the display unit rather than relabelling a metric axis, so the line sits where its axis says it does.

### How it stays metric underneath

`helpers/Units` converts one way, out of metric, at the last moment. Nothing upstream of a label ever holds an imperial number — the simulation, the saved games, the packed weather data and `feePerKgCO2e` are untouched, so switching systems can only change what a number is called.

The carbon fee picker is the one place worth a second look: the options are still the same four scenario values stored per kilogram, only quoted per whichever ton is being read.

### Why a context rather than props

The things that show a unit are leaves under components that block re-renders on purpose — `Compositor` ignores anything but the card, `Finances` throttles against the game clock, `ChartForecastWeather` is a `PureComponent`. Context updates go through all three, so nothing had to be loosened. It also defaults to metric rather than throwing, which is what lets the existing tests go on rendering `Manual` and `Finances` outside the store.

### Naming

Metric tons are spelled **tonnes**. Short tons are 10% lighter, and calling both "tons" makes a correct conversion look like a bug.

### Testing

- New `helpers/Units.test.tsx`: metric passes through untouched, conversions against exact definitions, and the fee restated without moving the stored value.
- Full suite: 414 tests, 31 suites, all passing. Typecheck and lint clean.
- Verified in the running app both ways: settings picker persists to `localStorage`, and the build screen, P&L, weather tooltip, victory conditions and manual all read correctly in each system (1,176kg ↔ 2,593lb on the same coal plant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
