### PR TITLE
Desktop UX: app bar, resizable columns, shared forecast axis (#177 items 1-5)

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -312,19 +312,26 @@ span.weak {
   vertical-align: middle;
 }
 
-// Fixed so the primary topbar and every pane header in the desktop 3-pane layout share the
-// exact same height, regardless of their differing content (icon buttons vs. plain text)
+// Tall enough for the icon buttons it carries
 $topbar_height: 56px;
 
 #topbar .MuiToolbar-root {
   min-height: $topbar_height !important;
 }
 
-// Stands in for the primary pane's topbar in the desktop 3-pane layout, so each pane is
-// identifiable without the (hidden, redundant) bottom nav. Selector needs to out-specificity
+// Never squeezed by whatever is below it, on either layout
+#appbar {
+  flex: 0 0 auto;
+}
+
+// Names a pane, since the bottom nav that would otherwise do it is hidden once all three are on
+// screen at once. One height for all of them so their contents start on the same line, whether
+// the header is plain text or carries the build buttons. Selector needs to out-specificity
 // ".base_main .MuiToolbar-root" above (also !important) or its min-height:0 wins instead
+$pane_header_height: 40px;
+
 .base_main .MuiToolbar-root.paneHeader {
-  min-height: $topbar_height !important;
+  min-height: $pane_header_height !important;
   border-bottom: $border_accent;
 }
 
@@ -488,6 +495,20 @@ $topbar_height: 56px;
   padding: 0 8px 0 55px; // line up with the plot area, past the y axis labels
   font-size: 12px;
   color: $font_color_faded;
+}
+
+// The same key, in the chart's title row instead of on a row of its own. Trailing edge, since
+// the title beside it is what the eye lands on first
+.chartLegend-inline {
+  padding: 0;
+  flex: 0 1 auto;
+  justify-content: flex-end;
+}
+
+// Spaces one forecast chart from the one above it. The stack used to sit on pairs of <br>s,
+// which cost more height than the gap needs and more than a screenful of charts can spare
+.base_main .MuiToolbar-root.forecastSection {
+  margin-top: 12px;
 }
 
 .chartLegendItem {
@@ -954,29 +975,66 @@ $sizemap: (
 
 // ===============================================
 // Above $desktop_breakpoint, let the app grow past the phone-width frame so Facilities,
-// Finances and Forecasts can render as panes side by side instead of one screen at a time
+// Finances and Forecasts can render as panes side by side instead of one screen at a time.
+// The type scale comes down with it: the vertical space that buys is what fits the extra
+// rows and the fifth forecast chart on screen
 // ===============================================
+
+$sizemap: (
+  large: 28px,
+  medium: 16px,
+  base: 8px,
+  small: 4px,
+  tiny: 2px,
+);
+
 @media screen and (min-width: $desktop_breakpoint) {
-  // Redundant once all three nav destinations are visible at the same time as panes
+  @include styling();
+
+  // The panes don't render one at this width -- all three destinations are already on screen.
+  // Kept as a backstop for the frame between a window crossing the breakpoint and the
+  // compositor hearing about it
   #navfooter {
     display: none;
   }
 
-  .desktop-panes {
-    display: flex;
-    flex-direction: row;
-    width: 100%;
+  .desktop-layout {
     height: 100%;
+    width: 100%;
+  }
 
-    > div {
-      flex: 1 1 0;
+  // The columns themselves, and the splitter tracks between them, come from DesktopPanes --
+  // they're state, since the player can drag them
+  .desktop-panes {
+    display: grid;
+    width: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .desktop-pane {
+    display: flex;
+    min-width: 0;
+    overflow: hidden;
+
+    > * {
+      flex: 1 1 auto;
       min-width: 0;
       height: 100%;
-      border-right: $border_accent;
+    }
+  }
 
-      &:last-child {
-        border-right: none;
-      }
+  .pane-splitter {
+    cursor: col-resize;
+    border-left: $border_accent;
+    background: transparent;
+    transition: background 0.15s;
+
+    &:hover,
+    &:focus-visible {
+      background: $interactive_blue;
+      border-left-color: $interactive_blue;
+      outline: none;
     }
   }
 }

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -28,7 +28,9 @@ import {
   UIType,
 } from "../Types";
 import AudioContainer from "./base/AudioContainer";
+import DesktopPanes from "./base/DesktopPanes";
 import DisplayNameDialogContainer from "./base/DisplayNameDialogContainer";
+import GameAppBarContainer from "./base/GameAppBar";
 import VictoryDialogContainer from "./base/VictoryDialogContainer";
 import BuildGeneratorsContainer from "./views/BuildGeneratorsContainer";
 import BuildStorageContainer from "./views/BuildStorageContainer";
@@ -258,13 +260,18 @@ export default class Compositor extends React.Component<Props, {}> {
   }
 
   private renderCard(): React.JSX.Element {
-    // Wide enough to show the fleet, P&L and forecast at once instead of tabbing between them
+    // Wide enough to show the fleet, P&L and forecast at once instead of tabbing between them.
+    // Cash, the date, the speed controls and the year's progress are the game's state rather
+    // than any one pane's, so they span all three columns instead of living in the first
     if (isDesktopScreen() && isNavCard(this.props.card.name)) {
       return (
-        <div className="desktop-panes">
-          <FacilitiesContainer />
-          <FinancesContainer />
-          <ForecastsContainer />
+        <div className="desktop-layout flexContainer">
+          <GameAppBarContainer />
+          <DesktopPanes>
+            <FacilitiesContainer />
+            <FinancesContainer />
+            <ForecastsContainer />
+          </DesktopPanes>
         </div>
       );
     }

--- a/src/components/base/ChartForecastFuelPrices.tsx
+++ b/src/components/base/ChartForecastFuelPrices.tsx
@@ -2,7 +2,10 @@ import * as React from "react";
 import uPlot from "uplot";
 import UPlotChart, { BuildContext } from "./UPlotChart";
 import {
+  AXIS_LABEL_SIZE,
   dashArray,
+  FORECAST_AXIS_LEFT,
+  FORECAST_AXIS_RIGHT,
   padRange,
   SPLINE,
   stepTicks,
@@ -23,10 +26,14 @@ export interface Props {
   domain: { x: [number, number] };
   startingYear: number;
   multiyear: boolean;
+  /** False where a chart below this one carries the month names for the whole stack */
+  showXLabels?: boolean;
+  /** Shares a cursor with the other charts drawn against the same months */
+  syncKey?: string;
 }
 
-type PricedFuelType = "Coal" | "Natural Gas" | "Oil" | "Uranium";
-const PRICED_FUELS: PricedFuelType[] = [
+export type PricedFuelType = "Coal" | "Natural Gas" | "Oil" | "Uranium";
+export const PRICED_FUELS: PricedFuelType[] = [
   "Coal",
   "Natural Gas",
   "Oil",
@@ -40,11 +47,11 @@ interface State {
   multiyear: boolean;
 }
 
-function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
-  return {
+function buildOptions(showXLabels: boolean) {
+  return ({ getState, scale }: BuildContext<State>): uPlot.Options => ({
     width: 0, // set by UPlotChart
     height: 0,
-    padding: [5 * scale, 5 * scale, 0, 0],
+    padding: [5 * scale, FORECAST_AXIS_RIGHT * scale, 0, 0],
     cursor: {
       x: true,
       y: false,
@@ -58,6 +65,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
     },
     axes: [
       xAxis(scale, {
+        showLabels: showXLabels,
         splits: () => {
           const [min, max] = getState().domain.x;
           return stepTicks(min, max, MINUTES_PER_MONTH);
@@ -72,6 +80,8 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
       yAxis(scale, {
         grid: true,
         label: "Per MMBTU",
+        // The label sits outside the axis, so it comes out of the shared gutter too
+        size: FORECAST_AXIS_LEFT - AXIS_LABEL_SIZE,
         values: (_u, splits) => splits.map((t) => formatMoneyConcise(t)),
       }),
     ],
@@ -87,7 +97,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         paths: SPLINE,
       })),
     ],
-  };
+  });
 }
 
 function tooltip(idx: number, state: State): string {
@@ -102,7 +112,15 @@ export default class ChartForecastFuelPrices extends React.PureComponent<
   {}
 > {
   public render() {
-    const { domain, height, timeline, startingYear, multiyear } = this.props;
+    const {
+      domain,
+      height,
+      timeline,
+      startingYear,
+      multiyear,
+      showXLabels,
+      syncKey,
+    } = this.props;
 
     const minutes = new Array<number>(timeline.length);
     // Every tick carries all four prices; the fallback is only here because the fuel prices
@@ -122,32 +140,11 @@ export default class ChartForecastFuelPrices extends React.PureComponent<
           height={height}
           state={{ prices, domain, startingYear, multiyear }}
           data={[minutes, ...prices]}
-          buildOptions={buildOptions}
+          buildOptions={buildOptions(showXLabels !== false)}
+          structureKey={String(showXLabels !== false)}
+          syncKey={syncKey}
           tooltip={tooltip}
         />
-        {/* Below the plot rather than floating in it, where it used to clip the data */}
-        <div className="chartLegend">
-          {PRICED_FUELS.map((f) => (
-            <span key={f} className="chartLegendItem">
-              <svg
-                className="chartLegendSwatch chartLegendSwatch-line"
-                viewBox="0 0 20 4"
-                aria-hidden="true"
-              >
-                <line
-                  x1="0"
-                  y1="2"
-                  x2="20"
-                  y2="2"
-                  stroke={fuelColors[f]}
-                  strokeWidth="3"
-                  strokeDasharray={fuelDashArrays[f]}
-                />
-              </svg>
-              {f}
-            </span>
-          ))}
-        </div>
       </div>
     );
   }

--- a/src/components/base/ChartForecastStorage.tsx
+++ b/src/components/base/ChartForecastStorage.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
 import uPlot from "uplot";
 import UPlotChart, { BuildContext } from "./UPlotChart";
-import { padRange, stepTicks, xAxis, yAxis } from "./UPlotHelpers";
+import {
+  FORECAST_AXIS_LEFT,
+  FORECAST_AXIS_RIGHT,
+  padRange,
+  stepTicks,
+  xAxis,
+  yAxis,
+} from "./UPlotHelpers";
 import { TickPresentFutureType } from "../../Types";
 import {
   formatMinuteAsMonthAxis,
@@ -16,6 +23,10 @@ export interface Props {
   domain: { x: [number, number] };
   startingYear: number;
   multiyear: boolean;
+  /** False where a chart below this one carries the month names for the whole stack */
+  showXLabels?: boolean;
+  /** Shares a cursor with the other charts drawn against the same months */
+  syncKey?: string;
 }
 
 interface State {
@@ -25,11 +36,11 @@ interface State {
   multiyear: boolean;
 }
 
-function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
-  return {
+function buildOptions(showXLabels: boolean) {
+  return ({ getState, scale }: BuildContext<State>): uPlot.Options => ({
     width: 0, // set by UPlotChart
     height: 0,
-    padding: [5 * scale, 5 * scale, 0, 0],
+    padding: [5 * scale, FORECAST_AXIS_RIGHT * scale, 0, 0],
     cursor: {
       x: true,
       y: false,
@@ -45,6 +56,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
     },
     axes: [
       xAxis(scale, {
+        showLabels: showXLabels,
         splits: () => {
           const [min, max] = getState().domain.x;
           return stepTicks(min, max, MINUTES_PER_MONTH);
@@ -57,12 +69,13 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         },
       }),
       yAxis(scale, {
+        size: FORECAST_AXIS_LEFT,
         values: (_u, splits) =>
           splits.map((t) => formatWattHoursAxis(t, splits)),
       }),
     ],
     series: [{}, { stroke: supplyColor, width: 1, points: { show: false } }],
-  };
+  });
 }
 
 function tooltip(idx: number, state: State): string {
@@ -75,7 +88,15 @@ export default class chartForecastStorage extends React.PureComponent<
   {}
 > {
   public render() {
-    const { domain, height, timeline, startingYear, multiyear } = this.props;
+    const {
+      domain,
+      height,
+      timeline,
+      startingYear,
+      multiyear,
+      showXLabels,
+      syncKey,
+    } = this.props;
 
     const minutes = new Array<number>(timeline.length);
     const stored = new Array<number>(timeline.length);
@@ -91,7 +112,9 @@ export default class chartForecastStorage extends React.PureComponent<
         height={height}
         state={{ timeline, domain, startingYear, multiyear }}
         data={[minutes, stored]}
-        buildOptions={buildOptions}
+        buildOptions={buildOptions(showXLabels !== false)}
+        structureKey={String(showXLabels !== false)}
+        syncKey={syncKey}
         tooltip={tooltip}
       />
     );

--- a/src/components/base/ChartForecastSupplyByFuel.tsx
+++ b/src/components/base/ChartForecastSupplyByFuel.tsx
@@ -1,7 +1,13 @@
 import * as React from "react";
 import uPlot from "uplot";
 import UPlotChart, { BuildContext } from "./UPlotChart";
-import { stepTicks, xAxis, yAxis } from "./UPlotHelpers";
+import {
+  FORECAST_AXIS_LEFT,
+  FORECAST_AXIS_RIGHT,
+  stepTicks,
+  xAxis,
+  yAxis,
+} from "./UPlotHelpers";
 import {
   formatMinuteAsMonthAxis,
   MINUTES_PER_MONTH,
@@ -16,8 +22,39 @@ export interface Props {
   domain: { x: [number, number] };
   startingYear: number;
   multiyear: boolean;
-  // Bottom-to-top order of the stack, ie the order these fuels are dispatched in
+  // Bottom-to-top order of the stack, ie the order these fuels are dispatched in. Already
+  // narrowed to the fuels this forecast actually burns -- see forecastFuels, which the pane
+  // calls too so its legend and this stack can't disagree about what is in the picture
   fuels: FuelNameType[];
+  /** False where a chart below this one carries the month names for the whole stack */
+  showXLabels?: boolean;
+  /** Shares a cursor with the other charts drawn against the same months */
+  syncKey?: string;
+}
+
+/**
+ * The fuels a forecast burns, bottom to top of the stack.
+ *
+ * Anything generating in the forecast window belongs in it, even if it was built partway through
+ * and so isn't in the fleet the dispatch order was derived from.
+ */
+export function forecastFuels(
+  dispatchOrder: FuelNameType[],
+  timeline: TickPresentFutureType[],
+): FuelNameType[] {
+  const inForecast = new Set<FuelNameType>();
+  timeline.forEach((t) => {
+    Object.keys(t.supplyByFuel).forEach((f) =>
+      inForecast.add(f as FuelNameType),
+    );
+  });
+  const fuels = dispatchOrder.filter((f) => inForecast.has(f));
+  inForecast.forEach((f) => {
+    if (fuels.indexOf(f) === -1) {
+      fuels.push(f);
+    }
+  });
+  return fuels;
 }
 
 interface State {
@@ -31,11 +68,11 @@ interface State {
   multiyear: boolean;
 }
 
-function buildOptions(fuels: FuelNameType[]) {
+function buildOptions(fuels: FuelNameType[], showXLabels: boolean) {
   return ({ getState, scale }: BuildContext<State>): uPlot.Options => ({
     width: 0, // set by UPlotChart
     height: 0,
-    padding: [5 * scale, 5 * scale, 0, 0],
+    padding: [5 * scale, FORECAST_AXIS_RIGHT * scale, 0, 0],
     cursor: {
       x: true,
       y: false,
@@ -49,6 +86,7 @@ function buildOptions(fuels: FuelNameType[]) {
     },
     axes: [
       xAxis(scale, {
+        showLabels: showXLabels,
         splits: () => {
           const [min, max] = getState().domain.x;
           return stepTicks(min, max, MINUTES_PER_MONTH);
@@ -61,6 +99,7 @@ function buildOptions(fuels: FuelNameType[]) {
         },
       }),
       yAxis(scale, {
+        size: FORECAST_AXIS_LEFT,
         values: (_u, splits) => splits.map((t) => formatWattsAxis(t, splits)),
       }),
     ],
@@ -106,22 +145,16 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
   {}
 > {
   public render() {
-    const { domain, height, timeline, startingYear, multiyear } = this.props;
-
-    // Anything generating in the forecast window belongs in the stack, even if it was built
-    // partway through and so isn't in the fleet the dispatch order was derived from
-    const fuelsInForecast = new Set<FuelNameType>();
-    timeline.forEach((t) => {
-      Object.keys(t.supplyByFuel).forEach((f) =>
-        fuelsInForecast.add(f as FuelNameType),
-      );
-    });
-    const fuels = this.props.fuels.filter((f) => fuelsInForecast.has(f));
-    fuelsInForecast.forEach((f) => {
-      if (fuels.indexOf(f) === -1) {
-        fuels.push(f);
-      }
-    });
+    const {
+      domain,
+      fuels,
+      height,
+      timeline,
+      startingYear,
+      multiyear,
+      showXLabels,
+      syncKey,
+    } = this.props;
 
     // Every band needs a value at every x or the stack tears, so backfill the whole series.
     // The sampled forecast repeats its first minute, and a stack lines its bands up by x, so a
@@ -172,26 +205,11 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
           height={height}
           state={state}
           data={[minutes, ...stacked, demand]}
-          buildOptions={buildOptions(fuels)}
-          structureKey={fuels.join(",")}
+          buildOptions={buildOptions(fuels, showXLabels !== false)}
+          structureKey={`${fuels.join(",")}|${showXLabels !== false}`}
+          syncKey={syncKey}
           tooltip={tooltip}
         />
-        {/* Below the plot rather than floating in it, where it used to clip the data */}
-        <div className="chartLegend">
-          {[...fuels].reverse().map((f: FuelNameType) => (
-            <span key={f} className="chartLegendItem">
-              <span
-                className="chartLegendSwatch"
-                style={{ backgroundColor: fuelColors[f] }}
-              />
-              {f}
-            </span>
-          ))}
-          <span className="chartLegendItem">
-            <span className="chartLegendSwatch chartLegendSwatch-demand" />
-            Demand
-          </span>
-        </div>
       </div>
     );
   }

--- a/src/components/base/ChartForecastSupplyDemand.tsx
+++ b/src/components/base/ChartForecastSupplyDemand.tsx
@@ -3,6 +3,8 @@ import uPlot from "uplot";
 import UPlotChart, { BuildContext } from "./UPlotChart";
 import {
   bandsPlugin,
+  FORECAST_AXIS_LEFT,
+  FORECAST_AXIS_RIGHT,
   padRange,
   spansFromEdges,
   stepTicks,
@@ -29,6 +31,10 @@ export interface Props {
   domain: { x: [number, number]; y: [number, number] };
   startingYear: number;
   multiyear: boolean;
+  /** False where a chart below this one carries the month names for the whole stack */
+  showXLabels?: boolean;
+  /** Shares a cursor with the other charts drawn against the same months */
+  syncKey?: string;
 }
 
 interface State {
@@ -39,11 +45,13 @@ interface State {
   multiyear: boolean;
 }
 
-function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
-  return {
+function buildOptions(showXLabels: boolean) {
+  return ({ getState, scale }: BuildContext<State>): uPlot.Options => ({
     width: 0, // set by UPlotChart
     height: 0,
-    padding: [5 * scale, 5 * scale, 0, 0],
+    // Right gutter reserved rather than used, so this plot ends where the weather chart's
+    // second axis makes that one end -- see FORECAST_AXIS_RIGHT
+    padding: [5 * scale, FORECAST_AXIS_RIGHT * scale, 0, 0],
     cursor: {
       x: true,
       y: false,
@@ -62,6 +70,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
     },
     axes: [
       xAxis(scale, {
+        showLabels: showXLabels,
         splits: () => {
           const [min, max] = getState().domain.x;
           return stepTicks(min, max, MINUTES_PER_MONTH);
@@ -74,6 +83,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         },
       }),
       yAxis(scale, {
+        size: FORECAST_AXIS_LEFT,
         values: (_u, splits) => splits.map((t) => formatWattsAxis(t, splits)),
       }),
     ],
@@ -83,7 +93,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
       { stroke: demandColor, width: 2, points: { show: false } },
     ],
     plugins: [bandsPlugin(() => getState().blackoutSpans, blackoutColor, 0.3)],
-  };
+  });
 }
 
 function tooltip(idx: number, state: State): string {
@@ -97,8 +107,16 @@ export default class chartForecastSupplyDemand extends React.PureComponent<
   {}
 > {
   public render() {
-    const { domain, height, timeline, blackouts, startingYear, multiyear } =
-      this.props;
+    const {
+      domain,
+      height,
+      timeline,
+      blackouts,
+      startingYear,
+      multiyear,
+      showXLabels,
+      syncKey,
+    } = this.props;
 
     const minutes = new Array<number>(timeline.length);
     const supply = new Array<number>(timeline.length);
@@ -124,7 +142,9 @@ export default class chartForecastSupplyDemand extends React.PureComponent<
         height={height}
         state={state}
         data={[minutes, supply, demand]}
-        buildOptions={buildOptions}
+        buildOptions={buildOptions(showXLabels !== false)}
+        structureKey={String(showXLabels !== false)}
+        syncKey={syncKey}
         tooltip={tooltip}
       />
     );

--- a/src/components/base/ChartForecastWeather.tsx
+++ b/src/components/base/ChartForecastWeather.tsx
@@ -1,7 +1,16 @@
 import * as React from "react";
 import uPlot from "uplot";
 import UPlotChart, { BuildContext } from "./UPlotChart";
-import { padRange, SPLINE, stepTicks, xAxis, yAxis } from "./UPlotHelpers";
+import {
+  AXIS_LABEL_SIZE,
+  FORECAST_AXIS_LEFT,
+  FORECAST_AXIS_RIGHT,
+  padRange,
+  SPLINE,
+  stepTicks,
+  xAxis,
+  yAxis,
+} from "./UPlotHelpers";
 import { TICK_MINUTES } from "../../Constants";
 import { TickPresentFutureType, UnitSystemType } from "../../Types";
 import {
@@ -25,6 +34,8 @@ export interface Props {
   domain: { x: [number, number] };
   startingYear: number;
   multiyear: boolean;
+  /** Shares a cursor with the other charts drawn against the same months */
+  syncKey?: string;
 }
 
 interface State {
@@ -44,7 +55,9 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
   return {
     width: 0, // set by UPlotChart
     height: 0,
-    padding: [5 * scale, 5 * scale, 0, 0],
+    // No right padding: unlike the charts above it, this one's right gutter is a second axis,
+    // and anything on top of that would push its plot in from where theirs end
+    padding: [5 * scale, 0, 0, 0],
     cursor: {
       x: true,
       y: false,
@@ -70,10 +83,13 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
           );
         },
       }),
+      // Sized rather than fitted, so this plot starts and ends exactly where the charts stacked
+      // above it do and the month names below it line up with all of them
       yAxis(scale, {
         grid: true,
         label: `Heat (${temperatureUnit(getState().units)})`,
         stroke: temperatureAxisColor,
+        size: FORECAST_AXIS_LEFT - AXIS_LABEL_SIZE,
         values: (_u, splits) => splits.map((t) => String(Math.round(t))),
       }),
       yAxis(scale, {
@@ -81,6 +97,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         side: 1,
         label: `Wind (${speedUnit(getState().units)})`,
         stroke: windColor,
+        size: FORECAST_AXIS_RIGHT - AXIS_LABEL_SIZE,
         values: (_u, splits) => splits.map((t) => String(Math.round(t))),
       }),
     ],
@@ -120,7 +137,8 @@ export default class ChartForecastWeather extends React.PureComponent<
 
   public render() {
     const units = this.context as UnitSystemType;
-    const { domain, height, timeline, startingYear, multiyear } = this.props;
+    const { domain, height, timeline, startingYear, multiyear, syncKey } =
+      this.props;
     // Downsample the data to 6 per day to make it more vague / forecast-y
     const data = timeline.filter(
       (t: TickPresentFutureType) => t.minute % 240 < TICK_MINUTES,
@@ -148,6 +166,7 @@ export default class ChartForecastWeather extends React.PureComponent<
         buildOptions={buildOptions}
         // The axis labels are baked into the options, so a change of system rebuilds the plot
         structureKey={units}
+        syncKey={syncKey}
         tooltip={tooltip}
       />
     );

--- a/src/components/base/ChartLegend.tsx
+++ b/src/components/base/ChartLegend.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+
+/**
+ * The key to a chart's series, as plain HTML below or beside the plot rather than something
+ * drawn inside it -- so it wraps on a narrow screen, and a screen reader can read it.
+ *
+ * `inline` puts it in the chart's own header instead of on a row of its own, which is what the
+ * stacked forecasts use: five charts each giving up a row to a legend is five rows that could
+ * have been plot.
+ */
+
+export interface LegendItemType {
+  name: string;
+  color: string;
+  /** SVG dash pattern, for series told apart by their line style as well as their colour */
+  dash?: string | undefined;
+  /** Drawn as a rule rather than a block, for a series that is a line over the others */
+  rule?: boolean;
+}
+
+export interface Props {
+  items: LegendItemType[];
+  inline?: boolean;
+}
+
+export default function ChartLegend(props: Props): React.JSX.Element {
+  return (
+    <div
+      className={"chartLegend" + (props.inline ? " chartLegend-inline" : "")}
+    >
+      {props.items.map((item) => (
+        <span key={item.name} className="chartLegendItem">
+          {item.dash ? (
+            <svg
+              className="chartLegendSwatch chartLegendSwatch-line"
+              viewBox="0 0 20 4"
+              aria-hidden="true"
+            >
+              <line
+                x1="0"
+                y1="2"
+                x2="20"
+                y2="2"
+                stroke={item.color}
+                strokeWidth="3"
+                strokeDasharray={item.dash}
+              />
+            </svg>
+          ) : item.rule ? (
+            <span className="chartLegendSwatch chartLegendSwatch-demand" />
+          ) : (
+            <span
+              className="chartLegendSwatch"
+              style={{ backgroundColor: item.color }}
+            />
+          )}
+          {item.name}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/base/DesktopPanes.tsx
+++ b/src/components/base/DesktopPanes.tsx
@@ -1,0 +1,205 @@
+import * as React from "react";
+import { getStorageJson, setStorageKeyValue } from "../../LocalStorage";
+
+/**
+ * The desktop column layout: the panes side by side, with a splitter the player can drag
+ * between each neighbouring pair.
+ *
+ * The three panes want different amounts of room -- Facilities is a list of short rows, Finances
+ * is a two-column table of text, Forecasts is a stack of charts -- so equal thirds waste the
+ * screen on one and cramp the others. Below are the starting weights; whatever the player drags
+ * them to is remembered, since a column layout is the sort of thing people set once.
+ */
+
+const WEIGHTS_KEY = "desktopPaneWeights";
+
+// Facilities needs the least width, Finances and Forecasts the most
+const DEFAULT_WEIGHTS = [1, 1.15, 1.15];
+
+// A pane narrower than this stops being readable, so a drag can't push one past it
+const MIN_PANE_PX = 240;
+
+// How far one press of an arrow key moves a splitter
+const KEYBOARD_STEP_PX = 24;
+
+// Width of a splitter's own grid track. Set here rather than in CSS because it goes into the
+// grid template alongside the pane weights, which are state
+const SPLITTER_PX = 5;
+
+function isUsableWeights(value: unknown, count: number): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.length === count &&
+    value.every((w) => typeof w === "number" && isFinite(w) && w > 0)
+  );
+}
+
+function defaultWeights(count: number): number[] {
+  return DEFAULT_WEIGHTS.slice(0, count);
+}
+
+function loadWeights(count: number): number[] {
+  const stored = getStorageJson<number[]>(WEIGHTS_KEY, []);
+  // A layout saved when there were a different number of panes says nothing about this one
+  return isUsableWeights(stored, count) ? stored : defaultWeights(count);
+}
+
+/**
+ * Pixel widths back to weights. Only their ratios matter -- they go straight into a grid
+ * template as `fr` -- so a layout saved at one window width means the same thing at another.
+ */
+function toWeights(widths: number[]): number[] {
+  const total = widths.reduce((sum, w) => sum + w, 0);
+  if (!(total > 0)) {
+    return defaultWeights(widths.length);
+  }
+  return widths.map((w) => (w / total) * widths.length);
+}
+
+export interface Props {
+  children: React.ReactNode;
+}
+
+export default function DesktopPanes(props: Props): React.JSX.Element {
+  const panes = React.Children.toArray(props.children);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [weights, setWeights] = React.useState(() => loadWeights(panes.length));
+  // Where the drag started, and how wide every pane was at that moment -- the move handler works
+  // from those rather than from the live widths, so rounding doesn't accumulate over a drag
+  const dragRef = React.useRef<{
+    index: number;
+    startX: number;
+    widths: number[];
+  } | null>(null);
+  // The layout as of the last resize, rather than as of the last render. Two arrow key repeats
+  // can land before React has painted the first, and reading the DOM back then would have the
+  // second start from where the first did -- so this is written to as soon as a resize is worked
+  // out, and is what the next one measures from
+  const weightsRef = React.useRef(weights);
+  weightsRef.current = weights;
+
+  // The room the panes have to share, split the way the weights currently say to
+  const paneWidths = (): number[] => {
+    const container = containerRef.current;
+    if (!container) {
+      return [];
+    }
+    const total = Array.from(
+      container.querySelectorAll<HTMLElement>(":scope > .desktop-pane"),
+    ).reduce((sum, el) => sum + el.getBoundingClientRect().width, 0);
+    const current = weightsRef.current;
+    const weighted = current.reduce((sum, w) => sum + w, 0);
+    return weighted > 0 ? current.map((w) => (w / weighted) * total) : [];
+  };
+
+  /**
+   * Moves `delta` pixels of pane `index` onto the pane after it -- or the other way, for a
+   * negative delta -- without letting either end up too narrow to read. Returns the new weights,
+   * or undefined if it was handed widths it couldn't use.
+   */
+  const resize = (
+    index: number,
+    widths: number[],
+    delta: number,
+  ): number[] | undefined => {
+    if (widths.length !== panes.length) {
+      return undefined;
+    }
+    const pair = widths[index] + widths[index + 1];
+    const first = Math.max(
+      MIN_PANE_PX,
+      Math.min(pair - MIN_PANE_PX, widths[index] + delta),
+    );
+    const next = [...widths];
+    next[index] = first;
+    next[index + 1] = pair - first;
+    const resized = toWeights(next);
+    weightsRef.current = resized;
+    setWeights(resized);
+    return resized;
+  };
+
+  const onPointerDown =
+    (index: number) => (e: React.PointerEvent<HTMLDivElement>) => {
+      dragRef.current = { index, startX: e.clientX, widths: paneWidths() };
+      e.currentTarget.setPointerCapture(e.pointerId);
+      // Otherwise the drag selects the pane text it passes over
+      e.preventDefault();
+    };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) {
+      return;
+    }
+    resize(drag.index, drag.widths, e.clientX - drag.startX);
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) {
+      return;
+    }
+    dragRef.current = null;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+    setStorageKeyValue(WEIGHTS_KEY, weightsRef.current);
+  };
+
+  const onKeyDown =
+    (index: number) => (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const step =
+        e.key === "ArrowLeft"
+          ? -KEYBOARD_STEP_PX
+          : e.key === "ArrowRight"
+            ? KEYBOARD_STEP_PX
+            : 0;
+      if (!step) {
+        return;
+      }
+      e.preventDefault();
+      const resized = resize(index, paneWidths(), step);
+      if (resized) {
+        setStorageKeyValue(WEIGHTS_KEY, resized);
+      }
+    };
+
+  // Double-clicking a divider is the usual way back to the layout you started with
+  const onDoubleClick = () => {
+    const reset = defaultWeights(panes.length);
+    weightsRef.current = reset;
+    setWeights(reset);
+    setStorageKeyValue(WEIGHTS_KEY, reset);
+  };
+
+  // Splitters are grid tracks of their own rather than borders on the panes, so dragging one
+  // never changes the total width the panes have to share
+  const template = weights.map((w) => `${w}fr`).join(` ${SPLITTER_PX}px `);
+
+  return (
+    <div
+      className="desktop-panes"
+      ref={containerRef}
+      style={{ gridTemplateColumns: template }}
+    >
+      {panes.map((pane, i) => (
+        <React.Fragment key={i}>
+          {i > 0 && (
+            <div
+              className="pane-splitter"
+              role="separator"
+              aria-orientation="vertical"
+              aria-label={`Resize pane ${i} and pane ${i + 1}`}
+              tabIndex={0}
+              onPointerDown={onPointerDown(i - 1)}
+              onPointerMove={onPointerMove}
+              onPointerUp={endDrag}
+              onPointerCancel={endDrag}
+              onKeyDown={onKeyDown(i - 1)}
+              onDoubleClick={onDoubleClick}
+            />
+          )}
+          <div className="desktop-pane">{pane}</div>
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -1,0 +1,334 @@
+import type { AppDispatch } from "../../Store";
+import * as React from "react";
+import { connect } from "react-redux";
+import { IconButton, Menu, MenuItem, Toolbar, Typography } from "@mui/material";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import FastForwardIcon from "@mui/icons-material/FastForward";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import PauseIcon from "@mui/icons-material/Pause";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import { formatHour, getTimeFromTimeline } from "../../helpers/DateTime";
+import { formatMoneyStable } from "../../helpers/Format";
+import { navigate } from "../../reducers/Card";
+import { isBigScreen, isSmallScreen, openWindow } from "../../Globals";
+import { getNextTutorial } from "../../data/Scenarios";
+import { quit, setSpeed, startTutorial } from "../../reducers/Game";
+import { AppStateType, GameType, SpeedType } from "../../Types";
+
+/**
+ * The game's global state: cash, the date, how fast time is running, how far through the year it
+ * is, and whether the lights are currently out.
+ *
+ * This used to live inside whichever pane happened to be showing, which on desktop meant all of
+ * it was reported from the top-left corner of column one. None of it belongs to a single pane,
+ * so it spans the app instead -- one bar above the panes on desktop, and the card's own header
+ * on a phone, where there is only ever one pane anyway.
+ */
+
+export interface StateProps {
+  game: GameType;
+}
+
+export interface DispatchProps {
+  onManual: () => void;
+  onSpeedChange: (speed: SpeedType) => void;
+  onNextTutorial: (scenarioId: number) => void;
+  onQuit: () => void;
+}
+
+export interface Props extends StateProps, DispatchProps {}
+
+interface SpeedOptionsProps {
+  smallScreen: boolean;
+  speed: SpeedType;
+  onSpeedChange: (speed: SpeedType) => void;
+  speedAnchorEl: HTMLElement | null;
+  handleSpeedClick: (event: React.MouseEvent<HTMLElement>) => void;
+  handleSpeedClose: () => void;
+}
+
+// Pulled out of the component so it can be memoised on the handful of things it actually
+// depends on, rather than rebuilt on every tick along with the cash readout beside it
+function buildSpeedOptions({
+  smallScreen,
+  speed,
+  onSpeedChange,
+  speedAnchorEl,
+  handleSpeedClick,
+  handleSpeedClose,
+}: SpeedOptionsProps): React.JSX.Element {
+  if (!smallScreen) {
+    return (
+      <span>
+        <IconButton
+          onClick={() => onSpeedChange("PAUSED")}
+          disabled={speed === "PAUSED"}
+          aria-label="pause"
+          edge="end"
+          color="primary"
+          size="large"
+        >
+          <PauseIcon />
+        </IconButton>
+        <IconButton
+          onClick={() => onSpeedChange("SLOW")}
+          disabled={speed === "SLOW"}
+          aria-label="slow speed"
+          edge="end"
+          color="primary"
+          size="large"
+        >
+          <ChevronRightIcon />
+        </IconButton>
+        <IconButton
+          onClick={() => onSpeedChange("NORMAL")}
+          disabled={speed === "NORMAL"}
+          aria-label="normal speed"
+          edge="end"
+          color="primary"
+          size="large"
+        >
+          <PlayArrowIcon />
+        </IconButton>
+        <IconButton
+          onClick={() => onSpeedChange("FAST")}
+          disabled={speed === "FAST"}
+          aria-label="fast speed"
+          edge="end"
+          color="primary"
+          size="large"
+        >
+          <FastForwardIcon />
+        </IconButton>
+      </span>
+    );
+  }
+
+  let speedIcon = <PlayArrowIcon />;
+  switch (speed) {
+    case "PAUSED":
+      speedIcon = <PlayArrowIcon />;
+      break;
+    case "SLOW":
+      speedIcon = <ChevronRightIcon />;
+      break;
+    case "NORMAL":
+      speedIcon = <PlayArrowIcon />;
+      break;
+    case "FAST":
+      speedIcon = <FastForwardIcon />;
+      break;
+    default:
+      break;
+  }
+  return (
+    <span>
+      {speed !== "PAUSED" && (
+        <IconButton
+          onClick={() => onSpeedChange("PAUSED")}
+          aria-label="pause"
+          size="large"
+        >
+          <PauseIcon color="primary" />
+        </IconButton>
+      )}
+      <IconButton
+        onClick={handleSpeedClick}
+        aria-label="change speed"
+        edge="end"
+        color="primary"
+        size="large"
+      >
+        {speedIcon}
+      </IconButton>
+      <Menu
+        id="speedMenu"
+        anchorEl={speedAnchorEl}
+        keepMounted
+        open={Boolean(speedAnchorEl)}
+        onClose={handleSpeedClose}
+      >
+        <MenuItem
+          onClick={() => {
+            onSpeedChange("SLOW");
+            handleSpeedClose();
+          }}
+          disabled={speed === "SLOW"}
+          aria-label="slow-speed"
+        >
+          <ChevronRightIcon color="primary" />
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            onSpeedChange("NORMAL");
+            handleSpeedClose();
+          }}
+          disabled={speed === "NORMAL"}
+          aria-label="normal-speed"
+        >
+          <PlayArrowIcon color="primary" />
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            onSpeedChange("FAST");
+            handleSpeedClose();
+          }}
+          disabled={speed === "FAST"}
+          aria-label="fast-speed"
+        >
+          <FastForwardIcon color="primary" />
+        </MenuItem>
+      </Menu>
+    </span>
+  );
+}
+
+export function GameAppBar(props: Props) {
+  const { game, onManual, onNextTutorial, onQuit, onSpeedChange } = props;
+  const date = game.date;
+  const now = getTimeFromTimeline(date.minute, game.timeline);
+  const [menuAnchorEl, setMenuAnchorEl] = React.useState<HTMLElement | null>(
+    null,
+  );
+  const [speedAnchorEl, setSpeedAnchorEl] = React.useState<HTMLElement | null>(
+    null,
+  );
+
+  const smallScreen = isSmallScreen();
+  const bigScreen = isBigScreen();
+  const speed = game.speed;
+  // Watching somebody else's run rather than playing your own. The speed controls stay live --
+  // being able to pause and fast forward is most of the point of a replay
+  const isReplay = !!game.replayPlayback;
+  // Undefined outside a tutorial, and on the last one - so this doubles as "is there a next
+  // tutorial to offer?" for the menu item below. Also undefined throughout a replay, since a
+  // tutorial never sets a score and so never has one to watch
+  const nextTutorial = getNextTutorial(game.scenarioId);
+
+  const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
+    setMenuAnchorEl(event.currentTarget);
+  const handleMenuClose = () => setMenuAnchorEl(null);
+  const handleSpeedClick = (event: React.MouseEvent<HTMLElement>) =>
+    setSpeedAnchorEl(event.currentTarget);
+  const handleSpeedClose = () => setSpeedAnchorEl(null);
+
+  /**
+   * The bar has to re-render every tick to keep the cash and the clock honest, which at FAST is
+   * a hundred times a second. Everything else in it -- five icon buttons and a kept-mounted menu
+   * -- only changes when the player clicks something, so those subtrees are built once per actual
+   * change and handed back as the same elements. React then skips them entirely on the frames in
+   * between, which is where a good quarter of the frame budget went.
+   */
+  const speedOptions = React.useMemo(
+    () =>
+      buildSpeedOptions({
+        smallScreen,
+        speed,
+        onSpeedChange,
+        speedAnchorEl,
+        handleSpeedClick,
+        handleSpeedClose,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [smallScreen, speed, onSpeedChange, speedAnchorEl],
+  );
+
+  const menu = React.useMemo(
+    () => (
+      <>
+        <IconButton
+          onClick={handleMenuClick}
+          aria-label="menu"
+          edge="start"
+          color="primary"
+          size="large"
+        >
+          <MoreVertIcon />
+        </IconButton>
+        <Menu
+          id="gameCardMenu"
+          anchorEl={menuAnchorEl}
+          keepMounted
+          open={Boolean(menuAnchorEl)}
+          onClose={handleMenuClose}
+        >
+          <MenuItem onClick={onManual}>Manual</MenuItem>
+          <MenuItem onClick={() => openWindow("mailto:todd@fabricate.io")}>
+            Send feedback
+          </MenuItem>
+          {/* Mid-tutorial, the thing a player who has seen enough wants is the next tutorial,
+              not the scenario list they would have to go back through to reach it */}
+          {nextTutorial && (
+            <MenuItem onClick={() => onNextTutorial(nextTutorial.id)}>
+              Next tutorial
+            </MenuItem>
+          )}
+          <MenuItem onClick={onQuit}>
+            {isReplay ? "Exit replay" : "Quit"}
+          </MenuItem>
+        </Menu>
+      </>
+    ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [menuAnchorEl, onManual, onNextTutorial, onQuit, nextTutorial, isReplay],
+  );
+
+  if (!game.inGame || !now) {
+    return <span />;
+  }
+
+  const inBlackout = now.supplyW < now.demandW;
+
+  return (
+    <div id="appbar">
+      <div id="topbar">
+        <Toolbar className={inBlackout ? "blackout-pulsing" : ""}>
+          {menu}
+          <Typography variant="h6">
+            {formatMoneyStable(now.cash)}&nbsp;
+            <span className="weak">
+              {date.month} {date.year}
+              {bigScreen ? `, ${formatHour(date)}` : ""}
+            </span>
+            {isReplay && <span className="replayBadge">REPLAY</span>}
+          </Typography>
+          <div id="speedChangeButtons">{speedOptions}</div>
+        </Toolbar>
+      </div>
+      <div
+        id="yearProgressBar"
+        style={{
+          width: `${date.percentOfYear * 100}%`,
+        }}
+      />
+    </div>
+  );
+}
+
+const mapStateToProps = (state: AppStateType): StateProps => ({
+  game: state.game,
+});
+
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
+  return {
+    onManual: () => {
+      dispatch(navigate("MANUAL"));
+    },
+    onSpeedChange: (speed: SpeedType) => {
+      dispatch(setSpeed(speed));
+    },
+    onNextTutorial: (scenarioId: number) => {
+      startTutorial(dispatch, scenarioId);
+    },
+    onQuit: () => {
+      dispatch(quit());
+    },
+  };
+};
+
+const GameAppBarContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(GameAppBar);
+
+export default GameAppBarContainer;

--- a/src/components/base/GameCard.tsx
+++ b/src/components/base/GameCard.tsx
@@ -1,288 +1,48 @@
-import type { AppDispatch } from "../../Store";
 import * as React from "react";
 import { connect } from "react-redux";
-import { IconButton, Menu, MenuItem, Toolbar, Typography } from "@mui/material";
-import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import FastForwardIcon from "@mui/icons-material/FastForward";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
-import PauseIcon from "@mui/icons-material/Pause";
-import PlayArrowIcon from "@mui/icons-material/PlayArrow";
-import { formatHour, getTimeFromTimeline } from "../../helpers/DateTime";
-import { formatMoneyStable } from "../../helpers/Format";
-import { navigate } from "../../reducers/Card";
-import { isBigScreen, isSmallScreen, openWindow } from "../../Globals";
-import { getNextTutorial } from "../../data/Scenarios";
-import { quit, setSpeed, startTutorial } from "../../reducers/Game";
-import { AppStateType, GameType, SpeedType } from "../../Types";
+import { Toolbar, Typography } from "@mui/material";
+import { getTimeFromTimeline } from "../../helpers/DateTime";
+import { isDesktopScreen } from "../../Globals";
+import { AppStateType, GameType } from "../../Types";
+import GameAppBarContainer from "./GameAppBar";
 import NavigationContainer from "./NavigationContainer";
+
+/**
+ * The frame the three in-game panes sit in.
+ *
+ * On a phone there is one pane on screen at a time, so the card carries the app bar and the
+ * bottom nav that switches between them. On desktop all three are already on screen and the app
+ * bar spans them (see Compositor.renderCard), so a card is just a pane: a header naming it and
+ * its own contents.
+ */
 
 export interface GameCardProps extends React.ComponentPropsWithoutRef<"div"> {
   children?: React.JSX.Element | React.JSX.Element[] | undefined;
   className?: string | undefined;
   game: GameType;
-  // When this pane is shown alongside the others in the desktop layout, skip the header/nav
-  // chrome (money, date, speed controls, tab bar) since the primary pane already shows it once
-  chromeless?: boolean;
-  // Shown as this pane's own header when chromeless, since there's no bottom nav in that layout
-  // to tell the panes apart
+  // Shown as this pane's own header in the desktop layout, since there's no bottom nav there to
+  // tell the panes apart. Panes whose contents already lead with a header of their own (see
+  // Facilities, whose header carries the build buttons) leave this unset.
   title?: string;
 }
 
-export interface DispatchProps {
-  onManual: () => void;
-  onSpeedChange: (speed: SpeedType) => void;
-  onNextTutorial: (scenarioId: number) => void;
-  onQuit: () => void;
-}
-
-export interface Props extends GameCardProps, DispatchProps {}
-
-interface SpeedOptionsProps {
-  smallScreen: boolean;
-  speed: SpeedType;
-  onSpeedChange: (speed: SpeedType) => void;
-  speedAnchorEl: HTMLElement | null;
-  handleSpeedClick: (event: React.MouseEvent<HTMLElement>) => void;
-  handleSpeedClose: () => void;
-}
-
-// Pulled out of the component so it can be memoised on the handful of things it actually
-// depends on, rather than rebuilt on every tick along with the cash readout beside it
-function buildSpeedOptions({
-  smallScreen,
-  speed,
-  onSpeedChange,
-  speedAnchorEl,
-  handleSpeedClick,
-  handleSpeedClose,
-}: SpeedOptionsProps): React.JSX.Element {
-  if (!smallScreen) {
-    return (
-      <span>
-        <IconButton
-          onClick={() => onSpeedChange("PAUSED")}
-          disabled={speed === "PAUSED"}
-          aria-label="pause"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <PauseIcon />
-        </IconButton>
-        <IconButton
-          onClick={() => onSpeedChange("SLOW")}
-          disabled={speed === "SLOW"}
-          aria-label="slow speed"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <ChevronRightIcon />
-        </IconButton>
-        <IconButton
-          onClick={() => onSpeedChange("NORMAL")}
-          disabled={speed === "NORMAL"}
-          aria-label="normal speed"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <PlayArrowIcon />
-        </IconButton>
-        <IconButton
-          onClick={() => onSpeedChange("FAST")}
-          disabled={speed === "FAST"}
-          aria-label="fast speed"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <FastForwardIcon />
-        </IconButton>
-      </span>
-    );
-  }
-
-  let speedIcon = <PlayArrowIcon />;
-  switch (speed) {
-    case "PAUSED":
-      speedIcon = <PlayArrowIcon />;
-      break;
-    case "SLOW":
-      speedIcon = <ChevronRightIcon />;
-      break;
-    case "NORMAL":
-      speedIcon = <PlayArrowIcon />;
-      break;
-    case "FAST":
-      speedIcon = <FastForwardIcon />;
-      break;
-    default:
-      break;
-  }
-  return (
-    <span>
-      {speed !== "PAUSED" && (
-        <IconButton
-          onClick={() => onSpeedChange("PAUSED")}
-          aria-label="pause"
-          size="large"
-        >
-          <PauseIcon color="primary" />
-        </IconButton>
-      )}
-      <IconButton
-        onClick={handleSpeedClick}
-        aria-label="change speed"
-        edge="end"
-        color="primary"
-        size="large"
-      >
-        {speedIcon}
-      </IconButton>
-      <Menu
-        id="speedMenu"
-        anchorEl={speedAnchorEl}
-        keepMounted
-        open={Boolean(speedAnchorEl)}
-        onClose={handleSpeedClose}
-      >
-        <MenuItem
-          onClick={() => {
-            onSpeedChange("SLOW");
-            handleSpeedClose();
-          }}
-          disabled={speed === "SLOW"}
-          aria-label="slow-speed"
-        >
-          <ChevronRightIcon color="primary" />
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            onSpeedChange("NORMAL");
-            handleSpeedClose();
-          }}
-          disabled={speed === "NORMAL"}
-          aria-label="normal-speed"
-        >
-          <PlayArrowIcon color="primary" />
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            onSpeedChange("FAST");
-            handleSpeedClose();
-          }}
-          disabled={speed === "FAST"}
-          aria-label="fast-speed"
-        >
-          <FastForwardIcon color="primary" />
-        </MenuItem>
-      </Menu>
-    </span>
-  );
-}
+export interface Props extends GameCardProps {}
 
 export function GameCard(props: Props) {
-  const { game, onManual, onNextTutorial, onQuit, onSpeedChange } = props;
-  const date = game.date;
-  const now = getTimeFromTimeline(date.minute, game.timeline);
-  const [menuAnchorEl, setMenuAnchorEl] = React.useState<HTMLElement | null>(
-    null,
-  );
-  const [speedAnchorEl, setSpeedAnchorEl] = React.useState<HTMLElement | null>(
-    null,
-  );
-
-  const smallScreen = isSmallScreen();
-  const bigScreen = isBigScreen();
-  const speed = game.speed;
-  // Watching somebody else's run rather than playing your own. The speed controls stay live --
-  // being able to pause and fast forward is most of the point of a replay
-  const isReplay = !!game.replayPlayback;
-  // Undefined outside a tutorial, and on the last one - so this doubles as "is there a next
-  // tutorial to offer?" for the menu item below. Also undefined throughout a replay, since a
-  // tutorial never sets a score and so never has one to watch
-  const nextTutorial = getNextTutorial(game.scenarioId);
-
-  const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
-    setMenuAnchorEl(event.currentTarget);
-  const handleMenuClose = () => setMenuAnchorEl(null);
-  const handleSpeedClick = (event: React.MouseEvent<HTMLElement>) =>
-    setSpeedAnchorEl(event.currentTarget);
-  const handleSpeedClose = () => setSpeedAnchorEl(null);
-
-  /**
-   * The top bar has to re-render every tick to keep the cash and the clock honest, which at FAST
-   * is a hundred times a second. Everything else in it -- five icon buttons, a kept-mounted menu
-   * and the bottom nav -- only changes when the player clicks something, so those subtrees are
-   * built once per actual change and handed back as the same elements. React then skips them
-   * entirely on the frames in between, which is where a good quarter of the frame budget went.
-   */
-  const speedOptions = React.useMemo(
-    () =>
-      buildSpeedOptions({
-        smallScreen,
-        speed,
-        onSpeedChange,
-        speedAnchorEl,
-        handleSpeedClick,
-        handleSpeedClose,
-      }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [smallScreen, speed, onSpeedChange, speedAnchorEl],
-  );
-
-  const menu = React.useMemo(
-    () => (
-      <>
-        <IconButton
-          onClick={handleMenuClick}
-          aria-label="menu"
-          edge="start"
-          color="primary"
-          size="large"
-        >
-          <MoreVertIcon />
-        </IconButton>
-        <Menu
-          id="gameCardMenu"
-          anchorEl={menuAnchorEl}
-          keepMounted
-          open={Boolean(menuAnchorEl)}
-          onClose={handleMenuClose}
-        >
-          <MenuItem onClick={onManual}>Manual</MenuItem>
-          <MenuItem onClick={() => openWindow("mailto:todd@fabricate.io")}>
-            Send feedback
-          </MenuItem>
-          {/* Mid-tutorial, the thing a player who has seen enough wants is the next tutorial,
-              not the scenario list they'd have to go back through to reach it */}
-          {nextTutorial && (
-            <MenuItem onClick={() => onNextTutorial(nextTutorial.id)}>
-              Next tutorial
-            </MenuItem>
-          )}
-          <MenuItem onClick={onQuit}>
-            {isReplay ? "Exit replay" : "Quit"}
-          </MenuItem>
-        </Menu>
-      </>
-    ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [menuAnchorEl, onManual, onNextTutorial, onQuit, nextTutorial, isReplay],
-  );
-
-  const nav = React.useMemo(() => <NavigationContainer />, []);
+  const { game } = props;
+  const now = getTimeFromTimeline(game.date.minute, game.timeline);
 
   if (!game.inGame || !now) {
     return <span />;
   }
 
-  if (props.chromeless) {
+  const classes = ["flexContainer", props.className].filter(Boolean).join(" ");
+
+  if (isDesktopScreen()) {
     return (
       // id is how tutorial steps address an individual pane, since the bottom nav they'd
       // otherwise point at is hidden in this layout
-      <div id={props.id} className={props.className + " flexContainer pane"}>
+      <div id={props.id} className={classes + " pane"}>
         {props.title && (
           <Toolbar className="paneHeader">
             <Typography variant="h6">{props.title}</Typography>
@@ -293,32 +53,11 @@ export function GameCard(props: Props) {
     );
   }
 
-  const inBlackout = now.supplyW < now.demandW;
-
   return (
-    <div className={props.className + " flexContainer"} id="gameCard">
-      <div id="topbar">
-        <Toolbar className={inBlackout ? "blackout-pulsing" : ""}>
-          {menu}
-          <Typography variant="h6">
-            {formatMoneyStable(now.cash)}&nbsp;
-            <span className="weak">
-              {date.month} {date.year}
-              {bigScreen ? `, ${formatHour(date)}` : ""}
-            </span>
-            {isReplay && <span className="replayBadge">REPLAY</span>}
-          </Typography>
-          <div id="speedChangeButtons">{speedOptions}</div>
-        </Toolbar>
-      </div>
-      <div
-        id="yearProgressBar"
-        style={{
-          width: `${date.percentOfYear * 100}%`,
-        }}
-      />
+    <div className={classes} id="gameCard">
+      <GameAppBarContainer />
       {props.children}
-      {nav}
+      <NavigationContainer />
     </div>
   );
 }
@@ -331,26 +70,6 @@ const mapStateToProps = (
   ...ownProps,
 });
 
-const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
-  return {
-    onManual: () => {
-      dispatch(navigate("MANUAL"));
-    },
-    onSpeedChange: (speed: SpeedType) => {
-      dispatch(setSpeed(speed));
-    },
-    onNextTutorial: (scenarioId: number) => {
-      startTutorial(dispatch, scenarioId);
-    },
-    onQuit: () => {
-      dispatch(quit());
-    },
-  };
-};
-
-const GameCardContainer = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(GameCard);
+const GameCardContainer = connect(mapStateToProps)(GameCard);
 
 export default GameCardContainer;

--- a/src/components/base/UPlotChart.tsx
+++ b/src/components/base/UPlotChart.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import uPlot from "uplot";
 import "uplot/dist/uPlot.min.css";
-import { DESIGN_WIDTH } from "./UPlotHelpers";
+import { chartScale } from "./UPlotHelpers";
 
 /**
  * The React shell every chart in the game sits in.
@@ -39,6 +39,12 @@ export interface UPlotChartProps<S> {
   structureKey?: string | number;
   /** One tooltip covering every series at the hovered x */
   tooltip?: (idx: number, state: S) => string;
+  /**
+   * Charts sharing this key share a cursor: hovering one puts a crosshair at the same x on all
+   * of them. Only for charts drawn against the same x scale, one above another. Numbers stay
+   * with the pointer -- five tooltips at once would cover the data they are about.
+   */
+  syncKey?: string;
 }
 
 const TOOLTIP_OFFSET = 8;
@@ -46,19 +52,34 @@ const TOOLTIP_OFFSET = 8;
 function tooltipPlugin<S>(
   getState: () => S,
   getLabel: () => ((idx: number, state: S) => string) | undefined,
+  hoverOnly: boolean,
 ): uPlot.Plugin {
   let el: HTMLDivElement | null = null;
+  // A synced chart moves its cursor when a neighbour is hovered, which is the point -- but it
+  // should not also open a tooltip over data the pointer isn't anywhere near
+  let hovering = !hoverOnly;
   return {
     hooks: {
       init: (u: uPlot) => {
         el = document.createElement("div");
         el.className = "chartTooltip";
         u.over.appendChild(el);
+        if (hoverOnly) {
+          u.over.addEventListener("mouseenter", () => {
+            hovering = true;
+          });
+          u.over.addEventListener("mouseleave", () => {
+            hovering = false;
+            if (el) {
+              el.style.display = "none";
+            }
+          });
+        }
       },
       setCursor: (u: uPlot) => {
         const label = getLabel();
         const idx = u.cursor.idx;
-        if (!el || !label || idx == null) {
+        if (!el || !label || idx == null || !hovering) {
           if (el) {
             el.style.display = "none";
           }
@@ -83,7 +104,7 @@ function tooltipPlugin<S>(
 export default function UPlotChart<S>(
   props: UPlotChartProps<S>,
 ): React.JSX.Element {
-  const { ariaLabel, id, height, state, data, structureKey } = props;
+  const { ariaLabel, id, height, state, data, structureKey, syncKey } = props;
   const rootRef = React.useRef<HTMLDivElement>(null);
   const plotRef = React.useRef<uPlot | null>(null);
   const drawnRef = React.useRef<uPlot.AlignedData | null>(null);
@@ -118,16 +139,24 @@ export default function UPlotChart<S>(
       return;
     }
     const getState = () => stateRef.current;
-    const scale = width / DESIGN_WIDTH;
+    const scale = chartScale(width);
     const built = buildRef.current({ getState, scale });
     const plot = new uPlot(
       {
         ...built,
         width,
         height: Math.max(1, Math.round((height || 300) * scale)),
+        // Only x is synced: these charts plot watts against watt-hours against dollars, so
+        // matching their y scales would line up numbers that have nothing to do with each other
+        cursor: syncKey
+          ? {
+              ...built.cursor,
+              sync: { key: syncKey, setSeries: false, scales: ["x", null] },
+            }
+          : built.cursor,
         plugins: [
           ...(built.plugins || []),
-          tooltipPlugin(getState, () => tooltipRef.current),
+          tooltipPlugin(getState, () => tooltipRef.current, !!syncKey),
         ],
       },
       dataRef.current,

--- a/src/components/base/UPlotHelpers.ts
+++ b/src/components/base/UPlotHelpers.ts
@@ -15,6 +15,22 @@ import { chartTheme, withAlpha } from "../../Theme";
 
 export const DESIGN_WIDTH = 350;
 
+/**
+ * How far past its design width a chart is allowed to be blown up.
+ *
+ * The 350-wide design space was drawn for a phone, and scaling it straight to the pane means a
+ * chart in a 700px column gets 24px axis labels: "440MW" and "12am" set larger than any text
+ * around them, for no more information than they carried at 12px. Past this the pane gets the
+ * extra width as plot rather than as type -- which is also where the room for a fifth chart on
+ * screen comes from, since heights are quoted in the same space.
+ */
+const MAX_CHART_SCALE = 1.4;
+
+/** Design units to CSS pixels for a chart of `width`. */
+export function chartScale(width: number): number {
+  return Math.min(width / DESIGN_WIDTH, MAX_CHART_SCALE);
+}
+
 export const CHART_FONT_FAMILY = `Roboto, "Helvetica Neue", Helvetica, sans-serif`;
 export const TICK_LABEL_FILL = chartTheme.tickLabels.fill;
 
@@ -32,6 +48,25 @@ const LABEL_GAP = 4;
 const LABEL_EDGE_PAD = 4;
 // Victory drew legend text in its material theme's near-black rather than the axes' grey
 const LEGEND_TEXT = "#252525";
+
+/** What an axis carrying a `label` adds to its own size, in design units. */
+export const AXIS_LABEL_SIZE = 16;
+
+/**
+ * The gutters the stacked forecast charts leave either side of their plots, in design units.
+ *
+ * They read as one picture under one shared x axis, which only works if every plot starts and
+ * ends at the same place: an axis sized to its own labels would put "1.2GWh" and "$12" on
+ * different left edges, and the month labels under the bottom chart would then line up with
+ * nothing above them.
+ *
+ * Wide enough for the widest label any of them draws, since a fixed size clips rather than
+ * grows: the left is set by watt-hours ("800MWh" is as long as a niceSplits tick gets), the
+ * right by the weather chart's wind axis, whose labels are three digits at most. Both include
+ * the AXIS_LABEL_SIZE that the axes carrying a label spend on it.
+ */
+export const FORECAST_AXIS_LEFT = 60;
+export const FORECAST_AXIS_RIGHT = 48;
 
 /**
  * A font string at the chart's current scale.
@@ -53,7 +88,7 @@ export function chartFont(scale: number, sizePx = 12): string {
  * any display that isn't at 100%.
  */
 function canvasScale(u: uPlot): number {
-  return (u.width / DESIGN_WIDTH) * uPlot.pxRatio;
+  return chartScale(u.width) * uPlot.pxRatio;
 }
 
 // A context of our own to ask how wide a label will be, since axis sizes have to be settled
@@ -93,6 +128,8 @@ interface AxisOptions {
   side?: 1 | 3;
   /** Ticks, labels and axis label in one colour, to tie an axis to its series */
   stroke?: string;
+  /** x only: false keeps the baseline and ticks but drops the labels, for a shared axis */
+  showLabels?: boolean;
 }
 
 /**
@@ -141,19 +178,27 @@ function axisCommon(scale: number, o: AxisOptions) {
     border: { show: true, stroke: chartTheme.axis.stroke, width: 1 },
     label: o.label,
     labelFont: chartFont(scale),
-    labelSize: o.label ? 16 * scale : undefined,
+    labelSize: o.label ? AXIS_LABEL_SIZE * scale : undefined,
     splits: o.splits,
     values: o.values,
   };
 }
 
-/** The x axis every chart shares: black baseline, faded labels, no grid. */
+/**
+ * The x axis every chart shares: black baseline, faded labels, no grid.
+ *
+ * `showLabels: false` keeps the baseline and the tick marks but not the month names underneath,
+ * which is what a chart stacked above another chart that carries them wants -- the ticks still
+ * say where the months are, and the height the labels would have taken goes to the plot.
+ */
 export function xAxis(scale: number, o: AxisOptions): uPlot.Axis {
+  const showLabels = o.showLabels !== false;
   return {
     ...axisCommon(scale, o),
     scale: "x",
-    size: (o.size ?? 25) * scale,
+    size: (o.size ?? (showLabels ? 25 : 8)) * scale,
     gap: 2 * scale,
+    values: showLabels ? o.values : (_u, splits) => splits.map(() => ""),
   };
 }
 

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -386,7 +386,35 @@ export default class Facilities extends React.Component<Props, {}> {
     const readOnly = !!game.replayPlayback;
 
     return (
-      <GameCard>
+      <GameCard className="facilities" id="facilitiesPane">
+        {/* The pane's own header rather than a row inside the list, so it lines up with the
+            other panes' headers and the build buttons stay put as the fleet scrolls */}
+        <Toolbar className="paneHeader">
+          <Typography variant="h6">Facilities</Typography>
+          {!readOnly && (
+            <>
+              <Button
+                size="small"
+                variant="outlined"
+                color="primary"
+                onClick={onGeneratorBuild}
+                className="button-buildGenerator"
+              >
+                + Generator
+              </Button>
+              &nbsp;&nbsp;&nbsp;
+              <Button
+                size="small"
+                variant="outlined"
+                color="primary"
+                onClick={onStorageBuild}
+                className="button-buildStorage"
+              >
+                + Storage
+              </Button>
+            </>
+          )}
+        </Toolbar>
         <ChartSupplyDemand
           height={180}
           timeline={game.timeline}
@@ -396,32 +424,6 @@ export default class Facilities extends React.Component<Props, {}> {
           startingYear={game.startingYear}
         />
         <List dense className="scrollable">
-          <Toolbar style={{ paddingBottom: "4px" }}>
-            <Typography variant="h6">Facilities</Typography>
-            {!readOnly && (
-              <>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  color="primary"
-                  onClick={onGeneratorBuild}
-                  className="button-buildGenerator"
-                >
-                  + Generator
-                </Button>
-                &nbsp;&nbsp;&nbsp;
-                <Button
-                  size="small"
-                  variant="outlined"
-                  color="primary"
-                  onClick={onStorageBuild}
-                  className="button-buildStorage"
-                >
-                  + Storage
-                </Button>
-              </>
-            )}
-          </Toolbar>
           <DragDropContext onDragEnd={this.onDragEnd}>
             <Droppable droppableId="droppable">
               {(provided) => (

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -35,7 +35,6 @@ import {
   getStorageChoice,
   setStorageKeyValue,
 } from "../../LocalStorage";
-import { isDesktopScreen } from "../../Globals";
 import { generateNewTimeline } from "../../reducers/Game";
 import { MANUAL_ENTRY } from "../../data/Manual";
 import ManualLink from "../base/ManualLink";
@@ -605,12 +604,7 @@ export default class Finances extends React.Component<Props, State> {
     );
 
     return (
-      <GameCard
-        className="finances"
-        chromeless={isDesktopScreen()}
-        title="Finances"
-        id="financesPane"
-      >
+      <GameCard className="finances" title="Finances" id="financesPane">
         <div className="scrollable">
           <br />
           <Toolbar>

--- a/src/components/views/Forecasts.tsx
+++ b/src/components/views/Forecasts.tsx
@@ -21,17 +21,28 @@ import { formatWattHours, formatWatts } from "../../helpers/Format";
 import { getDispatchOrderedFuels } from "../../helpers/Energy";
 import { getStorageChoice, setStorageKeyValue } from "../../LocalStorage";
 import { generateNewTimeline } from "../../reducers/Game";
-import ChartForecastFuelPrices from "../base/ChartForecastFuelPrices";
+import ChartForecastFuelPrices, {
+  PRICED_FUELS,
+} from "../base/ChartForecastFuelPrices";
 import ChartForecastSupplyDemand from "../base/ChartForecastSupplyDemand";
-import ChartForecastSupplyByFuel from "../base/ChartForecastSupplyByFuel";
+import ChartForecastSupplyByFuel, {
+  forecastFuels,
+} from "../base/ChartForecastSupplyByFuel";
 import ChartForecastWeather from "../base/ChartForecastWeather";
 import ChartForecastStorage from "../base/ChartForecastStorage";
+import ChartLegend from "../base/ChartLegend";
 import GameCard from "../base/GameCard";
 import { TICK_MINUTES } from "../../Constants";
-import { isDesktopScreen } from "../../Globals";
+import { fuelColors, fuelDashArrays } from "../../Theme";
 
 const FORECAST_YEARS_KEY = "forecastYears";
 const FORECAST_YEARS_OPTIONS = [1, 5, 10, 20];
+
+// Everything in this pane is drawn against the same months, so hovering any of it should say
+// where you are in all of it -- the whole point of the pane is that these five things move
+// together. Only the bottom chart draws the month names; the rest keep their ticks and hand
+// the height back to the plot
+const FORECAST_SYNC_KEY = "forecasts";
 
 interface BlackoutEdges {
   minute: number;
@@ -191,13 +202,15 @@ export default class Forecasts extends React.Component<Props, State> {
       forecastedTimeline[forecastedTimeline.length - 1],
     );
 
+    // Derived here rather than inside the chart, since the legend beside the chart's title has
+    // to name exactly the bands the chart draws
+    const fuels = forecastFuels(
+      getDispatchOrderedFuels(game.facilities) as FuelNameType[],
+      sampledForecastedTimeline,
+    );
+
     return (
-      <GameCard
-        className="Forecasts"
-        chromeless={isDesktopScreen()}
-        title="Forecasts"
-        id="forecastsPane"
-      >
+      <GameCard className="Forecasts" title="Forecasts" id="forecastsPane">
         <div className="scrollable">
           <Toolbar>
             <Typography variant="h6">
@@ -225,6 +238,8 @@ export default class Forecasts extends React.Component<Props, State> {
             domain={{ x: [rangeMin, rangeMax], y: [domainMin, domainMax] }}
             startingYear={game.startingYear}
             multiyear={years > 1}
+            showXLabels={false}
+            syncKey={FORECAST_SYNC_KEY}
           />
           {blackoutTotalWh > 0 && (
             <Table size="small">
@@ -262,10 +277,19 @@ export default class Forecasts extends React.Component<Props, State> {
               </TableBody>
             </Table>
           )}
-          <br />
-          <br />
-          <Toolbar>
+          {/* Each chart's key sits in its title row rather than on a row of its own below the
+              plot, which is a chart's worth of height across the five of them */}
+          <Toolbar className="forecastSection">
             <Typography variant="h6">Supply by Fuel</Typography>
+            <ChartLegend
+              inline
+              items={[
+                ...[...fuels]
+                  .reverse()
+                  .map((f) => ({ name: f, color: fuelColors[f] })),
+                { name: "Demand", color: "", rule: true },
+              ]}
+            />
           </Toolbar>
           <ChartForecastSupplyByFuel
             height={140}
@@ -273,13 +297,13 @@ export default class Forecasts extends React.Component<Props, State> {
             domain={{ x: [rangeMin, rangeMax] }}
             startingYear={game.startingYear}
             multiyear={years > 1}
-            fuels={getDispatchOrderedFuels(game.facilities) as FuelNameType[]}
+            fuels={fuels}
+            showXLabels={false}
+            syncKey={FORECAST_SYNC_KEY}
           />
           {hasStorage && (
             <div>
-              <br />
-              <br />
-              <Toolbar>
+              <Toolbar className="forecastSection">
                 <Typography variant="h6">Stored power</Typography>
               </Toolbar>
               <ChartForecastStorage
@@ -288,13 +312,21 @@ export default class Forecasts extends React.Component<Props, State> {
                 domain={{ x: [rangeMin, rangeMax] }}
                 startingYear={game.startingYear}
                 multiyear={years > 1}
+                showXLabels={false}
+                syncKey={FORECAST_SYNC_KEY}
               />
             </div>
           )}
-          <br />
-          <br />
-          <Toolbar>
+          <Toolbar className="forecastSection">
             <Typography variant="h6">Fuel Prices</Typography>
+            <ChartLegend
+              inline
+              items={PRICED_FUELS.map((f) => ({
+                name: f,
+                color: fuelColors[f],
+                dash: fuelDashArrays[f],
+              }))}
+            />
           </Toolbar>
           <ChartForecastFuelPrices
             height={140}
@@ -302,20 +334,22 @@ export default class Forecasts extends React.Component<Props, State> {
             domain={{ x: [rangeMin, rangeMax] }}
             startingYear={game.startingYear}
             multiyear={years > 1}
+            showXLabels={false}
+            syncKey={FORECAST_SYNC_KEY}
           />
-          <br />
-          <br />
-          <Toolbar>
+          <Toolbar className="forecastSection">
             <Typography variant="h6">
               Weather in {game.location.name}
             </Typography>
           </Toolbar>
+          {/* Last, so it's the one that draws the month names the whole stack is read against */}
           <ChartForecastWeather
             height={140}
             timeline={sampledForecastedTimeline}
             domain={{ x: [rangeMin, rangeMax] }}
             startingYear={game.startingYear}
             multiyear={years > 1}
+            syncKey={FORECAST_SYNC_KEY}
           />
         </div>
       </GameCard>


### PR DESCRIPTION
Implements items 1–5 of https://github.com/toddmedema/electrify/issues/177.

### 1. The topbar is a real app bar

Cash, the date, the speed controls, the year progress bar and the blackout pulse lived inside `Facilities`, because Facilities was the one pane that didn't pass `chromeless` — so the game's global state was reported from the top-left corner of column one, and `.paneHeader` carried a `min-height: 56px` hack to fake alignment with it.

They now live in `GameAppBar`, which `Compositor.renderCard()` renders once above all three columns (and `GameCard` renders on a phone, where there's only one pane anyway). `chromeless` is gone: `GameCard` decides for itself whether it's a pane or a card. `.paneHeader` keeps a min-height, but a modest one of its own (40px) so the three pane headers line up with each other rather than with a topbar that isn't there any more.

Facilities' `Facilities + Generator + Storage` toolbar moves out of its scrolling list to become that pane's header. That lines its contents up with the other two panes, and on a phone it means the build buttons stay put instead of scrolling away with the fleet.

### 2. Weighted, resizable columns

`1fr 1.15fr 1.15fr` instead of equal thirds, and a new `DesktopPanes` puts a draggable splitter between each pair. Pointer drag, arrow keys (it's a `role="separator"`, focusable), double-click to reset, persisted through `setStorageKeyValue`. Splitters are grid tracks of their own, so a drag moves width between two panes rather than changing what the row has to divide up.

### 3. Capped type scale

The real culprit turned out not to be `$sizemap` — Sass folds `5vmin * calc(1025px / 120vmin)` at compile time, so the "desktop" map was already fixed px. What actually scaled without limit was the charts: every one is described in a 350-wide space drawn for a phone and multiplied by `paneWidth / 350`, which on a wide monitor is where 24px `440MW` and `12am` came from. `chartScale()` now caps that at 1.4x, so past that the pane gets the extra width as plot and the extra height back. The desktop `$sizemap` also drops to tighter px values, which is where the row density comes from.

### 4. Synced chart cursors

`UPlotChart` takes a `syncKey`; the five forecast charts share one. Hovering July on the fuel-price chart puts a crosshair on July in supply/demand, supply-by-fuel, storage and weather. Only x is synced (`scales: ["x", null]`) — these plot watts against watt-hours against dollars. The numbers stay with the pointer: five tooltips at once would cover the data they're about.

### 5. One shared time axis

Only the bottom chart draws the month names; the rest keep their baseline and tick marks and hand the label row back to the plot. For that to be honest the plots have to start and end in the same place, so the forecast charts size their y axes to fixed gutters (`FORECAST_AXIS_LEFT` / `FORECAST_AXIS_RIGHT`) instead of fitting each to its own labels — otherwise `1.2GWh` and `$12` sit on different left edges and the months underneath line up with nothing.

The two legends move into their chart's title row (new shared `ChartLegend`), and the pairs of `<br>`s between sections become a 12px margin.

### Verified

Driven in the browser at 1600x1000 and at 390x844:

- app bar spans 1600px; panes measure 482 / 554 / 554; three pane headers all at `y=53, h=41`
- all four forecast plot areas align to the pixel (`L=81, R=70, W=402` desktop; `L=67, R=53, W=270` on the phone)
- hovering chart 1 puts all four crosshairs at the same x, with the tooltip only on the hovered chart
- splitter drag, arrow keys and double-click-to-reset all move the grid template and write to local storage; a reload restores it
- phone layout unchanged in shape: app bar 53, pane header 41, chart 201, list 492, nav 57 = 844

`npm run typecheck`, `npm run lint`, `npm run format:check` clean; 528 tests in 38 suites pass.

### Trade-off worth knowing

Fixed gutters cost about 15% of plot width (a 390px phone goes from ~325px of plot to ~270px). That buys the alignment the shared axis needs plus, across four charts, roughly a chart's worth of height. At 1000px tall the pane still scrolls by ~57px with four charts — item 5's "probably fits all five without scrolling" doesn't quite land, but the stack is materially shorter.

### Not touched

Items 6–17 (facility detail, delta column, small multiples, keyboard map, speed toggle group, event log, the 650–1300px gap, dark mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
