### PR TITLE
Export and import a save from the settings screen

### DIFF
--- a/src/SaveFile.test.tsx
+++ b/src/SaveFile.test.tsx
@@ -1,0 +1,170 @@
+import { LOCATIONS } from "./Constants";
+import { CUSTOM_SCENARIO_ID } from "./data/Scenarios";
+import {
+  describeSave,
+  downloadSave,
+  MAX_SAVE_FILE_BYTES,
+  readSaveFile,
+  resumableSave,
+  saveFilename,
+} from "./SaveFile";
+import { clearSave, SAVE_VERSION, serializeSave, writeSave } from "./SaveGame";
+import { GameType } from "./Types";
+
+// Enough of a game slice to be a valid save: parseSave checks the fields the simulation would
+// crash on, not the whole of GameType, and building a real game here would cost a minute of setup
+function fakeGame(overrides: Partial<GameType> = {}): GameType {
+  return {
+    scenarioId: 101, // Rise of Renewables
+    seed: 31337,
+    startingYear: 2020,
+    location: LOCATIONS.PIT,
+    date: { minute: 1000, year: 2035, month: 6 },
+    facilities: [],
+    timeline: [],
+    monthlyHistory: [],
+    ...overrides,
+  } as unknown as GameType;
+}
+
+function saveFile(contents: unknown, name = "save.json"): File {
+  const text =
+    typeof contents === "string" ? contents : JSON.stringify(contents);
+  return new File([text], name, { type: "application/json" });
+}
+
+describe("SaveFile", () => {
+  beforeEach(() => {
+    clearSave();
+  });
+
+  describe("resumableSave", () => {
+    it("is nothing when no game has been saved", () => {
+      expect(resumableSave()).toBeNull();
+    });
+
+    it("resolves the scenario the save was played in", () => {
+      writeSave(fakeGame());
+      expect(describeSave(resumableSave()!)).toBe("Rise of Renewables, 2035");
+    });
+
+    it("ignores a save whose scenario this build no longer has", () => {
+      writeSave(fakeGame({ scenarioId: 99999 }));
+      expect(resumableSave()).toBeNull();
+    });
+
+    it("takes a custom game's scenario from the save itself", () => {
+      writeSave(
+        fakeGame({
+          scenarioId: CUSTOM_SCENARIO_ID,
+          customScenario: { id: CUSTOM_SCENARIO_ID, name: "My Grid" } as never,
+        }),
+      );
+      expect(describeSave(resumableSave()!)).toBe("My Grid, 2035");
+    });
+  });
+
+  describe("saveFilename", () => {
+    it("slugs the scenario name", () => {
+      expect(saveFilename("Rise of Renewables", 2035)).toBe(
+        "electrify-rise-of-renewables-2035.json",
+      );
+    });
+
+    // A custom game's name is typed by the player, so it reaches here as anything at all
+    it("folds away everything a filename shouldn't carry", () => {
+      expect(saveFilename("../../etc/passwd", 2020)).toBe(
+        "electrify-etc-passwd-2020.json",
+      );
+      expect(saveFilename("!!!", 2020)).toBe("electrify-game-2020.json");
+    });
+  });
+
+  describe("downloadSave", () => {
+    let clicked: HTMLAnchorElement | undefined;
+    let revoked: string[] = [];
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      clicked = undefined;
+      revoked = [];
+      URL.createObjectURL = jest.fn(() => "blob:save");
+      URL.revokeObjectURL = jest.fn((url: string) => revoked.push(url));
+      jest
+        .spyOn(HTMLAnchorElement.prototype, "click")
+        .mockImplementation(function (this: HTMLAnchorElement) {
+          clicked = this;
+          // The anchor has to be in the document at the moment of the click for Firefox
+          expect(this.isConnected).toBe(true);
+        });
+    });
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    it("downloads the save under the scenario's name", () => {
+      writeSave(fakeGame());
+      downloadSave(resumableSave()!);
+
+      expect(clicked?.download).toBe("electrify-rise-of-renewables-2035.json");
+      expect(clicked?.href).toBe("blob:save");
+      // Left where it was found, and the object URL released once the download has started
+      expect(clicked?.isConnected).toBe(false);
+      expect(revoked).toEqual([]);
+      jest.runOnlyPendingTimers();
+      expect(revoked).toEqual(["blob:save"]);
+    });
+  });
+
+  describe("readSaveFile", () => {
+    it("accepts a save this build can play", async () => {
+      const game = fakeGame();
+      const { save, error } = await readSaveFile(saveFile(serializeSave(game)));
+      expect(error).toBeUndefined();
+      expect(save?.game.seed).toBe(game.seed);
+    });
+
+    it("round trips an exported save", async () => {
+      writeSave(fakeGame());
+      const exported = resumableSave()!.save;
+      const { save } = await readSaveFile(saveFile(exported));
+      expect(save).toEqual(exported);
+    });
+
+    it("rejects a file that isn't JSON", async () => {
+      const { save, error } = await readSaveFile(saveFile("not json {"));
+      expect(save).toBeUndefined();
+      expect(error).toMatch(/isn't an Electrify save/);
+    });
+
+    it("rejects a save from an incompatible version", async () => {
+      const { save, error } = await readSaveFile(
+        saveFile({ ...serializeSave(fakeGame()), version: SAVE_VERSION + 1 }),
+      );
+      expect(save).toBeUndefined();
+      expect(error).toMatch(/incompatible version/);
+    });
+
+    it("rejects a save whose scenario this build doesn't have", async () => {
+      const { save, error } = await readSaveFile(
+        saveFile(serializeSave(fakeGame({ scenarioId: 99999 }))),
+      );
+      expect(save).toBeUndefined();
+      expect(error).toMatch(/scenario/);
+    });
+
+    // Whatever the player picked, it's read into memory before anything else looks at it
+    it("rejects a file too big to be a save", async () => {
+      const file = saveFile(serializeSave(fakeGame()));
+      Object.defineProperty(file, "size", {
+        value: MAX_SAVE_FILE_BYTES + 1,
+      });
+      const { save, error } = await readSaveFile(file);
+      expect(save).toBeUndefined();
+      expect(error).toMatch(/too big/);
+    });
+  });
+});

--- a/src/SaveFile.tsx
+++ b/src/SaveFile.tsx
@@ -1,0 +1,128 @@
+import { getScenario } from "./data/Scenarios";
+import { parseSave, readSave, SaveGameType } from "./SaveGame";
+import { ScenarioType } from "./Types";
+
+/**
+ * Moving a save between the browser and a file, plus the question the settings screen and the
+ * title screen both ask first: is there a game worth resuming?
+ *
+ * Separate from SaveGame so that module can keep to storage and nothing else (see the note at the
+ * top of it). Answering that question means resolving a scenario, and data/Scenarios imports the
+ * game reducer, which imports SaveGame -- a cycle reducers/ImportOrder.test.tsx guards against.
+ * Nothing in the reducers imports this file, so the chain stops here.
+ */
+
+export interface ResumableSaveType {
+  save: SaveGameType;
+  scenario: ScenarioType;
+}
+
+/**
+ * The saved game, if there is one and this build still has the scenario it was played in. A save
+ * whose scenario has since been removed can't be resumed, so it may as well not be offered; a
+ * custom game carries its own scenario in the save, so it resolves the same way any other does.
+ */
+export function resumableSave(): ResumableSaveType | null {
+  const save = readSave();
+  const scenario = save
+    ? getScenario(save.game.scenarioId, save.game.customScenario)
+    : undefined;
+  return save && scenario ? { save, scenario } : null;
+}
+
+/** What the player sees the save called: "Rise of Renewables, 2035". */
+export function describeSave({ save, scenario }: ResumableSaveType): string {
+  return `${scenario.name}, ${save.game.date.year}`;
+}
+
+/**
+ * electrify-rise-of-renewables-2035.json. Scenario names are authored, but a custom game's is
+ * typed by the player, so everything outside a-z0-9 is folded away rather than trusted in a
+ * filename.
+ */
+export function saveFilename(scenarioName: string, year: number): string {
+  const slug = scenarioName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `electrify-${slug || "game"}-${year}.json`;
+}
+
+/** Hands the saved game to the browser as a download. */
+export function downloadSave(resumable: ResumableSaveType) {
+  const url = URL.createObjectURL(
+    new Blob([JSON.stringify(resumable.save)], { type: "application/json" }),
+  );
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = saveFilename(
+    resumable.scenario.name,
+    resumable.save.game.date.year,
+  );
+  // Firefox only follows the click of an anchor that's actually in the document
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  // Revoking in the same task cancels the download in Safari; a task later is after it started
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+/**
+ * A cap on what will be read into memory. A century-long run saves at a few hundred kilobytes, so
+ * this sits far past any real save; it's here so that pointing the file picker at a video doesn't
+ * hang the tab before the JSON parse gets a chance to reject it.
+ */
+export const MAX_SAVE_FILE_BYTES = 8 * 1024 * 1024;
+
+/** Either the save, or why the file the player picked isn't one. */
+export interface ImportedSaveType {
+  save?: SaveGameType;
+  error?: string;
+}
+
+/**
+ * Validates a file the player picked. Everything about it is untrusted -- a save is plain JSON,
+ * hand-editable, and shared between players -- so it's checked all the way down to the scenario
+ * being one this build has, rather than crashing the sim mid-tick on the first missing field.
+ */
+export async function readSaveFile(file: File): Promise<ImportedSaveType> {
+  if (file.size > MAX_SAVE_FILE_BYTES) {
+    return { error: "That file is too big to be an Electrify save." };
+  }
+  let text: string;
+  try {
+    text = await readText(file);
+  } catch (_err) {
+    return { error: "Couldn't read that file." };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (_err) {
+    return { error: "That file isn't an Electrify save game." };
+  }
+  const save = parseSave(parsed);
+  if (!save) {
+    return {
+      error:
+        "That save was made by an incompatible version of Electrify, or isn't a save at all.",
+    };
+  }
+  if (!getScenario(save.game.scenarioId, save.game.customScenario)) {
+    return {
+      error:
+        "That save is from a scenario this version of Electrify doesn't have.",
+    };
+  }
+  return { save };
+}
+
+// FileReader rather than file.text(), which older mobile Safari and jsdom both lack
+function readText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+}

--- a/src/components/views/MainMenuContainer.tsx
+++ b/src/components/views/MainMenuContainer.tsx
@@ -1,26 +1,16 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { AppStateType } from "../../Types";
-import { getScenario } from "../../data/Scenarios";
 import { navigate } from "../../reducers/Card";
 import { resume } from "../../reducers/Game";
 import { change as changeSettings } from "../../reducers/Settings";
-import { readSave } from "../../SaveGame";
+import { resumableSave } from "../../SaveFile";
 import MainMenu, { DispatchProps, StateProps } from "./MainMenu";
-
-// A save whose scenario no longer exists can't be resumed, so it may as well not be offered. A
-// custom game carries its own scenario in the save, so it resolves the same way any other does
-function hasSavedGame(): boolean {
-  const save = readSave();
-  return (
-    !!save && !!getScenario(save.game.scenarioId, save.game.customScenario)
-  );
-}
 
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
     audioEnabled: state.settings.audioEnabled,
-    hasSavedGame: hasSavedGame(),
+    hasSavedGame: !!resumableSave(),
     uid: state.user.uid,
   };
 };
@@ -31,10 +21,10 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
       dispatch(changeSettings({ audioEnabled: v }));
     },
     onContinue: () => {
-      const save = readSave();
-      if (save) {
+      const resumable = resumableSave();
+      if (resumable) {
         // Card sends this to LOADING, which re-reads the CSVs and then dispatches loaded()
-        dispatch(resume(save.game));
+        dispatch(resume(resumable.save.game));
       }
     },
     onManual: () => {

--- a/src/components/views/Settings.test.tsx
+++ b/src/components/views/Settings.test.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Settings, { Props } from "./Settings";
+
+function renderSettings(overrides: Partial<Props> = {}) {
+  const props: Props = {
+    settings: { units: "metric" },
+    onAudioChange: () => undefined,
+    onUnitsChange: () => undefined,
+    onExportSave: () => undefined,
+    onImportSave: () => undefined,
+    onBack: () => undefined,
+    ...overrides,
+  };
+  render(<Settings {...props} />);
+}
+
+function exportButton(): HTMLButtonElement {
+  return screen.getByText("Export").closest("button") as HTMLButtonElement;
+}
+
+function fileInput(): HTMLInputElement {
+  return screen.getByLabelText("Save game file") as HTMLInputElement;
+}
+
+describe("Settings", () => {
+  it("names the saved game that Export would download", async () => {
+    const onExportSave = jest.fn();
+    renderSettings({ savedGame: "Rise of Renewables, 2035", onExportSave });
+
+    expect(exportButton().disabled).toBe(false);
+    expect(screen.getByText(/Rise of Renewables, 2035/)).toBeInTheDocument();
+
+    await userEvent.click(exportButton());
+    expect(onExportSave).toHaveBeenCalled();
+  });
+
+  // The button being greyed out says nothing about why, and "start a game first" is not something
+  // a player would otherwise guess from a settings screen
+  it("disables Export and says what's missing when there's no saved game", () => {
+    renderSettings();
+    expect(exportButton().disabled).toBe(true);
+    expect(
+      screen.getByText(/need a game in progress to export/),
+    ).toBeInTheDocument();
+  });
+
+  it("imports whichever file the player picks, saved game or not", async () => {
+    const onImportSave = jest.fn();
+    renderSettings({ onImportSave });
+
+    const file = new File(["{}"], "save.json", { type: "application/json" });
+    await userEvent.upload(fileInput(), file);
+    expect(onImportSave).toHaveBeenCalledWith(file);
+
+    // Picking the same file again still counts, for the player who went and fixed a bad one
+    expect(fileInput().value).toBe("");
+  });
+});

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {
+  Button,
   Checkbox,
   IconButton,
   MenuItem,
@@ -16,11 +17,15 @@ import packageJson from "../../../package.json";
 
 export interface StateProps {
   settings: SettingsType;
+  // What the saved game is called, or undefined when there's nothing to export
+  savedGame?: string;
 }
 
 export interface DispatchProps {
   onAudioChange: (change: boolean) => void;
   onUnitsChange: (change: UnitSystemType) => void;
+  onExportSave: () => void;
+  onImportSave: (file: File) => void;
   onBack: () => void;
 }
 
@@ -45,6 +50,19 @@ export default function Settings(props: Props): React.JSX.Element {
   // <Checkbox id="experimental" label="Experimental" value={props.settings.experimental} onChange={props.onExperimentalChange}>
   //   {(props.settings.experimental) ? 'Experimental features are currently enabled.' : 'Experimental features are currently disabled.'}
   // </Checkbox>
+
+  // The file picker is driven by the Import button rather than wrapping it, so that both buttons
+  // are plainly buttons and the disabled Export one behaves like one
+  const fileInput = React.useRef<HTMLInputElement>(null);
+  const onFileChosen = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files && e.target.files[0];
+    // Cleared so that picking the same file again still counts as a change, which is what a
+    // player who fixed a bad file by hand and came back would expect
+    e.target.value = "";
+    if (file) {
+      props.onImportSave(file);
+    }
+  };
 
   return (
     <div className="flexContainer" id="gameCard">
@@ -96,6 +114,41 @@ export default function Settings(props: Props): React.JSX.Element {
           {props.settings.units === "imperial"
             ? "Temperatures in °F, wind in mph, emissions in pounds and tons."
             : "Temperatures in °C, wind in km/h, emissions in kilograms and tonnes."}
+        </Typography>
+        <Typography variant="h6" style={{ marginTop: 24 }}>
+          Saved Game
+        </Typography>
+        <div>
+          <Button
+            variant="outlined"
+            color="primary"
+            disabled={!props.savedGame}
+            onClick={props.onExportSave}
+            style={{ margin: "0 6px" }}
+          >
+            Export
+          </Button>
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={() => fileInput.current?.click()}
+            style={{ margin: "0 6px" }}
+          >
+            Import
+          </Button>
+          <input
+            ref={fileInput}
+            type="file"
+            accept="application/json,.json"
+            style={{ display: "none" }}
+            aria-label="Save game file"
+            onChange={onFileChosen}
+          />
+        </div>
+        <Typography variant="body2" color="textSecondary">
+          {props.savedGame
+            ? `Export downloads your saved game (${props.savedGame}) to keep or share. Importing one replaces it.`
+            : "You need a game in progress to export one - start a game, then come back here. You can still import a save that someone shared with you."}
         </Typography>
         <Typography variant="h6" style={{ marginTop: 24 }}>
           Keyboard Shortcuts

--- a/src/components/views/SettingsContainer.tsx
+++ b/src/components/views/SettingsContainer.tsx
@@ -1,13 +1,24 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigate } from "../../reducers/Card";
+import { resume } from "../../reducers/Game";
 import { change as changeSettings } from "../../reducers/Settings";
+import { snackbarOpen } from "../../reducers/UI";
+import {
+  describeSave,
+  downloadSave,
+  readSaveFile,
+  resumableSave,
+} from "../../SaveFile";
 import { AppStateType, UnitSystemType } from "../../Types";
 import Settings, { DispatchProps, StateProps } from "./Settings";
+import { confirmReplacingSave } from "./StartGame";
 
 const mapStateToProps = (state: AppStateType): StateProps => {
+  const resumable = resumableSave();
   return {
     settings: state.settings,
+    savedGame: resumable ? describeSave(resumable) : undefined,
   };
 };
 
@@ -18,6 +29,31 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     },
     onUnitsChange: (v: UnitSystemType) => {
       dispatch(changeSettings({ units: v }));
+    },
+    onExportSave: () => {
+      // Read again rather than trusting the render: the button is only enabled when there's a
+      // save, but nothing stops another tab clearing it in between
+      const resumable = resumableSave();
+      if (!resumable) {
+        dispatch(snackbarOpen("There's no saved game to export."));
+        return;
+      }
+      downloadSave(resumable);
+    },
+    onImportSave: (file: File) => {
+      readSaveFile(file).then(({ save, error }) => {
+        if (!save) {
+          dispatch(snackbarOpen(error || "That file isn't a save game."));
+          return;
+        }
+        confirmReplacingSave(
+          dispatch,
+          { title: "Load this save?", actionLabel: "Load game" },
+          // Card sends this to LOADING, which re-reads the CSVs and then dispatches loaded().
+          // The autosave picks the imported game up from there, so it survives a reload
+          () => dispatch(resume(save.game)),
+        );
+      });
     },
     onBack: () => {
       dispatch(navigate("MAIN_MENU"));

--- a/src/components/views/StartGame.tsx
+++ b/src/components/views/StartGame.tsx
@@ -1,7 +1,37 @@
 import type { AppDispatch } from "../../Store";
-import { getScenario } from "../../data/Scenarios";
 import { dialogClose, dialogOpen } from "../../reducers/UI";
-import { readSave } from "../../SaveGame";
+import { describeSave, resumableSave } from "../../SaveFile";
+
+/**
+ * Runs something that would replace the autosave, first asking about the game already in it.
+ *
+ * Autosave keeps one slot, so starting a new game or importing someone else's replaces whatever
+ * is there. Proceeds straight away when there's nothing to lose.
+ */
+export function confirmReplacingSave(
+  dispatch: AppDispatch,
+  { title, actionLabel }: { title: string; actionLabel: string },
+  proceed: () => void,
+) {
+  const resumable = resumableSave();
+  if (!resumable) {
+    return proceed();
+  }
+  dispatch(
+    dialogOpen({
+      title,
+      message: `Your saved game (${describeSave(resumable)}) will be replaced.`,
+      open: true,
+      closeText: "Cancel",
+      actionLabel,
+      // The dialog's action button doesn't close the dialog on its own
+      action: () => {
+        dispatch(dialogClose());
+        proceed();
+      },
+    }),
+  );
+}
 
 /**
  * Starts a game, first asking about the autosave if starting would overwrite it.
@@ -14,26 +44,9 @@ export function startWithSaveGuard(
   dispatch: AppDispatch,
   startGame: () => void,
 ) {
-  // Autosave keeps one slot, so a new game replaces whatever's in it
-  const save = readSave();
-  const saved = save
-    ? getScenario(save.game.scenarioId, save.game.customScenario)
-    : undefined;
-  if (!save || !saved) {
-    return startGame();
-  }
-  dispatch(
-    dialogOpen({
-      title: "Start a new game?",
-      message: `Your saved game (${saved.name}, ${save.game.date.year}) will be replaced.`,
-      open: true,
-      closeText: "Cancel",
-      actionLabel: "Start new game",
-      // The dialog's action button doesn't close the dialog on its own
-      action: () => {
-        dispatch(dialogClose());
-        startGame();
-      },
-    }),
+  confirmReplacingSave(
+    dispatch,
+    { title: "Start a new game?", actionLabel: "Start new game" },
+    startGame,
   );
 }


### PR DESCRIPTION
Phase 2 of #109 — the last unimplemented item on that plan.

## What this adds

The settings screen grows a **Saved Game** section between Units and Keyboard Shortcuts:

- **Export** hands the autosaved game to the browser as `electrify-<scenario>-<year>.json`.
- **Import** reads one back, then routes it through the same `resume` path the Continue button uses.

Because the seed determines the run (phase 0), a save shared with someone else replays the donor's exact weather and fuel prices on the recipient's machine — the file carries no extra bytes for it.

Both live on the settings screen **only**. Settings is reachable from the title screen and nowhere else, so neither button can be reached mid-game, and neither has to think about what happens to a run that's already going.

## Details worth a look

**Export is disabled, and says why, when there's nothing to export.** A greyed-out button says nothing about what would fix it, and "start a game first" is not something a player would guess from a settings screen. With a save, the same line names it: *"Export downloads your saved game (Carbon Fee, 2020) to keep or share. Importing one replaces it."*

**Import stays enabled either way** — a save someone shared is worth loading whether or not you have one of your own.

**An imported file is untrusted.** A save is plain JSON, hand-editable, and passed between players, so `readSaveFile` checks size → JSON parse → `parseSave` → the scenario being one this build has, before anything reaches the reducer, and tells the player which check it failed rather than crashing the sim mid-tick.

**Loading one replaces the autosave, so it asks first**, the same way starting a new game does. That confirmation moved out of `startWithSaveGuard` into a shared `confirmReplacingSave`; both call it now.

**New `src/SaveFile.tsx`** holds all of this plus `resumableSave` — the "is there a game worth resuming" question the title screen and the scenario guard were each answering for themselves. It's separate from `SaveGame` because answering it means importing `data/Scenarios`, which imports the game reducer, which imports `SaveGame` — the cycle `reducers/ImportOrder.test.tsx` guards against. Nothing in `reducers/` imports the new module, so the chain stops there.

`FileReader` rather than `file.text()`, which older mobile Safari and jsdom both lack.

## Verification

- 457 tests pass — 13 new in `SaveFile.test.tsx`, 3 in `Settings.test.tsx`. Typecheck, lint and format clean.
- Imported a save through the real file input in the running app: the confirm dialog appeared, and Load game restored the run (Jan 2020, $330M, both facilities intact).
- Export produced an anchor with `download="electrify-carbon-fee-2020.json"`, attached to the document at click time and removed after, with the object URL revoked a task later.

Not verified live: the disabled-Export state needs an empty save slot, and clearing a real save to look at a greyed-out button wasn't worth it. Covered by unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
