### PR TITLE
Fix the high scores table being cut off on the left

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -611,6 +611,30 @@ $pane_header_height: 40px;
   }
 }
 
+// The leaderboard on the scenario details screen. The rank and replay columns used to be
+// padding="none", which put the rank digits hard against x=0 -- on a desktop window that is the
+// window edge, so they read as clipped. They still need to stay narrow, so they get a small
+// gutter instead of none, and 1% width so the browser shrinks them to their content and spends
+// the leftover on the name.
+#HighScores {
+  max-width: $abswidthmax;
+  margin: 0 auto;
+
+  .MuiTableCell-root {
+    padding: 6px;
+  }
+
+  .rank,
+  .replay {
+    width: 1%;
+    white-space: nowrap;
+  }
+
+  .replay {
+    text-align: center;
+  }
+}
+
 .points {
   max-width: 100%;
 

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -177,18 +177,18 @@ export default class NewGameDetails extends React.Component<Props, State> {
 
   private renderReplayCell(score: ScoreType) {
     if (!score.replayId) {
-      return <TableCell padding="none" />;
+      return <TableCell className="replay" />;
     }
     const replayId = score.replayId;
     if (this.state.loadingReplayId === replayId) {
       return (
-        <TableCell padding="none">
+        <TableCell className="replay">
           <CircularProgress size={20} />
         </TableCell>
       );
     }
     return (
-      <TableCell padding="none">
+      <TableCell className="replay">
         <IconButton
           onClick={() => this.watchReplay(replayId)}
           aria-label="Watch replay"
@@ -366,17 +366,17 @@ export default class NewGameDetails extends React.Component<Props, State> {
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell padding="none">#</TableCell>
+                <TableCell className="rank">#</TableCell>
                 <TableCell>Name</TableCell>
                 <TableCell>Score</TableCell>
                 <TableCell>Difficulty</TableCell>
-                <TableCell padding="none">Replay</TableCell>
+                <TableCell className="replay">Replay</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
               {myTopScore && (
                 <TableRow style={OWN_ROW_STYLE}>
-                  <TableCell padding="none" />
+                  <TableCell className="rank" />
                   <TableCell colSpan={2}>
                     Your best: {formatScore(myTopScore.score)}
                   </TableCell>
@@ -409,7 +409,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   const mine = Boolean(uid) && score.uid === uid;
                   return (
                     <TableRow key={i} style={mine ? OWN_ROW_STYLE : undefined}>
-                      <TableCell padding="none">{i + 1}</TableCell>
+                      <TableCell className="rank">{i + 1}</TableCell>
                       {/* Scores set before display names existed carry no name */}
                       <TableCell>{score.displayName || "Anonymous"}</TableCell>
                       <TableCell>{formatScore(score.score)}</TableCell>


### PR DESCRIPTION
## What was wrong

The rank and replay columns of the leaderboard were `padding="none"`, so the rank cell's content box started at x=0 — the frame edge on a phone, the window edge on desktop. That put the `#` header and the numbers under it hard against the edge with no gutter at all, reading as clipped, while every neighbouring cell (16px of MUI padding) looked fine.

Measured on the scenario details screen in a 1000px window before the fix:

| cell | left | width |
| --- | --- | --- |
| `#` | **0** | 44 |
| Name | 44 | 342 |
| Score | 387 | 200 |
| Difficulty | 587 | 267 |
| Replay | 854 | 131 |

The table also stretched the full width of the window while the rest of the details stay centred, which is why Name and Difficulty ballooned to 342px and 267px.

## The fix

- The rank and replay cells swap `padding="none"` for `.rank` / `.replay` classes. They still need to be narrow, so they get a small gutter instead of none, plus `width: 1%` so the browser shrinks them to their content and spends the leftover width on the name.
- Every cell in the board goes to 6px of padding, which keeps the whole thing inside 320px — the narrowest phone worth supporting — now that the two compact columns are no longer free.
- The table is capped at the layout's existing `$abswidthmax` (650px) and centred, so a desktop window no longer stretches it edge to edge.

## Verified in the browser

Loaded the Carbon Fee scenario details against the live leaderboard (50 rows) and measured the layout at three widths:

- **1000px** — table 650px wide, centred at left 168; rank column 28px, its digits starting 6px inside the table edge.
- **375px** — fits exactly, no horizontal scroll.
- **320px** — `scrollWidth` 320 vs `clientWidth` 320, so nothing overflows or clips.

`npm run typecheck`, eslint, prettier and the full suite (528 tests, 38 suites) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
