### PR TITLE
Point the tutorial back at the charts it lost to uPlot

### DIFF
--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import * as React from "react";
 import type { UnknownAction } from "redux";
 import { ACTIONS, EVENTS, type EventData } from "react-joyride";
@@ -164,6 +166,48 @@ describe("onTutorialStep", () => {
   });
 });
 
+/**
+ * Every component's markup as one blob to search. Source only: the test files are full of
+ * fixture markup no walkthrough will ever point at.
+ */
+const SOURCE = (function read(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return read(full);
+    }
+    return /\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)
+      ? [fs.readFileSync(full, "utf8")]
+      : [];
+  });
+})(path.join(__dirname, "..")).join("\n");
+
+/** Both targets a step can carry, since the desktop override is a selector of its own */
+function targetsOf(steps: TutorialStepType[]): string[] {
+  return steps
+    .flatMap((s) => [s.target, s.desktop && s.desktop.target])
+    .filter((t): t is string => Boolean(t));
+}
+
+/** Whether anything in the app still declares the id or class a simple selector names */
+function declares(simple: string): boolean {
+  const name = simple.slice(1);
+  if (simple.startsWith("#")) {
+    return SOURCE.includes(`id="${name}"`);
+  }
+  // MUI generates its own class names, so there is nothing of ours to find. Those steps lean
+  // on the card check above instead
+  if (name.startsWith("Mui")) {
+    return true;
+  }
+  // Class attributes are often assembled from a template, so look for the whole word anywhere
+  // on a line that sets one rather than trying to parse the value out
+  return SOURCE.split("\n").some(
+    (line) =>
+      line.includes("className") && line.split(/[^\w-]+/).includes(name),
+  );
+}
+
 describe("walkthrough steps", () => {
   const tutorials = SCENARIOS.filter((s) => s.tutorialSteps);
 
@@ -206,6 +250,22 @@ describe("walkthrough steps", () => {
           toStep,
           cardOf(steps[toStep]),
         ]);
+      });
+    });
+
+    /**
+     * Joyride reports a selector matching nothing as TARGET_NOT_FOUND, which the walkthrough
+     * handles by moving straight on - so a step pointing at markup that has since been renamed
+     * quietly vanishes rather than failing. The move off Victory took `.VictoryContainer` with
+     * it exactly that way, and the tutorial lost its tour of the supply/demand graph without a
+     * single red test. Rendering every card would be the airtight check; scanning the source
+     * for the id or class each selector names catches the same kind of rename far cheaper.
+     */
+    it(`${scenario.name} points every step at markup that still exists`, () => {
+      targetsOf(steps).forEach((target) => {
+        target.split(/\s+/).forEach((simple) => {
+          expect([target, declares(simple)]).toEqual([target, true]);
+        });
       });
     });
   });

--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -127,6 +127,7 @@ const ChartFinances = (props: Props): React.JSX.Element => {
   return (
     <UPlotChart<State>
       ariaLabel={`Chart of ${props.title} over time`}
+      id="chartFinances"
       height={props.height}
       state={state}
       data={[months, past, projected]}

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -277,6 +277,7 @@ const ChartSupplyDemand = (props: Props): React.JSX.Element => {
   return (
     <UPlotChart<State>
       ariaLabel="Chart of electricity supply and demand over the day"
+      id="chartSupplyDemand"
       height={height}
       state={state}
       data={[minutes, supplyHistoric, supplyForecast, demand]}

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -38,7 +38,7 @@ export const SCENARIOS = [
       },
       {
         card: "FACILITIES",
-        target: ".VictoryContainer",
+        target: "#chartSupplyDemand",
         content: (
           <Typography variant="body1">
             Make money by supplying demand for electricity, measured in
@@ -55,7 +55,7 @@ export const SCENARIOS = [
       },
       {
         card: "FACILITIES",
-        target: ".VictoryContainer",
+        target: "#chartSupplyDemand",
         content: (
           <Typography variant="body1">
             Your generators automatically spin up to meet demand as best they
@@ -324,10 +324,7 @@ export const SCENARIOS = [
       },
       {
         card: "FINANCES",
-        target: ".VictoryContainer",
-        // Unqualified, this matches the Facilities pane's chart first once all three panes
-        // are on screen
-        desktop: { target: "#financesPane .VictoryContainer" },
+        target: "#chartFinances",
         content: (
           <Typography variant="body1">
             You can plot a variety of metrics by changing the dropdowns above


### PR DESCRIPTION
Three walkthrough steps in `src/data/Scenarios.tsx` still targeted `.VictoryContainer`, a selector the Victory → uPlot migration took with it. Joyride reports a target matching nothing as `TARGET_NOT_FOUND`, which `Compositor.handleJoyrideCallback` handles by advancing — so **101: Electricity** quietly dropped both steps explaining the supply/demand graph, and **104: Finances** dropped its tour of the metric chart. No error, no failing test, just missing tutorial.

## Changes

- `ChartSupplyDemand` and `ChartFinances` now pass an `id` through to `UPlotChart`'s root div (`#chartSupplyDemand`, `#chartFinances`), following the `#chartForecast*` convention the forecast charts already use.
- The three steps target those ids.
- The finances step's `desktop` override is gone. It only existed because the bare class matched the Facilities pane's chart first once all three panes are on screen; a unique id makes it moot.
- New per-walkthrough test in `CompositorContainer.test.tsx`: every step's target — and any desktop override — must name an id or class the source still declares. MUI's own class names (`.MuiTable-root`) are exempt with a comment, since nothing of ours declares them.

## Verification

- Full suite green: 534 tests, 38 suites. Typecheck, lint, prettier clean.
- The new test is a real guard — putting `.VictoryContainer` back on one step fails `101: Electricity points every step at markup that still exists`, naming the offending selector.
- In the running app, starting tutorial 101 and stepping forward anchors the "Make money by supplying demand for electricity…" tooltip directly under the supply/demand chart (chart bottom 346px, tooltip top 382px) instead of skipping it.
- At 1500px wide with all three panes side by side, `#chartSupplyDemand` and `#chartFinances` each match exactly one element, in the Facilities and Finances panes respectively — confirming the dropped qualifier isn't needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
