### PR TITLE
Fixes from a review of the past week on master

### DIFF
--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -221,7 +221,6 @@ export function decodeReplay(raw: unknown): ReplayType | null {
   if (
     !isFiniteNumber(doc.scenarioId) ||
     !isFiniteNumber(doc.seed) ||
-    !isFiniteNumber(doc.startingYear) ||
     typeof doc.difficulty !== "string" ||
     // Checked in full rather than trusted: the location's id becomes the path of the weather file
     // the loading screen fetches, and its lat/long drive the sun model
@@ -239,7 +238,10 @@ export function decodeReplay(raw: unknown): ReplayType | null {
     scenarioId: doc.scenarioId,
     difficulty: doc.difficulty as ReplayType["difficulty"],
     seed: doc.seed,
-    startingYear: doc.startingYear,
+    // Diagnostic only (see ReplayType), so a document without one is still a replay
+    startingYear: isFiniteNumber(doc.startingYear)
+      ? doc.startingYear
+      : undefined,
     location: doc.location,
     durationMinutes: isFiniteNumber(doc.durationMinutes)
       ? doc.durationMinutes

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -104,6 +104,29 @@ describe("SaveGame", () => {
     ).toBeNull();
   });
 
+  // The location is checked in full rather than just for being an object, the same way a replay's
+  // is: its id becomes the path of the weather file the loading screen fetches, and the rest of it
+  // drives the sun model
+  it("ignores a save whose location isn't one", () => {
+    const save = serializeSave(game);
+    const withLocation = (location: unknown) =>
+      parseSave({ ...save, game: { ...save.game, location } });
+    expect(withLocation(undefined)).toBeNull();
+    expect(withLocation({})).toBeNull();
+    // Straight into `/data/weather/<id>.bin`
+    expect(
+      withLocation({ ...save.game.location, id: "../../secrets" }),
+    ).toBeNull();
+    // Off the globe, which the sun model has no answer for
+    expect(withLocation({ ...save.game.location, lat: 400 })).toBeNull();
+    expect(withLocation({ ...save.game.location, long: "west" })).toBeNull();
+    expect(
+      withLocation({ ...save.game.location, timeZone: undefined }),
+    ).toBeNull();
+    // And the real one still round trips
+    expect(parseSave(save)).not.toBeNull();
+  });
+
   // Tutorials run a single month and hit the win trigger on the way past. Clearing on any
   // scenario ending would throw away a real game the player still wanted.
   it("only clears the save belonging to the scenario that ended", () => {

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -1,4 +1,5 @@
 import packageJson from "../package.json";
+import { isValidLocation } from "./helpers/Locations";
 import {
   getStorageJson,
   removeStorageKey,
@@ -71,8 +72,10 @@ export function parseSave(raw: unknown): SaveGameType | null {
     typeof game.scenarioId !== "number" ||
     typeof game.seed !== "number" ||
     typeof game.startingYear !== "number" ||
-    typeof game.location !== "object" ||
-    game.location === null
+    // Checked in full rather than trusted, the same way decodeReplay checks a replay's: the
+    // location's id becomes the path of the weather file the loading screen fetches, and its
+    // lat/long and time zone drive the sun model. A save is hand-editable too
+    !isValidLocation(game.location)
   ) {
     return null;
   }

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -139,7 +139,11 @@ export interface ReplayType {
   scenarioId: number;
   difficulty: DifficultyType;
   seed: number;
-  startingYear: number;
+  // Recorded for bug reports, alongside appVersion, and deliberately not read back: playback
+  // reloads the scenario and takes the year from it, so a replay that disagreed with its own
+  // scenario would be describing a run that could not be reproduced anyway. Not required on the
+  // way in for the same reason
+  startingYear?: number;
   // Where the run was played. A scenario id no longer pins this down -- a custom game carries its
   // own location, and an authored one could be given a location that isn't in LOCATIONS -- so
   // without it a replay would silently be re-simulated against a different city's weather

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -124,8 +124,8 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
     plugins: [
       bandsPlugin(() => getState().blackoutSpans, blackoutColor, 0.3),
       verticalLinePlugin(() => getState().currentMinute, "#000000", 0.5),
-      // Flush with the plot's right edge: 350 design units less the 5 of right padding
-      legendPlugin(() => getState().legendItems, 345, 18, "right"),
+      // Flush with the plot's own right edge, wherever the y axis leaves it
+      legendPlugin(() => getState().legendItems, 0, 18, "right"),
     ],
   };
 }

--- a/src/components/base/UPlotHelpers.ts
+++ b/src/components/base/UPlotHelpers.ts
@@ -273,14 +273,20 @@ export function verticalLinePlugin(
 }
 
 /**
- * A legend inside the plot, where Victory's was. Position is in design units, so it lands in
- * the same place it used to at any pane width. `align` says which edge of the block designX
- * anchors: "left" pins the dots, "right" pins the end of the longest label, so a legend can sit
- * flush with the plot's right edge whatever its labels happen to be.
+ * A legend inside the plot, where Victory's was.
+ *
+ * `inset` is how far in from the plot's own edge the block sits, in design units, and `align`
+ * says which edge that is: "left" pins the dots to the left edge, "right" pins the end of the
+ * longest label to the right one, so a legend sits flush whatever its labels happen to be.
+ *
+ * Measured off `u.bbox` rather than the canvas, for the same reason titlePlugin is: the y axis
+ * is only as wide as its labels, so the plot no longer starts or ends where a fixed offset from
+ * the canvas edge would put it. `designY` stays a canvas offset, which is what the title uses
+ * too -- it is the top padding these charts share, not anything the axes move.
  */
 export function legendPlugin(
   getItems: () => LegendItem[],
-  designX: number,
+  inset: number,
   designY: number,
   align: "left" | "right" = "left",
 ): uPlot.Plugin {
@@ -301,12 +307,18 @@ export function legendPlugin(
         u.ctx.textAlign = "left";
         u.ctx.textBaseline = "middle";
         // The dots share a column, so the block is only as wide as its longest label
-        let x = designX * scale;
+        let x;
         if (align === "right") {
           const widest = Math.max(
             ...items.map((item) => u.ctx.measureText(item.name).width),
           );
-          x -= radius + gap + widest;
+          x =
+            u.bbox.left +
+            u.bbox.width -
+            inset * scale -
+            (radius + gap + widest);
+        } else {
+          x = u.bbox.left + inset * scale;
         }
         let y = designY * scale;
         for (const item of items) {

--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { produce } from "immer";
 import Finances, { parseRange, projectMonths } from "./Finances";
@@ -8,10 +8,11 @@ import { tickState } from "../../reducers/Game";
 import { MINUTES_PER_MONTH, summarizeTimeline } from "../../helpers/DateTime";
 import { GameType, MonthlyHistoryType, SpeedType } from "../../Types";
 
-// Every test in here plays a couple of game years and then renders the real pane, chart and all,
-// so the slowest of them sit close enough to Jest's 5s default to turn into a coin flip once the
-// machine is under load. Nothing here waits on anything, so a ceiling this high only ever catches
-// a genuine hang
+// Every test in here plays a couple of game years and then renders the real pane, chart and all.
+// The slowest now runs in about a second -- see `choose` and `summarised` for where the rest of
+// it went -- so nothing should come near this. Kept well clear of the default only because
+// nothing here waits on anything, which makes a ceiling this high a hang detector rather than
+// something a loaded machine can trip
 jest.setTimeout(30000);
 
 // The card chrome is connected to the store and hides its children until a game is running, none
@@ -53,9 +54,19 @@ function summarised(label: string): string {
   return labelCell.nextElementSibling?.textContent || "";
 }
 
+// `delay: null` drops the timer userEvent otherwise waits on between the events of a click.
+// There are roughly forty clicks in this file and nothing in the pane is waiting on a timer, so
+// that wait was most of what the suite spent its time on
+const user = userEvent.setup({ delay: null });
+
+// Found by text inside the open listbox rather than by accessible name, for the same reason
+// `summarised` is: asking for an option by name makes testing-library compute one for every
+// option in the list, at over a second a call. The role query for the listbox itself carries no
+// name, so it stays cheap
 async function choose(select: HTMLElement, option: string) {
-  await userEvent.click(select);
-  await userEvent.click(await screen.findByRole("option", { name: option }));
+  await user.click(select);
+  const listbox = await screen.findByRole("listbox");
+  await user.click(within(listbox).getByText(option));
 }
 
 // Carbon Fee: a twelve year scenario, so a couple of years in it is still running and none of the

--- a/src/data/Economy.tsx
+++ b/src/data/Economy.tsx
@@ -152,10 +152,12 @@ function collectEconomyRow(data: RawEconomyType) {
     return;
   }
   economy[+data.year] = economy[+data.year] || {};
-  economy[+data.year][+data.month] = {
+  // Frozen because getEconomy hands the cached object straight to its callers rather than
+  // copying it per read, and a caller that wrote to one would be rewriting history
+  economy[+data.year][+data.month] = Object.freeze({
     prime: +data.prime / 100,
     inflation: +data.inflation,
-  };
+  });
   const month = absoluteMonth(+data.year, +data.month);
   if (month > seamMonth) {
     seamMonth = month;
@@ -336,9 +338,8 @@ function getEconomy(date: MonthRefType, seed: number): MonthEconomyType {
     economy[year] = {};
   }
   if (economy[year][date.monthNumber] === undefined) {
-    economy[year][date.monthNumber] = projectMonth(
-      absoluteMonth(year, date.monthNumber),
-      seed,
+    economy[year][date.monthNumber] = Object.freeze(
+      projectMonth(absoluteMonth(year, date.monthNumber), seed),
     );
   }
   return economy[year][date.monthNumber];

--- a/src/data/FuelPrices.test.tsx
+++ b/src/data/FuelPrices.test.tsx
@@ -177,6 +177,23 @@ describe("getFuelPricesPerMBTU", () => {
     );
   });
 
+  // Handed out by reference rather than copied per tick, so a caller that wrote to one would be
+  // rewriting the record for every read after it
+  it("hands back prices nothing can write to", () => {
+    const prices = pricesIn(FIXTURE_STARTING_YEAR, 6);
+    expect(() => {
+      (prices as FuelPricesType).Coal = 999;
+    }).toThrow();
+  });
+
+  // The same, for a month the projection invented rather than one the record carried
+  it("hands back projected prices nothing can write to", () => {
+    const prices = pricesIn(FIXTURE_ENDING_YEAR + 5, 6);
+    expect(() => {
+      (prices as FuelPricesType).Coal = 999;
+    }).toThrow();
+  });
+
   // The projection carries the last recorded month's departure from trend forward rather than
   // restarting at the trend, so the handoff out of the data is a month's move, not a step change
   it("picks up where the record left off rather than jumping", () => {

--- a/src/data/FuelPrices.tsx
+++ b/src/data/FuelPrices.tsx
@@ -260,12 +260,14 @@ function collectFuelPriceRow(data: RawFuelPricesType) {
     return;
   }
   fuelPrices[+data.year] = fuelPrices[+data.year] || {};
-  fuelPrices[+data.year][+data.month] = {
+  // Frozen because getFuelPricesPerMBTU hands the cached object straight to its callers rather
+  // than copying it per tick, and a caller that wrote to one would be rewriting the record
+  fuelPrices[+data.year][+data.month] = Object.freeze({
     "Natural Gas": +data.naturalgas,
     Coal: +data.coal,
     Uranium: +data.uranium,
     Oil: +data.oil,
-  };
+  });
 }
 
 /**
@@ -351,7 +353,7 @@ function projectYear(
         anchorPrice(trend, thisMonth) *
         Math.exp(Math.min(limit, Math.max(-limit, departure)));
     });
-    fuelPrices[year][month] = prices;
+    fuelPrices[year][month] = Object.freeze(prices);
     previous = prices;
   }
 }

--- a/src/data/Weather.test.tsx
+++ b/src/data/Weather.test.tsx
@@ -155,6 +155,23 @@ describe("getWeather", () => {
     expect(getWeather(dateAt(3, 10), SEED)).toEqual(fixtureRow(0, 3, 10));
   });
 
+  // A forecast day is last year's same day nudged, so with less than a year loaded forecastDay
+  // reaches back past the start of the array and dies on `previous.YEAR` -- mid-tick, a long way
+  // from the load that caused it, and only once the player has started playing. Said here
+  // instead, the way decodeWeather refuses a file it cannot vouch for
+  it("refuses a record too short to forecast from", () => {
+    const short = fixtureRows().slice(0, MONTHS_PER_YEAR * HOURS_PER_MONTH - 1);
+    expect(() => initWeatherFromRows("PIT", short)).toThrow(/at least/);
+    expect(() => initWeatherFromRows("PIT", [])).toThrow(/at least/);
+    // Exactly a year is enough: there is a year to forecast the next one from
+    expect(() =>
+      initWeatherFromRows(
+        "PIT",
+        fixtureRows().slice(0, MONTHS_PER_YEAR * HOURS_PER_MONTH),
+      ),
+    ).not.toThrow();
+  });
+
   it("blends towards the next hour as the minutes tick over", () => {
     const here = fixtureRow(0, 3, 10).TEMP_C;
     const next = fixtureRow(0, 3, 11).TEMP_C;
@@ -323,9 +340,18 @@ describe("getWeather", () => {
     it("keeps a century of forecasts centred on the month's own average", () => {
       for (const month of [1, 4, 7, 10]) {
         const means = forecastDailyMeans(month, "TEMP_C", 100);
-        // Standard error over 100 years is a tenth of the month's spread, so anything approaching
-        // a whole standard deviation of bias is a walk, not noise
-        expect(mean(means)).toBeCloseTo(monthlyTempC(month), 0);
+        // Judged against the standard error rather than a flat tolerance. A hundred draws of a
+        // month whose spread is `tempSpreadC` puts the error on their mean at a tenth of that --
+        // 0.8C for January -- so a fixed 0.5C was inside the noise and passed or failed on which
+        // seed the fixture happened to use: measured across forty of them the bias averages
+        // 0.04C with a standard deviation of 0.78C, and better than half of them clear 0.5C.
+        // Three standard errors keeps that at a fraction of a percent while still being a long
+        // way inside the walk this guards against, which reached +12C.
+        const standardError = tempSpreadC(month) / 10;
+        expect(Math.abs(mean(means) - monthlyTempC(month))).toBeLessThan(
+          3 * standardError,
+        );
+        // And well inside the month's own year to year spread, whatever the seed
         expect(Math.abs(mean(means) - monthlyTempC(month))).toBeLessThan(
           tempSpreadC(month),
         );

--- a/src/data/Weather.tsx
+++ b/src/data/Weather.tsx
@@ -15,9 +15,11 @@ const ROWS_PER_DAY = 24;
 const ROWS_PER_YEAR = DAYS_PER_YEAR * ROWS_PER_DAY;
 const EXPECTED_ROWS = (ENDING_YEAR - STARTING_YEAR + 1) * ROWS_PER_YEAR;
 const MONTHS_PER_YEAR = 12;
-// One normal each for temperature, wind and cloud cover, plus a uniform to pick which historic
-// year the day borrows its hour to hour shape from
-const DRAWS_PER_FORECAST_DAY = 4;
+// One normal each for temperature, wind and cloud cover. The uniform that picks which recorded
+// day a forecast borrows its shape from is addressed by day index on a stream of its own, since
+// normalAt and randomAt cannot share one (see RANDOM_STREAM).
+// (kept a literal rather than FORECAST_FIELDS.length, which is declared further down this file)
+const DRAWS_PER_FORECAST_DAY = 3;
 
 // How much of last year's departure from normal carries into this year's, for the same month.
 // The point of it being well under 1 is that the departure decays back towards normal instead of
@@ -81,6 +83,10 @@ interface MonthClimatologyType {
 // its seasonality from its own forty years rather than from anything written per location here,
 // which is what makes this scale to a seventh city.
 let climatology: MonthClimatologyType[] = [];
+
+// Bumped by every initWeather call, so an earlier download that lands after a later one can tell
+// that it is no longer the load anybody is waiting on
+let loadGeneration = 0;
 
 // Which calendar month a day index falls in, 0 based. Written against the constants rather than
 // assuming twelve days a year, so raising DAYS_PER_MONTH does not silently scramble the seasons.
@@ -163,11 +169,23 @@ function buildClimatology() {
  *
  * Everything else in this file reads `weather` by row offset, so nothing may be forecast until
  * this has run and the climatology has been built off real data.
+ *
+ * Short data throws rather than warning, the same way decodeWeather does. A forecast day is last
+ * year's same day nudged, so with less than a year loaded `forecastDay` reaches back past the
+ * start of the array and dies on `previous.YEAR` mid-tick -- a crash a long way from the load
+ * that caused it, and only once the player has started playing.
  */
 export function initWeatherFromRows(
   location: string,
   rows: RawWeatherType[],
 ): void {
+  if (rows.length < ROWS_PER_YEAR) {
+    weather = [];
+    climatology = [];
+    throw new Error(
+      `Weather data for ${location} holds ${rows.length} rows, and a forecast needs at least the ${ROWS_PER_YEAR} of one year`,
+    );
+  }
   weather = rows; // replaced rather than appended to, so a second game doesn't inherit the first's
   if (weather.length < EXPECTED_ROWS) {
     console.warn(
@@ -201,8 +219,19 @@ export function initWeather(
   location: string,
   callback?: (failure?: string) => void,
 ) {
-  weather = []; // reset immediately, so a failed load can't be played on the last game's weather
+  // Reset immediately, so a failed load can't be played on the last game's weather. The
+  // climatology goes with it: leaving the last location's monthly means behind would let
+  // applyClimateForcing bend a reading against a city it never came from.
+  weather = [];
+  climatology = [];
+  // Two loads can be in flight at once -- backing out of the loading screen and picking somewhere
+  // else -- and without this the slower one wins simply by finishing last, handing the player a
+  // game played somewhere they didn't choose
+  const generation = ++loadGeneration;
   const done = (failure?: string) => {
+    if (generation !== loadGeneration) {
+      return; // Superseded by a later initWeather; that call owns the callback now
+    }
     if (callback) {
       callback(failure);
     }
@@ -220,6 +249,9 @@ export function initWeather(
       return response.arrayBuffer();
     })
     .then((buffer: ArrayBuffer) => {
+      if (generation !== loadGeneration) {
+        return; // A later load is already the one that counts; don't overwrite its rows
+      }
       initWeatherFromBinary(location, buffer);
       done();
     })
@@ -376,11 +408,13 @@ function forecastDay(seed: number, dayIndex: number) {
   const previousYearRow = (dayIndex - DAYS_PER_YEAR) * ROWS_PER_DAY;
   const draw = dayIndex * DRAWS_PER_FORECAST_DAY;
 
-  // A real day of this same month, whose hour to hour shape this day borrows
+  // A real day of this same month, whose hour to hour shape this day borrows. Addressed by day
+  // index on its own stream: a uniform drawn from the anomalies' stream would land on one of the
+  // pair some other day's normal is built from, since normalAt addresses those at 2 * index.
   const shapeRow =
     month.historicRows[
       Math.floor(
-        randomAt(seed, RANDOM_STREAM.weather, draw + FORECAST_FIELDS.length) *
+        randomAt(seed, RANDOM_STREAM.weatherShape, dayIndex) *
           month.historicRows.length,
       )
     ];

--- a/src/data/WeatherBinary.test.tsx
+++ b/src/data/WeatherBinary.test.tsx
@@ -125,6 +125,22 @@ describe("decodeWeather", () => {
       ),
     ).toThrow(/describes 24/);
   });
+
+  // A row's month is worked out from its position -- one recorded day per calendar month -- so a
+  // file claiming more days than a year has months would hand every reader of RawWeatherType a
+  // MONTH of 13 and up, which is not a month and which nothing downstream would question
+  it("refuses more days a year than a year has months", () => {
+    expect(() =>
+      decodeWeather(
+        buildFile({ daysPerYear: 13, hoursPerDay: 1, yearCount: 1 }, [
+          { temp: 0, cloud: 0, wind: 0, precip: 0 },
+        ]),
+      ),
+    ).toThrow(/13 days a year/);
+    expect(() =>
+      decodeWeather(buildFile({ daysPerYear: 0, hoursPerDay: 1 })),
+    ).toThrow(/0 days a year/);
+  });
 });
 
 // Reading what is actually in public/data is the only check that the fetch script and this

--- a/src/data/WeatherBinary.tsx
+++ b/src/data/WeatherBinary.tsx
@@ -18,6 +18,11 @@ const MAGIC = "EWX1";
 const SUPPORTED_VERSION = 1;
 const HEADER_BYTES = 16;
 const BYTES_PER_ROW = 5;
+// decodeWeather works out which month a row belongs to from its position -- one recorded day per
+// calendar month -- so a file claiming more days than a year has months would number rows MONTH
+// 13 and up, which is not a month and which every reader of RawWeatherType would go on to
+// believe. The decoder is otherwise happy at any smaller shape, which is what its tests use.
+const MAX_DAYS_PER_YEAR = 12;
 
 export interface WeatherFileHeaderType {
   version: number;
@@ -61,6 +66,20 @@ function readHeader(view: DataView, byteLength: number): WeatherFileHeaderType {
     yearCount: view.getUint16(10, true),
     rowCount: Math.floor((byteLength - HEADER_BYTES) / BYTES_PER_ROW),
   };
+  if (header.daysPerYear < 1 || header.daysPerYear > MAX_DAYS_PER_YEAR) {
+    throw new Error(
+      `Weather file holds ${header.daysPerYear} days a year, and a day has to be a month of the ${MAX_DAYS_PER_YEAR} in one`,
+    );
+  }
+  if (header.hoursPerDay < 1) {
+    throw new Error("Weather file holds no hours a day");
+  }
+  const bodyBytes = byteLength - HEADER_BYTES;
+  if (bodyBytes % BYTES_PER_ROW !== 0) {
+    throw new Error(
+      `Weather file has ${bodyBytes % BYTES_PER_ROW} bytes left over after its ${header.rowCount} rows`,
+    );
+  }
   const expected = header.daysPerYear * header.hoursPerDay * header.yearCount;
   if (header.rowCount !== expected) {
     throw new Error(

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -35,6 +35,15 @@ function aFacility(
 }
 
 describe("getMonthlyPayment", () => {
+  // The amortisation formula is 0/0 at a rate of zero, and a NaN payment spreads to the balance,
+  // the cash and the net worth without ever announcing itself. Nothing in the game reaches this
+  // today -- prime has a 3.25% floor and the credit premium only multiplies it -- but this is
+  // exported, and an interest free loan is a plain division rather than an undefined one
+  it("splits the principal evenly when there is no interest to pay", () => {
+    expect(getMonthlyPayment(1200, 0, 12)).toBe(100);
+    expect(getMonthlyPayment(1200, 0, 0)).toBe(1200);
+  });
+
   it("amortizes the principal away over the term", () => {
     const principal = 1000000;
     const rate = 0.06;

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -24,6 +24,13 @@ export function getMonthlyPayment(
   months: number,
 ): number {
   const monthlyRate = interestRate / 12;
+  // The amortisation formula is 0/0 at a rate of zero, and a NaN payment spreads to the balance,
+  // the cash and the net worth without ever announcing itself. Prime has a floor of 3.25% and
+  // the credit premium only multiplies it, so nothing in the game reaches this today -- but this
+  // is exported, and an interest free loan is a plain division rather than an undefined one
+  if (monthlyRate === 0) {
+    return months > 0 ? principal / months : principal;
+  }
   return principal * (monthlyRate / (1 - Math.pow(1 + monthlyRate, -months)));
 }
 

--- a/src/helpers/Math.test.tsx
+++ b/src/helpers/Math.test.tsx
@@ -5,6 +5,7 @@ import {
   newSeed,
   normalAt,
   randomAt,
+  RANDOM_STREAM,
 } from "./Math";
 
 const STREAM = 1;
@@ -129,6 +130,33 @@ describe("normalAt", () => {
         expect(Number.isFinite(normalAt(seed, STREAM, index))).toBe(true);
       }
     }
+  });
+
+  // The reason RANDOM_STREAM is one entry per kind of draw rather than one per subsystem, and
+  // the bug that made it so: a normal is built from the uniforms at 2*index and 2*index+1, so a
+  // stream taking plain randomAt draws as well hands the same uniform out twice. Weather did
+  // exactly that -- half its shape-day picks were also the second half of another day's cloud
+  // cover normal -- and pinning the addressing here is what stops the two spaces silently
+  // merging again
+  it("is built from the uniforms at 2*index and 2*index+1", () => {
+    const seed = 12345;
+    for (const index of [0, 1, 3, 17]) {
+      const u1 = Math.max(Number.MIN_VALUE, randomAt(seed, STREAM, index * 2));
+      const u2 = randomAt(seed, STREAM, index * 2 + 1);
+      expect(normalAt(seed, STREAM, index)).toBeCloseTo(
+        Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2),
+        12,
+      );
+    }
+  });
+});
+
+describe("RANDOM_STREAM", () => {
+  // Two subsystems sharing a stream would have one's draws shift the other's, and a stream that
+  // changed value would change what every existing seed produces
+  it("names every stream once", () => {
+    const ids = Object.values(RANDOM_STREAM);
+    expect(new Set(ids).size).toEqual(ids.length);
   });
 });
 

--- a/src/helpers/Math.tsx
+++ b/src/helpers/Math.tsx
@@ -32,10 +32,15 @@ export function getIntersectionX(
 // prices each walk their own index space, so adding a draw to one never shifts the other. The
 // values are arbitrary but have to stay distinct, and have to stay put -- changing one changes
 // what every existing seed produces.
+//
+// `normalAt` costs two uniforms per draw and addresses them at `2 * index`, so a stream it is
+// used on is not a stream `randomAt` may also be used on: the two index spaces interleave and
+// half the uniforms come out shared. Weather needs both kinds, so it gets a stream per kind.
 export const RANDOM_STREAM = {
-  weather: 1,
-  fuelPrices: 2,
-  economy: 3,
+  weather: 1, // normalAt only -- the per field anomalies
+  fuelPrices: 2, // normalAt only
+  economy: 3, // randomAt only
+  weatherShape: 4, // randomAt only -- which recorded day a forecast borrows its shape from
 };
 
 // https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript
@@ -82,6 +87,10 @@ export function getRandomRangeAt(
  * Box-Muller over a pair of uniforms, which is why one normal costs two indexes: the pair is
  * taken from `2 * index` and `2 * index + 1` rather than from neighbouring indexes, so callers
  * can walk their own index space one normal at a time without two of them ever sharing a uniform.
+ *
+ * That holds only against other `normalAt` draws. Because it consumes `2 * index`, a stream that
+ * also takes plain `randomAt` draws interleaves the two spaces and hands the same uniform out
+ * twice -- so a caller needing both kinds takes a stream for each, the way weather does.
  *
  * Weather anomalies are the reason this exists. A uniform nudge gives every deviation inside its
  * range the same likelihood and nothing at all outside it, which is the wrong shape for a

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1134,6 +1134,9 @@ function updateSupplyFacilitiesFinances(
   let expensesFuel = 0;
   let expensesInterest = 0;
   let principalRepayment = 0;
+  // Hoisted out of the loop below, the way the demand pass at the top of this file already does
+  // it: prices move by the month, and this is per facility per tick
+  const fuelPrices = getFuelPricesPerMBTU(date, state.seed);
   facilities.forEach((g: FacilityShoppingType) => {
     if (g.yearsToBuildLeft === 0) {
       if (g.paused) {
@@ -1146,8 +1149,7 @@ function updateSupplyFacilitiesFinances(
         const fuelBtu =
           ((g.currentW * (g.btuPerWh || 0)) / TICKS_PER_HOUR) *
           GAME_TO_REAL_YEARS; // Output-dependent #'s converted to real months, since we don't simulate every day
-        expensesFuel +=
-          (fuelBtu * getFuelPricesPerMBTU(date, state.seed)[g.fuel]) / 1000000;
+        expensesFuel += (fuelBtu * fuelPrices[g.fuel]) / 1000000;
         kgco2e += fuelBtu * FUELS[g.fuel].kgCO2ePerBtu;
       }
       if (g.loanAmountLeft > 0) {
@@ -1177,7 +1179,12 @@ function updateSupplyFacilitiesFinances(
   const expensesMarketing = state.monthlyMarketingSpend / TICKS_PER_MONTH;
 
   // Customers
-  const percentDemandUnfulfilled = (demandWh - supplyWh) / demandWh;
+  // Demand is the customer count times a multiple, so a run that blacks out for long enough
+  // rounds its last customer away and arrives here with no demand at all. Without the guard that
+  // is 0/0, and the NaN goes straight into the customer count and the cash balance and stays
+  // there -- a lost game turned into a corrupted one, with no way back to a number
+  const percentDemandUnfulfilled =
+    demandWh > 0 ? (demandWh - supplyWh) / demandWh : 0;
   const organicGrowthRate =
     ORGANIC_GROWTH_MAX_ANNUAL -
     difficulty.blackoutPenalty * percentDemandUnfulfilled;


### PR DESCRIPTION
Acting on a review of `516d01c..45fbb83` (116 commits, ~26k insertions). Fourteen findings, grouped into four commits.

## Correctness

**The weather's two kinds of random draw shared uniforms.** `normalAt` builds a normal from the uniforms at `2*index` and `2*index+1`, so a stream also taking plain `randomAt` draws hands the same uniform out twice. Weather was the one caller doing both, and exactly half its shape-day picks were also the second half of another day's cloud-cover normal. The shape pick gets its own stream.

Measured across forty seeds either side of the change, the forecast's century bias is unchanged — 0.05 °C before, 0.14 °C after, against a standard error of 0.78 °C. The draws were already deterministic; they simply weren't independent.

**A trailing newline would have NaN'd every projected fuel price.** `collectEconomyRow` drops Papa's blank row; `collectFuelPriceRow` didn't. It works today only because `FuelPricesRaw.csv` happens not to end in a newline — add one, which is what every formatter does, and `fuelPrices[NaN]` sorts to the end of the year list, becomes the "latest year", and takes the trend anchor and every price after 2019 with it.

**Neither CSV loader handled a failed download.** Papa never calls `complete` for a download that failed, and no `error` handler was passed — a dropped connection left the loading screen spinning with nothing to say, where `initWeather` has reported its failures all along.

**A lost game could become a corrupted one.** A run that blacks out long enough rounds its last customer away and reaches the growth calculation with zero demand: `0/0`, and the NaN lands in the customer count and cash balance permanently.

**Short weather data crashed mid-tick** rather than at load, and `initWeather` left the previous location's climatology behind on failure, with no guard against two loads racing.

**Saves skipped the location validation replays get** — same hand-editable input, and the id becomes a fetch path.

## Smaller

Zero-rate `getMonthlyPayment` (`0/0`), a `daysPerYear` header check, frozen price/rate caches, and the per-facility fuel-price lookup hoisted out of the tick loop.

`ReplayType.startingYear` was recorded, uploaded, required on decode, and never read. Kept for bug reports and documented as diagnostic rather than removed — removing it would mean bumping `REPLAY_VERSION` and discarding every replay stored against a high score.

## Tests

**`Finances.test.tsx`: 1231s → 75s, three timeouts → none.** `fb2292f` raised the timeout; the cost was `findByRole({ name })` in `choose`, at over a second a call across forty-odd calls — the same cost the neighbouring `summarised` helper already documents avoiding.

**Full suite: 1237s → 26s, 406 tests → 414.** New coverage for the blank row, the short-data throw, the save's location check, the zero-rate payment, the header check, and `normalAt`'s addressing.

## Two judgement calls worth a look

1. **I loosened the forecast drift tolerance.** It asserted a bias under 0.5 °C where its own comment puts the standard error at a tenth of the month's spread — 0.8 °C for January — so it was inside the noise: 23 of 40 seeds fail it on the *old* code, 24 on the new. It now allows three standard errors, still far inside the +12 °C walk it exists to catch. The measurement is in the commit message.

2. **The `daysPerYear` check is narrower than the review proposed.** The decoder's own tests build synthetic 1- and 2-day-per-year files, so it's deliberately generic; requiring exactly 12 would break that. It now rejects only more days than a year has months, which is the invariant that actually matters for `MONTH`.

## Verification

`tsc --noEmit`, `eslint --max-warnings=0`, `prettier --check` and all 414 tests pass. Ran the app end to end — started a scenario (exercising the changed loading path), confirmed the supply/demand chart and all four forecast charts render, and sampled the canvas to confirm the legend draws flush with the plot frame. Only console errors are Firebase complaining about a missing local API key.

The legend change is coherence rather than a visible fix: its right edge already landed correctly at the current padding, but `titlePlugin` was moved onto `u.bbox` in `876fad9` and `legendPlugin` was left measuring from the canvas origin, and the two disagreeing about where "the plot" is is how the next axis change goes wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)