### PR TITLE
Stop the scenario screens hiding what they list

### DIFF
--- a/src/components/base/UPlotHelpers.ts
+++ b/src/components/base/UPlotHelpers.ts
@@ -24,6 +24,12 @@ const TICK_STROKE = "#90A4AE";
 // How far a tick pokes out of the axis, and how far the label then sits from it, in design units
 const TICK_SIZE = 5;
 const LABEL_GAP = 4;
+// A gutter outside the widest label. uPlot leaves no padding on a side that carries an axis, so
+// an axis sized to the exact width of its labels draws them flush against the canvas edge, and
+// anything that measures a hair narrower than it paints - a font that finished loading after the
+// axis was sized, a glyph with a negative left bearing, plain antialiasing - clips the first
+// character off every label.
+const LABEL_EDGE_PAD = 4;
 // Victory drew legend text in its material theme's near-black rather than the axes' grey
 const LEGEND_TEXT = "#252525";
 
@@ -161,7 +167,7 @@ export function xAxis(scale: number, o: AxisOptions): uPlot.Axis {
 export function yAxis(scale: number, o: AxisOptions): uPlot.Axis {
   const font = chartFont(scale);
   const fontSize = 12 * scale;
-  const fixed = TICK_SIZE * scale + LABEL_GAP * scale;
+  const fixed = (TICK_SIZE + LABEL_GAP + LABEL_EDGE_PAD) * scale;
   return {
     ...axisCommon(scale, o),
     scale: o.scale ?? "y",

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -111,8 +111,8 @@ function nearestIndex(options: number[], value: number): number {
 }
 
 /**
- * A stored custom game with its rate and fee snapped onto the options its own starting year
- * offers.
+ * A stored custom game with its cash, rate and fee snapped onto the options this screen
+ * offers - the rate and fee against its own starting year.
  *
  * Only ever changes a game saved before those became era-aware. Doing it on the way in rather
  * than on the way out is what keeps the screen honest: showing the nearest option while the
@@ -129,6 +129,9 @@ function inEraScenario(scenario: ScenarioType): ScenarioType {
   );
   return {
     ...scenario,
+    // Cash is quoted the same in every era, so this only catches a game stored against an
+    // amount the picker no longer offers - which would otherwise render the field blank
+    cash: STARTING_CASH[nearestIndex(STARTING_CASH, scenario.cash)],
     dollarsPerkWh: rates[nearestIndex(rates, scenario.dollarsPerkWh)],
     feePerKgCO2e: fees[nearestIndex(fees, scenario.feePerKgCO2e * 1000)] / 1000,
   };
@@ -215,13 +218,6 @@ export default function CustomGame(props: Props): React.JSX.Element {
   const sizes = (adding?.storage ? STORAGE_SIZES_WH : GENERATOR_SIZES_W).filter(
     (size) => !adding || size <= adding.maxSize,
   );
-  // Starting facilities are built free and already finished, so the only limit is what the
-  // technology could actually be built at in that year
-  const totalPeakW = scenario.facilities.reduce(
-    (sum: number, f: Partial<FacilityShoppingType>) => sum + (f.peakW || 0),
-    0,
-  );
-
   // What a kilowatt hour may be charged at, and what a ton of CO2e may be feed, in the money of
   // the year the game starts in. Both move with the starting year, which is why changing that
   // year has to re-quote whatever was already chosen rather than leaving a 2020 rate on a 2080
@@ -567,15 +563,6 @@ export default function CustomGame(props: Props): React.JSX.Element {
 
         <Typography variant="h6" sx={{ paddingLeft: 1, paddingTop: 1 }}>
           Starting facilities
-        </Typography>
-        <Typography
-          variant="body2"
-          color="textSecondary"
-          sx={{ paddingLeft: 1 }}
-        >
-          {scenario.facilities.length === 0
-            ? "None - you'll be blacking out until you build something"
-            : `${formatWatts(totalPeakW)} of generation, free and already running`}
         </Typography>
         {unavailable.length > 0 && (
           <Typography variant="body2" color="error" sx={{ paddingLeft: 1 }}>

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -208,7 +208,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
     }
 
     return (
-      <div id="listCard">
+      <div id="listCard" className="flexContainer">
         <div id="topbar">
           <Toolbar>
             <IconButton
@@ -223,169 +223,178 @@ export default class NewGameDetails extends React.Component<Props, State> {
             <Typography variant="h6">{scenario.name}</Typography>
           </Toolbar>
         </div>
-        <div
-          style={{ textAlign: "center", margin: "20px 0", lineHeight: "30px" }}
-        >
-          Victory Conditions: {scenario.ownership}-Owned
-          <IconButton
-            onClick={toggleVictoryDialog}
-            aria-label="Victory conditions"
-            color="primary"
-            size="small"
+        <div className="scrollable">
+          <div
+            style={{
+              textAlign: "center",
+              margin: "20px 0",
+              lineHeight: "30px",
+            }}
           >
-            <InfoIcon />
-          </IconButton>
-          <br />
-          Timeframe: {scenario.startingYear} to{" "}
-          {scenario.startingYear + Math.floor(scenario.durationMonths / 12)}
-          <br />
-          Location: {location.name}
-          <br />
-          Difficulty:&nbsp;
-          <Select
-            value={game.difficulty}
-            onChange={(e: SelectChangeEvent<DifficultyType>) =>
-              onDelta({ difficulty: e.target.value as DifficultyType })
-            }
-          >
-            {Object.keys(DIFFICULTIES).map((d: string) => {
-              return (
-                <MenuItem value={d} key={d}>
-                  <Tooltip
-                    title={DIFFICULTIES[d].description}
-                    placement="right"
-                  >
-                    <span>{d}</span>
-                  </Tooltip>
-                </MenuItem>
-              );
-            })}
-          </Select>
-        </div>
-
-        <div style={{ textAlign: "center" }}>
-          <Button
-            size="large"
-            variant="contained"
-            color="primary"
-            onClick={() => onStart(scenario.id)}
-            autoFocus
-          >
-            Play
-          </Button>
-        </div>
-
-        <Dialog open={victoryDialogOpen || false} onClose={toggleVictoryDialog}>
-          <DialogTitle>
             Victory Conditions: {scenario.ownership}-Owned
             <IconButton
-              aria-label="close"
               onClick={toggleVictoryDialog}
-              className="top-right"
-              size="large"
-            >
-              <CloseIcon />
-            </IconButton>
-          </DialogTitle>
-          <DialogContent>
-            <VictoryConditions
-              ownership={scenario.ownership}
-              dollarsPerkWh={scenario.dollarsPerkWh}
-            />
-          </DialogContent>
-          <DialogActions>
-            <Button
+              aria-label="Victory conditions"
               color="primary"
-              variant="contained"
-              onClick={(e: React.MouseEvent<HTMLElement>) => {
-                toggleVictoryDialog(e);
-              }}
+              size="small"
             >
-              Close
-            </Button>
-          </DialogActions>
-        </Dialog>
+              <InfoIcon />
+            </IconButton>
+            <br />
+            Timeframe: {scenario.startingYear} to{" "}
+            {scenario.startingYear + Math.floor(scenario.durationMonths / 12)}
+            <br />
+            Location: {location.name}
+            <br />
+            Difficulty:&nbsp;
+            <Select
+              value={game.difficulty}
+              onChange={(e: SelectChangeEvent<DifficultyType>) =>
+                onDelta({ difficulty: e.target.value as DifficultyType })
+              }
+            >
+              {Object.keys(DIFFICULTIES).map((d: string) => {
+                return (
+                  <MenuItem value={d} key={d}>
+                    <Tooltip
+                      title={DIFFICULTIES[d].description}
+                      placement="right"
+                    >
+                      <span>{d}</span>
+                    </Tooltip>
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </div>
 
-        <Table id="HighScores">
-          <TableHead>
-            <TableRow>
-              <TableCell colSpan={3}>
-                <Typography variant="h6">Global High Scores</Typography>
-              </TableCell>
-            </TableRow>
-            {uid && (
+          <div style={{ textAlign: "center" }}>
+            <Button
+              size="large"
+              variant="contained"
+              color="primary"
+              onClick={() => onStart(scenario.id)}
+              autoFocus
+            >
+              Play
+            </Button>
+          </div>
+
+          <Dialog
+            open={victoryDialogOpen || false}
+            onClose={toggleVictoryDialog}
+          >
+            <DialogTitle>
+              Victory Conditions: {scenario.ownership}-Owned
+              <IconButton
+                aria-label="close"
+                onClick={toggleVictoryDialog}
+                className="top-right"
+                size="large"
+              >
+                <CloseIcon />
+              </IconButton>
+            </DialogTitle>
+            <DialogContent>
+              <VictoryConditions
+                ownership={scenario.ownership}
+                dollarsPerkWh={scenario.dollarsPerkWh}
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button
+                color="primary"
+                variant="contained"
+                onClick={(e: React.MouseEvent<HTMLElement>) => {
+                  toggleVictoryDialog(e);
+                }}
+              >
+                Close
+              </Button>
+            </DialogActions>
+          </Dialog>
+
+          <Table id="HighScores">
+            <TableHead>
               <TableRow>
-                <TableCell>Score</TableCell>
-                <TableCell>Difficulty</TableCell>
-                <TableCell padding="none">Replay</TableCell>
-              </TableRow>
-            )}
-          </TableHead>
-          {!uid && (
-            <TableBody>
-              <TableRow>
-                <TableCell colSpan={3} style={{ textAlign: "center" }}>
-                  <Button variant="outlined" color="primary" onClick={login}>
-                    Log in
-                  </Button>
-                  <Typography variant="body2" color="textSecondary">
-                    To view and set high scores
-                  </Typography>
+                <TableCell colSpan={3}>
+                  <Typography variant="h6">Global High Scores</Typography>
                 </TableCell>
               </TableRow>
-            </TableBody>
-          )}
-          {uid && (
-            <TableBody>
-              {myTopScore && (
-                <TableRow style={{ fontWeight: "bold", background: "#eee" }}>
-                  <TableCell>
-                    Your best:{" "}
-                    {numbro(myTopScore.score).format({
-                      thousandSeparated: true,
-                      mantissa: 0,
-                    })}
-                  </TableCell>
-                  <TableCell>{myTopScore.difficulty}</TableCell>
-                  {this.renderReplayCell(myTopScore)}
+              {uid && (
+                <TableRow>
+                  <TableCell>Score</TableCell>
+                  <TableCell>Difficulty</TableCell>
+                  <TableCell padding="none">Replay</TableCell>
                 </TableRow>
               )}
-              {!scores && (
+            </TableHead>
+            {!uid && (
+              <TableBody>
                 <TableRow>
-                  <TableCell colSpan={3}>
+                  <TableCell colSpan={3} style={{ textAlign: "center" }}>
+                    <Button variant="outlined" color="primary" onClick={login}>
+                      Log in
+                    </Button>
                     <Typography variant="body2" color="textSecondary">
-                      Loading...
+                      To view and set high scores
                     </Typography>
                   </TableCell>
                 </TableRow>
-              )}
-              {scores && scores.length === 0 && (
-                <TableRow>
-                  <TableCell colSpan={3}>
-                    <Typography variant="body2" color="textSecondary">
-                      Play the scenario to set a high score
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              )}
-              {scores &&
-                scores.map((score: ScoreType, i: number) => {
-                  return (
-                    <TableRow key={i}>
-                      <TableCell>
-                        {numbro(score.score).format({
-                          thousandSeparated: true,
-                          mantissa: 0,
-                        })}
-                      </TableCell>
-                      <TableCell>{score.difficulty}</TableCell>
-                      {this.renderReplayCell(score)}
-                    </TableRow>
-                  );
-                })}
-            </TableBody>
-          )}
-        </Table>
+              </TableBody>
+            )}
+            {uid && (
+              <TableBody>
+                {myTopScore && (
+                  <TableRow style={{ fontWeight: "bold", background: "#eee" }}>
+                    <TableCell>
+                      Your best:{" "}
+                      {numbro(myTopScore.score).format({
+                        thousandSeparated: true,
+                        mantissa: 0,
+                      })}
+                    </TableCell>
+                    <TableCell>{myTopScore.difficulty}</TableCell>
+                    {this.renderReplayCell(myTopScore)}
+                  </TableRow>
+                )}
+                {!scores && (
+                  <TableRow>
+                    <TableCell colSpan={3}>
+                      <Typography variant="body2" color="textSecondary">
+                        Loading...
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
+                {scores && scores.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={3}>
+                      <Typography variant="body2" color="textSecondary">
+                        Play the scenario to set a high score
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
+                {scores &&
+                  scores.map((score: ScoreType, i: number) => {
+                    return (
+                      <TableRow key={i}>
+                        <TableCell>
+                          {numbro(score.score).format({
+                            thousandSeparated: true,
+                            mantissa: 0,
+                          })}
+                        </TableCell>
+                        <TableCell>{score.difficulty}</TableCell>
+                        {this.renderReplayCell(score)}
+                      </TableRow>
+                    );
+                  })}
+              </TableBody>
+            )}
+          </Table>
+        </div>
       </div>
     );
   }

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -700,7 +700,7 @@ export const DEFAULT_CUSTOM_SCENARIO = {
   locationId: "SF",
   ownership: "Investor",
   startingYear: 2020,
-  cash: 220000000,
+  cash: 200000000,
   dollarsPerkWh: 0.07,
   durationMonths: 12 * 20,
   feePerKgCO2e: 0,


### PR DESCRIPTION
Four fixes to the setup screens.

**The high scores table had nowhere to scroll.** `NewGameDetails` was a plain `div` inside a fixed-height pane, so a leaderboard of fifty ran off the bottom of the screen with no way to reach it. It now uses the same `flexContainer` / `.scrollable` pairing the scenario list and custom setup screens already use.

**Starting cash opened blank.** The default custom game carried $220M, which is not one of the four amounts the picker offers, so MUI rendered the field empty. The default is now $200M, and a game stored against an amount no longer offered snaps to the nearest one on the way in — the same treatment the rate and the carbon fee already get, so an old saved setup doesn't come back with a blank field.

**Removed the subtitle under "Starting facilities"** on the custom setup screen.

**Chart y axis labels were clipped on the left.** uPlot leaves no padding on a side that carries an axis, and the axis reserved exactly the width its labels measured — 185px against 184.5px needed — so the labels were drawn flush against the canvas edge and anything measuring a hair narrower than it painted (a font that finished loading after the axis was sized, a glyph with a negative left bearing, plain antialiasing) took the first character off every label. `yAxis` now keeps a small gutter outside its widest label, which fixes every chart at once.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- Full suite: 457 tests, 34 suites, all passing
- Verified live in the dev server:
  - scenario details with 50 injected score rows: scroller reports `scrollHeight` 1396 vs `clientHeight` 756, and the last row scrolls fully into view
  - custom setup with the old $220M in `localStorage`: field shows `$200M` instead of blank, and no subtitle under "Starting facilities"
  - supply/demand chart at 375px wide: gutter outside the widest label went from ~0.1px to ~4.6px

🤖 Generated with [Claude Code](https://claude.com/claude-code)