### PR TITLE
Display names on the leaderboard, and a real end-of-run celebration

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,6 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,22 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "scores",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "scenarioId", "order": "ASCENDING" },
+        { "fieldPath": "score", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "scores",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "scenarioId", "order": "ASCENDING" },
+        { "fieldPath": "uid", "order": "ASCENDING" },
+        { "fieldPath": "score", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,80 @@
+rules_version = '2';
+
+// Firestore security rules for electrify-game.
+//
+// These used to live only in the Firebase console, where a rule change was invisible to reviewers
+// and easy to forget before a deploy. They ship from the repo now:
+//
+//   firebase deploy --only firestore
+//
+// which has to run BEFORE the client bundle that depends on them, or reads fail closed.
+//
+// Accepted limitation, unchanged from before: scores are client-authoritative. Rules cannot
+// re-run a simulation, so nothing here proves a score was actually earned. If cheating on the
+// board becomes a real problem, the fix is a Cloud Function that recomputes the score from the
+// seed and the replay's action log.
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(uid) {
+      return isSignedIn() && request.auth.uid == uid;
+    }
+
+    // Keep in sync with validateDisplayName in src/helpers/DisplayName.tsx. The client is what
+    // gives a player a useful error message; this is what makes the constraint true.
+    // matches() is anchored to the whole string, so the pattern covers the charset and rules out
+    // a leading or trailing space in one go; the second clause rules out doubled spaces.
+    function isValidDisplayName(name) {
+      return name is string
+        && name.size() >= 3
+        && name.size() <= 20
+        && name.matches('[A-Za-z0-9_-][A-Za-z0-9 _-]*[A-Za-z0-9_-]')
+        && !name.matches('.*  .*');
+    }
+
+    // A player's profile. Public: it holds a leaderboard name and per-scenario bests, nothing
+    // private. Only the player themselves may write it.
+    match /users/{uid} {
+      allow read: if true;
+      allow create, update: if isOwner(uid)
+        && (!('displayName' in request.resource.data)
+            || isValidDisplayName(request.resource.data.displayName));
+      allow delete: if false;
+    }
+
+    // The uniqueness guarantee for display names, claimed by document id. `create` already fails
+    // on an existing document, so a name can only be taken once; a claim is never updated, only
+    // released by its owner when they move to a different name.
+    match /usernames/{nameLower} {
+      allow read: if true;
+      allow create: if isSignedIn() && request.resource.data.uid == request.auth.uid;
+      allow delete: if isSignedIn() && resource.data.uid == request.auth.uid;
+      allow update: if false;
+    }
+
+    // Publicly readable: hiding the board from logged-out players inverts the incentive to sign
+    // up, since seeing named strangers above you is the reason to bother.
+    match /scores/{scoreId} {
+      allow read: if true;
+      allow create: if isSignedIn() && request.resource.data.uid == request.auth.uid;
+      // Renaming backfills the denormalized name onto the player's own old scores, and that is
+      // the only field a score may ever change.
+      allow update: if isSignedIn()
+        && resource.data.uid == request.auth.uid
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['displayName']);
+      allow delete: if false;
+    }
+
+    // The run behind a score. Immutable once written, so a replay always matches the score that
+    // points at it.
+    match /replays/{replayId} {
+      allow read: if true;
+      allow create: if isSignedIn() && request.resource.data.uid == request.auth.uid;
+      allow update, delete: if false;
+    }
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { navigateBack } from "./reducers/Card";
 import { pauseAudio, resumeAudio } from "./reducers/Settings";
 import { snackbarOpen } from "./reducers/UI";
 import { firebaseAppAuth, getDevicePlatform } from "./Globals";
-import { delta } from "./reducers/User";
+import { delta, loadProfile, reset } from "./reducers/User";
 import { SCENARIOS } from "./data/Scenarios";
 import { startAutosave } from "./SaveGame";
 import { store } from "./Store";
@@ -95,7 +95,23 @@ export default function App() {
     // Returns its own unsubscribe, which was previously dropped on the floor
     const unsubscribeAuth = firebaseAppAuth.onAuthStateChanged(
       (user: User | null) => {
-        store.dispatch(delta({ uid: (user || ({} as Partial<User>)).uid }));
+        if (!user) {
+          // Signed out, or never signed in: drop the whole slice rather than only the uid, so one
+          // player's name and bests can't linger into the next player's session
+          store.dispatch(reset());
+          return;
+        }
+        // The provider's name is only a seed for the name dialog. The leaderboard name is the one
+        // claimed against users/{uid}, which is what loadProfile goes and reads
+        store.dispatch(
+          delta({
+            uid: user.uid,
+            googleDisplayName: user.displayName || undefined,
+          }),
+        );
+        store.dispatch(
+          loadProfile({ uid: user.uid, googleDisplayName: user.displayName }),
+        );
       },
     );
 

--- a/src/Globals.tsx
+++ b/src/Globals.tsx
@@ -1,6 +1,11 @@
 import { getAnalytics, logEvent as firebaseLogEvent } from "firebase/analytics";
 import { initializeApp } from "firebase/app";
-import { getAuth, GoogleAuthProvider, signInWithPopup } from "firebase/auth";
+import {
+  getAuth,
+  GoogleAuthProvider,
+  signInWithPopup,
+  signOut,
+} from "firebase/auth";
 import { Firestore, getFirestore } from "firebase/firestore";
 
 const firebaseApp = initializeApp({
@@ -33,6 +38,14 @@ export function login() {
         GoogleAuthProvider.credentialFromError(error),
       );
     });
+}
+
+/**
+ * Signs the player out. The app hears about it through firebaseAppAuth.onAuthStateChanged the
+ * same way it hears about signing in, so nothing needs to be reset here -- see App.tsx.
+ */
+export function logout(): Promise<void> {
+  return signOut(firebaseAppAuth);
 }
 
 // The slice of the History API the game uses. Card navigation pushes a hash entry so the

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -109,6 +109,10 @@ export interface ScoreType {
   // Timestamp on the way back in
   date: Timestamp | FieldValue;
   uid: string;
+  // The player's leaderboard name as it was when the score was set, denormalized so that
+  // rendering a board is one query rather than one plus a profile read per row. Absent on scores
+  // set before display names existed, and those fall back to Anonymous
+  displayName?: string;
   // Id of the document in the `replays` collection holding the run that set this score, when one
   // was small enough to keep. A reference rather than the replay itself, so that opening a
   // leaderboard downloads fifty scores instead of fifty replays
@@ -430,13 +434,60 @@ export interface SnackbarType {
   timeout: number;
 }
 
+/**
+ * The end of a run, which the victory dialog turns into a score screen. Everything here is known
+ * the moment the scenario ends; the rank and the score write are enrichment that lands later.
+ */
+export interface VictoryType {
+  scenarioId: number;
+  scenarioName: string;
+  difficulty: DifficultyType;
+  score: number;
+  // The per-category points behind `score`, in the order they should be listed
+  breakdown: ScoreBreakdownType;
+  endTitle?: string;
+  endMessage?: string;
+  // Whether the run counts for the leaderboard. A custom game (every one shares an id) or a
+  // replay of someone else's run gets the breakdown without a rank or a personal best
+  ranked: boolean;
+  // The player's best on this scenario BEFORE this run, read at the moment the scenario ended so
+  // that "was 640" reports the run before this one rather than the one just finished
+  previousBest?: number;
+}
+
 export interface UIType {
   dialog: DialogType;
   snackbar: SnackbarType;
+  // The score screen for a run that just ended, or null when none has. Its own slot rather than a
+  // `dialog`, because the shared dialog only holds a title and a message and this one fills
+  // itself in as async results arrive
+  victory: VictoryType | null;
+}
+
+// A player's best run on one scenario, mirrored from users/{uid}.bests so that the victory dialog
+// can compare against it without a read
+export interface BestScoreType {
+  score: number;
+  difficulty: string;
+  // Epoch ms rather than a Timestamp: this one is read back into a plain Redux slice
+  date: number;
 }
 
 export interface UserType {
   uid?: string;
+  // The leaderboard name, once one has been claimed
+  displayName?: string;
+  // The name the identity provider knows them by. Kept only to seed the name dialog -- it is
+  // never what the board shows, since it is neither unique nor within the board's charset
+  googleDisplayName?: string;
+  // Keyed by scenario id as a string, which is how it comes back out of Firestore
+  bests?: { [scenarioId: string]: BestScoreType };
+  // Set once users/{uid} has been read or created, so the UI can tell "this player has no name"
+  // apart from "we have not looked yet"
+  profileLoaded?: boolean;
+  // Whether to prompt for a display name. Set on first login, and by the Settings card's
+  // "Change name"; cleared once the dialog is answered or dismissed
+  needsDisplayName?: boolean;
 }
 
 export type TransitionClassType = "next" | "prev" | "instant" | "nav";

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -28,6 +28,8 @@ import {
   UIType,
 } from "../Types";
 import AudioContainer from "./base/AudioContainer";
+import DisplayNameDialogContainer from "./base/DisplayNameDialogContainer";
+import VictoryDialogContainer from "./base/VictoryDialogContainer";
 import BuildGeneratorsContainer from "./views/BuildGeneratorsContainer";
 import BuildStorageContainer from "./views/BuildStorageContainer";
 import CustomGameContainer from "./views/CustomGameContainer";
@@ -447,6 +449,10 @@ export default class Compositor extends React.Component<Props, {}> {
               : []
           }
         />
+        {/* Connected, so they still update when shouldComponentUpdate blocks this component --
+            neither is driven by the current card, and both can open over any of them */}
+        <VictoryDialogContainer />
+        <DisplayNameDialogContainer />
         <AudioContainer />
       </div>
     );

--- a/src/components/base/DisplayNameDialog.test.tsx
+++ b/src/components/base/DisplayNameDialog.test.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DisplayNameDialog, { Props } from "./DisplayNameDialog";
+
+function renderDialog(overrides: Partial<Props> = {}) {
+  const props: Props = {
+    open: true,
+    onSave: async () => undefined,
+    onClose: () => undefined,
+    ...overrides,
+  };
+  render(<DisplayNameDialog {...props} />);
+}
+
+function nameField(): HTMLInputElement {
+  return screen.getByLabelText("Name") as HTMLInputElement;
+}
+
+describe("DisplayNameDialog", () => {
+  it("seeds a first name from the one Google knows", () => {
+    renderDialog({ googleDisplayName: "Ada Lovelace" });
+    expect(nameField().value).toBe("Ada Lovelace");
+    expect(
+      screen.getByText("Choose your leaderboard name"),
+    ).toBeInTheDocument();
+  });
+
+  it("starts from the current name when changing it", () => {
+    renderDialog({ currentName: "Ada", googleDisplayName: "Ada Lovelace" });
+    expect(nameField().value).toBe("Ada");
+    expect(screen.getByText("Change your name")).toBeInTheDocument();
+  });
+
+  it("saves a valid name and closes", async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    const onClose = jest.fn();
+    renderDialog({ onSave, onClose });
+
+    await userEvent.type(nameField(), "Grace");
+    await userEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(onSave).toHaveBeenCalledWith("Grace");
+  });
+
+  // Local rules first, so an obviously bad name never costs a round trip to Firestore and back
+  it("refuses an invalid name without asking the server", async () => {
+    const onSave = jest.fn();
+    renderDialog({ onSave });
+
+    await userEvent.type(nameField(), "Ada!");
+    await userEvent.click(screen.getByText("Save"));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText(/letters, numbers/)).toBeInTheDocument();
+  });
+
+  /**
+   * Uniqueness can only be decided by the claim transaction, so a name that looked fine here can
+   * still come back taken. That has to leave the dialog open with the name still in the box -- a
+   * collision needs another try, not a dismissal.
+   */
+  it("stays open and explains itself when the name is already taken", async () => {
+    const onClose = jest.fn();
+    renderDialog({
+      onSave: async () => "That name is taken. Please pick another.",
+      onClose,
+    });
+
+    await userEvent.type(nameField(), "Ada");
+    await userEvent.click(screen.getByText("Save"));
+
+    expect(await screen.findByText(/taken/)).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(nameField().value).toBe("Ada");
+  });
+
+  // Being held at a form before having played anything is a good way to lose a new player
+  it("can be dismissed without picking a name", async () => {
+    const onClose = jest.fn();
+    renderDialog({ onClose });
+
+    await userEvent.click(screen.getByText("Not now"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("saves on Enter", async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    renderDialog({ onSave });
+
+    await userEvent.type(nameField(), "Grace{Enter}");
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith("Grace"));
+  });
+});

--- a/src/components/base/DisplayNameDialog.tsx
+++ b/src/components/base/DisplayNameDialog.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
+  DISPLAY_NAME_MAX_LENGTH,
+  suggestDisplayName,
+  validateDisplayName,
+} from "../../helpers/DisplayName";
+
+export interface StateProps {
+  open: boolean;
+  // The name the player already has, when they came here to change it rather than to pick a first
+  currentName?: string;
+  // What the identity provider handed over, used to seed the very first name
+  googleDisplayName?: string | null;
+}
+
+export interface DispatchProps {
+  // Resolves to the reason it couldn't be saved, or undefined once it has been
+  onSave: (name: string) => Promise<string | undefined>;
+  onClose: () => void;
+}
+
+export interface Props extends StateProps, DispatchProps {}
+
+/**
+ * Picks the name that shows up on the leaderboard.
+ *
+ * Its own dialog rather than the shared ui.dialog, which only carries a title and a message: this
+ * one has a text field whose error comes back from a Firestore transaction, so it has to be able
+ * to fail and stay open.
+ */
+export default function DisplayNameDialog(props: Props): React.JSX.Element {
+  const { open, currentName, googleDisplayName, onSave, onClose } = props;
+  const [name, setName] = React.useState("");
+  const [error, setError] = React.useState<string | undefined>(undefined);
+  const [saving, setSaving] = React.useState(false);
+
+  // Seeded when the dialog opens rather than on every render, so typing isn't fought by the prop
+  React.useEffect(() => {
+    if (open) {
+      setName(currentName || suggestDisplayName(googleDisplayName));
+      setError(undefined);
+      setSaving(false);
+    }
+  }, [open, currentName, googleDisplayName]);
+
+  const save = () => {
+    const invalid = validateDisplayName(name);
+    if (invalid) {
+      setError(invalid);
+      return;
+    }
+    setSaving(true);
+    onSave(name).then((failure) => {
+      setSaving(false);
+      // Left open on failure: a taken name needs another try, not a dismissal
+      setError(failure);
+      if (!failure) {
+        onClose();
+      }
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} aria-labelledby="display-name-title">
+      <DialogTitle id="display-name-title">
+        {currentName ? "Change your name" : "Choose your leaderboard name"}
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="textSecondary" gutterBottom>
+          This is the name other players see next to your high scores.
+        </Typography>
+        <TextField
+          autoFocus
+          fullWidth
+          margin="dense"
+          label="Name"
+          value={name}
+          error={Boolean(error)}
+          helperText={
+            error ||
+            `3-${DISPLAY_NAME_MAX_LENGTH} characters: letters, numbers, spaces, hyphens and underscores.`
+          }
+          slotProps={{ htmlInput: { maxLength: DISPLAY_NAME_MAX_LENGTH } }}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setName(e.target.value);
+            setError(undefined);
+          }}
+          onKeyDown={(e: React.KeyboardEvent) => {
+            if (e.key === "Enter") {
+              save();
+            }
+          }}
+        />
+      </DialogContent>
+      <DialogActions>
+        {/* Dismissible on purpose. A player who wants to get on with the game can pick a name
+            later from Settings, and being held at a form on first login is a good way to lose
+            them before they have played anything */}
+        <Button color="primary" onClick={onClose} disabled={saving}>
+          Not now
+        </Button>
+        <Button
+          color="primary"
+          variant="contained"
+          onClick={save}
+          disabled={saving}
+        >
+          {saving ? "Saving..." : "Save"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/base/DisplayNameDialogContainer.tsx
+++ b/src/components/base/DisplayNameDialogContainer.tsx
@@ -1,0 +1,42 @@
+import { connect } from "react-redux";
+import type { AppDispatch } from "../../Store";
+import { claimDisplayName, delta } from "../../reducers/User";
+import { snackbarOpen } from "../../reducers/UI";
+import { AppStateType } from "../../Types";
+import DisplayNameDialog, {
+  DispatchProps,
+  StateProps,
+} from "./DisplayNameDialog";
+
+const mapStateToProps = (state: AppStateType): StateProps => {
+  return {
+    open: Boolean(state.user.needsDisplayName),
+    currentName: state.user.displayName,
+    googleDisplayName: state.user.googleDisplayName,
+  };
+};
+
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
+  return {
+    onSave: async (name: string) => {
+      const result = await dispatch(claimDisplayName(name));
+      if (claimDisplayName.rejected.match(result)) {
+        // rejectWithValue carries the reason the player can act on; anything else means the thunk
+        // itself threw, which it is not supposed to
+        return result.payload || "Couldn't save that name. Please try again.";
+      }
+      dispatch(snackbarOpen(`You're on the board as ${result.payload}.`));
+      return undefined;
+    },
+    onClose: () => {
+      dispatch(delta({ needsDisplayName: false }));
+    },
+  };
+};
+
+const DisplayNameDialogContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DisplayNameDialog);
+
+export default DisplayNameDialogContainer;

--- a/src/components/base/VictoryDialog.test.tsx
+++ b/src/components/base/VictoryDialog.test.tsx
@@ -1,0 +1,180 @@
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import VictoryDialog, { Props } from "./VictoryDialog";
+import { VictoryType } from "../../Types";
+
+const mockFetchGlobalRank = jest.fn();
+jest.mock("../../reducers/User", () => ({
+  fetchGlobalRank: (...args: unknown[]) => mockFetchGlobalRank(...args),
+}));
+
+const mockShareText = jest.fn();
+jest.mock("../../helpers/Share", () => ({
+  buildShareText: () => "I scored 812 ...",
+  canShare: () => true,
+  shareText: (...args: unknown[]) => mockShareText(...args),
+}));
+
+function aVictory(overrides: Partial<VictoryType> = {}): VictoryType {
+  return {
+    scenarioId: 101,
+    scenarioName: "Deregulation",
+    difficulty: "CEO",
+    score: 812,
+    breakdown: { supply: 800, emissions: 30, blackouts: -18 },
+    ranked: true,
+    ...overrides,
+  };
+}
+
+function renderDialog(overrides: Partial<Props> = {}) {
+  const props: Props = {
+    victory: aVictory(),
+    loggedIn: true,
+    onClose: () => undefined,
+    onQuit: () => undefined,
+    onLogin: () => undefined,
+    onShared: () => undefined,
+    onShareFailed: () => undefined,
+    ...overrides,
+  };
+  render(<VictoryDialog {...props} />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // A rank that never resolves, so the synchronous half of the dialog can be asserted on its own
+  mockFetchGlobalRank.mockReturnValue(new Promise(() => undefined));
+  mockShareText.mockResolvedValue("share");
+});
+
+describe("VictoryDialog", () => {
+  it("renders nothing until a run has ended", () => {
+    renderDialog({ victory: null });
+    expect(screen.queryByText(/final score/)).not.toBeInTheDocument();
+  });
+
+  /**
+   * The whole point of moving this out of the reducer: the score the player earned is on screen
+   * immediately, and the parts that come over the network fill themselves in afterwards. A
+   * Firestore hiccup must never cost someone their score screen.
+   */
+  it("shows the breakdown before any of the async data lands", () => {
+    renderDialog();
+    expect(screen.getByText(/812/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/800 pts from electricity supplied/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/-18 pts from blackouts/)).toBeInTheDocument();
+  });
+
+  it("fills in the global rank once it resolves", async () => {
+    mockFetchGlobalRank.mockResolvedValue(4);
+    renderDialog();
+    expect(
+      await screen.findByText(/on the global leaderboard/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("#4")).toBeInTheDocument();
+    expect(mockFetchGlobalRank).toHaveBeenCalledWith(101, 812);
+  });
+
+  it("drops the rank line rather than the dialog when the query fails", async () => {
+    const warn = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    mockFetchGlobalRank.mockRejectedValue(new Error("unavailable"));
+    renderDialog();
+
+    await waitFor(() =>
+      expect(
+        screen.queryByLabelText("Working out your rank"),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/800 pts from electricity supplied/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/global leaderboard/)).not.toBeInTheDocument();
+    warn.mockRestore();
+  });
+
+  // previousBest is read when the run ends, before the score write, so it is the run before this
+  // one rather than the one just finished
+  it("celebrates a personal best against the previous one", () => {
+    renderDialog({ victory: aVictory({ previousBest: 640 }) });
+    expect(screen.getByText(/New personal best/)).toBeInTheDocument();
+    expect(screen.getByText(/was 640/)).toBeInTheDocument();
+  });
+
+  it("reports the best that still stands when the run didn't beat it", () => {
+    renderDialog({ victory: aVictory({ score: 500, previousBest: 640 }) });
+    expect(screen.getByText(/Your best: 640/)).toBeInTheDocument();
+    expect(screen.queryByText(/New personal best/)).not.toBeInTheDocument();
+  });
+
+  // Nothing is known about a logged-out player's history, so claiming anything about it would be
+  // a guess - the prompt to log in is what belongs there instead
+  it("offers a login rather than a personal best when logged out", () => {
+    renderDialog({ loggedIn: false });
+    expect(screen.queryByText(/personal best/)).not.toBeInTheDocument();
+    expect(screen.getByText(/under your name/)).toBeInTheDocument();
+  });
+
+  // A custom game shares its scenario id with every other custom game, and a replay is someone
+  // else's run - neither is comparable to anything on the board
+  it("leaves out the rank and the best for an unranked run", () => {
+    renderDialog({ victory: aVictory({ ranked: false }) });
+    expect(mockFetchGlobalRank).not.toHaveBeenCalled();
+    expect(screen.queryByText(/personal best/)).not.toBeInTheDocument();
+    expect(screen.getByText(/812/)).toBeInTheDocument();
+  });
+
+  it("reports how a share went out", async () => {
+    const onShared = jest.fn();
+    mockShareText.mockResolvedValue("clipboard");
+    renderDialog({ onShared });
+
+    await userEvent.click(screen.getByText("Share"));
+    await waitFor(() => expect(onShared).toHaveBeenCalled());
+    expect(onShared.mock.calls[0][1]).toBe("clipboard");
+  });
+
+  // Closing the share sheet is a decision, not a failure, and must not surface as an error
+  it("says nothing when the player backs out of the share sheet", async () => {
+    const onShared = jest.fn();
+    const onShareFailed = jest.fn();
+    mockShareText.mockResolvedValue("cancelled");
+    renderDialog({ onShared, onShareFailed });
+
+    await userEvent.click(screen.getByText("Share"));
+    await waitFor(() => expect(mockShareText).toHaveBeenCalled());
+    expect(onShared).not.toHaveBeenCalled();
+    expect(onShareFailed).not.toHaveBeenCalled();
+  });
+
+  it("keeps the ways out of a finished run", async () => {
+    const onClose = jest.fn();
+    const onQuit = jest.fn();
+    renderDialog({ onClose, onQuit });
+
+    await userEvent.click(screen.getByText("Keep playing"));
+    expect(onClose).toHaveBeenCalled();
+    await userEvent.click(screen.getByText("Return to scenarios"));
+    expect(onQuit).toHaveBeenCalled();
+  });
+
+  it("uses the scenario's own ending when it has one", () => {
+    renderDialog({
+      victory: aVictory({
+        endTitle: "The lights stayed on",
+        endMessage: "Your city never noticed.",
+      }),
+    });
+    expect(screen.getByText("The lights stayed on")).toBeInTheDocument();
+    expect(screen.getByText("Your city never noticed.")).toBeInTheDocument();
+    // The breakdown is still there: the override replaces the flavour text, not the score
+    expect(
+      screen.getByText(/800 pts from electricity supplied/),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/base/VictoryDialog.tsx
+++ b/src/components/base/VictoryDialog.tsx
@@ -1,0 +1,200 @@
+import * as React from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Skeleton,
+  Typography,
+} from "@mui/material";
+import ShareIcon from "@mui/icons-material/Share";
+import numbro from "numbro";
+import { VictoryType } from "../../Types";
+import { fetchGlobalRank } from "../../reducers/User";
+import { buildShareText, canShare, shareText } from "../../helpers/Share";
+
+// What each scored category is called on the score screen. The breakdown's keys differ by
+// ownership (see reducers/Game), so this is a lookup rather than a fixed list -- a scenario type
+// with new categories shows up here as soon as it scores them, in the order they were scored.
+const SCORE_LABELS: { [key: string]: string } = {
+  supply: "electricity supplied",
+  netWorth: "final net worth",
+  customers: "final customers",
+  rate: "electric rates",
+  emissions: "emissions",
+  blackouts: "blackouts",
+};
+
+export interface StateProps {
+  victory: VictoryType | null;
+  loggedIn: boolean;
+}
+
+export interface DispatchProps {
+  onClose: () => void;
+  onQuit: () => void;
+  onLogin: () => void;
+  // Reported once the player has actually shared, with how it went out
+  onShared: (victory: VictoryType, method: string) => void;
+  onShareFailed: () => void;
+}
+
+export interface Props extends StateProps, DispatchProps {}
+
+function formatScore(score: number): string {
+  return numbro(score).format({ thousandSeparated: true, mantissa: 0 });
+}
+
+/**
+ * The end of a run: the score breakdown, how it compares to the player's own best, where it lands
+ * on the global board, and a way to tell someone about it.
+ *
+ * The breakdown renders the moment the dialog opens and never waits on anything. The rank is a
+ * network read and the personal best depends on being logged in, so both are enrichment that
+ * appears when (and if) it can -- a Firestore hiccup must not cost the player their score screen.
+ */
+export default function VictoryDialog(props: Props): React.JSX.Element {
+  const { victory, loggedIn, onClose, onQuit, onLogin } = props;
+  const [rank, setRank] = React.useState<number | undefined>(undefined);
+  const [rankFailed, setRankFailed] = React.useState(false);
+
+  // Identity rather than the object, so re-renders while the dialog is open don't refetch
+  const scenarioId = victory?.scenarioId;
+  const score = victory?.score;
+  const ranked = Boolean(victory?.ranked);
+
+  React.useEffect(() => {
+    if (scenarioId === undefined || score === undefined || !ranked) {
+      return;
+    }
+    setRank(undefined);
+    setRankFailed(false);
+    // Guarded rather than cancelled: an aggregate read that lands after the player has closed the
+    // dialog must not set state on an unmounted tree
+    let live = true;
+    fetchGlobalRank(scenarioId, score)
+      .then((position) => {
+        if (live) {
+          setRank(position);
+        }
+      })
+      .catch((err) => {
+        console.warn("Couldn't work out your rank: ", err);
+        if (live) {
+          setRankFailed(true);
+        }
+      });
+    return () => {
+      live = false;
+    };
+  }, [scenarioId, score, ranked]);
+
+  if (!victory) {
+    // Rendered closed rather than not at all, so MUI can animate the dialog out
+    return <Dialog open={false} />;
+  }
+
+  const { previousBest, breakdown, endTitle, endMessage } = victory;
+  const isPersonalBest =
+    previousBest === undefined || victory.score > previousBest;
+
+  const onShare = () => {
+    const text = buildShareText({
+      score: victory.score,
+      scenarioName: victory.scenarioName,
+      difficulty: victory.difficulty,
+    });
+    shareText(text).then((method) => {
+      if (method === "cancelled") {
+        return; // The player changed their mind, which is not a failure to report
+      }
+      if (method === "unavailable") {
+        props.onShareFailed();
+        return;
+      }
+      props.onShared(victory, method);
+    });
+  };
+
+  return (
+    <Dialog
+      open={true}
+      // The run is over either way; dismissing by backdrop or Esc is the same as "Keep playing"
+      onClose={onClose}
+      aria-labelledby="victory-title"
+    >
+      <DialogTitle id="victory-title">
+        {endTitle || `You've retired!`}
+      </DialogTitle>
+      <DialogContent>
+        {endMessage && (
+          <Typography variant="body1" gutterBottom>
+            {endMessage}
+          </Typography>
+        )}
+        <Typography variant="body1">
+          Your final score is <strong>{formatScore(victory.score)}</strong>:
+        </Typography>
+        <div style={{ margin: "8px 0" }}>
+          {Object.keys(breakdown).map((category: string) => (
+            <div key={category}>
+              {breakdown[category]} pts from{" "}
+              {SCORE_LABELS[category] || category}
+            </div>
+          ))}
+        </div>
+        {ranked && loggedIn && (
+          <Typography variant="body1" style={{ marginTop: 12 }}>
+            {isPersonalBest ? (
+              <strong>
+                New personal best
+                {previousBest !== undefined
+                  ? ` - was ${formatScore(previousBest)}`
+                  : ""}
+              </strong>
+            ) : (
+              <span>Your best: {formatScore(previousBest as number)}</span>
+            )}
+          </Typography>
+        )}
+        {ranked && !rankFailed && (
+          <Typography variant="body1" component="div">
+            {rank === undefined ? (
+              <Skeleton width={200} aria-label="Working out your rank" />
+            ) : (
+              <span>
+                <strong>#{formatScore(rank)}</strong> on the global leaderboard
+              </span>
+            )}
+          </Typography>
+        )}
+        {ranked && !loggedIn && (
+          <Typography variant="body2" color="textSecondary" component="div">
+            <Button
+              color="primary"
+              onClick={onLogin}
+              style={{ paddingLeft: 0 }}
+            >
+              Log in
+            </Button>
+            to put this score on the board under your name
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        {canShare() && (
+          <Button color="primary" onClick={onShare} startIcon={<ShareIcon />}>
+            Share
+          </Button>
+        )}
+        <Button color="primary" onClick={onClose}>
+          Keep playing
+        </Button>
+        <Button color="primary" variant="contained" onClick={onQuit}>
+          Return to scenarios
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/base/VictoryDialogContainer.tsx
+++ b/src/components/base/VictoryDialogContainer.tsx
@@ -1,0 +1,53 @@
+import { connect } from "react-redux";
+import type { AppDispatch } from "../../Store";
+import { quit } from "../../reducers/Game";
+import { snackbarOpen, victoryClose } from "../../reducers/UI";
+import { login, logEvent } from "../../Globals";
+import { AppStateType, VictoryType } from "../../Types";
+import VictoryDialog, { DispatchProps, StateProps } from "./VictoryDialog";
+
+const mapStateToProps = (state: AppStateType): StateProps => {
+  return {
+    victory: state.ui.victory,
+    loggedIn: Boolean(state.user.uid),
+  };
+};
+
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
+  return {
+    onClose: () => {
+      dispatch(victoryClose());
+    },
+    onQuit: () => {
+      dispatch(victoryClose());
+      dispatch(quit({ toScenarioList: true }));
+    },
+    onLogin: () => {
+      login();
+    },
+    onShared: (victory: VictoryType, method: string) => {
+      // The share button is the lever this whole feature is pulling, so measure whether anyone
+      // actually pulls it
+      logEvent("score_share", {
+        scenarioId: victory.scenarioId,
+        difficulty: victory.difficulty,
+        score: victory.score,
+        method,
+      });
+      if (method === "clipboard") {
+        // A platform share sheet is its own confirmation; a silent clipboard write isn't
+        dispatch(snackbarOpen("Copied! Paste it wherever you like."));
+      }
+    },
+    onShareFailed: () => {
+      dispatch(snackbarOpen("Couldn't share that from this browser."));
+    },
+  };
+};
+
+const VictoryDialogContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(VictoryDialog);
+
+export default VictoryDialogContainer;

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -50,6 +50,13 @@ import {
 
 import numbro from "numbro";
 
+// The player's own rows, so they can find themselves without reading fifty names
+const OWN_ROW_STYLE = { fontWeight: "bold", background: "#eee" };
+
+function formatScore(score: number): string {
+  return numbro(score).format({ thousandSeparated: true, mantissa: 0 });
+}
+
 export interface StateProps {
   game: GameType;
   uid?: string;
@@ -66,6 +73,8 @@ export interface DispatchProps {
 interface State {
   scores?: ScoreType[];
   myTopScore?: ScoreType;
+  // Tells "nobody has played this yet" apart from "the board couldn't be read"
+  boardFailed?: boolean;
   scenario: ScenarioType | null;
   location: LocationType | null;
   victoryDialogOpen?: boolean;
@@ -84,40 +93,59 @@ export default class NewGameDetails extends React.Component<Props, State> {
       scenario,
       location: getScenarioLocation(scenario) || null,
     };
-    if (props.uid) {
-      this.loadScores(props.uid);
+  }
+
+  /**
+   * The board itself, which is public -- anyone can read it, logged in or not. Seeing named
+   * strangers above you is the reason to sign up, so hiding it behind a login inverted the very
+   * incentive it exists to create.
+   */
+  private async loadBoard() {
+    const scenario = this.state.scenario;
+    if (!scenario) {
+      return;
+    }
+    try {
+      const querySnapshot = await getDocs(
+        query(
+          collection(getDb(), "scores"),
+          where("scenarioId", "==", scenario.id),
+          orderBy("score", "desc"),
+          limit(50),
+        ),
+      );
+      // Set in one go rather than once per document: fifty setStates to draw one table meant
+      // laying out a table that grew by a row each time
+      this.setState({
+        scores: querySnapshot.docs.map((doc) => doc.data() as ScoreType),
+      });
+    } catch (err) {
+      console.warn("Couldn't load the high scores: ", err);
+      this.setState({ scores: [], boardFailed: true });
     }
   }
 
-  private async loadScores(uid: string) {
-    if (this.state.scenario && uid) {
-      const db = getDb();
-      // Tracked synchronously here because React state updates are async
-      let scores: ScoreType[] = [];
-
-      let q = query(
-        collection(db, "scores"),
-        where("scenarioId", "==", this.state.scenario.id),
-        orderBy("score", "desc"),
-        limit(50),
+  /** The player's own best, which is the one row worth showing above the rest. */
+  private async loadMyBest(uid: string) {
+    const scenario = this.state.scenario;
+    if (!scenario) {
+      return;
+    }
+    try {
+      const querySnapshot = await getDocs(
+        query(
+          collection(getDb(), "scores"),
+          where("scenarioId", "==", scenario.id),
+          where("uid", "==", uid),
+          orderBy("score", "desc"),
+          limit(1),
+        ),
       );
-      let querySnapshot = await getDocs(q);
-      querySnapshot.forEach((doc) => {
-        scores = [...scores, doc.data() as ScoreType];
-        this.setState({ scores });
-      });
-
-      q = query(
-        collection(db, "scores"),
-        where("scenarioId", "==", this.state.scenario.id),
-        where("uid", "==", uid),
-        orderBy("score", "desc"),
-        limit(1),
-      );
-      querySnapshot = await getDocs(q);
       querySnapshot.forEach((doc) => {
         this.setState({ myTopScore: doc.data() as ScoreType });
       });
+    } catch (err) {
+      console.warn("Couldn't load your best score: ", err);
     }
   }
 
@@ -173,17 +201,33 @@ export default class NewGameDetails extends React.Component<Props, State> {
     );
   }
 
-  public shouldComponentUpdate(nextProps: Props) {
-    if (!this.props.uid && nextProps.uid) {
-      this.loadScores(nextProps.uid);
+  public componentDidMount() {
+    // Unconditional: the board is public, so it no longer waits on a login that may never come.
+    // It used to be kicked off from shouldComponentUpdate, which is a purity hook and not a place
+    // to start network requests from
+    this.loadBoard();
+    if (this.props.uid) {
+      this.loadMyBest(this.props.uid);
     }
-    return true;
+  }
+
+  public componentDidUpdate(prevProps: Props) {
+    // Logging in from the button below the board is what makes "your best" answerable
+    if (this.props.uid && this.props.uid !== prevProps.uid) {
+      this.loadMyBest(this.props.uid);
+    }
   }
 
   public render() {
     const { onBack, onDelta, onStart, game, uid } = this.props;
-    const { scenario, scores, myTopScore, location, victoryDialogOpen } =
-      this.state;
+    const {
+      scenario,
+      scores,
+      myTopScore,
+      location,
+      victoryDialogOpen,
+      boardFailed,
+    } = this.state;
 
     const toggleVictoryDialog = (e: React.SyntheticEvent) => {
       this.setState({ victoryDialogOpen: !victoryDialogOpen });
@@ -309,83 +353,76 @@ export default class NewGameDetails extends React.Component<Props, State> {
         <Table id="HighScores">
           <TableHead>
             <TableRow>
-              <TableCell colSpan={3}>
+              <TableCell colSpan={5}>
                 <Typography variant="h6">Global High Scores</Typography>
               </TableCell>
             </TableRow>
-            {uid && (
-              <TableRow>
-                <TableCell>Score</TableCell>
-                <TableCell>Difficulty</TableCell>
-                <TableCell padding="none">Replay</TableCell>
+            <TableRow>
+              <TableCell padding="none">#</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Score</TableCell>
+              <TableCell>Difficulty</TableCell>
+              <TableCell padding="none">Replay</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {myTopScore && (
+              <TableRow style={OWN_ROW_STYLE}>
+                <TableCell padding="none" />
+                <TableCell colSpan={2}>
+                  Your best: {formatScore(myTopScore.score)}
+                </TableCell>
+                <TableCell>{myTopScore.difficulty}</TableCell>
+                {this.renderReplayCell(myTopScore)}
               </TableRow>
             )}
-          </TableHead>
-          {!uid && (
-            <TableBody>
+            {!scores && (
               <TableRow>
-                <TableCell colSpan={3} style={{ textAlign: "center" }}>
-                  <Button variant="outlined" color="primary" onClick={login}>
-                    Log in
-                  </Button>
+                <TableCell colSpan={5}>
                   <Typography variant="body2" color="textSecondary">
-                    To view and set high scores
+                    Loading...
                   </Typography>
                 </TableCell>
               </TableRow>
-            </TableBody>
-          )}
-          {uid && (
-            <TableBody>
-              {myTopScore && (
-                <TableRow style={{ fontWeight: "bold", background: "#eee" }}>
-                  <TableCell>
-                    Your best:{" "}
-                    {numbro(myTopScore.score).format({
-                      thousandSeparated: true,
-                      mantissa: 0,
-                    })}
-                  </TableCell>
-                  <TableCell>{myTopScore.difficulty}</TableCell>
-                  {this.renderReplayCell(myTopScore)}
-                </TableRow>
-              )}
-              {!scores && (
-                <TableRow>
-                  <TableCell colSpan={3}>
-                    <Typography variant="body2" color="textSecondary">
-                      Loading...
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              )}
-              {scores && scores.length === 0 && (
-                <TableRow>
-                  <TableCell colSpan={3}>
-                    <Typography variant="body2" color="textSecondary">
-                      Play the scenario to set a high score
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              )}
-              {scores &&
-                scores.map((score: ScoreType, i: number) => {
-                  return (
-                    <TableRow key={i}>
-                      <TableCell>
-                        {numbro(score.score).format({
-                          thousandSeparated: true,
-                          mantissa: 0,
-                        })}
-                      </TableCell>
-                      <TableCell>{score.difficulty}</TableCell>
-                      {this.renderReplayCell(score)}
-                    </TableRow>
-                  );
-                })}
-            </TableBody>
-          )}
+            )}
+            {scores && scores.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5}>
+                  <Typography variant="body2" color="textSecondary">
+                    {boardFailed
+                      ? "Couldn't load the high scores right now."
+                      : "Play the scenario to set a high score"}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+            {scores &&
+              scores.map((score: ScoreType, i: number) => {
+                const mine = Boolean(uid) && score.uid === uid;
+                return (
+                  <TableRow key={i} style={mine ? OWN_ROW_STYLE : undefined}>
+                    <TableCell padding="none">{i + 1}</TableCell>
+                    {/* Scores set before display names existed carry no name */}
+                    <TableCell>{score.displayName || "Anonymous"}</TableCell>
+                    <TableCell>{formatScore(score.score)}</TableCell>
+                    <TableCell>{score.difficulty}</TableCell>
+                    {this.renderReplayCell(score)}
+                  </TableRow>
+                );
+              })}
+          </TableBody>
         </Table>
+        {/* Below the board rather than in place of it: the board is the reason to log in */}
+        {!uid && (
+          <div style={{ textAlign: "center", margin: "12px 0 24px" }}>
+            <Button variant="outlined" color="primary" onClick={login}>
+              Log in
+            </Button>
+            <Typography variant="body2" color="textSecondary">
+              To set a high score under your own name
+            </Typography>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/components/views/Settings.test.tsx
+++ b/src/components/views/Settings.test.tsx
@@ -6,6 +6,10 @@ import Settings, { Props } from "./Settings";
 function renderSettings(overrides: Partial<Props> = {}) {
   const props: Props = {
     settings: { units: "metric" },
+    loggedIn: false,
+    onLogin: () => undefined,
+    onLogout: () => undefined,
+    onChangeName: () => undefined,
     onAudioChange: () => undefined,
     onUnitsChange: () => undefined,
     onExportSave: () => undefined,
@@ -44,6 +48,31 @@ describe("Settings", () => {
     expect(
       screen.getByText(/need a game in progress to export/),
     ).toBeInTheDocument();
+  });
+
+  it("offers a way in when nobody is logged in", () => {
+    renderSettings();
+    expect(screen.getByText("Log in")).toBeInTheDocument();
+    expect(screen.queryByText("Log out")).not.toBeInTheDocument();
+  });
+
+  it("names the player and offers a rename once they're logged in", async () => {
+    const onChangeName = jest.fn();
+    renderSettings({ loggedIn: true, displayName: "Ada", onChangeName });
+
+    expect(screen.getByText(/On the leaderboard as Ada/)).toBeInTheDocument();
+    await userEvent.click(screen.getByText("Change name"));
+    expect(onChangeName).toHaveBeenCalled();
+  });
+
+  // Logged in with no name is the state a player lands in by dismissing the first-login dialog,
+  // and it is the one that leaves their scores showing as Anonymous
+  it("prompts for a name when a logged-in player hasn't picked one", () => {
+    renderSettings({ loggedIn: true });
+    expect(
+      screen.getByText(/haven't picked a leaderboard name/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Pick a name")).toBeInTheDocument();
   });
 
   it("imports whichever file the player picks, saved game or not", async () => {

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -19,9 +19,15 @@ export interface StateProps {
   settings: SettingsType;
   // What the saved game is called, or undefined when there's nothing to export
   savedGame?: string;
+  loggedIn: boolean;
+  // The leaderboard name, when one has been claimed
+  displayName?: string;
 }
 
 export interface DispatchProps {
+  onLogin: () => void;
+  onLogout: () => void;
+  onChangeName: () => void;
   onAudioChange: (change: boolean) => void;
   onUnitsChange: (change: UnitSystemType) => void;
   onExportSave: () => void;
@@ -94,6 +100,48 @@ export default function Settings(props: Props): React.JSX.Element {
         {props.settings.audioEnabled
           ? "Music and sound effects enabled."
           : "Music and sound effects disabled."}
+        <Typography variant="h6" style={{ marginTop: 24 }}>
+          Account
+        </Typography>
+        {props.loggedIn ? (
+          <div>
+            <Typography variant="body2" color="textSecondary">
+              {props.displayName
+                ? `On the leaderboard as ${props.displayName}.`
+                : "You're logged in, but haven't picked a leaderboard name yet."}
+            </Typography>
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={props.onChangeName}
+              style={{ margin: "0 6px" }}
+            >
+              {props.displayName ? "Change name" : "Pick a name"}
+            </Button>
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={props.onLogout}
+              style={{ margin: "0 6px" }}
+            >
+              Log out
+            </Button>
+          </div>
+        ) : (
+          <div>
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={props.onLogin}
+              style={{ margin: "0 6px" }}
+            >
+              Log in
+            </Button>
+            <Typography variant="body2" color="textSecondary">
+              Log in to put your name on the global high score board.
+            </Typography>
+          </div>
+        )}
         <Typography variant="h6" style={{ marginTop: 24 }}>
           Units
         </Typography>

--- a/src/components/views/SettingsContainer.tsx
+++ b/src/components/views/SettingsContainer.tsx
@@ -4,6 +4,8 @@ import { navigate } from "../../reducers/Card";
 import { resume } from "../../reducers/Game";
 import { change as changeSettings } from "../../reducers/Settings";
 import { snackbarOpen } from "../../reducers/UI";
+import { delta as userDelta, logout } from "../../reducers/User";
+import { login } from "../../Globals";
 import {
   describeSave,
   downloadSave,
@@ -19,11 +21,24 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   return {
     settings: state.settings,
     savedGame: resumable ? describeSave(resumable) : undefined,
+    loggedIn: Boolean(state.user.uid),
+    displayName: state.user.displayName,
   };
 };
 
 const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
+    onLogin: () => {
+      login();
+    },
+    onLogout: () => {
+      dispatch(logout());
+    },
+    // The dialog itself lives next to the global one in Compositor, so it can also open on first
+    // login from whichever card the player happens to be on
+    onChangeName: () => {
+      dispatch(userDelta({ needsDisplayName: true }));
+    },
     onAudioChange: (v: boolean) => {
       dispatch(changeSettings({ audioEnabled: v }));
     },

--- a/src/helpers/DisplayName.test.tsx
+++ b/src/helpers/DisplayName.test.tsx
@@ -1,0 +1,77 @@
+import {
+  DISPLAY_NAME_MAX_LENGTH,
+  displayNameKey,
+  normalizeDisplayName,
+  suggestDisplayName,
+  validateDisplayName,
+} from "./DisplayName";
+
+describe("validateDisplayName", () => {
+  const accepted = [
+    "Ada",
+    "ada-lovelace",
+    "Grid_Operator 7",
+    "a".repeat(DISPLAY_NAME_MAX_LENGTH),
+    "  Padded  ", // trimmed rather than rejected
+  ];
+  accepted.forEach((name) => {
+    it(`accepts ${JSON.stringify(name)}`, () => {
+      expect(validateDisplayName(name)).toBeUndefined();
+    });
+  });
+
+  const rejected: Array<[string, RegExp]> = [
+    ["", /at least 3/],
+    ["ab", /at least 3/],
+    ["a".repeat(DISPLAY_NAME_MAX_LENGTH + 1), /at most 20/],
+    ["Ada!", /letters, numbers/],
+    ["<script>x", /letters, numbers/],
+    ["Ada  Lovelace", /double spaces/],
+    ["Admin", /reserved/],
+    ["anonymous", /reserved/],
+  ];
+  rejected.forEach(([name, message]) => {
+    it(`rejects ${JSON.stringify(name)}`, () => {
+      expect(validateDisplayName(name)).toMatch(message);
+    });
+  });
+});
+
+describe("displayNameKey", () => {
+  // The claim document is what makes a name unique, so two names that differ only in case or
+  // padding have to land on the same key or both get claimed
+  it("folds case and padding together", () => {
+    expect(displayNameKey("  Ada  ")).toBe("ada");
+    expect(displayNameKey("ADA")).toBe(displayNameKey("ada"));
+  });
+});
+
+describe("normalizeDisplayName", () => {
+  it("stores what the player meant, not their whitespace", () => {
+    expect(normalizeDisplayName(" Ada Lovelace ")).toBe("Ada Lovelace");
+  });
+});
+
+describe("suggestDisplayName", () => {
+  it("seeds from the Google name when it is usable as-is", () => {
+    expect(suggestDisplayName("Ada Lovelace")).toBe("Ada Lovelace");
+  });
+
+  // A full name is a suggestion, not a constraint - trimming one the board would reject beats
+  // handing the player an empty box
+  it("strips characters the board doesn't take", () => {
+    expect(suggestDisplayName("Ada  Lovelace-King!")).toBe("Ada Lovelace-King");
+  });
+
+  it("truncates a name past the limit", () => {
+    expect(suggestDisplayName("Bartholomew Featherstonehaugh")).toBe(
+      "Bartholomew Feathers",
+    );
+  });
+
+  it("gives up rather than suggesting something invalid", () => {
+    expect(suggestDisplayName("...")).toBe("");
+    expect(suggestDisplayName(undefined)).toBe("");
+    expect(suggestDisplayName(null)).toBe("");
+  });
+});

--- a/src/helpers/DisplayName.tsx
+++ b/src/helpers/DisplayName.tsx
@@ -1,0 +1,75 @@
+// The leaderboard name a player picks. Kept deliberately free of Firebase so the rules it
+// enforces can be read (and tested) in one place -- firestore.rules re-states the same
+// constraints, because only the server can actually make them true.
+
+export const DISPLAY_NAME_MIN_LENGTH = 3;
+export const DISPLAY_NAME_MAX_LENGTH = 20;
+
+// Not a moderation system, and not trying to be one: this only stops the handful of names that
+// would let someone pose as the game or its staff on a public board.
+const BLOCKED_NAMES = [
+  "admin",
+  "administrator",
+  "anonymous",
+  "electrify",
+  "moderator",
+  "mod",
+  "support",
+  "system",
+];
+
+/**
+ * What the player typed, as it would be stored. Surrounding whitespace is forgiven rather than
+ * rejected -- it is almost always a stray copy/paste rather than a name someone meant to type.
+ */
+export function normalizeDisplayName(raw: string): string {
+  return raw.trim();
+}
+
+/** The key a name is claimed under, so that Ada and ada cannot both exist. */
+export function displayNameKey(name: string): string {
+  return normalizeDisplayName(name).toLowerCase();
+}
+
+/**
+ * Why a name cannot be used, or undefined when it can. A message rather than a boolean, because
+ * every caller has to tell the player what to change.
+ */
+export function validateDisplayName(raw: string): string | undefined {
+  const name = normalizeDisplayName(raw);
+  if (name.length < DISPLAY_NAME_MIN_LENGTH) {
+    return `Names need at least ${DISPLAY_NAME_MIN_LENGTH} characters.`;
+  }
+  if (name.length > DISPLAY_NAME_MAX_LENGTH) {
+    return `Names can be at most ${DISPLAY_NAME_MAX_LENGTH} characters.`;
+  }
+  if (!/^[A-Za-z0-9 _-]+$/.test(name)) {
+    return "Names can only use letters, numbers, spaces, hyphens and underscores.";
+  }
+  if (name.includes("  ")) {
+    return "Names can't contain double spaces.";
+  }
+  if (BLOCKED_NAMES.indexOf(name.toLowerCase()) !== -1) {
+    return "That name is reserved. Please pick another.";
+  }
+  return undefined;
+}
+
+/**
+ * A starting point for the name dialog, from whatever the identity provider handed over. Google
+ * names are full names, which are frequently too long and often contain characters the board
+ * doesn't take, so this trims rather than rejects -- a suggestion the player can overwrite is
+ * worth more than an empty box.
+ */
+export function suggestDisplayName(googleDisplayName?: string | null): string {
+  if (!googleDisplayName) {
+    return "";
+  }
+  const cleaned = googleDisplayName
+    .replace(/[^A-Za-z0-9 _-]/g, "")
+    .replace(/ +/g, " ")
+    .trim()
+    .slice(0, DISPLAY_NAME_MAX_LENGTH)
+    .trim();
+  return validateDisplayName(cleaned) ? "" : cleaned;
+}

--- a/src/helpers/Share.test.tsx
+++ b/src/helpers/Share.test.tsx
@@ -1,0 +1,95 @@
+import { buildShareText, canShare, shareText } from "./Share";
+
+interface Shareable {
+  share?: (data: { text: string }) => Promise<void>;
+  clipboard?: { writeText?: (text: string) => Promise<void> };
+}
+
+const nav = navigator as Navigator & Shareable;
+const original = { share: nav.share, clipboard: nav.clipboard };
+
+function setNavigator(overrides: Shareable) {
+  Object.defineProperty(nav, "share", {
+    value: overrides.share,
+    configurable: true,
+  });
+  Object.defineProperty(nav, "clipboard", {
+    value: overrides.clipboard,
+    configurable: true,
+  });
+}
+
+afterEach(() => setNavigator(original));
+
+describe("buildShareText", () => {
+  it("reads as something a person would post", () => {
+    expect(
+      buildShareText({
+        score: 1812,
+        scenarioName: "Deregulation",
+        difficulty: "CEO",
+      }),
+    ).toBe(
+      "I scored 1,812 running Deregulation at CEO difficulty on Electrify - electrifygame.com",
+    );
+  });
+});
+
+describe("canShare", () => {
+  it("is false when the browser offers neither route", () => {
+    setNavigator({});
+    expect(canShare()).toBe(false);
+  });
+
+  it("is true with only a clipboard", () => {
+    setNavigator({ clipboard: { writeText: async () => undefined } });
+    expect(canShare()).toBe(true);
+  });
+});
+
+describe("shareText", () => {
+  it("uses the platform share sheet when there is one", async () => {
+    const share = jest.fn().mockResolvedValue(undefined);
+    setNavigator({ share });
+    expect(await shareText("hello")).toBe("share");
+    expect(share).toHaveBeenCalledWith({ text: "hello" });
+  });
+
+  /**
+   * Closing the share sheet rejects with an AbortError. That is a decision, not a failure: the
+   * player must not see an error, and the text must not be quietly copied to their clipboard
+   * instead of being sent where they chose not to send it.
+   */
+  it("reports a dismissed share sheet as a cancellation, without touching the clipboard", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    setNavigator({
+      share: jest.fn().mockRejectedValue(new Error("AbortError")),
+      clipboard: { writeText },
+    });
+    expect(await shareText("hello")).toBe("cancelled");
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the clipboard when there is no share sheet", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    setNavigator({ clipboard: { writeText } });
+    expect(await shareText("hello")).toBe("clipboard");
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("gives up when the clipboard is refused", async () => {
+    const warn = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    setNavigator({
+      clipboard: { writeText: jest.fn().mockRejectedValue(new Error("nope")) },
+    });
+    expect(await shareText("hello")).toBe("unavailable");
+    warn.mockRestore();
+  });
+
+  it("gives up when the browser offers nothing", async () => {
+    setNavigator({});
+    expect(await shareText("hello")).toBe("unavailable");
+  });
+});

--- a/src/helpers/Share.tsx
+++ b/src/helpers/Share.tsx
@@ -1,0 +1,67 @@
+import numbro from "numbro";
+
+// Sharing a score, which is the whole point of putting a name and a rank on the board. Kept out
+// of Globals so the text builder can be tested without a DOM and the transport without Firebase.
+
+export interface ShareScoreType {
+  score: number;
+  scenarioName: string;
+  difficulty: string;
+}
+
+/**
+ * How a share actually went. "cancelled" is deliberately distinct from "unavailable": a player who
+ * opened the share sheet and backed out did not fail at anything, and should not be told they did.
+ */
+export type ShareResultType =
+  "share" | "clipboard" | "cancelled" | "unavailable";
+
+export function buildShareText({
+  score,
+  scenarioName,
+  difficulty,
+}: ShareScoreType): string {
+  const formatted = numbro(score).format({
+    thousandSeparated: true,
+    mantissa: 0,
+  });
+  return `I scored ${formatted} running ${scenarioName} at ${difficulty} difficulty on Electrify - electrifygame.com`;
+}
+
+/** Whether there is any way to share at all, so the button can be hidden rather than dead. */
+export function canShare(): boolean {
+  return Boolean(
+    typeof navigator !== "undefined" &&
+    (navigator.share || navigator.clipboard?.writeText),
+  );
+}
+
+/**
+ * Hands the text to the platform share sheet, falling back to the clipboard. A rejected
+ * navigator.share is treated as a cancellation and NOT retried against the clipboard: the player
+ * just decided not to send this, and quietly copying it anyway is the opposite of what they asked.
+ */
+export async function shareText(text: string): Promise<ShareResultType> {
+  if (typeof navigator === "undefined") {
+    return "unavailable";
+  }
+  if (navigator.share) {
+    try {
+      await navigator.share({ text });
+      return "share";
+    } catch (_err) {
+      return "cancelled";
+    }
+  }
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return "clipboard";
+    } catch (err) {
+      // Denied permission, or an insecure origin. Nothing to fall back to
+      console.warn("Couldn't copy the score: ", err);
+      return "unavailable";
+    }
+  }
+  return "unavailable";
+}

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -29,7 +29,13 @@ import { formatLargeMass } from "../helpers/Units";
 import { getSolarOutputFactor, getWindOutputFactor } from "../helpers/Energy";
 import { getFuelPricesPerMBTU } from "../data/FuelPrices";
 import { getWeather, getRawSolarIrradianceWM2 } from "../data/Weather";
-import { dialogOpen, dialogClose, snackbarOpen } from "./UI";
+import {
+  dialogOpen,
+  dialogClose,
+  snackbarOpen,
+  victoryOpen,
+  victoryClose,
+} from "./UI";
 import { navigate, navigateBack } from "./Card";
 import {
   DIFFICULTIES,
@@ -387,6 +393,16 @@ export const gameSlice = createSlice({
       state.speed = "PAUSED";
     });
     builder.addCase(dialogClose, (state) => {
+      state.speed = speedBeforeDialog;
+      ensureTicking(state);
+    });
+    // The score screen stops the clock the same way any other dialog does - "Keep playing"
+    // resumes at whatever speed the run was going when it ended
+    builder.addCase(victoryOpen, (state) => {
+      speedBeforeDialog = state.speed;
+      state.speed = "PAUSED";
+    });
+    builder.addCase(victoryClose, (state) => {
       state.speed = speedBeforeDialog;
       ensureTicking(state);
     });
@@ -787,13 +803,17 @@ export function tickState(state: GameType) {
         // draft, so the fields the timeouts below read come out here too
         const {
           id: scoredScenarioId,
+          name: scenarioName,
           endTitle,
           endMessage,
-          ownership,
         } = scenario;
         const isTutorial = Boolean(scenario.tutorialSteps);
         // Read out here with everything else the timeouts need, rather than from inside them
         const nextTutorial = getNextTutorial(scoredScenarioId);
+        // Read now rather than inside the timeout, so that "was 640" reports the run before this
+        // one: submitHighscore below overwrites it the moment its write lands
+        const previousBest =
+          getStore().getState().user.bests?.[String(scoredScenarioId)]?.score;
 
         // The leaderboard is keyed on scenario id alone, so custom runs - whatever cash, duration
         // and rules the player gave themselves - would be scored against each other as if they
@@ -840,43 +860,19 @@ export function tickState(state: GameType) {
               }),
             );
           }
+          // Only the numbers: the breakdown, the personal best and the rank are base/VictoryDialog's
+          // to render, so that the parts which arrive over the network can fill themselves in
           getStore().dispatch(
-            dialogOpen({
-              title: endTitle || `You've retired!`,
-              message: endMessage || (
-                <div>
-                  Your final score is {finalScore}:<br />
-                  <br />
-                  {score.supply} pts from electricity supplied
-                  <br />
-                  {ownership === "Investor" && (
-                    <span>
-                      {score.netWorth} pts from final net worth
-                      <br />
-                    </span>
-                  )}
-                  {ownership === "Investor" && (
-                    <span>
-                      {score.customers} pts from final customers
-                      <br />
-                    </span>
-                  )}
-                  {ownership === "Public" && (
-                    <span>
-                      {score.rate} pts from electric rates
-                      <br />
-                    </span>
-                  )}
-                  {score.emissions} pts from emissions
-                  <br />
-                  {score.blackouts} pts from blackouts
-                  <br />
-                </div>
-              ),
-              open: true,
-              closeText: "Keep playing",
-              actionLabel: "Return to scenarios",
-              action: () => getStore().dispatch(quit({ toScenarioList: true })),
+            victoryOpen({
+              scenarioId: scoredScenarioId,
+              scenarioName,
+              difficulty,
+              score: finalScore,
+              breakdown: score,
+              endTitle,
+              endMessage,
+              ranked,
+              previousBest,
             }),
           );
         }, 1);

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -50,6 +50,30 @@ describe("ending a scenario from inside the reducer", () => {
     expect(() => jest.runOnlyPendingTimers()).not.toThrow();
   });
 
+  /**
+   * The score screen is a component now rather than JSX built in here, so what the reducer owes it
+   * is the numbers. previousBest in particular is read before the score write, so that "was 640"
+   * reports the run before this one and not the one just finished.
+   */
+  it("hands the score screen everything it needs", () => {
+    getStore().dispatch(quit());
+    const scenario = customScenario({ durationMonths: 2, name: "A Test Run" });
+    let state = createGame({ scenarioId: CUSTOM_SCENARIO_ID, scenario });
+    while (state.date.monthsEllapsed < (scenario.durationMonths as number)) {
+      state = tick(state);
+    }
+    jest.runOnlyPendingTimers();
+
+    const victory = getStore().getState().ui.victory;
+    expect(victory).not.toBeNull();
+    expect(victory?.scenarioName).toBe("A Test Run");
+    expect(Object.keys(victory?.breakdown || {}).length).toBeGreaterThan(0);
+    // Every custom game shares one id, so its score belongs to nothing comparable
+    expect(victory?.ranked).toBe(false);
+    // Opening the score screen stops the clock, the way any other dialog does
+    expect(getStore().getState().game.speed).toBe("PAUSED");
+  });
+
   it("goes bankrupt without reading the revoked draft", () => {
     // No cash and a marketing budget far past what the fleet earns: it is under within a month
     const scenario = customScenario({ cash: 0, durationMonths: 12 * 20 });

--- a/src/reducers/UI.tsx
+++ b/src/reducers/UI.tsx
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { DialogType, SnackbarType, UIType } from "../Types";
+import { DialogType, SnackbarType, UIType, VictoryType } from "../Types";
 import { quit } from "./GameActions";
 
 export const initialUI: UIType = {
@@ -13,6 +13,7 @@ export const initialUI: UIType = {
     open: false,
     timeout: 6000,
   },
+  victory: null,
 };
 
 export const uiSlice = createSlice({
@@ -54,16 +55,33 @@ export const uiSlice = createSlice({
     dialogClose: (state) => {
       state.dialog = { ...initialUI.dialog };
     },
+    // The score screen for a run that just ended. Separate from dialogOpen because the victory
+    // dialog is a component rather than a title and a message: it fills in the personal best and
+    // the global rank as those resolve, which a snapshot of JSX cannot do
+    victoryOpen: (state, action: PayloadAction<VictoryType>) => {
+      state.victory = { ...action.payload };
+    },
+    victoryClose: (state) => {
+      state.victory = null;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(quit, (state) => {
       state.snackbar = { ...initialUI.snackbar };
       state.dialog = { ...initialUI.dialog };
+      state.victory = null;
     });
   },
 });
 
-export const { delta, snackbarOpen, snackbarClose, dialogOpen, dialogClose } =
-  uiSlice.actions;
+export const {
+  delta,
+  snackbarOpen,
+  snackbarClose,
+  dialogOpen,
+  dialogClose,
+  victoryOpen,
+  victoryClose,
+} = uiSlice.actions;
 
 export default uiSlice.reducer;

--- a/src/reducers/User.test.tsx
+++ b/src/reducers/User.test.tsx
@@ -1,21 +1,55 @@
-import userReducer, { submitHighscore } from "./User";
+import { configureStore } from "@reduxjs/toolkit";
+import userReducer, {
+  claimDisplayName,
+  fetchGlobalRank,
+  loadProfile,
+  logout,
+  submitHighscore,
+} from "./User";
 import { MAX_REPLAY_BYTES, REPLAY_VERSION } from "../Replay";
 import { LOCATIONS } from "../Constants";
 import { ReplayType, UserType } from "../Types";
 
 const mockAddDoc = jest.fn();
+const mockGetDoc = jest.fn();
+const mockGetDocs = jest.fn();
+const mockSetDoc = jest.fn();
+const mockGetCount = jest.fn();
+const mockRunTransaction = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn();
+const mockSignOut = jest.fn();
 
 jest.mock("firebase/firestore", () => ({
   addDoc: (...args: unknown[]) => mockAddDoc(...args),
   collection: (_db: unknown, name: string) => ({ name }),
+  doc: (_db: unknown, name: string, id: string) => ({ path: `${name}/${id}` }),
+  getCountFromServer: (...args: unknown[]) => mockGetCount(...args),
+  getDoc: (...args: unknown[]) => mockGetDoc(...args),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  limit: (n: number) => ({ limit: n }),
+  orderBy: (field: string) => ({ orderBy: field }),
+  query: (...parts: unknown[]) => ({ parts }),
+  runTransaction: (_db: unknown, fn: unknown) => mockRunTransaction(fn),
   serverTimestamp: () => "SERVER_TIMESTAMP",
+  setDoc: (...args: unknown[]) => mockSetDoc(...args),
+  where: (field: string, op: string, value: unknown) => ({ field, op, value }),
+  writeBatch: () => ({ update: mockBatchUpdate, commit: mockBatchCommit }),
 }));
 
 jest.mock("../Globals", () => ({
   getDb: () => ({}),
+  logout: () => mockSignOut(),
 }));
 
 const SIGNED_IN: UserType = { uid: "player-1" };
+
+function makeStore(user: UserType = {}) {
+  return configureStore({
+    reducer: { user: userReducer },
+    preloadedState: { user },
+  });
+}
 
 function aReplay(overrides: Partial<ReplayType> = {}): ReplayType {
   return {
@@ -32,9 +66,9 @@ function aReplay(overrides: Partial<ReplayType> = {}): ReplayType {
   };
 }
 
-function aSubmission(replay?: ReplayType) {
+function aSubmission(replay?: ReplayType, score = 420) {
   return {
-    score: 420,
+    score,
     scoreBreakdown: { supply: 400, blackouts: 20 },
     scenarioId: 101,
     difficulty: "Employee" as const,
@@ -42,30 +76,52 @@ function aSubmission(replay?: ReplayType) {
   };
 }
 
-// The writes are fired off without being awaited -- nothing in the app waits on them either
-function settled() {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 function writesTo(name: string) {
   return mockAddDoc.mock.calls.filter((call) => call[0].name === name);
 }
 
-describe("submitHighscore", () => {
-  beforeEach(() => {
-    mockAddDoc.mockReset();
-    mockAddDoc.mockResolvedValue({ id: "replay-1" });
+/** A transaction that finds the claim document already held by `uid`, or by nobody. */
+function transactionSeeing(holder?: string) {
+  const get = jest.fn().mockResolvedValue({
+    exists: () => holder !== undefined,
+    data: () => ({ uid: holder }),
   });
+  const set = jest.fn();
+  const del = jest.fn();
+  mockRunTransaction.mockImplementation(
+    (fn: (t: unknown) => Promise<void>) =>
+      fn({ get, set, delete: del }) as Promise<void>,
+  );
+  return { get, set, delete: del };
+}
 
+function silenceWarnings() {
+  return jest.spyOn(console, "warn").mockImplementation(() => undefined);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAddDoc.mockResolvedValue({ id: "replay-1" });
+  mockSetDoc.mockResolvedValue(undefined);
+  mockGetDocs.mockResolvedValue({
+    empty: true,
+    docs: [],
+    forEach: () => undefined,
+  });
+  mockBatchCommit.mockResolvedValue(undefined);
+  mockSignOut.mockResolvedValue(undefined);
+});
+
+describe("submitHighscore", () => {
   it("writes nothing for a player who isn't signed in", async () => {
-    userReducer({}, submitHighscore(aSubmission(aReplay())));
-    await settled();
+    await makeStore().dispatch(submitHighscore(aSubmission(aReplay())));
     expect(mockAddDoc).not.toHaveBeenCalled();
   });
 
   it("stores the replay and points the score at it", async () => {
-    userReducer(SIGNED_IN, submitHighscore(aSubmission(aReplay())));
-    await settled();
+    await makeStore(SIGNED_IN).dispatch(
+      submitHighscore(aSubmission(aReplay())),
+    );
 
     const [replayWrite] = writesTo("replays");
     expect(replayWrite[1].seed).toBe(12345);
@@ -78,14 +134,27 @@ describe("submitHighscore", () => {
     expect(scoreWrite[1].replayId).toBe("replay-1");
   });
 
+  // Denormalized onto the score so that drawing a fifty row board is one query rather than
+  // fifty-one, and so a board row survives the profile it came from being unreadable
+  it("carries the player's leaderboard name onto the score", async () => {
+    await makeStore({ ...SIGNED_IN, displayName: "Ada" }).dispatch(
+      submitHighscore(aSubmission()),
+    );
+    expect(writesTo("scores")[0][1].displayName).toBe("Ada");
+  });
+
+  it("leaves the name off a score set before one was picked", async () => {
+    await makeStore(SIGNED_IN).dispatch(submitHighscore(aSubmission()));
+    // Firestore rejects a document carrying an undefined field
+    expect("displayName" in writesTo("scores")[0][1]).toBe(false);
+  });
+
   it("still submits the score when the run wasn't recorded", async () => {
-    userReducer(SIGNED_IN, submitHighscore(aSubmission()));
-    await settled();
+    await makeStore(SIGNED_IN).dispatch(submitHighscore(aSubmission()));
 
     expect(writesTo("replays").length).toBe(0);
     const [scoreWrite] = writesTo("scores");
     expect(scoreWrite[1].score).toBe(420);
-    // Firestore rejects a document carrying an undefined field
     expect("replayId" in scoreWrite[1]).toBe(false);
   });
 
@@ -95,14 +164,13 @@ describe("submitHighscore", () => {
    * the score the player actually earned.
    */
   it("submits the score even when the replay write is rejected", async () => {
-    const warn = jest
-      .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
+    const warn = silenceWarnings();
     mockAddDoc.mockRejectedValueOnce(new Error("permission-denied"));
     mockAddDoc.mockResolvedValueOnce({ id: "score-1" });
 
-    userReducer(SIGNED_IN, submitHighscore(aSubmission(aReplay())));
-    await settled();
+    await makeStore(SIGNED_IN).dispatch(
+      submitHighscore(aSubmission(aReplay())),
+    );
 
     const [scoreWrite] = writesTo("scores");
     expect(scoreWrite[1].score).toBe(420);
@@ -111,9 +179,7 @@ describe("submitHighscore", () => {
   });
 
   it("drops a replay too big for a Firestore document", async () => {
-    const warn = jest
-      .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
+    const warn = silenceWarnings();
     // One oversized payload rather than a realistic action list; what matters is the byte count
     const huge = aReplay({
       actions: [
@@ -125,11 +191,233 @@ describe("submitHighscore", () => {
       ],
     });
 
-    userReducer(SIGNED_IN, submitHighscore(aSubmission(huge)));
-    await settled();
+    await makeStore(SIGNED_IN).dispatch(submitHighscore(aSubmission(huge)));
 
     expect(writesTo("replays").length).toBe(0);
     expect(writesTo("scores").length).toBe(1);
     warn.mockRestore();
+  });
+
+  it("records a first score as the personal best", async () => {
+    const store = makeStore(SIGNED_IN);
+    await store.dispatch(submitHighscore(aSubmission(undefined, 640)));
+
+    expect(store.getState().user.bests?.["101"].score).toBe(640);
+    // Mirrored onto the profile document too, so it survives a new browser
+    const [ref, data] = mockSetDoc.mock.calls[0];
+    expect(ref.path).toBe("users/player-1");
+    expect(data.bests["101"].score).toBe(640);
+  });
+
+  it("replaces the personal best only when the run beat it", async () => {
+    const store = makeStore({
+      ...SIGNED_IN,
+      bests: { "101": { score: 640, difficulty: "VP", date: 1 } },
+    });
+
+    await store.dispatch(submitHighscore(aSubmission(undefined, 500)));
+    expect(store.getState().user.bests?.["101"].score).toBe(640);
+    expect(mockSetDoc).not.toHaveBeenCalled();
+
+    await store.dispatch(submitHighscore(aSubmission(undefined, 812)));
+    expect(store.getState().user.bests?.["101"]).toEqual(
+      expect.objectContaining({ score: 812, difficulty: "Employee" }),
+    );
+  });
+
+  // Every scenario keeps its own best, so beating one must not wipe the others
+  it("leaves other scenarios' bests alone", async () => {
+    const store = makeStore({
+      ...SIGNED_IN,
+      bests: { "102": { score: 900, difficulty: "CEO", date: 1 } },
+    });
+    await store.dispatch(submitHighscore(aSubmission()));
+    expect(store.getState().user.bests?.["102"].score).toBe(900);
+    expect(store.getState().user.bests?.["101"].score).toBe(420);
+  });
+});
+
+describe("loadProfile", () => {
+  it("takes the name and bests off an existing profile", async () => {
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        displayName: "Ada",
+        bests: { "101": { score: 640, difficulty: "VP", date: 1 } },
+      }),
+    });
+    const store = makeStore(SIGNED_IN);
+    await store.dispatch(loadProfile({ uid: "player-1" }));
+
+    const user = store.getState().user;
+    expect(user.displayName).toBe("Ada");
+    expect(user.bests?.["101"].score).toBe(640);
+    expect(user.profileLoaded).toBe(true);
+    expect(user.needsDisplayName).toBe(false);
+  });
+
+  it("creates a profile on first login and asks for a name", async () => {
+    mockGetDoc.mockResolvedValue({ exists: () => false });
+    const store = makeStore(SIGNED_IN);
+    await store.dispatch(loadProfile({ uid: "player-1" }));
+
+    expect(mockSetDoc.mock.calls[0][0].path).toBe("users/player-1");
+    expect(store.getState().user.needsDisplayName).toBe(true);
+  });
+
+  /**
+   * The profile is a leaderboard nicety. Rules that haven't been deployed yet, or a player on a
+   * plane, must not leave the game prompting for a name it could not save anyway.
+   */
+  it("doesn't prompt for a name it couldn't store", async () => {
+    const warn = silenceWarnings();
+    mockGetDoc.mockRejectedValue(new Error("permission-denied"));
+    const store = makeStore(SIGNED_IN);
+    await store.dispatch(loadProfile({ uid: "player-1" }));
+
+    expect(store.getState().user.profileLoaded).toBe(true);
+    expect(store.getState().user.needsDisplayName).toBeFalsy();
+    warn.mockRestore();
+  });
+});
+
+describe("claimDisplayName", () => {
+  it("claims a free name and writes it to the profile", async () => {
+    const transaction = transactionSeeing(undefined);
+    const store = makeStore(SIGNED_IN);
+    await store.dispatch(claimDisplayName("  Ada Lovelace "));
+
+    expect(store.getState().user.displayName).toBe("Ada Lovelace");
+    expect(store.getState().user.needsDisplayName).toBe(false);
+    // Claimed lowercased, so Ada and ada cannot both be taken
+    expect(transaction.set.mock.calls[0][0].path).toBe(
+      "usernames/ada lovelace",
+    );
+    expect(transaction.set.mock.calls[1][0].path).toBe("users/player-1");
+  });
+
+  it("releases the old claim when renaming, in the same transaction", async () => {
+    const transaction = transactionSeeing(undefined);
+    await makeStore({ ...SIGNED_IN, displayName: "Ada" }).dispatch(
+      claimDisplayName("Grace"),
+    );
+    expect(transaction.delete).toHaveBeenCalledWith({ path: "usernames/ada" });
+  });
+
+  // Re-saving the same name is a no-op, not a self-collision that would release the claim the
+  // player is standing on
+  it("doesn't release the claim when the name hasn't changed", async () => {
+    const transaction = transactionSeeing("player-1");
+    const store = makeStore({ ...SIGNED_IN, displayName: "Ada" });
+    await store.dispatch(claimDisplayName("ada"));
+
+    expect(transaction.delete).not.toHaveBeenCalled();
+    expect(store.getState().user.displayName).toBe("ada");
+  });
+
+  it("fails cleanly on a name someone else holds, leaving the old one in place", async () => {
+    transactionSeeing("someone-else");
+    const store = makeStore({ ...SIGNED_IN, displayName: "Ada" });
+    const result = await store.dispatch(claimDisplayName("Grace"));
+
+    expect(claimDisplayName.rejected.match(result)).toBe(true);
+    expect(result.payload).toMatch(/taken/);
+    expect(store.getState().user.displayName).toBe("Ada");
+  });
+
+  it("rejects an invalid name without touching Firestore", async () => {
+    const result = await makeStore(SIGNED_IN).dispatch(claimDisplayName("!!"));
+    expect(claimDisplayName.rejected.match(result)).toBe(true);
+    expect(mockRunTransaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects when nobody is logged in", async () => {
+    const result = await makeStore().dispatch(claimDisplayName("Ada"));
+    expect(claimDisplayName.rejected.match(result)).toBe(true);
+    expect(result.payload).toMatch(/logged in/);
+  });
+
+  it("reports a failed write rather than pretending the name was claimed", async () => {
+    const warn = silenceWarnings();
+    mockRunTransaction.mockRejectedValue(new Error("unavailable"));
+    const store = makeStore(SIGNED_IN);
+    const result = await store.dispatch(claimDisplayName("Ada"));
+
+    expect(claimDisplayName.rejected.match(result)).toBe(true);
+    expect(store.getState().user.displayName).toBeUndefined();
+    warn.mockRestore();
+  });
+
+  // Cosmetic, and explicitly best effort: a rename must not fail because old rows couldn't be
+  // refreshed
+  it("keeps the name when backfilling old scores fails", async () => {
+    const warn = silenceWarnings();
+    transactionSeeing(undefined);
+    mockGetDocs.mockRejectedValue(new Error("permission-denied"));
+    const store = makeStore(SIGNED_IN);
+    await store.dispatch(claimDisplayName("Ada"));
+
+    expect(store.getState().user.displayName).toBe("Ada");
+    warn.mockRestore();
+  });
+
+  it("rewrites the name on the player's own old scores", async () => {
+    transactionSeeing(undefined);
+    mockGetDocs.mockResolvedValue({
+      empty: false,
+      docs: [],
+      forEach: (fn: (d: { ref: string }) => void) => {
+        fn({ ref: "scores/a" });
+        fn({ ref: "scores/b" });
+      },
+    });
+    await makeStore(SIGNED_IN).dispatch(claimDisplayName("Ada"));
+    // The backfill is deliberately not awaited by the thunk
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockBatchUpdate).toHaveBeenCalledWith("scores/a", {
+      displayName: "Ada",
+    });
+    expect(mockBatchCommit).toHaveBeenCalled();
+  });
+});
+
+describe("logout", () => {
+  it("drops the whole slice, not just the uid", async () => {
+    const store = makeStore({
+      ...SIGNED_IN,
+      displayName: "Ada",
+      bests: { "101": { score: 640, difficulty: "VP", date: 1 } },
+      profileLoaded: true,
+    });
+    await store.dispatch(logout());
+    expect(store.getState().user).toEqual({});
+  });
+
+  // Sign-out failed, so the player is still signed in - clearing the slice would have shown them
+  // a logged-out game they are not actually logged out of
+  it("keeps the player signed in when sign-out fails", async () => {
+    const warn = silenceWarnings();
+    mockSignOut.mockRejectedValue(new Error("network"));
+    const store = makeStore({ ...SIGNED_IN, displayName: "Ada" });
+    await store.dispatch(logout());
+
+    expect(store.getState().user.uid).toBe("player-1");
+    warn.mockRestore();
+  });
+});
+
+describe("fetchGlobalRank", () => {
+  it("is one more than the number of runs that beat it", async () => {
+    mockGetCount.mockResolvedValue({ data: () => ({ count: 3 }) });
+    expect(await fetchGlobalRank(101, 812)).toBe(4);
+    // Strictly greater, so the player's own run never counts against them
+    const { parts } = mockGetCount.mock.calls[0][0];
+    expect(parts).toContainEqual({ field: "score", op: ">", value: 812 });
+  });
+
+  it("is first when nothing beats it", async () => {
+    mockGetCount.mockResolvedValue({ data: () => ({ count: 0 }) });
+    expect(await fetchGlobalRank(101, 9999)).toBe(1);
   });
 });

--- a/src/reducers/User.tsx
+++ b/src/reducers/User.tsx
@@ -1,5 +1,6 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import {
+  BestScoreType,
   DifficultyType,
   ReplayType,
   ScoreBreakdownType,
@@ -7,11 +8,47 @@ import {
   UserType,
 } from "../Types";
 import type { RootState } from "../Store";
-import { collection, addDoc, serverTimestamp } from "firebase/firestore";
-import { getDb } from "../Globals";
+import {
+  addDoc,
+  collection,
+  doc,
+  getCountFromServer,
+  getDoc,
+  getDocs,
+  limit,
+  query,
+  runTransaction,
+  serverTimestamp,
+  setDoc,
+  where,
+  writeBatch,
+} from "firebase/firestore";
+import { getDb, logout as signOutOfFirebase } from "../Globals";
+import {
+  displayNameKey,
+  normalizeDisplayName,
+  validateDisplayName,
+} from "../helpers/DisplayName";
 import { encodeReplay, MAX_REPLAY_BYTES, replayByteLength } from "../Replay";
 
 export const initialUser: UserType = {};
+
+/**
+ * The only slice these thunks read. Narrower than RootState on purpose: it keeps them dispatchable
+ * against a store holding nothing but this reducer, which is what the tests do.
+ */
+interface UserSliceStateType {
+  user: UserType;
+}
+
+// How many of a player's own scores a rename backfills. Denormalized names are a display
+// convenience, so the cost of keeping them fresh is capped rather than unbounded -- and a
+// Firestore batch tops out at 500 writes anyway
+const RENAME_BACKFILL_LIMIT = 100;
+
+// Thrown inside the claim transaction, which is the only place that can tell "someone else has
+// this name" apart from "the write failed"
+const NAME_TAKEN = "display-name-taken";
 
 export interface HighscoreSubmissionType {
   score: number;
@@ -55,7 +92,11 @@ async function uploadReplay(
   }
 }
 
-async function submitScore(uid: string, submission: HighscoreSubmissionType) {
+async function submitScore(
+  uid: string,
+  displayName: string | undefined,
+  submission: HighscoreSubmissionType,
+) {
   const replayId = submission.replay
     ? await uploadReplay(uid, submission.replay)
     : undefined;
@@ -68,6 +109,8 @@ async function submitScore(uid: string, submission: HighscoreSubmissionType) {
     uid,
     // Spread rather than assigned: Firestore rejects a document with an undefined field
     ...(replayId ? { replayId } : {}),
+    // Denormalized so that rendering a board is one query rather than one plus a read per row
+    ...(displayName ? { displayName } : {}),
   } as ScoreType;
   try {
     await addDoc(collection(getDb(), "scores"), scoreSubmission);
@@ -76,6 +119,183 @@ async function submitScore(uid: string, submission: HighscoreSubmissionType) {
   }
 }
 
+/**
+ * Mirrors a new personal best onto the profile document. Its own write and its own failure: a
+ * board score that landed shouldn't be lost because the profile write didn't.
+ */
+async function saveBest(uid: string, scenarioId: number, best: BestScoreType) {
+  try {
+    await setDoc(
+      doc(getDb(), "users", uid),
+      { bests: { [String(scenarioId)]: best }, updatedAt: serverTimestamp() },
+      { merge: true },
+    );
+  } catch (err) {
+    console.warn("Couldn't save your best score: ", err);
+  }
+}
+
+/**
+ * Rewrites the denormalized name on the player's own past scores, so old rows don't keep showing
+ * the name they just left behind. Best effort by design: the board reads fine either way, and a
+ * rename must not fail because a backfill did.
+ */
+async function backfillScoreNames(uid: string, displayName: string) {
+  try {
+    const db = getDb();
+    const mine = await getDocs(
+      query(
+        collection(db, "scores"),
+        where("uid", "==", uid),
+        limit(RENAME_BACKFILL_LIMIT),
+      ),
+    );
+    if (mine.empty) {
+      return;
+    }
+    const batch = writeBatch(db);
+    mine.forEach((score) => batch.update(score.ref, { displayName }));
+    await batch.commit();
+  } catch (err) {
+    console.warn("Couldn't update the name on your old scores: ", err);
+  }
+}
+
+/**
+ * Where a score sits on the global board: one aggregate read counting the runs that beat it,
+ * rather than downloading them.
+ *
+ * Counts runs, not distinct players, so someone holding the top three scores occupies three
+ * ranks. That matches the board itself, which already lists one row per run.
+ */
+export async function fetchGlobalRank(
+  scenarioId: number,
+  score: number,
+): Promise<number> {
+  const better = await getCountFromServer(
+    query(
+      collection(getDb(), "scores"),
+      where("scenarioId", "==", scenarioId),
+      where("score", ">", score),
+    ),
+  );
+  return better.data().count + 1;
+}
+
+export interface ProfileType {
+  displayName?: string;
+  bests?: { [scenarioId: string]: BestScoreType };
+}
+
+/**
+ * Reads users/{uid} on login, creating it when it isn't there yet. A new profile is created empty
+ * rather than with a guessed name: a name has to be unique, and only the claim transaction below
+ * can make that true.
+ */
+export const loadProfile = createAsyncThunk<
+  ProfileType,
+  { uid: string; googleDisplayName?: string | null }
+>("user/loadProfile", async ({ uid }) => {
+  const ref = doc(getDb(), "users", uid);
+  const snapshot = await getDoc(ref);
+  if (!snapshot.exists()) {
+    await setDoc(ref, { createdAt: serverTimestamp() }, { merge: true });
+    return {};
+  }
+  const data = snapshot.data() as ProfileType;
+  return { displayName: data.displayName, bests: data.bests };
+});
+
+/**
+ * Claims a name, or explains why it couldn't be. The document under `usernames` is what makes a
+ * name unique -- created only when absent, inside a transaction, so two players racing for the
+ * same name cannot both win it.
+ */
+export const claimDisplayName = createAsyncThunk<
+  string,
+  string,
+  { state: UserSliceStateType; rejectValue: string }
+>("user/claimDisplayName", async (requested, { getState, rejectWithValue }) => {
+  const { uid, displayName: previous } = getState().user;
+  if (!uid) {
+    return rejectWithValue("You need to be logged in to pick a name.");
+  }
+  const invalid = validateDisplayName(requested);
+  if (invalid) {
+    return rejectWithValue(invalid);
+  }
+  const name = normalizeDisplayName(requested);
+  const key = displayNameKey(name);
+  const db = getDb();
+  try {
+    await runTransaction(db, async (transaction) => {
+      const claim = doc(db, "usernames", key);
+      const existing = await transaction.get(claim);
+      if (existing.exists() && existing.data().uid !== uid) {
+        throw new Error(NAME_TAKEN);
+      }
+      transaction.set(claim, { uid, createdAt: serverTimestamp() });
+      // The old claim is released in the same transaction, so a rename can never leave the player
+      // holding two names or -- worse -- none
+      if (previous && displayNameKey(previous) !== key) {
+        transaction.delete(doc(db, "usernames", displayNameKey(previous)));
+      }
+      transaction.set(
+        doc(db, "users", uid),
+        {
+          displayName: name,
+          displayNameLower: key,
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true },
+      );
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message === NAME_TAKEN) {
+      return rejectWithValue("That name is taken. Please pick another.");
+    }
+    console.warn("Couldn't claim the name: ", err);
+    return rejectWithValue("Couldn't save that name. Please try again.");
+  }
+  // Deliberately not awaited: the name is the player's the moment the transaction commits, and
+  // refreshing their old rows is cosmetic
+  void backfillScoreNames(uid, name);
+  return name;
+});
+
+export const logout = createAsyncThunk("user/logout", async () => {
+  await signOutOfFirebase();
+});
+
+/**
+ * Writes the score, and the personal best behind it. A thunk rather than the side effect inside a
+ * reducer this used to be: it has to be awaitable for anything to know the write landed, and
+ * firing network calls out of a reducer is what made that impossible.
+ */
+export const submitHighscore = createAsyncThunk<
+  { scenarioId: number; best?: BestScoreType },
+  HighscoreSubmissionType,
+  { state: UserSliceStateType }
+>("user/submitHighscore", async (submission, { getState }) => {
+  const { uid, displayName, bests } = getState().user;
+  if (!uid) {
+    return { scenarioId: submission.scenarioId };
+  }
+  await submitScore(uid, displayName, submission);
+
+  const previous = (bests || {})[String(submission.scenarioId)];
+  if (previous && previous.score >= submission.score) {
+    return { scenarioId: submission.scenarioId };
+  }
+  const best: BestScoreType = {
+    score: submission.score,
+    difficulty: submission.difficulty,
+    date: Date.now(),
+  };
+  await saveBest(uid, submission.scenarioId, best);
+  return { scenarioId: submission.scenarioId, best };
+});
+
 export const userSlice = createSlice({
   name: "user",
   initialState: initialUser,
@@ -83,20 +303,51 @@ export const userSlice = createSlice({
     delta: (state, action: PayloadAction<Partial<UserType>>) => {
       return { ...state, ...action.payload };
     },
-    submitHighscore: (
-      state,
-      action: PayloadAction<HighscoreSubmissionType>,
-    ) => {
-      if (state.uid) {
-        // Deliberately not awaited: the reducer can't be async, and nothing in the app is
-        // waiting on the write. Every failure inside is caught and logged
-        void submitScore(state.uid, action.payload);
-      }
+    // Everything about the signed-in player, gone. Dispatched when auth reports nobody is signed
+    // in, so that one player's name and bests can't survive into the next player's session
+    reset: () => {
+      return { ...initialUser };
     },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(loadProfile.fulfilled, (state, action) => {
+        state.displayName = action.payload.displayName;
+        state.bests = action.payload.bests;
+        state.profileLoaded = true;
+        // Nobody is forced to pick one -- the dialog can be dismissed, and Settings offers it
+        // again -- but a board full of Anonymous is worth one prompt
+        state.needsDisplayName = !action.payload.displayName;
+      })
+      .addCase(loadProfile.rejected, (state, action) => {
+        // A profile that can't be read (rules not deployed yet, offline) mustn't block play, and
+        // mustn't prompt for a name that couldn't be saved either
+        console.warn("Couldn't load your profile: ", action.error.message);
+        state.profileLoaded = true;
+      })
+      .addCase(claimDisplayName.fulfilled, (state, action) => {
+        state.displayName = action.payload;
+        state.needsDisplayName = false;
+      })
+      .addCase(logout.fulfilled, () => {
+        return { ...initialUser };
+      })
+      .addCase(logout.rejected, (state, action) => {
+        // Sign-out failed, so the player is still signed in and the state is still accurate
+        console.warn("Couldn't log out: ", action.error.message);
+      })
+      .addCase(submitHighscore.fulfilled, (state, action) => {
+        if (action.payload.best) {
+          state.bests = {
+            ...state.bests,
+            [String(action.payload.scenarioId)]: action.payload.best,
+          };
+        }
+      });
   },
 });
 
-export const { delta, submitHighscore } = userSlice.actions;
+export const { delta, reset } = userSlice.actions;
 
 export const selectUid = (state: RootState) => state.user.uid;
 


### PR DESCRIPTION
Implements phases 1 and 4 of #46, plus the minimum of phase 0 that phase 1 needs. Achievements (phases 2 and 3) are deliberately out of scope.

## Why

The board was a wall of anonymous numbers that logged-out players couldn't even see, and the end of a scenario was a static list of points. Neither gives anyone a reason to come back, or to tell a friend.

## Phase 0 (the parts phase 1 needs)

- **`firestore.rules`, `firestore.indexes.json`, `firebase.json` move into the repo.** Rules were console-managed, so a rule change was invisible to reviewers and easy to forget before a deploy. `usernames/{lower}` is the uniqueness guarantee: `create` only, which already fails on an existing document.
- **`submitHighscore` stops being a side effect inside a reducer** and becomes a `createAsyncThunk` that can be awaited, denormalizes `displayName` onto the score, and mirrors a new personal best onto `users/{uid}.bests`.

## Phase 1 — display names

- `users/{uid}` read (or created) on login; `UserType` grows `displayName`, `bests`, `profileLoaded`, `needsDisplayName`.
- `src/helpers/DisplayName.tsx` — pure validation, no Firebase, mirrored by the same constraints in `firestore.rules`.
- `claimDisplayName` runs a transaction: fail if the claim is held by someone else, otherwise create it, release the old one, write the profile. A best-effort batch then refreshes the name on the player's own past scores.
- A name dialog on first login, seeded from the Google name and **dismissable** — being held at a form before having played anything is a good way to lose a new player. Settings offers it again.
- Settings gains an Account section: who you're on the board as, rename, and **the app's first sign-out**.

## Phase 4 — leaderboard and celebration

- **The board is public.** Hiding it from logged-out players inverted the incentive it exists to create. Columns are rank / name / score / difficulty / replay, own rows highlighted, `Anonymous` for scores set before names existed, and the log-in prompt sits *below* the table rather than in place of it.
- Its load moves out of `shouldComponentUpdate` — a purity hook, not a place to start network requests from — into `componentDidMount`, with the uid-dependent "your best" query in `componentDidUpdate`.
- **The victory dialog becomes a component.** The reducer used to build the breakdown as JSX and hand it to `dialogOpen` inside a `setTimeout`; a static snapshot cannot fill in async results. Now `ui.victory` carries only numbers, and `base/VictoryDialog` renders the breakdown immediately, filling in the personal best and the global rank as they resolve. A Firestore hiccup costs a line, not the score screen. As a bonus the payload is fully serializable, unlike the dialog it replaces.
- Personal best is read at the moment the run ends, *before* the score write, so "was 640" reports the run before this one.
- Global rank is one `getCountFromServer` on `score > mine`.
- Share via `navigator.share`, falling back to the clipboard, reported as `score_share`. A dismissed share sheet is a cancellation, not a failure — and the text is deliberately *not* copied to the clipboard instead of being sent somewhere the player chose not to send it.

## Accepted limitations, stated on purpose

- **Rank counts runs, not distinct players**, so someone holding the top three scores occupies three ranks. Consistent with the board, which already lists one row per run.
- **Scores stay client-authoritative**, unchanged from today. Rules cannot re-run a simulation.
- **Denormalized names go stale on rename**, mitigated by a capped best-effort backfill.

## Deploy ordering

`deploy.sh` only pushes to S3/CloudFront. The rules go out separately and **must land before the client bundle**, or the profile reads fail closed:

```bash
firebase deploy --only firestore
```

The public board already works against today's rules — verified live in a dev build, logged out, against production scores.

## Tests

`npm run check` passes: 528 tests across 38 suites, coverage thresholds met, plus `npm run sim -- --all` holding every invariant.

New: `DisplayName.test.tsx` (validation table), `Share.test.tsx` (text builder; share sheet present / absent / dismissed / refused), `VictoryDialog.test.tsx` (breakdown renders before async data; PB and rank appear when resolved; a rejected rank query leaves the rest intact), `DisplayNameDialog.test.tsx` (collision keeps the dialog open with the name still in the box). `User.test.tsx` grew to cover the claim transaction, the rename release, `bests` only moving on an improvement, logout, and the rank arithmetic. `ScenarioEnd.test.tsx` gained a case asserting the victory payload.

Closes part of #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
