### PR TITLE
Make the fleet list say what each facility is worth (#177 items 6-10)

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -258,7 +258,7 @@ export type FacilityOperatingType =
   GeneratorOperatingType | StorageOperatingType;
 
 export interface GeneratorOperatingType
-  extends GeneratorShoppingType, LoanInfo {
+  extends GeneratorShoppingType, LoanInfo, LifetimeTotals {
   id: number; // Monotonically increasing
   currentW: number;
   yearsToBuildLeft: number;
@@ -266,11 +266,32 @@ export interface GeneratorOperatingType
   paused: boolean;
 }
 
-export interface StorageOperatingType extends StorageShoppingType, LoanInfo {
+export interface StorageOperatingType
+  extends StorageShoppingType, LoanInfo, LifetimeTotals {
   id: number; // Monotonically increasing
   currentWh: number;
   yearsToBuildLeft: number;
   minuteCreated: number; // That the user clicked buy, not construction complete
+}
+
+/**
+ * What one facility has actually done since it came online, so a row can report whether it is
+ * earning its keep rather than only what it cost to build. Accumulated per tick by
+ * updateSupplyFacilitiesFinances, and only while the game is really ticking -- a forecast runs
+ * against a deep clone of the fleet and throws the clone away, so its ticks never land here.
+ *
+ * Every field is optional because a save written before these existed has none of them, and a
+ * fleet resumed from one should keep playing rather than start reporting NaN. Read them through
+ * helpers/Financials' facilityLifetime, which is where the zero defaults live.
+ */
+export interface LifetimeTotals {
+  lifetimeWh?: number; // Delivered to the grid. Storage counts discharge only, not charging
+  // What it could have delivered running flat out over the same span, ie the denominator of its
+  // capacity factor. Accrues from the moment construction finishes, so pauses and idle hours
+  // count against it the way they do for a real plant
+  lifetimePotentialWh?: number;
+  lifetimeRevenue?: number; // Its pro-rata share of what the company sold
+  lifetimeExpenses?: number; // Its own fuel, O&M, carbon fees and loan interest
 }
 
 interface LoanInfo {
@@ -458,6 +479,11 @@ export interface VictoryType {
 export interface UIType {
   dialog: DialogType;
   snackbar: SnackbarType;
+  // The facility the player has clicked in the fleet list, or null for none. UI rather than game
+  // state: it changes nothing about the simulation, and it is read by all three panes -- the
+  // fleet row expands, Supply by Fuel dims everything it doesn't burn, and Finances reports what
+  // it has earned. Cleared when the run ends, or when the facility is sold out from under it
+  selectedFacilityId: number | null;
   // The score screen for a run that just ended, or null when none has. Its own slot rather than a
   // `dialog`, because the shared dialog only holds a title and a message and this one fills
   // itself in as async results arrive

--- a/src/app.scss
+++ b/src/app.scss
@@ -15,6 +15,11 @@ $bg_dark_primary: #161011;
 
 $blackout_red: #c62828; /* red800 https://material-ui.com/customization/color/ - matches blackoutColor in Theme.tsx */
 $interactive_blue: #1e88e5; /* blue 600 */
+// The two directions a number can move in. Both are the darker end of their ramp so they
+// clear 4.5:1 on white as text, since the arrow beside them is decoration rather than the
+// message -- red/green alone would leave a colourblind reader with only the arrow
+$delta_good: #2e7d32; /* green800 */
+$delta_bad: #c62828; /* red800 */
 
 // ===============================================
 // Transitional animation classes
@@ -858,6 +863,109 @@ $pane_header_height: 40px;
     border-top: 1px #eeeeee solid; /* grey200 */
   }
 
+  // The whole row selects, so it has to look like it does something before it is clicked
+  .facilityRow {
+    outline: none;
+
+    &:hover .facility {
+      background: #fafafa; /* grey50 */
+    }
+
+    // WCAG 2.4.7 -- and the row is reachable by Tab, since it doubles as the drag handle
+    &:focus-visible .facility {
+      outline: 2px solid $interactive_blue;
+      outline-offset: -2px;
+    }
+
+    &.selected {
+      background: #e3f2fd; /* blue50 */
+      // Reads down the left edge of the list, so which row is open survives scrolling past
+      // the details themselves
+      box-shadow: inset 3px 0 0 0 $interactive_blue;
+
+      .facility {
+        border-top-color: transparent;
+      }
+    }
+  }
+
+  // What the row is worth, opened underneath it. A wrapping grid rather than fixed columns:
+  // the pane is resizable, and a stat that has to be truncated to fit is worth less than one
+  // that wraps onto the next line
+  .facilityDetails {
+    padding: size(small) 16px size(base) 56px;
+  }
+
+  .facilityStats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: size(base) size(medium);
+  }
+
+  .facilityStat {
+    min-width: 72px;
+  }
+
+  .facilityStatValue {
+    &.good {
+      color: $delta_good;
+    }
+    &.bad {
+      color: $delta_bad;
+    }
+  }
+
+  .facilityTrend {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .sparkline {
+    display: block;
+    overflow: visible;
+  }
+
+  // Buttons that only appear when a mouse is near them (see the desktop block below); on a
+  // touch screen there is no hover to reveal them with, so they stay put
+  .facilityActions {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  // The change column, and the facility figures that use the same two colours
+  .deltaCell {
+    white-space: nowrap;
+
+    &.good {
+      color: $delta_good;
+    }
+    &.bad {
+      color: $delta_bad;
+    }
+    &.flat {
+      color: $font_color_faded;
+    }
+  }
+
+  .deltaArrow {
+    // Sits on the text baseline rather than pushing the row taller
+    vertical-align: middle;
+    margin-right: -2px;
+    font-size: 1.1em;
+  }
+
+  // Which money is the selected facility's, above the chart that shows the company's
+  .selectedFacilitySummary {
+    padding: size(small) 16px;
+    background: #e3f2fd; /* blue50 */
+    border-bottom: 1px solid #bbdefb; /* blue100 */
+  }
+
+  .chartLegendItem-muted {
+    opacity: 0.35;
+  }
+
   .version {
     text-align: center;
     opacity: 0.7;
@@ -1022,6 +1130,20 @@ $sizemap: (
       min-width: 0;
       height: 100%;
     }
+  }
+
+  // There is a mouse now, so the row's actions can wait to be asked for -- which gives the
+  // numbers in the details panel the width the buttons were holding. Anything that reveals
+  // them has to include focus, or they'd be unreachable by keyboard
+  .facilityActions {
+    opacity: 0;
+    transition: opacity 0.15s;
+  }
+
+  .facilityRow:hover .facilityActions,
+  .facilityRow:focus-within .facilityActions,
+  .facilityRow.selected .facilityActions {
+    opacity: 1;
   }
 
   .pane-splitter {

--- a/src/components/base/ChartForecastSupplyByFuel.tsx
+++ b/src/components/base/ChartForecastSupplyByFuel.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../helpers/DateTime";
 import { formatWatts, formatWattsAxis } from "../../helpers/Format";
 import { FuelNameType, TickPresentFutureType } from "../../Types";
-import { demandColor, fuelColors } from "../../Theme";
+import { demandColor, fuelColors, withAlpha } from "../../Theme";
 
 export interface Props {
   height?: number;
@@ -30,6 +30,12 @@ export interface Props {
   showXLabels?: boolean;
   /** Shares a cursor with the other charts drawn against the same months */
   syncKey?: string;
+  /**
+   * The one fuel to draw at full strength, with every other band faded back. Set from the
+   * facility the player has selected in the fleet list, so that clicking a coal plant says
+   * which part of the stack is theirs.
+   */
+  highlightFuel?: FuelNameType;
 }
 
 /**
@@ -68,7 +74,15 @@ interface State {
   multiyear: boolean;
 }
 
-function buildOptions(fuels: FuelNameType[], showXLabels: boolean) {
+// Faded far enough that the highlighted band is unmistakably the subject, but not so far
+// that the rest of the stack stops being readable as context
+const MUTED_BAND_ALPHA = 0.15;
+
+function buildOptions(
+  fuels: FuelNameType[],
+  showXLabels: boolean,
+  highlightFuel?: FuelNameType,
+) {
   return ({ getState, scale }: BuildContext<State>): uPlot.Options => ({
     width: 0, // set by UPlotChart
     height: 0,
@@ -106,7 +120,10 @@ function buildOptions(fuels: FuelNameType[], showXLabels: boolean) {
     series: [
       {},
       ...fuels.map((f) => ({
-        fill: fuelColors[f],
+        fill:
+          highlightFuel && f !== highlightFuel
+            ? withAlpha(fuelColors[f], MUTED_BAND_ALPHA)
+            : fuelColors[f],
         // A hairline of background between bands keeps them apart even where two
         // fuel colors are close, since seven series can't all be far apart
         stroke: "#ffffff",
@@ -154,6 +171,7 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
       multiyear,
       showXLabels,
       syncKey,
+      highlightFuel,
     } = this.props;
 
     // Every band needs a value at every x or the stack tears, so backfill the whole series.
@@ -205,8 +223,12 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
           height={height}
           state={state}
           data={[minutes, ...stacked, demand]}
-          buildOptions={buildOptions(fuels, showXLabels !== false)}
-          structureKey={`${fuels.join(",")}|${showXLabels !== false}`}
+          buildOptions={buildOptions(
+            fuels,
+            showXLabels !== false,
+            highlightFuel,
+          )}
+          structureKey={`${fuels.join(",")}|${showXLabels !== false}|${highlightFuel || ""}`}
           syncKey={syncKey}
           tooltip={tooltip}
         />

--- a/src/components/base/ChartLegend.tsx
+++ b/src/components/base/ChartLegend.tsx
@@ -16,6 +16,8 @@ export interface LegendItemType {
   dash?: string | undefined;
   /** Drawn as a rule rather than a block, for a series that is a line over the others */
   rule?: boolean;
+  /** Faded back, for a series the chart itself is currently drawing faded back */
+  muted?: boolean;
 }
 
 export interface Props {
@@ -29,7 +31,12 @@ export default function ChartLegend(props: Props): React.JSX.Element {
       className={"chartLegend" + (props.inline ? " chartLegend-inline" : "")}
     >
       {props.items.map((item) => (
-        <span key={item.name} className="chartLegendItem">
+        <span
+          key={item.name}
+          className={
+            "chartLegendItem" + (item.muted ? " chartLegendItem-muted" : "")
+          }
+        >
           {item.dash ? (
             <svg
               className="chartLegendSwatch chartLegendSwatch-line"

--- a/src/components/base/FacilityDetails.tsx
+++ b/src/components/base/FacilityDetails.tsx
@@ -1,0 +1,212 @@
+import * as React from "react";
+import { Typography } from "@mui/material";
+import { getFuelPricesPerMBTU } from "../../data/FuelPrices";
+import { facilityLifetime } from "../../helpers/Financials";
+import {
+  formatMoneyConcise,
+  formatWattHours,
+  formatWattHoursOfPeak,
+  formatWatts,
+} from "../../helpers/Format";
+import { fuelColors, storageColor } from "../../Theme";
+import {
+  DateType,
+  FacilityOperatingType,
+  FuelNameType,
+  GeneratorOperatingType,
+  StorageOperatingType,
+} from "../../Types";
+import Sparkline from "./Sparkline";
+
+/**
+ * What a selected facility has actually been doing: how hard it has run, what a MWh out of it
+ * costs against what it fetches, what it has made or lost, and - for anything that burns
+ * something - where the price of that something has been heading.
+ *
+ * All of it comes off totals the simulation already keeps (see LifetimeTotals) plus the fuel
+ * price table, so opening a row costs a handful of lookups rather than a re-simulation.
+ */
+
+// How far back the fuel price trend looks. A year is long enough to show a direction and short
+// enough that the last few months are still legible in 72 pixels
+const TREND_MONTHS = 12;
+
+export interface Props {
+  facility: FacilityOperatingType;
+  date: DateType;
+  seed: number;
+}
+
+interface StatProps {
+  label: string;
+  value: string;
+  // Profit is the one number here that means something different either side of zero
+  tone?: "good" | "bad";
+}
+
+function Stat(props: StatProps): React.JSX.Element {
+  return (
+    <div className="facilityStat">
+      <Typography variant="caption" color="textSecondary" component="div">
+        {props.label}
+      </Typography>
+      <Typography
+        variant="body2"
+        component="div"
+        className={props.tone ? `facilityStatValue ${props.tone}` : undefined}
+      >
+        {props.value}
+      </Typography>
+    </div>
+  );
+}
+
+const percent = (fraction: number) => `${Math.round(fraction * 100)}%`;
+
+/**
+ * The last year of this fuel's price, oldest first. Empty when the game hasn't been running long
+ * enough for a trend, or when the price table isn't loaded - which is every render outside a real
+ * game, and not worth a crash in a list row.
+ */
+export function fuelPriceTrend(
+  fuel: FuelNameType,
+  date: DateType,
+  seed: number,
+): number[] {
+  const months = Math.min(TREND_MONTHS, date.monthsEllapsed + 1);
+  if (months < 2) {
+    return [];
+  }
+  const prices: number[] = [];
+  try {
+    for (let back = months - 1; back >= 0; back--) {
+      // monthNumber is 1-12, so shift to a 0-based count of months before dividing it back out
+      const absolute = date.year * 12 + (date.monthNumber - 1) - back;
+      const price = getFuelPricesPerMBTU(
+        {
+          year: Math.floor(absolute / 12),
+          monthNumber: (absolute % 12) + 1,
+        } as DateType,
+        seed,
+      )[fuel];
+      if (price === undefined) {
+        return [];
+      }
+      prices.push(price);
+    }
+  } catch {
+    // The table is only loaded once a game is running; a row rendered before that just goes
+    // without its trend line
+    return [];
+  }
+  return prices;
+}
+
+export default function FacilityDetails(props: Props): React.JSX.Element {
+  const { facility, date, seed } = props;
+  const lifetime = facilityLifetime(facility);
+  const fuel = (facility as Partial<GeneratorOperatingType>).fuel;
+  const isStorage = facility.peakWh > 0;
+  const accentColor = (fuel && fuelColors[fuel]) || storageColor;
+  const underConstruction = facility.yearsToBuildLeft > 0;
+
+  const trend = fuel ? fuelPriceTrend(fuel, date, seed) : [];
+  const trendChange =
+    trend.length > 1 && trend[0] > 0
+      ? trend[trend.length - 1] / trend[0] - 1
+      : 0;
+
+  return (
+    <div className="facilityDetails">
+      <div className="facilityStats">
+        {underConstruction ? (
+          <Stat
+            label="Completes in"
+            value={`${Math.ceil(facility.yearsToBuildLeft * 12)} months`}
+          />
+        ) : (
+          <Stat
+            // Capacity factor is the generator's word for it; a battery isn't producing
+            // anything, it's being used or it isn't
+            label={isStorage ? "Utilization" : "Capacity factor"}
+            value={
+              lifetime.capacityFactor === undefined
+                ? "—"
+                : percent(lifetime.capacityFactor)
+            }
+          />
+        )}
+        <Stat
+          label="Cost"
+          value={
+            lifetime.costPerMWh === undefined
+              ? "—"
+              : `${formatMoneyConcise(lifetime.costPerMWh)}/MWh`
+          }
+        />
+        <Stat
+          label="Earned"
+          value={
+            lifetime.revenuePerMWh === undefined
+              ? "—"
+              : `${formatMoneyConcise(lifetime.revenuePerMWh)}/MWh`
+          }
+        />
+        <Stat
+          label="Lifetime profit"
+          value={formatMoneyConcise(lifetime.profit)}
+          tone={lifetime.profit < 0 ? "bad" : "good"}
+        />
+        <Stat label="Delivered" value={formatWattHours(lifetime.wh)} />
+        {isStorage && (
+          <Stat
+            label="Charge"
+            value={formatWattHoursOfPeak(
+              facility.currentWh,
+              (facility as StorageOperatingType).peakWh,
+            )}
+          />
+        )}
+        {isStorage && (
+          <Stat
+            label="Round trip"
+            value={percent(
+              (facility as StorageOperatingType).roundTripEfficiency,
+            )}
+          />
+        )}
+        {!isStorage && (
+          <Stat label="Nameplate" value={formatWatts(facility.peakW)} />
+        )}
+        {facility.loanAmountLeft > 0 && (
+          <Stat
+            label="Loan left"
+            value={formatMoneyConcise(facility.loanAmountLeft)}
+          />
+        )}
+        {trend.length > 1 && fuel && (
+          <div className="facilityStat">
+            <Typography variant="caption" color="textSecondary" component="div">
+              {fuel} price, {trend.length}mo
+            </Typography>
+            <div className="facilityTrend">
+              <Sparkline
+                values={trend}
+                color={accentColor}
+                ariaLabel={`${fuel} price over the last ${trend.length} months, ${trendChange >= 0 ? "up" : "down"} ${Math.abs(Math.round(trendChange * 100))} percent`}
+              />
+              <Typography
+                variant="body2"
+                component="span"
+                className={`facilityStatValue ${trendChange > 0 ? "bad" : "good"}`}
+              >
+                {trendChange >= 0 ? "+" : ""}
+                {Math.round(trendChange * 100)}%
+              </Typography>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/base/Sparkline.tsx
+++ b/src/components/base/Sparkline.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+
+/**
+ * A trend line small enough to sit inside a list row.
+ *
+ * Deliberately not a uPlot chart: the fleet list draws one of these per expanded facility, and
+ * uPlot's per-instance canvas, resize observer and cursor plugins are all overhead for a shape
+ * with no axes, no ticks and nothing to hover. An inline SVG polyline costs a string.
+ */
+
+export interface Props {
+  values: number[];
+  color: string;
+  width?: number;
+  height?: number;
+  ariaLabel: string;
+}
+
+const STROKE_WIDTH = 1.5;
+
+export default function Sparkline(props: Props): React.JSX.Element | null {
+  const { values, color, ariaLabel } = props;
+  const width = props.width || 72;
+  const height = props.height || 20;
+
+  // One point is a dot rather than a trend, and nothing to say about it
+  if (values.length < 2) {
+    return null;
+  }
+
+  let min = values[0];
+  let max = values[0];
+  values.forEach((v) => {
+    min = Math.min(min, v);
+    max = Math.max(max, v);
+  });
+  // A flat series has no range to scale against; draw it down the middle rather than dividing by
+  // zero, which is what a price that hasn't moved actually looks like
+  const span = max - min || 1;
+  // Inset by the stroke so the first and last points aren't clipped in half by the viewBox
+  const top = STROKE_WIDTH / 2;
+  const usable = height - STROKE_WIDTH;
+  const points = values
+    .map((v, i) => {
+      const x = (i / (values.length - 1)) * width;
+      const y = top + (1 - (v - min) / span) * usable;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  return (
+    <svg
+      className="sparkline"
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={ariaLabel}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke={color}
+        strokeWidth={STROKE_WIDTH}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -1,0 +1,160 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Facilities from "./Facilities";
+import { tickState } from "../../reducers/Game";
+import { createGame } from "../../testing/Simulator";
+import { FacilityOperatingType, GameType } from "../../Types";
+
+// The pane renders its own supply chart, which jsdom never lays out; nothing here waits on
+// anything, so a ceiling this high is a hang detector rather than something a loaded machine trips
+jest.setTimeout(30000);
+
+// The card chrome is connected to the store and hides its children until a game is running, none
+// of which this is about
+jest.mock("../base/GameCard", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+// `delay: null` drops the timer userEvent otherwise waits on between the events of a click
+const user = userEvent.setup({ delay: null });
+
+function playedGame(ticks: number): GameType {
+  // Carbon Fee, which starts with two generators - a fleet of one hides every row action, since
+  // there is nothing to reorder it against and nothing to fall back on if it is paused or sold
+  const state = createGame({ scenarioId: 100 });
+  for (let i = 0; i < ticks; i++) {
+    tickState(state);
+  }
+  return state;
+}
+
+interface Handlers {
+  onSelect: jest.Mock;
+  onReprioritize: jest.Mock;
+}
+
+function renderFacilities(
+  game: GameType,
+  selectedFacilityId: number | null,
+): Handlers {
+  const handlers: Handlers = {
+    onSelect: jest.fn(),
+    onReprioritize: jest.fn(),
+  };
+  render(
+    <Facilities
+      game={game}
+      selectedFacilityId={selectedFacilityId}
+      onGeneratorBuild={() => undefined}
+      onStorageBuild={() => undefined}
+      onSell={() => undefined}
+      onTogglePause={() => undefined}
+      onPause={() => undefined}
+      onReprioritize={handlers.onReprioritize}
+      onSelect={handlers.onSelect}
+    />,
+  );
+  return handlers;
+}
+
+// The row is the drag handle as well as the select target, so it is addressed by its own class
+// rather than by a role -- and asking testing-library for a role by name computes an accessible
+// name for every candidate, which over a rendered pane costs about a second a call
+function rows(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(".facilityRow"));
+}
+
+describe("the fleet list", () => {
+  // Long enough that both generators have a record worth reporting in an expanded row
+  const game = playedGame(60);
+
+  it("selects a facility when its row is clicked", async () => {
+    const { onSelect } = renderFacilities(game, null);
+    await user.click(rows()[0]);
+    expect(onSelect).toHaveBeenCalledWith(game.facilities[0].id);
+  });
+
+  it("deselects when the row that is already open is clicked again", async () => {
+    const { onSelect } = renderFacilities(game, game.facilities[0].id);
+    await user.click(rows()[0]);
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("shows what the selected facility has earned, and only that one", () => {
+    renderFacilities(game, game.facilities[0].id);
+    // One panel, not one per row -- getByText throws if a second facility opened too
+    expect(screen.getByText("Lifetime profit")).toBeInTheDocument();
+    expect(screen.getByText("Capacity factor")).toBeInTheDocument();
+    expect(screen.getByText("Cost")).toBeInTheDocument();
+    expect(screen.getByText("Earned")).toBeInTheDocument();
+  });
+
+  it("leaves every row closed when nothing is selected", () => {
+    renderFacilities(game, null);
+    expect(screen.queryByText("Lifetime profit")).toBeNull();
+  });
+
+  /**
+   * onReprioritize was declared and passed for years without the row ever calling it: dispatch
+   * order could only be changed by dragging, which is undiscoverable with a mouse and unusable
+   * once the list has scrolled.
+   */
+  it("reorders from the row's own arrows", async () => {
+    const { onReprioritize } = renderFacilities(game, null);
+    await user.click(
+      screen.getByLabelText(
+        `Move ${game.facilities[1].name} earlier in the dispatch order`,
+      ),
+    );
+    expect(onReprioritize).toHaveBeenCalledWith(1, -1);
+
+    await user.click(
+      screen.getByLabelText(
+        `Move ${game.facilities[0].name} later in the dispatch order`,
+      ),
+    );
+    expect(onReprioritize).toHaveBeenCalledWith(0, 1);
+  });
+
+  it("offers no way to move the ends of the list past themselves", () => {
+    renderFacilities(game, null);
+    const last = game.facilities.length - 1;
+    expect(
+      screen.getByLabelText(
+        `Move ${game.facilities[0].name} earlier in the dispatch order`,
+      ),
+    ).toBeDisabled();
+    expect(
+      screen.getByLabelText(
+        `Move ${game.facilities[last].name} later in the dispatch order`,
+      ),
+    ).toBeDisabled();
+  });
+
+  it("does not select the row when a row action is used", async () => {
+    const { onSelect } = renderFacilities(game, null);
+    await user.click(
+      screen.getByLabelText(
+        `Move ${game.facilities[1].name} earlier in the dispatch order`,
+      ),
+    );
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("hides the player's controls while a replay is being watched", () => {
+    const replay = {
+      ...game,
+      replayPlayback: { actions: [], index: 0 },
+    } as GameType;
+    renderFacilities(replay, null);
+    game.facilities.forEach((f: FacilityOperatingType) => {
+      expect(
+        screen.queryByLabelText(`Move ${f.name} earlier in the dispatch order`),
+      ).toBeNull();
+    });
+  });
+});

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -25,6 +25,8 @@ import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 import PowerSettingsNewIcon from "@mui/icons-material/PowerSettingsNew";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import {
   DragDropContext,
   Draggable,
@@ -49,12 +51,16 @@ import {
   formatWattsOfPeak,
 } from "../../helpers/Format";
 import ChartSupplyDemand from "../base/ChartSupplyDemand";
+import FacilityDetails from "../base/FacilityDetails";
 import GameCard from "../base/GameCard";
 
 interface FacilityListItemProps {
   facility: FacilityOperatingType;
   spotInList: number;
   listLength: number;
+  game: GameType;
+  selected: boolean;
+  onSelect: (id: FacilityOperatingType["id"] | null) => void;
   // A replay is a recording of somebody else's decisions; letting the viewer make their own
   // would desync the run from the actions still queued up against it
   readOnly: boolean;
@@ -114,7 +120,17 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
     setOpen(!open);
   };
 
-  const { facility, onTogglePause, onPause, readOnly } = props;
+  const {
+    facility,
+    game,
+    onTogglePause,
+    onPause,
+    onReprioritize,
+    onSelect,
+    readOnly,
+    selected,
+    spotInList,
+  } = props;
   const underConstruction = facility.yearsToBuildLeft > 0;
   const isStorage = facility.peakWh > 0;
 
@@ -164,10 +180,26 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
       isDragDisabled={readOnly}
     >
       {(provided, snapshot) => (
+        // Selecting is on the row rather than on a control inside it: the icon buttons were
+        // the only thing a click did anything to, which is the opposite of what a list of
+        // rows leads a mouse to expect. dragHandleProps already makes this focusable and
+        // announces it as a button, so only a read-only row - which gets none of them - has
+        // to say so itself. dnd owns Space (lift) and the arrows (move), leaving Enter free
         <div
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
+          className={selected ? "facilityRow selected" : "facilityRow"}
+          role={provided.dragHandleProps ? undefined : "button"}
+          tabIndex={provided.dragHandleProps ? undefined : 0}
+          aria-expanded={selected}
+          onClick={() => onSelect(selected ? null : facility.id)}
+          onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onSelect(selected ? null : facility.id);
+            }
+          }}
           style={getDraggableStyle(
             snapshot.isDragging,
             provided.draggableProps.style,
@@ -183,55 +215,104 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                 : undefined
             }
             secondaryAction={
-              <>
+              // Hidden until the row is hovered, focused or selected (desktop only - see
+              // app.scss), because a permanent cluster of buttons takes the width the numbers
+              // below want. Each one stops its click short of the row, which would otherwise
+              // read the same click as "select this facility" on the way past
+              <span className="facilityActions">
+                {!readOnly && props.listLength > 1 && (
+                  <>
+                    {/* Dispatch order is a core mechanic, and dragging was the only way to set
+                        it - undiscoverable with a mouse, and unusable once the list has
+                        scrolled. These move one place at a time, the way a drag does */}
+                    <IconButton
+                      onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        onReprioritize(spotInList, -1);
+                      }}
+                      aria-label={`Move ${facility.name} earlier in the dispatch order`}
+                      disabled={spotInList === 0}
+                      edge="end"
+                      color="primary"
+                      size="small"
+                    >
+                      <KeyboardArrowUpIcon />
+                    </IconButton>
+                    <IconButton
+                      onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        onReprioritize(spotInList, 1);
+                      }}
+                      aria-label={`Move ${facility.name} later in the dispatch order`}
+                      disabled={spotInList === props.listLength - 1}
+                      edge="end"
+                      color="primary"
+                      size="small"
+                    >
+                      <KeyboardArrowDownIcon />
+                    </IconButton>
+                  </>
+                )}
                 {!readOnly &&
                   !underConstruction &&
                   props.listLength > 1 &&
                   !facility.paused && (
                     <IconButton
-                      onClick={() => onPause(facility.id, facility.name)}
+                      onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        onPause(facility.id, facility.name);
+                      }}
                       aria-label={`Pause ${facility.name}`}
                       edge="end"
                       color="primary"
-                      size="large"
+                      size="small"
                     >
                       <PauseIcon />
                     </IconButton>
                   )}
                 {!readOnly && facility.paused && (
                   <IconButton
-                    onClick={() => onTogglePause(facility.id)}
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      onTogglePause(facility.id);
+                    }}
                     aria-label={`Resume ${facility.name}`}
                     edge="end"
                     color="primary"
-                    size="large"
+                    size="small"
                   >
                     <PlayIcon />
                   </IconButton>
                 )}
                 {!readOnly && !underConstruction && props.listLength > 1 && (
                   <IconButton
-                    onClick={toggleDialog}
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      toggleDialog();
+                    }}
                     aria-label={`Sell ${facility.name}`}
                     edge="end"
                     color="primary"
-                    size="large"
+                    size="small"
                   >
                     <DeleteForeverIcon />
                   </IconButton>
                 )}
                 {!readOnly && underConstruction && (
                   <IconButton
-                    onClick={toggleDialog}
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      toggleDialog();
+                    }}
                     aria-label={`Cancel construction of ${facility.name}`}
                     edge="end"
                     color="primary"
-                    size="large"
+                    size="small"
                   >
                     <CancelIcon />
                   </IconButton>
                 )}
-              </>
+              </span>
             }
           >
             {!readOnly && (
@@ -279,7 +360,13 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
             </ListItemAvatar>
             <ListItemText primary={facility.name} secondary={secondaryText} />
             {open && (
-              <Dialog open onClose={toggleDialog}>
+              // Inside the row, so without this every click in the confirmation dialog also
+              // lands on the row behind it and toggles the selection
+              <Dialog
+                open
+                onClose={toggleDialog}
+                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+              >
                 <DialogTitle>
                   {underConstruction ? "Cancel construction of" : "Sell"}{" "}
                   {facility.peakWh
@@ -316,6 +403,13 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
               </Dialog>
             )}
           </ListItem>
+          {selected && (
+            <FacilityDetails
+              facility={facility}
+              date={game.date}
+              seed={game.seed}
+            />
+          )}
         </div>
       )}
     </Draggable>
@@ -324,6 +418,9 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
 
 export interface StateProps {
   game: GameType;
+  // The row the player has open, from the UI slice rather than this component's own state:
+  // Finances and Forecasts read it too, and building a facility unmounts this pane
+  selectedFacilityId: number | null;
 }
 
 export interface DispatchProps {
@@ -332,6 +429,7 @@ export interface DispatchProps {
   onTogglePause: (id: FacilityOperatingType["id"]) => void;
   onPause: (id: FacilityOperatingType["id"], name: string) => void;
   onReprioritize: (spotInList: number, delta: number) => void;
+  onSelect: (id: FacilityOperatingType["id"] | null) => void;
   onStorageBuild: () => void;
 }
 
@@ -350,7 +448,13 @@ export default class Facilities extends React.Component<Props, {}> {
   // same render is 3.6ms, so 1 in 2 refreshes the pane four times as often and still costs less
   // per tick than the old setting did.
   public shouldComponentUpdate(nextProps: Props) {
-    if (nextProps.game.speed !== "FAST") {
+    // Opening a row is something the player just did, not something the clock did, so it
+    // goes through whatever the throttle is up to - otherwise the row waits for the next
+    // unskipped frame, and at FAST that reads as a click that missed
+    if (
+      nextProps.game.speed !== "FAST" ||
+      nextProps.selectedFacilityId !== this.props.selectedFacilityId
+    ) {
       return true;
     }
     return this.throttle.due(nextProps.game.date.minute, 2);
@@ -380,7 +484,9 @@ export default class Facilities extends React.Component<Props, {}> {
       onTogglePause,
       onPause,
       onReprioritize,
+      onSelect,
       onStorageBuild,
+      selectedFacilityId,
     } = this.props;
     const facilitiesCount = game.facilities.length;
     const readOnly = !!game.replayPlayback;
@@ -432,11 +538,14 @@ export default class Facilities extends React.Component<Props, {}> {
                     (g: FacilityOperatingType, i: number) => (
                       <FacilityListItem
                         facility={g}
+                        game={game}
                         key={g.id}
                         onSell={onSell}
                         onTogglePause={onTogglePause}
                         onPause={onPause}
                         onReprioritize={onReprioritize}
+                        onSelect={onSelect}
+                        selected={selectedFacilityId === g.id}
                         spotInList={i}
                         listLength={facilitiesCount}
                         readOnly={readOnly}

--- a/src/components/views/FacilitiesContainer.tsx
+++ b/src/components/views/FacilitiesContainer.tsx
@@ -6,13 +6,14 @@ import {
   togglePauseFacility,
   reprioritizeFacility,
 } from "../../reducers/Game";
-import { snackbarOpen } from "../../reducers/UI";
+import { selectFacility, snackbarOpen } from "../../reducers/UI";
 import { AppStateType } from "../../Types";
 import Facilities, { DispatchProps, StateProps } from "./Facilities";
 
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
     game: state.game,
+    selectedFacilityId: state.ui.selectedFacilityId,
   };
 };
 
@@ -22,6 +23,9 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
       dispatch(navigate({ name: "BUILD_GENERATORS", dontRemember: true }));
     },
     onSell: (id) => {
+      // Ids are handed out monotonically, so a stale selection can't come back to life on a
+      // later facility - but a pane still shouldn't go on reporting one that isn't there
+      dispatch(selectFacility(null));
       dispatch(sellFacility(id));
     },
     onTogglePause: (id) => {
@@ -41,6 +45,9 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     },
     onReprioritize: (spotInList: number, delta: number) => {
       dispatch(reprioritizeFacility({ spotInList, delta }));
+    },
+    onSelect: (id) => {
+      dispatch(selectFacility(id));
     },
     onStorageBuild: () => {
       dispatch(navigate({ name: "BUILD_STORAGE", dontRemember: true }));

--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { produce } from "immer";
-import Finances, { parseRange, projectMonths } from "./Finances";
+import Finances, { getComparison, parseRange, projectMonths } from "./Finances";
 import { createGame } from "../../testing/Simulator";
 import { tickState } from "../../reducers/Game";
 import { MINUTES_PER_MONTH, summarizeTimeline } from "../../helpers/DateTime";
@@ -81,9 +81,17 @@ function playMonths(months: number): GameType {
   return state;
 }
 
-function renderFinances(game: GameType, speed: SpeedType) {
+function renderFinances(
+  game: GameType,
+  speed: SpeedType,
+  selectedFacilityId: number | null = null,
+) {
   return render(
-    <Finances game={{ ...game, speed }} onDelta={() => undefined} />,
+    <Finances
+      game={{ ...game, speed }}
+      selectedFacilityId={selectedFacilityId}
+      onDelta={() => undefined}
+    />,
   );
 }
 
@@ -312,5 +320,114 @@ describe("projectMonths", () => {
       Math.floor(game.timeline[0].minute / MINUTES_PER_MONTH),
     );
     expect(months[0].month).toEqual(game.date.monthNumber);
+  });
+});
+
+/**
+ * The change column, which is what turns a table of totals into something scannable: a
+ * profit of "-$51.4K" says nothing on its own about whether the company is recovering.
+ */
+describe("the month over month column", () => {
+  const game = playMonths(26);
+
+  // The change sits in the row's third cell, past the label and the period total. Both role
+  // queries go without a `name`, which is what keeps them cheap over a table this size
+  function changeCell(label: string): HTMLElement {
+    const row = screen
+      .getAllByRole("row")
+      .find((r: HTMLElement) =>
+        r.textContent?.startsWith(label),
+      ) as HTMLElement;
+    return within(row).getAllByRole("cell")[2];
+  }
+
+  function toneOf(label: string): string {
+    const cell = changeCell(label);
+    if (cell.className.includes("good")) {
+      return "good";
+    }
+    return cell.className.includes("bad") ? "bad" : "flat";
+  }
+
+  /**
+   * The game with a two month record of its own making, so a test can say which way a
+   * number moved instead of asking the simulation what it happened to do.
+   */
+  function withChange(changes: Partial<MonthlyHistoryType>): GameType {
+    const previous = game.monthlyHistory[1];
+    return {
+      ...game,
+      // Newest first, the order the game itself keeps
+      monthlyHistory: [{ ...previous, ...changes }, previous],
+    };
+  }
+
+  it("compares the month just closed against the one before it", () => {
+    const comparison = getComparison(game);
+    const [latest, previous] = game.monthlyHistory;
+    expect(comparison).toBeDefined();
+    expect(comparison?.label).toBeTruthy();
+    expect(comparison?.current.revenue).toEqual(latest.revenue);
+    expect(comparison?.previous.revenue).toEqual(previous.revenue);
+  });
+
+  it("has nothing to compare against in a company's first month", () => {
+    const newborn = createGame({ scenarioId: 100 });
+    expect(newborn.monthlyHistory).toHaveLength(0);
+    expect(getComparison(newborn)).toBeUndefined();
+    // And one month on the record is still one month short of a comparison
+    expect(
+      getComparison({
+        ...newborn,
+        monthlyHistory: [game.monthlyHistory[0]],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("puts the change beside each total once there are two months on the record", () => {
+    renderFinances(game, "PAUSED");
+    const comparison = getComparison(game);
+    expect(screen.getByText(comparison?.label || "")).toBeInTheDocument();
+    // Every metric gets one, even if it is the em dash that means it hasn't moved
+    expect(changeCell("Profit").textContent).not.toEqual("");
+    expect(changeCell("Revenue").textContent).not.toEqual("");
+  });
+
+  // Both point up, so the arrow alone can't tell these apart -- and colouring a rise in
+  // spending the same green as a rise in earnings would be exactly backwards
+  it("reads a rise in revenue as good news and a rise in an expense as bad", () => {
+    renderFinances(withChange({ revenue: 0 }), "PAUSED");
+    expect(toneOf("Revenue")).toEqual("bad");
+
+    cleanup();
+    const previous = game.monthlyHistory[1];
+    renderFinances(
+      withChange({
+        revenue: previous.revenue * 1.5,
+        expensesFuel: previous.expensesFuel * 1.5,
+      }),
+      "PAUSED",
+    );
+    expect(toneOf("Revenue")).toEqual("good");
+    expect(toneOf("Fuel")).toEqual("bad");
+    expect(toneOf("Expenses")).toEqual("bad");
+  });
+
+  it("says nothing about a month that came in where the last one did", () => {
+    renderFinances(withChange({}), "PAUSED");
+    expect(toneOf("Revenue")).toEqual("flat");
+    expect(changeCell("Revenue").textContent).toEqual("—");
+  });
+
+  it("reports what a selected facility has contributed, and nothing when none is", () => {
+    renderFinances(game, "PAUSED", null);
+    expect(screen.queryByText(/of your fleet/)).toBeNull();
+
+    cleanup();
+    renderFinances(game, "PAUSED", game.facilities[0].id);
+    expect(
+      screen.getByText(game.facilities[0].name, { selector: "strong" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/of your fleet/)).toBeInTheDocument();
   });
 });

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -7,13 +7,14 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableHead,
   TableRow,
   Toolbar,
   Typography,
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
-import { TICKS_PER_MONTH } from "../../Constants";
+import { MONTHS, TICKS_PER_MONTH } from "../../Constants";
 import { TickThrottle } from "../../helpers/RenderThrottle";
 import {
   deriveExpandedSummary,
@@ -24,10 +25,14 @@ import {
   summarizeTimeline,
   summarizeTimelineByMonth,
 } from "../../helpers/DateTime";
-import { customersFromMarketingSpend } from "../../helpers/Financials";
+import {
+  customersFromMarketingSpend,
+  facilityLifetime,
+} from "../../helpers/Financials";
 import {
   formatMoneyConcise,
   formatMoneyStable,
+  formatWattHours,
   formatWatts,
 } from "../../helpers/Format";
 import {
@@ -40,6 +45,8 @@ import { MANUAL_ENTRY } from "../../data/Manual";
 import ManualLink from "../base/ManualLink";
 import {
   DerivedHistoryKeysType,
+  DerivedHistoryType,
+  FacilityOperatingType,
   GameType,
   MonthlyHistoryType,
   UnitSystemType,
@@ -63,6 +70,12 @@ interface ChartKeyMetadataType {
   formatTable?: (n: number) => number | string; // if different than chart formatting
   suffix?: string;
   nesting?: number; // default 0 / unnested
+  /**
+   * Which direction of the change column is good news, so the arrow can be coloured. Left
+   * unset for the metrics that are neither: marketing spend is a decision rather than a
+   * result, and inflation is weather. Those get an arrow with no colour on it.
+   */
+  higherIsBetter?: boolean;
 }
 
 // Two tables rather than one built per render: the labels are the same either way, and only
@@ -73,11 +86,13 @@ function buildChartKeys(units: UnitSystemType): {
   return {
     profit: {
       label: "Profit",
+      higherIsBetter: true,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
     },
     profitPerkWh: {
       label: "Unit profit",
+      higherIsBetter: true,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
       suffix: "/kWh",
@@ -85,11 +100,13 @@ function buildChartKeys(units: UnitSystemType): {
     },
     revenue: {
       label: "Revenue",
+      higherIsBetter: true,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
     },
     revenuePerkWh: {
       label: "Unit revenue",
+      higherIsBetter: true,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
       suffix: "/kWh",
@@ -97,31 +114,37 @@ function buildChartKeys(units: UnitSystemType): {
     },
     supplyWh: {
       label: "Power sold",
+      higherIsBetter: true,
       format: (n: number) => `${formatWatts(n, 0)}h`,
       nesting: 1,
     },
     demandWh: {
       label: "Demand",
+      higherIsBetter: true,
       format: (n: number) => `${formatWatts(n, 0)}h`,
     },
     customers: {
       label: "Customers",
+      higherIsBetter: true,
       format: (n: number) => numbro(n).format({ average: true }),
       nesting: 1,
     },
     expenses: {
       label: "Expenses",
+      higherIsBetter: false,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
     },
     expensesFuel: {
       label: "Fuel",
+      higherIsBetter: false,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
       nesting: 1,
     },
     expensesOM: {
       label: "Operations",
+      higherIsBetter: false,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
       nesting: 1,
@@ -134,29 +157,34 @@ function buildChartKeys(units: UnitSystemType): {
     },
     expensesInterest: {
       label: "Loan interest",
+      higherIsBetter: false,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
       nesting: 1,
     },
     interestRate: {
       label: "Interest rate",
+      higherIsBetter: false,
       format: (n: number) => `${(n * 100).toFixed(2)}%`,
       nesting: 2,
     },
     expensesCarbonFee: {
       label: "Carbon fees",
+      higherIsBetter: false,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
       nesting: 1,
     },
     kgco2e: {
       label: "CO2e emitted",
+      higherIsBetter: false,
       format: (n: number) => formatLargeMassValue(n, units),
       suffix: largeMassUnit(units),
       nesting: 2,
     },
     kgco2ePerMWh: {
       label: "Emissions factor",
+      higherIsBetter: false,
       format: (n: number) =>
         numbro(toDisplayMass(n, units)).format({
           thousandSeparated: true,
@@ -167,11 +195,13 @@ function buildChartKeys(units: UnitSystemType): {
     },
     netWorth: {
       label: "Net Worth",
+      higherIsBetter: true,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
     },
     cash: {
       label: "Cash",
+      higherIsBetter: true,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
       nesting: 1,
@@ -300,6 +330,9 @@ export function projectMonths(
 
 export interface StateProps {
   game: GameType;
+  // Set from the fleet list. When it names a facility, this pane reports what that one has
+  // contributed rather than only what the company as a whole has
+  selectedFacilityId: number | null;
 }
 
 export interface DispatchProps {
@@ -319,6 +352,76 @@ interface ChartPointType {
   year: number;
   value: number;
   projected: boolean;
+}
+
+/**
+ * The change column: the month just closed, against the one before it.
+ *
+ * A month rather than the period the rest of the table is totalled over, because a period
+ * total has no honest predecessor while it is still being played -- ten months of this year
+ * against twelve of last year is a fall in everything every time. Two whole months are always
+ * the same length as each other, so the arrow only ever means what it says, and the header
+ * names them both rather than leaving the column to be read as "vs the number on its left".
+ */
+interface ComparisonType {
+  label: string;
+  current: DerivedHistoryType;
+  previous: DerivedHistoryType;
+}
+
+export function getComparison(game: GameType): ComparisonType | undefined {
+  // monthlyHistory is newest first, and only holds months that have finished
+  const [latest, previous] = game.monthlyHistory;
+  if (!latest || !previous) {
+    return undefined;
+  }
+  return {
+    label: `${MONTHS[latest.month - 1]} vs ${MONTHS[previous.month - 1]}`,
+    current: deriveExpandedSummary(latest),
+    previous: deriveExpandedSummary(previous),
+  };
+}
+
+// How small a change counts as no change. Relative, because these run from fractions of a
+// percent to hundreds of millions of dollars, and an arrow on a rounding error is noise
+const FLAT_FRACTION = 0.005;
+
+interface DeltaCellProps {
+  metadata: ChartKeyMetadataType;
+  value: number;
+  previous: number;
+}
+
+function DeltaCell(props: DeltaCellProps): React.JSX.Element {
+  const { metadata, value, previous } = props;
+  const delta = value - previous;
+  const format = metadata.formatTable || metadata.format;
+  const reference = Math.max(Math.abs(value), Math.abs(previous));
+  if (!Number.isFinite(delta) || Math.abs(delta) <= reference * FLAT_FRACTION) {
+    return (
+      <TableCell align="right" className="deltaCell flat">
+        —
+      </TableCell>
+    );
+  }
+  const up = delta > 0;
+  // Colour is the second reading of the arrow, not the only one: an expense going up and
+  // revenue going up both point up, and only one of them is good news
+  const good =
+    metadata.higherIsBetter === undefined
+      ? undefined
+      : up === metadata.higherIsBetter;
+  const tone = good === undefined ? "" : good ? " good" : " bad";
+  return (
+    <TableCell align="right" className={"deltaCell" + tone}>
+      {up ? (
+        <ArrowDropUpIcon className="deltaArrow" />
+      ) : (
+        <ArrowDropDownIcon className="deltaArrow" />
+      )}
+      {format(Math.abs(delta))}
+    </TableCell>
+  );
 }
 
 // -1:0 -> 0:$100k, each tick increments the front number - when it overflows, instead add a 0 (i.e. 1->2M, 9->10M, 10->20M)
@@ -403,7 +506,13 @@ export default class Finances extends React.Component<Props, State> {
   // that does nothing, and if the clock has stopped (a scenario that has ended, a backgrounded
   // tab) it never comes round at all.
   public shouldComponentUpdate(nextProps: Props, nextState: State) {
-    if (nextState !== this.state || nextProps.game.speed !== "FAST") {
+    if (
+      nextState !== this.state ||
+      nextProps.game.speed !== "FAST" ||
+      // Selecting a facility in the fleet list is the same kind of direct request the
+      // dropdowns below are, and gets the same exemption
+      nextProps.selectedFacilityId !== this.props.selectedFacilityId
+    ) {
       return true;
     }
     return this.throttle.due(nextProps.game.date.minute, 2);
@@ -554,7 +663,7 @@ export default class Finances extends React.Component<Props, State> {
   }
 
   public render() {
-    const { game, onDelta } = this.props;
+    const { game, onDelta, selectedFacilityId } = this.props;
     const chartKeys = CHART_KEYS_BY_SYSTEM[this.context as UnitSystemType];
     const { startingYear, timeline, date } = game;
     const { expanded, chartKey } = this.state;
@@ -602,10 +711,49 @@ export default class Finances extends React.Component<Props, State> {
     const summary = deriveExpandedSummary(
       summaryMonths.reduce(reduceHistories, { ...EMPTY_HISTORY }),
     );
+    const comparison = getComparison(game);
+
+    // What the one facility the player has open has contributed. Its share is measured
+    // against the fleet's own delivered total rather than against the company's recorded
+    // sales, so the two numbers are the same kind of thing and the shares add to 100%
+    const selectedFacility = game.facilities.find(
+      (f: FacilityOperatingType) => f.id === selectedFacilityId,
+    );
+    const selectedLifetime =
+      selectedFacility && facilityLifetime(selectedFacility);
+    const fleetWh = game.facilities.reduce(
+      (sum: number, f: FacilityOperatingType) => sum + (f.lifetimeWh || 0),
+      0,
+    );
 
     return (
       <GameCard className="finances" title="Finances" id="financesPane">
         <div className="scrollable">
+          {selectedFacility && selectedLifetime && (
+            // The other half of clicking a row in the fleet list: the stack in Forecasts
+            // says which power is this facility's, and this says which money is
+            <div className="selectedFacilitySummary">
+              <Typography variant="body2" component="div">
+                <strong>{selectedFacility.name}</strong> has delivered{" "}
+                {formatWattHours(selectedLifetime.wh)}
+                {fleetWh > 0 &&
+                  ` (${Math.round((selectedLifetime.wh / fleetWh) * 100)}% of your fleet)`}
+              </Typography>
+              <Typography variant="body2" color="textSecondary" component="div">
+                {formatMoneyConcise(selectedLifetime.revenue)} earned,{" "}
+                {formatMoneyConcise(selectedLifetime.expenses)} spent,{" "}
+                <span
+                  className={
+                    selectedLifetime.profit < 0
+                      ? "deltaCell bad"
+                      : "deltaCell good"
+                  }
+                >
+                  {formatMoneyConcise(selectedLifetime.profit)} profit
+                </span>
+              </Typography>
+            </div>
+          )}
           <br />
           <Toolbar>
             {scenario.ownership === "Investor" && (
@@ -764,7 +912,19 @@ export default class Finances extends React.Component<Props, State> {
             className={`expandable ${!expanded && "notExpanded"}`}
             onClick={() => this.setExpand(!expanded)}
           >
-            <Table size="small">
+            <Table size="small" className="summaryTable">
+              {/* Two numbers a row rather than one: a total on its own says nothing about
+                  whether it is heading the right way, which is the question the table is
+                  actually being read for */}
+              {comparison && (
+                <TableHead>
+                  <TableRow>
+                    <TableCell />
+                    <TableCell />
+                    <TableCell align="right">{comparison.label}</TableCell>
+                  </TableRow>
+                </TableHead>
+              )}
               <TableBody>
                 {CHART_KEY_NAMES.map((key: string) => {
                   const k = chartKeys[key];
@@ -784,6 +944,17 @@ export default class Finances extends React.Component<Props, State> {
                           </span>
                         )}
                       </TableCell>
+                      {comparison && (
+                        <DeltaCell
+                          metadata={k}
+                          value={
+                            comparison.current[key as DerivedHistoryKeysType]
+                          }
+                          previous={
+                            comparison.previous[key as DerivedHistoryKeysType]
+                          }
+                        />
+                      )}
                     </TableRow>
                   );
                 })}

--- a/src/components/views/FinancesContainer.tsx
+++ b/src/components/views/FinancesContainer.tsx
@@ -7,6 +7,7 @@ import Finances, { DispatchProps, StateProps } from "./Finances";
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
     game: state.game,
+    selectedFacilityId: state.ui.selectedFacilityId,
   };
 };
 

--- a/src/components/views/Forecasts.tsx
+++ b/src/components/views/Forecasts.tsx
@@ -11,7 +11,12 @@ import {
   Typography,
 } from "@mui/material";
 import { TICKS_PER_YEAR } from "../../Constants";
-import { FuelNameType, GameType, TickPresentFutureType } from "../../Types";
+import {
+  FuelNameType,
+  GameType,
+  GeneratorOperatingType,
+  TickPresentFutureType,
+} from "../../Types";
 import {
   formatHour,
   getDateFromMinute,
@@ -51,6 +56,8 @@ interface BlackoutEdges {
 
 export interface StateProps {
   game: GameType;
+  // Which facility the fleet list has open, so Supply by Fuel can say which band is its
+  selectedFacilityId: number | null;
 }
 
 export interface DispatchProps {}
@@ -77,15 +84,18 @@ export default class Forecasts extends React.Component<Props, State> {
   }
 
   public shouldComponentUpdate(nextProps: Props, nextState: State) {
-    // Because forecasts are computationally intense and long term, only update when the month or state changes
+    // Because forecasts are computationally intense and long term, only update when the
+    // month or state changes -- plus when the player selects a facility, which is a direct
+    // request to re-highlight the stack and would otherwise wait for a month rollover
     return (
       this.props.game.date.monthNumber !== nextProps.game.date.monthNumber ||
+      this.props.selectedFacilityId !== nextProps.selectedFacilityId ||
       this.state.years !== nextState.years
     );
   }
 
   public render() {
-    const { game } = this.props;
+    const { game, selectedFacilityId } = this.props;
     const { years } = this.state;
     const now = getTimeFromTimeline(game.date.minute, game.timeline);
     if (!now) {
@@ -209,6 +219,16 @@ export default class Forecasts extends React.Component<Props, State> {
       sampledForecastedTimeline,
     );
 
+    // Storage has no band of its own in this chart, so selecting a battery highlights
+    // nothing rather than emptying the stack
+    const selected = game.facilities.find(
+      (f) => f.id === selectedFacilityId,
+    ) as Partial<GeneratorOperatingType> | undefined;
+    const highlightFuel =
+      selected && selected.fuel && fuels.indexOf(selected.fuel) > -1
+        ? selected.fuel
+        : undefined;
+
     return (
       <GameCard className="Forecasts" title="Forecasts" id="forecastsPane">
         <div className="scrollable">
@@ -284,9 +304,11 @@ export default class Forecasts extends React.Component<Props, State> {
             <ChartLegend
               inline
               items={[
-                ...[...fuels]
-                  .reverse()
-                  .map((f) => ({ name: f, color: fuelColors[f] })),
+                ...[...fuels].reverse().map((f) => ({
+                  name: f,
+                  color: fuelColors[f],
+                  muted: !!highlightFuel && f !== highlightFuel,
+                })),
                 { name: "Demand", color: "", rule: true },
               ]}
             />
@@ -300,6 +322,7 @@ export default class Forecasts extends React.Component<Props, State> {
             fuels={fuels}
             showXLabels={false}
             syncKey={FORECAST_SYNC_KEY}
+            highlightFuel={highlightFuel}
           />
           {hasStorage && (
             <div>

--- a/src/components/views/ForecastsContainer.tsx
+++ b/src/components/views/ForecastsContainer.tsx
@@ -5,6 +5,7 @@ import Forecasts, { StateProps } from "./Forecasts";
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
     game: state.game,
+    selectedFacilityId: state.ui.selectedFacilityId,
   };
 };
 

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -2,6 +2,7 @@ import {
   customersFromMarketingSpend,
   CreditInputsType,
   facilityCashBack,
+  facilityLifetime,
   getCompanyInterestRate,
   getCreditInputs,
   getCreditPremium,
@@ -356,5 +357,49 @@ describe("getCreditInputs", () => {
       aFacility({ loanAmountLeft: 1000 }),
     ]);
     expect(inputs.debtToCapital).toBeCloseTo(0.5, 10);
+  });
+});
+
+describe("facilityLifetime", () => {
+  // A megawatt hour, in the watt hours the simulation counts in
+  const MWH = 1000000;
+
+  it("reports nothing rather than a division by zero on a facility that has never run", () => {
+    const lifetime = facilityLifetime(aFacility());
+    expect(lifetime.wh).toBe(0);
+    expect(lifetime.profit).toBe(0);
+    expect(lifetime.capacityFactor).toBeUndefined();
+    expect(lifetime.costPerMWh).toBeUndefined();
+    expect(lifetime.revenuePerMWh).toBeUndefined();
+  });
+
+  it("reads the totals the simulation keeps on the facility", () => {
+    const lifetime = facilityLifetime(
+      aFacility({
+        lifetimeWh: 100 * MWH,
+        lifetimePotentialWh: 400 * MWH,
+        lifetimeRevenue: 7000,
+        lifetimeExpenses: 4500,
+      }),
+    );
+    expect(lifetime.capacityFactor).toBeCloseTo(0.25, 10);
+    expect(lifetime.costPerMWh).toBeCloseTo(45, 10);
+    expect(lifetime.revenuePerMWh).toBeCloseTo(70, 10);
+    expect(lifetime.profit).toBeCloseTo(2500, 10);
+  });
+
+  // A plant that has been switched off all year has a real capacity factor of zero, and a
+  // cost per MWh that genuinely isn't a number - those are two different answers
+  it("quotes a capacity factor for a plant that has produced nothing, but no unit cost", () => {
+    const lifetime = facilityLifetime(
+      aFacility({
+        lifetimeWh: 0,
+        lifetimePotentialWh: 400 * MWH,
+        lifetimeExpenses: 4500,
+      }),
+    );
+    expect(lifetime.capacityFactor).toBe(0);
+    expect(lifetime.costPerMWh).toBeUndefined();
+    expect(lifetime.profit).toBeCloseTo(-4500, 10);
   });
 });

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -162,6 +162,44 @@ export function LCWH(
   return costPerWh;
 }
 
+/**
+ * What a facility has actually done for the company, read off the totals the simulation keeps on
+ * it. Every field is derived here rather than stored, so the only thing a save has to carry is
+ * the four running sums.
+ *
+ * capacityFactor is undefined until the plant has been online long enough to have one, and
+ * costPerMWh until it has delivered something -- a plant that has produced nothing has a cost per
+ * MWh of infinity, which is a true statement that no row should try to render.
+ */
+export interface FacilityLifetimeType {
+  wh: number;
+  revenue: number;
+  expenses: number;
+  profit: number;
+  capacityFactor?: number; // 0 - 1
+  costPerMWh?: number;
+  revenuePerMWh?: number;
+}
+
+export function facilityLifetime(
+  f: FacilityOperatingType,
+): FacilityLifetimeType {
+  const wh = f.lifetimeWh || 0;
+  const revenue = f.lifetimeRevenue || 0;
+  const expenses = f.lifetimeExpenses || 0;
+  const potentialWh = f.lifetimePotentialWh || 0;
+  const mwh = wh / 1000000;
+  return {
+    wh,
+    revenue,
+    expenses,
+    profit: revenue - expenses,
+    capacityFactor: potentialWh > 0 ? wh / potentialWh : undefined,
+    costPerMWh: mwh > 0 ? expenses / mwh : undefined,
+    revenuePerMWh: mwh > 0 ? revenue / mwh : undefined,
+  };
+}
+
 // Returns how much cash the user recieves if they sell / cancel the facility
 export function facilityCashBack(g: FacilityOperatingType): number {
   // Refund slightly more if construction isn't complete - after all, that money hasn't been spent yet

--- a/src/reducers/FacilityLifetime.test.tsx
+++ b/src/reducers/FacilityLifetime.test.tsx
@@ -1,0 +1,126 @@
+import cloneDeep from "lodash.clonedeep";
+import gameReducer, {
+  generateNewTimeline,
+  tickState,
+  togglePauseFacility,
+} from "./Game";
+import { TICKS_PER_DAY, TICKS_PER_MONTH } from "../Constants";
+import { facilityLifetime } from "../helpers/Financials";
+import { getTimeFromTimeline } from "../helpers/DateTime";
+import { createGame } from "../testing/Simulator";
+import { FacilityOperatingType, GameType } from "../Types";
+
+/**
+ * The running totals each facility keeps about itself, which is what lets the fleet list report
+ * a capacity factor and a lifetime profit per row rather than only a nameplate.
+ *
+ * The thing worth guarding here isn't the arithmetic, it's what counts as a tick of a facility's
+ * life: forecasts run the same simulation code against a clone of the fleet, dozens of times a
+ * second and up to twenty years at a time, and none of that ever happened.
+ */
+
+function play(state: GameType, ticks: number): GameType {
+  for (let i = 0; i < ticks; i++) {
+    tickState(state);
+  }
+  return state;
+}
+
+function totals(f: FacilityOperatingType) {
+  return {
+    wh: f.lifetimeWh,
+    potentialWh: f.lifetimePotentialWh,
+    revenue: f.lifetimeRevenue,
+    expenses: f.lifetimeExpenses,
+  };
+}
+
+describe("per-facility lifetime totals", () => {
+  it("starts a facility with nothing on its record", () => {
+    const state = createGame({ scenarioId: 103 });
+    state.facilities.forEach((f: FacilityOperatingType) => {
+      const lifetime = facilityLifetime(f);
+      expect(lifetime.wh).toBe(0);
+      expect(lifetime.profit).toBe(0);
+      // Nothing delivered means no cost per MWh to quote, rather than a division by zero
+      expect(lifetime.costPerMWh).toBeUndefined();
+      expect(lifetime.capacityFactor).toBeUndefined();
+    });
+  });
+
+  it("accrues output, revenue and costs as the game ticks", () => {
+    const state = play(createGame({ scenarioId: 103 }), TICKS_PER_DAY);
+    const generator = state.facilities.find(
+      (f: FacilityOperatingType) => f.fuel,
+    ) as FacilityOperatingType;
+
+    const lifetime = facilityLifetime(generator);
+    expect(lifetime.wh).toBeGreaterThan(0);
+    expect(lifetime.revenue).toBeGreaterThan(0);
+    expect(lifetime.expenses).toBeGreaterThan(0);
+    expect(lifetime.profit).toBeCloseTo(
+      lifetime.revenue - lifetime.expenses,
+      6,
+    );
+    // A capacity factor is a fraction of flat-out, so it can reach 1 but never pass it
+    expect(lifetime.capacityFactor).toBeGreaterThan(0);
+    expect(lifetime.capacityFactor).toBeLessThanOrEqual(1);
+  });
+
+  it("never books more than one company's revenue across the fleet", () => {
+    const booked = (state: GameType) =>
+      state.facilities.reduce(
+        (sum: number, f: FacilityOperatingType) =>
+          sum + (f.lifetimeRevenue || 0),
+        0,
+      );
+
+    const state = createGame({ scenarioId: 103 });
+    // The first tick of a fresh game rolls the month over, which replaces the timeline with a
+    // new forecast -- so the tick that was just played is no longer on the record to compare
+    // against. Start measuring from the one after it, and stop short of the next rollover
+    tickState(state);
+    const opening = booked(state);
+
+    let earned = 0;
+    for (let i = 0; i < TICKS_PER_MONTH - 3; i++) {
+      tickState(state);
+      const now = getTimeFromTimeline(state.date.minute, state.timeline);
+      earned += now ? now.revenue : 0;
+    }
+
+    // Each facility takes its share of what was actually sold, so the shares add back up to
+    // it -- relatively, since a month of accumulated floats won't land on a sum taken in a
+    // different order to the last cent
+    expect(earned).toBeGreaterThan(0);
+    expect((booked(state) - opening) / earned).toBeCloseTo(1, 9);
+  });
+
+  it("does not count a forecast as time the fleet lived through", () => {
+    const state = play(createGame({ scenarioId: 103 }), 8);
+    const before = state.facilities.map(totals);
+
+    const now = getTimeFromTimeline(state.date.minute, state.timeline);
+    // A year of simulation, which the Forecasts pane asks for on every month rollover
+    generateNewTimeline(
+      state,
+      now?.cash || 0,
+      now?.customers || 0,
+      TICKS_PER_DAY * 12,
+    );
+
+    expect(state.facilities.map(totals)).toEqual(before);
+  });
+
+  it("does not count the reforecast a player action triggers", () => {
+    const played = play(createGame({ scenarioId: 103 }), 8);
+    const before = played.facilities.map(totals);
+
+    // Pausing a plant reforecasts the whole timeline against the fleet it leaves behind
+    const after = cloneDeep(
+      gameReducer(played, togglePauseFacility(played.facilities[0].id)),
+    );
+
+    expect(after.facilities.map(totals)).toEqual(before);
+  });
+});

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1133,20 +1133,31 @@ function updateSupplyFacilitiesFinances(
   // Hoisted out of the loop below, the way the demand pass at the top of this file already does
   // it: prices move by the month, and this is per facility per tick
   const fuelPrices = getFuelPricesPerMBTU(date, state.seed);
+  // What one facility earns is its share of what the company actually sold, so the row can say
+  // whether it has paid for itself. Curtailed output earns nothing, which pro-rating against the
+  // served total is exactly what expresses
+  const revenuePerSuppliedW = supply > 0 ? revenue / supply : 0;
   facilities.forEach((g: FacilityShoppingType) => {
+    // Everything this facility costs the company this tick, so it can be booked against the
+    // facility as well as into the company's own totals below
+    let facilityExpenses = 0;
     if (g.yearsToBuildLeft === 0) {
       if (g.paused) {
         // paused facilities only pay half of their operating costs
-        expensesOM += g.annualOperatingCost / TICKS_PER_YEAR / 2;
+        facilityExpenses += g.annualOperatingCost / TICKS_PER_YEAR / 2;
       } else {
-        expensesOM += g.annualOperatingCost / TICKS_PER_YEAR;
+        facilityExpenses += g.annualOperatingCost / TICKS_PER_YEAR;
       }
+      expensesOM += facilityExpenses;
       if (g.fuel && FUELS[g.fuel]) {
         const fuelBtu =
           ((g.currentW * (g.btuPerWh || 0)) / TICKS_PER_HOUR) *
           GAME_TO_REAL_YEARS; // Output-dependent #'s converted to real months, since we don't simulate every day
-        expensesFuel += (fuelBtu * fuelPrices[g.fuel]) / 1000000;
-        kgco2e += fuelBtu * FUELS[g.fuel].kgCO2ePerBtu;
+        const facilityFuel = (fuelBtu * fuelPrices[g.fuel]) / 1000000;
+        const facilityKgco2e = fuelBtu * FUELS[g.fuel].kgCO2ePerBtu;
+        expensesFuel += facilityFuel;
+        kgco2e += facilityKgco2e;
+        facilityExpenses += facilityFuel + state.feePerKgCO2e * facilityKgco2e;
       }
       if (g.loanAmountLeft > 0) {
         const paymentInterest = getPaymentInterest(
@@ -1165,10 +1176,35 @@ function updateSupplyFacilitiesFinances(
         expensesInterest += paymentInterest / TICKS_PER_MONTH;
         principalRepayment += paymentPrincipal;
         g.loanAmountLeft -= paymentPrincipal;
+        facilityExpenses += paymentInterest / TICKS_PER_MONTH;
+      }
+      // Only a real tick is a tick of this facility's life. The pre-roll frames after a month
+      // rollover and every tick of every forecast come through here too, and neither happened
+      if (!simulated) {
+        // What the supply pass above actually counted: a paused facility is still winding
+        // down, and those watts are deliberately left out of the company's supply, so
+        // crediting them here would book revenue nobody was paid for. Its potential keeps
+        // accruing though -- being switched off is exactly what a capacity factor is for
+        const deliveredW = g.paused ? 0 : Math.max(0, g.currentW);
+        g.lifetimeWh =
+          (g.lifetimeWh || 0) +
+          (deliveredW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+        g.lifetimePotentialWh =
+          (g.lifetimePotentialWh || 0) +
+          (g.peakW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+        g.lifetimeRevenue =
+          (g.lifetimeRevenue || 0) + deliveredW * revenuePerSuppliedW;
+        g.lifetimeExpenses = (g.lifetimeExpenses || 0) + facilityExpenses;
       }
     } else {
-      expensesInterest +=
+      facilityExpenses =
         getPaymentInterest(g.loanAmountLeft, g.interestRate) / TICKS_PER_MONTH;
+      expensesInterest += facilityExpenses;
+      // A half-built plant is already costing interest, and a row that only started counting on
+      // the day it switched on would hide the cheapest place to notice that
+      if (!simulated) {
+        g.lifetimeExpenses = (g.lifetimeExpenses || 0) + facilityExpenses;
+      }
     }
   });
   const expensesCarbonFee = state.feePerKgCO2e * kgco2e;

--- a/src/reducers/UI.tsx
+++ b/src/reducers/UI.tsx
@@ -14,6 +14,7 @@ export const initialUI: UIType = {
     timeout: 6000,
   },
   victory: null,
+  selectedFacilityId: null,
 };
 
 export const uiSlice = createSlice({
@@ -64,12 +65,18 @@ export const uiSlice = createSlice({
     victoryClose: (state) => {
       state.victory = null;
     },
+    // Null deselects. Clicking the row that's already selected sends null rather than its own id,
+    // so the pane doesn't need a second action to close itself
+    selectFacility: (state, action: PayloadAction<number | null>) => {
+      state.selectedFacilityId = action.payload;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(quit, (state) => {
       state.snackbar = { ...initialUI.snackbar };
       state.dialog = { ...initialUI.dialog };
       state.victory = null;
+      state.selectedFacilityId = null;
     });
   },
 });
@@ -82,6 +89,7 @@ export const {
   dialogClose,
   victoryOpen,
   victoryClose,
+  selectFacility,
 } = uiSlice.actions;
 
 export default uiSlice.reducer;


### PR DESCRIPTION
Items 6-10 of https://github.com/toddmedema/electrify/issues/177.

The Facilities pane was ~60% white space showing a name and a wattage per row, and the Finances table was a column of totals with nothing to read them against.

## The simulation now keeps a record per facility

Four running totals on each facility: delivered watt hours, what it could have delivered flat out, its pro-rata share of what the company actually sold, and its own fuel, O&M, carbon fees and loan interest. Everything the UI shows is derived from those four in `facilityLifetime`, so a save only carries the sums.

Forecasts run the same simulation code against a deep clone of the fleet — dozens of times a second and up to twenty years at a time — and so do the pre-roll frames after a month rollover. None of that is a tick of a facility's life, and `src/reducers/FacilityLifetime.test.tsx` is mostly about holding that line.

## Facilities pane

**6 — per-facility detail.** Clicking a row opens a panel with its capacity factor (utilization, for storage), cost and revenue per MWh, lifetime profit, energy delivered, remaining loan, and a sparkline of its fuel's price over the last year with the percentage change beside it. The sparkline is inline SVG rather than a uPlot chart — no axes, no ticks, nothing to hover, and one per open row.

**7 — clickable rows and cross-highlighting.** The row itself is the select target now, not just the icon buttons. The selection lives in the UI slice, so all three panes see it: Supply by Fuel fades every band the facility doesn't burn (and its legend entry to match), and Finances reports what that one facility has delivered, earned, spent and made. Selling the selected facility clears it; so does quitting.

**8 — hover-revealed row actions.** Above the desktop breakpoint the action cluster is hidden until the row is hovered, focused or selected. That is where the width for the numbers in #6 came from. Below the breakpoint there is no hover to reveal them with, so they stay put. The buttons also came down from `size="large"` to `size="small"`.

**9 — `onReprioritize`.** It was declared and passed for years without the row ever calling it. Now it is what the hover-revealed up/down arrows call, disabled at each end of the list. Dragging was the only way to set dispatch order, which is undiscoverable with a mouse and unusable once the list has scrolled.

## Finances pane

**10 — a change column.** The month just closed against the one before it, headed with both month names (`Nov vs Oct`), with an arrow coloured by whether that direction is good news for that metric — a rise in expenses is not a rise in revenue, and both arrows point up. Changes under half a percent read as an em dash rather than an arrow on a rounding error.

Deliberately month-over-month rather than "this period vs the last one": a period still being played has no honest predecessor, and ten months of this year against twelve of last year is a fall in everything, every time.

## Testing

- `src/reducers/FacilityLifetime.test.tsx` (new) — the totals accrue, the fleet's booked revenue adds back up to the company's, and neither a forecast nor a player-triggered reforecast counts.
- `src/components/views/Facilities.test.tsx` (new) — select/deselect, the detail panel, the reorder arrows and their disabled ends, and that a row action doesn't also select the row.
- `src/components/views/Finances.test.tsx` — the comparison period, the arrow colours in both directions, the flat case, and the selected-facility strip.
- `src/helpers/Financials.test.tsx` — `facilityLifetime`, including the difference between "produced nothing" (capacity factor 0) and "has no cost per MWh to quote".

550 tests pass; typecheck, lint and format are clean. Also driven by hand in the browser at 1600px: selecting a coal plant fades the gas band in Supply by Fuel, the Finances strip reports its share of fleet output, and selling it clears the selection everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
