### PR TITLE
Deploy the Firestore rules from CI, before the bundle that needs them

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "electrify-game"
+  }
+}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -36,6 +36,33 @@ jobs:
 
       # Tests are not run here; workflow.yml already runs them on every push.
 
+      # Firestore rules and indexes go out BEFORE the bundle that depends on them.
+      # The other order ships a client whose reads the deployed rules still refuse,
+      # which fails closed and looks to a player like the game is broken.
+      #
+      # Refuses to continue without the credential rather than skipping, on the same
+      # reasoning as deploy.sh's REACT_APP_FIREBASE_API_KEY check: a silent skip would
+      # leave the rules and the bundle out of step with nothing to say so.
+      #
+      # The secret is the JSON from Firebase Console -> Project settings ->
+      # Service accounts -> Generate new private key, pasted whole.
+      - name: Deploy Firestore rules and indexes
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -z "$FIREBASE_SERVICE_ACCOUNT" ]; then
+            echo "FIREBASE_SERVICE_ACCOUNT is not set; refusing to deploy prod." >&2
+            echo "Add it as a repository secret, or the client will ship against stale rules." >&2
+            exit 1
+          fi
+          # Written outside the workspace so a stray build glob can never sweep a
+          # private key into the bundle, and removed even if the deploy fails.
+          key="$(mktemp -d)/firebase-service-account.json"
+          trap 'rm -f "$key"' EXIT
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$key"
+          GOOGLE_APPLICATION_CREDENTIALS="$key" \
+            npx --yes firebase-tools@15 deploy --only firestore --non-interactive
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/firestore.rules
+++ b/firestore.rules
@@ -24,10 +24,13 @@ service cloud.firestore {
       return isSignedIn() && request.auth.uid == uid;
     }
 
-    // Keep in sync with validateDisplayName in src/helpers/DisplayName.tsx. The client is what
-    // gives a player a useful error message; this is what makes the constraint true.
+    // The structural half of validateDisplayName in src/helpers/DisplayName.tsx -- length,
+    // charset, spacing. Keep the two in sync: the client is what gives a player a useful error
+    // message, and this is what makes the constraint true.
     // matches() is anchored to the whole string, so the pattern covers the charset and rules out
     // a leading or trailing space in one go; the second clause rules out doubled spaces.
+    // The reserved-name blocklist is deliberately NOT mirrored here. It is a courtesy, not a
+    // security boundary, and a list that has to be redeployed to change belongs in the client.
     function isValidDisplayName(name) {
       return name is string
         && name.size() >= 3


### PR DESCRIPTION
Follow-up to #176, which added `firestore.rules` / `firestore.indexes.json` to the repo but left pushing them a manual step.

## Why

The rules only matter in the repo if something actually deploys them, and the ordering guarantee only holds if the thing that ships the bundle does it *first*. Otherwise a prod deploy ships a client whose reads the deployed rules still refuse — which fails closed and, to a player, looks like the game is broken.

## What

- `deploy-prod.yml` deploys `firestore` before the S3 sync.
- It **refuses to continue without the credential** rather than skipping. Same reasoning as `deploy.sh`'s existing `REACT_APP_FIREBASE_API_KEY` check: a silent skip leaves the rules and the client out of step with nothing to say so.
- The service account JSON is written to a temp path *outside* the workspace, so a stray build glob can't sweep a private key into the bundle, and it's removed on exit even if the deploy fails.
- `.firebaserc` pins the project, so neither CI nor a local `firebase deploy` needs `--project`.
- Also tightens a comment in `firestore.rules`: the reserved-name blocklist is client-only and the rules comment shouldn't have implied otherwise.

## ⚠️ Needed before merging

Add a **`FIREBASE_SERVICE_ACCOUNT`** repository secret, or the next push to master will fail the deploy by design.

Firebase Console → Project settings → Service accounts → **Generate new private key** → paste the whole JSON as the secret value. The default `firebase-adminsdk` account has Editor, which covers Firebase Rules Admin and Cloud Datastore Index Admin.

## Verification

`firebase-tools@15.28.1` resolves and runs; the workflow YAML parses and the step order is Firestore → AWS credentials → build/deploy. The rules themselves compile server-side only — there's no offline linter, and the emulator's compile check needs Java, which isn't on this machine — so the first real deploy is what validates the rules syntax. `firebase deploy --only firestore --dry-run` does the same check without writing, if you want it separately first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
