### PR TITLE
Desktop UX, items 11-17: small multiples, an event log, and dark mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { Provider } from "react-redux";
 import type { User } from "firebase/auth";
 import CompositorContainer from "./components/CompositorContainer";
@@ -11,8 +11,14 @@ import { firebaseAppAuth, getDevicePlatform } from "./Globals";
 import { delta, loadProfile, reset } from "./reducers/User";
 import { SCENARIOS } from "./data/Scenarios";
 import { startAutosave } from "./SaveGame";
-import { store } from "./Store";
-import theme from "./Theme";
+import { store, useAppSelector } from "./Store";
+import {
+  createAppTheme,
+  prefersDarkMode,
+  resolveThemeMode,
+  setThemeMode,
+} from "./Theme";
+import { ThemeChoiceType } from "./Types";
 
 // Cordova's lifecycle events, only ever fired in an app build. Returns its own teardown so the
 // listeners go away with the rest of them rather than outliving the component that added them.
@@ -53,6 +59,55 @@ function setupStorage(document: Document) {
       );
     }, 0);
   }
+}
+
+/**
+ * Paints the app in the palette the player asked for.
+ *
+ * Three things have to agree on it and none of them can be reached the same way: MUI's own
+ * components read a theme through context, everything styled by hand reads custom properties off
+ * <html>, and the charts paint to a canvas and so have to be told in JavaScript (see Theme.tsx).
+ * This is the one place that knows, so it sets all three.
+ *
+ * Inside the Provider because it reads the setting from the store, and above everything else
+ * because a palette change has to reach the whole tree.
+ */
+function ThemedApp(props: { children: React.JSX.Element }): React.JSX.Element {
+  const choice: ThemeChoiceType = useAppSelector(
+    (state) => state.settings.theme,
+  );
+  // "System" is a standing instruction rather than a value, and the system can change its mind
+  // while the game is open - at sunset, on a schedule, or because the player just flipped it
+  const [systemDark, setSystemDark] = useState(prefersDarkMode);
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") {
+      return;
+    }
+    const query = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => setSystemDark(query.matches);
+    query.addEventListener("change", onChange);
+    // The listener can only have missed something between the first render and here
+    onChange();
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
+  const mode =
+    choice === "system"
+      ? systemDark
+        ? "dark"
+        : "light"
+      : resolveThemeMode(choice);
+  // In a layout effect rather than in the render body: telling Theme.tsx wakes every chart
+  // that subscribed to it, and waking a component while another one is rendering is exactly
+  // what React warns about. Before paint, so neither of the two lands a frame late
+  useLayoutEffect(() => {
+    document.documentElement.dataset.theme = mode;
+    setThemeMode(mode);
+  }, [mode]);
+
+  return (
+    <ThemeProvider theme={createAppTheme(mode)}>{props.children}</ThemeProvider>
+  );
 }
 
 export default function App() {
@@ -139,15 +194,15 @@ export default function App() {
 
   return (
     <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={theme}>
-        <Provider store={store}>
+      <Provider store={store}>
+        <ThemedApp>
           {/* Above the compositor, whose shouldComponentUpdate would otherwise swallow a
               settings change that did not also change the card */}
           <UnitsProvider>
             <CompositorContainer store={store} />
           </UnitsProvider>
-        </Provider>
-      </ThemeProvider>
+        </ThemedApp>
+      </Provider>
     </StyledEngineProvider>
   );
 }

--- a/src/Globals.tsx
+++ b/src/Globals.tsx
@@ -140,6 +140,32 @@ export function isDesktopScreen(): boolean {
   return getViewportWidth() >= 1300;
 }
 
+/**
+ * Whether the in-game cards render as panes side by side -- with the app bar, and below the
+ * desktop breakpoint the bottom nav, supplied by the layout around them -- rather than as one
+ * full-screen card carrying its own chrome.
+ *
+ * True from $abswidthmax up, which is also where the frame stops being phone-width: between
+ * there and the desktop breakpoint the layout is Facilities pinned beside whichever of Finances
+ * and Forecasts the nav is on, which is a laptop and a landscape tablet.
+ *
+ * @returns {boolean} - Returns true if the screen is wider than a phone, otherwise false.
+ */
+export function isPaneLayout(): boolean {
+  return isBigScreen();
+}
+
+/**
+ * This function checks whether there is room for a fourth column beside the three panes, which
+ * is where the event log goes -- keep in sync with $ultrawide_breakpoint in app.scss. Below
+ * this, a fourth column comes out of the width the three that carry the game are using.
+ *
+ * @returns {boolean} - Returns true if the screen width is at least 1800, otherwise false.
+ */
+export function isUltrawideScreen(): boolean {
+  return getViewportWidth() >= 1800;
+}
+
 export function getHistoryApi(): HistoryApi {
   return refs.history;
 }

--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -61,6 +61,9 @@ export const temperatureColor = red[500];
 // labels that name it, so the axis carrying it takes the darker shade instead
 export const temperatureAxisColor = red[800];
 export const cursorColor = grey[600]; // hover crosshair, lighter than the data it crosses
+// A trend line that is on offer rather than being read: the unselected metric tiles, which have
+// to stay legible without competing with the one promoted to the chart above them
+export const mutedSeriesColor = grey[600];
 export const windColor = fuelColors.Wind; // for weather forecasts
 
 export default createTheme({

--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -3,28 +3,65 @@
 // Shared Material-UI theming
 // https://material-ui.com/customization/themes
 
-import { blue, grey, red, amber } from "@mui/material/colors";
-import { createTheme } from "@mui/material/styles";
+import { blue, green, grey, red, amber } from "@mui/material/colors";
+import { createTheme, Theme } from "@mui/material/styles";
+import { FuelNameType, ThemeChoiceType, ThemeModeType } from "./Types";
+
+/**
+ * The game's two palettes.
+ *
+ * The charts draw to a canvas rather than to the DOM, so the custom properties app.scss switches
+ * on are no use to them: every colour they paint with has to be looked up in JavaScript, at the
+ * moment the plot is built. That is what this module is - the same light/dark split app.scss
+ * makes, in the form uPlot can read.
+ *
+ * Dark is not light inverted. A series tuned to clear 3:1 against a white plot area is often
+ * invisible against a near-black one - Coal at #1a1a1a most of all - so each one moves up its own
+ * ramp far enough to clear the same bar against #121212, keeping the luminance spread that lets
+ * four lines on one chart be told apart.
+ */
 
 // Seven series can never all clear WCAG's 3:1 non-text contrast against each other - the
 // luminance ladder runs out at about four - so these are tuned for two things that are achievable:
-// every fuel clears 3:1 against the white plot area, and the pairs that share a line chart
+// every fuel clears 3:1 against the plot area, and the pairs that share a line chart
 // (the four priced fuels) are spread as far apart in luminance as that constraint allows.
 // Where color still can't carry it alone, the charts add a second channel: stacked bands with
 // direct labels in Supply by Fuel, dash patterns and end-of-line labels in Fuel Prices.
 // Uranium is teal rather than green so that no series pairs red with green.
-export const fuelColors = {
-  Coal: "#1a1a1a", // 17.4:1 on white
-  Uranium: "#0f5b63", // 7.8:1
-  Oil: "#ac4e13", // 5.5:1
-  "Natural Gas": "#bb79e6", // 3.0:1
-  Sun: "#a87817", // 3.9:1
-  Wind: "#193f79", // 10.4:1
-  Geothermal: "#531834", // 13.6:1
+const FUEL_COLORS: { [mode in ThemeModeType]: { [fuel: string]: string } } = {
+  light: {
+    Coal: "#1a1a1a", // 17.4:1 on white
+    Uranium: "#0f5b63", // 7.8:1
+    Oil: "#ac4e13", // 5.5:1
+    "Natural Gas": "#bb79e6", // 3.0:1
+    Sun: "#a87817", // 3.9:1
+    Wind: "#193f79", // 10.4:1
+    Geothermal: "#531834", // 13.6:1
+  },
+  dark: {
+    Coal: "#d0d0d0", // 11.9:1 on #121212 - the darkest fuel has to become the lightest
+    Uranium: "#4dd0e1", // 9.9:1
+    Oil: "#ffa726", // 10.6:1
+    "Natural Gas": "#ce93d8", // 7.7:1
+    Sun: "#ffd54f", // 13.6:1
+    Wind: "#64b5f6", // 8.0:1
+    Geothermal: "#f48fb1", // 8.7:1
+  },
 };
 
+/** The fuel colours for the palette in use. */
+export function fuelColors(): { [fuel: string]: string } {
+  return FUEL_COLORS[currentMode];
+}
+
+/** One fuel's colour, or the storage colour for a facility that burns nothing. */
+export function facilityColor(fuel?: FuelNameType): string {
+  return (fuel && fuelColors()[fuel]) || chartPalette().storage;
+}
+
 // Second encoding channel for the fuel price chart, where the lines overlap and color alone
-// can't separate four series. Ordered to match the drawing order of the lines.
+// can't separate four series. Ordered to match the drawing order of the lines. Unlike colour,
+// a dash pattern reads the same on either palette.
 export const fuelDashArrays = {
   Coal: undefined, // solid
   "Natural Gas": "6,3",
@@ -32,9 +69,76 @@ export const fuelDashArrays = {
   Uranium: "9,3,2,3",
 };
 
-// Facilities that burn or catch something get their fuel's color; storage has no fuel, so it
-// borrows the interactive blue the rest of the battery UI already uses.
-export const storageColor = blue[800];
+interface ChartPaletteType {
+  /** Facilities that burn or catch nothing, which borrow the battery UI's blue */
+  storage: string;
+  demand: string;
+  supply: string;
+  blackout: string;
+  temperature: string;
+  /** The temperature line's punch is too thin for the axis labels naming it */
+  temperatureAxis: string;
+  wind: string;
+  /** Hover crosshair, lighter than the data it crosses */
+  cursor: string;
+  /** A trend line on offer rather than being read: the unselected metric tiles */
+  muted: string;
+  /** Baselines, and the captions the finance charts carry instead of a legend */
+  axis: string;
+  tickLabel: string;
+  grid: string;
+  tick: string;
+  legendText: string;
+  /** What the interactive blue is on this palette, for the bits of chrome that aren't MUI's */
+  interactive: string;
+  /** The page behind the plot, for decorations that have to read as a gap rather than a line */
+  background: string;
+}
+
+const CHART_PALETTES: { [mode in ThemeModeType]: ChartPaletteType } = {
+  light: {
+    storage: blue[800],
+    demand: grey[900],
+    supply: blue[600],
+    blackout: red[800], // darker than red[500] so the translucent band reads on white
+    temperature: red[500],
+    temperatureAxis: red[800],
+    // The weather chart draws wind in the same blue the wind generators are drawn in
+    wind: FUEL_COLORS.light.Wind,
+    cursor: grey[600],
+    muted: grey[600],
+    axis: "black",
+    tickLabel: "rgba(0, 0, 0, 0.54)",
+    grid: "#ECEFF1", // VictoryTheme.material's, which these charts inherited
+    tick: "#90A4AE",
+    legendText: "#252525",
+    interactive: blue[600],
+    background: "#ffffff",
+  },
+  dark: {
+    storage: blue[300],
+    demand: grey[100],
+    supply: blue[300],
+    blackout: red[400],
+    temperature: red[300],
+    temperatureAxis: red[300],
+    wind: FUEL_COLORS.dark.Wind,
+    cursor: grey[500],
+    muted: grey[500],
+    axis: grey[300],
+    tickLabel: "rgba(255, 255, 255, 0.7)",
+    grid: "#2f2f2f",
+    tick: "#6d7c85",
+    legendText: "#e0e0e0",
+    interactive: blue[300],
+    background: "#121212",
+  },
+};
+
+/** Every colour the charts paint with, for the palette in use. */
+export function chartPalette(): ChartPaletteType {
+  return CHART_PALETTES[currentMode];
+}
 
 // Tints a palette hex for use as a backdrop behind list text, where the full-strength color
 // would swamp the label sitting on top of it.
@@ -52,47 +156,107 @@ export function withAlpha(hex: string, alpha: number): string {
 // clears 4.5:1 against that label, so hovering is the more legible of the two states.
 export const primaryDarkColor = blue[800];
 export const disabledColor = grey[100];
-export const interactiveColor = blue[600];
-export const blackoutColor = red[800]; // darker than red[500] so the translucent band reads on white
-export const demandColor = grey[900];
-export const supplyColor = blue[600];
-export const temperatureColor = red[500];
-// The temperature line wants red500's punch against white, but 3.7:1 is too thin for the axis
-// labels that name it, so the axis carrying it takes the darker shade instead
-export const temperatureAxisColor = red[800];
-export const cursorColor = grey[600]; // hover crosshair, lighter than the data it crosses
-// A trend line that is on offer rather than being read: the unselected metric tiles, which have
-// to stay legible without competing with the one promoted to the chart above them
-export const mutedSeriesColor = grey[600];
-export const windColor = fuelColors.Wind; // for weather forecasts
 
-export default createTheme({
-  palette: {
-    mode: "light",
-    primary: {
-      light: disabledColor,
-      main: supplyColor,
-      dark: primaryDarkColor,
-      contrastText: grey[100],
-    },
-    secondary: amber,
-  },
-  typography: {
-    fontSize: 14,
-    body1: {
-      lineHeight: 1.2,
-    },
-  },
-});
+/**
+ * Which palette everything above is answering for.
+ *
+ * A module-level value rather than a React context because the things that read it are canvas
+ * painters and plugin callbacks reached from inside uPlot, none of which are components. The
+ * subscription below is what gets them repainted: a plot's options are built once and then fed
+ * with data, so a chart has to be told to rebuild when the palette changes under it.
+ */
+let currentMode: ThemeModeType = "light";
+let themeVersion = 0;
+const THEME_EVENT = "electrify-theme";
 
-export const chartTheme = {
-  axis: {
-    stroke: "black",
-    strokeWidth: 1,
-  },
-  tickLabels: {
-    fill: `rgba(0, 0, 0, 0.54)`,
-    fontWeight: 400,
-    fontFamily: `Roboto, "Helvetica Neue", Helvetica, sans-serif`,
-  },
+export function getThemeMode(): ThemeModeType {
+  return currentMode;
+}
+
+export function setThemeMode(mode: ThemeModeType) {
+  if (mode === currentMode) {
+    return;
+  }
+  currentMode = mode;
+  themeVersion++;
+  window.dispatchEvent(new Event(THEME_EVENT));
+}
+
+/** Bumped on every palette change, for the charts to rebuild against. */
+export function getThemeVersion(): number {
+  return themeVersion;
+}
+
+export function subscribeThemeMode(onChange: () => void): () => void {
+  window.addEventListener(THEME_EVENT, onChange);
+  return () => window.removeEventListener(THEME_EVENT, onChange);
+}
+
+/**
+ * The MUI theme for a palette. Cached per mode: MUI rebuilds every component's styles whenever
+ * it is handed a theme object it hasn't seen, which is not something a re-render should cost.
+ */
+const muiThemes: { [mode in ThemeModeType]?: Theme } = {};
+
+export function createAppTheme(mode: ThemeModeType): Theme {
+  const cached = muiThemes[mode];
+  if (cached) {
+    return cached;
+  }
+  const palette = CHART_PALETTES[mode];
+  const built = createTheme({
+    palette: {
+      mode,
+      primary: {
+        light: mode === "dark" ? blue[200] : disabledColor,
+        main: palette.interactive,
+        dark: mode === "dark" ? blue[400] : primaryDarkColor,
+        // Dark's primary is a pale blue, so the label on a filled button is the page behind it
+        contrastText: mode === "dark" ? "#0a0a0a" : grey[100],
+      },
+      secondary: amber,
+      success: { main: mode === "dark" ? green[400] : green[800] },
+      error: { main: mode === "dark" ? red[400] : red[800] },
+      // Kept in step with --bg-primary in app.scss, which paints everything MUI doesn't
+      background:
+        mode === "dark"
+          ? { default: "#121212", paper: "#1a1a1a" }
+          : { default: "#ffffff", paper: "#ffffff" },
+    },
+    typography: {
+      fontSize: 14,
+      body1: {
+        lineHeight: 1.2,
+      },
+    },
+  });
+  muiThemes[mode] = built;
+  return built;
+}
+
+export default createAppTheme("light");
+
+// In the order the settings screen lists them
+export const THEME_CHOICES: ThemeChoiceType[] = ["system", "light", "dark"];
+
+export const THEME_LABELS: { [choice in ThemeChoiceType]: string } = {
+  system: "Match my system",
+  light: "Light",
+  dark: "Dark",
 };
+
+/** What the OS is asking for, and false anywhere that can't be asked (jsdom, old browsers). */
+export function prefersDarkMode(): boolean {
+  return (
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+}
+
+/** The palette a choice resolves to right now. */
+export function resolveThemeMode(choice: ThemeChoiceType): ThemeModeType {
+  if (choice === "system") {
+    return prefersDarkMode() ? "dark" : "light";
+  }
+  return choice;
+}

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -388,6 +388,36 @@ export interface ScenarioType {
   facilities: Array<Partial<FacilityShoppingType>>;
 }
 
+/**
+ * What kind of thing happened, which is all the event log's icons and colours are keyed off.
+ * The text itself is written where the event is raised, since that's the only place that knows
+ * how much energy went unserved or which fuel moved.
+ */
+export type GameEventKindType =
+  | "BLACKOUT"
+  | "BLACKOUT_OVER"
+  | "CONSTRUCTION"
+  | "BUILD"
+  | "SELL"
+  | "LOAN"
+  | "FUEL_PRICE";
+
+/**
+ * One line of the company's history.
+ *
+ * A blackout used to be a toolbar that pulsed and then stopped, a finished plant a toast that
+ * lasted four seconds - so a player who was looking at another pane, or away from the screen,
+ * had no way to find out what had happened to them. These are kept instead.
+ */
+export interface GameEventType {
+  // Monotonic within a run, so React has a key that doesn't move when the log is trimmed
+  id: number;
+  kind: GameEventKindType;
+  // When it happened, as the game clock read it at the time ("Mar 2024")
+  label: string;
+  message: string;
+}
+
 export interface GameType {
   seed: number;
   difficulty: DifficultyType;
@@ -412,6 +442,9 @@ export interface GameType {
   startingYear: number;
   timeline: TickPresentFutureType[]; // anything before currentMinute is history, anything after is a forecast
   monthlyHistory: MonthlyHistoryType[]; // live updated; for calculation simplicity, 0 = most recent (prepend new entries)
+  // Newest first, capped at MAX_EVENTS. Optional because a save written before the log existed
+  // has none, and an empty log and a missing one mean the same thing to everything that reads it
+  eventLog?: GameEventType[];
   facilities: Array<StorageOperatingType | GeneratorOperatingType>;
   // Every simulation-affecting thing the player has done this run, for the replay attached to a
   // high score. Undefined means the run isn't being recorded: before a game starts, while one is
@@ -427,9 +460,18 @@ export interface GameType {
 // simulates is metric, and helpers/Units converts on the way out. See base/UnitsContext.
 export type UnitSystemType = "metric" | "imperial";
 
+// Which of the two palettes is being painted. See Theme.tsx (the charts, which draw to a canvas)
+// and the custom properties at the top of app.scss (everything else)
+export type ThemeModeType = "light" | "dark";
+
+// What the player asked for, which is a third thing: "system" is a standing instruction to
+// follow the OS rather than a palette of its own, and it can change while the game is open
+export type ThemeChoiceType = ThemeModeType | "system";
+
 export interface SettingsType {
   audioEnabled?: boolean;
   units: UnitSystemType;
+  theme: ThemeChoiceType;
 }
 
 export interface DialogType {

--- a/src/app.scss
+++ b/src/app.scss
@@ -1,25 +1,84 @@
 @use "sass:map";
 
-$font_color_primary: #000000;
-$font_color_faded: #666666;
+// ===============================================
+// Palette
+//
+// Every colour is a custom property rather than a Sass value, because Sass compiles once while
+// custom properties resolve per element at paint time -- which is what lets one attribute on
+// <html> repaint the whole app. The Sass names below are aliases onto them, so the hundred or
+// so rules that already read $bg_primary go on reading that way.
+//
+// Dark is not light inverted. The greys are lifted off pure black, which vibrates against light
+// text, and every accent moves up its ramp: a colour picked for 4.5:1 against white is nowhere
+// near that against #121212. Theme.tsx does the same for the charts.
+// ===============================================
 
-$border_primary: 0.02in solid #000;
-$border_accent: 0.01in solid #666;
+:root {
+  --bg-primary: #ffffff;
+  --bg-raised: #fafafa; /* grey50 - hover, one step off the page */
+  --bg-sunken: #eceff1; /* blueGray50 - behind lists of cards */
+  --bg-selected: #e3f2fd; /* blue50 */
+  --bg-fade-start: rgba(255, 255, 255, 0);
+  --border-selected: #bbdefb; /* blue100 */
+  --border-subtle: #eeeeee; /* grey200 */
+  --border-strong: #bdbdbd; /* grey400 */
+  --border-tile: #e0e0e0; /* grey300 */
+  --font-color-primary: #000000;
+  --font-color-faded: #666666;
+  --font-color-disabled: #bdbdbd; /* grey400 */
+  --interactive-blue: #1e88e5; /* blue600 */
+  --interactive-tint: rgba(30, 136, 229, 0.5);
+  --blackout-red: #c62828; /* red800 - matches blackoutColor in Theme.tsx */
+  --blackout-tint: rgba(198, 40, 40, 0.07);
+  // The two directions a number can move in. Both are the darker end of their ramp so they
+  // clear 4.5:1 on the page as text, since the arrow beside them is decoration rather than the
+  // message -- red/green alone would leave a colourblind reader with only the arrow
+  --delta-good: #2e7d32; /* green800 */
+  --delta-bad: #c62828; /* red800 */
+  --mark-bg: #ffe082; /* amber200 - the manual's search highlight */
+  --capacity-bar: #212121; /* grey900 */
+  --shadow-ring: rgba(0, 0, 0, 0.15);
+  --tooltip-border: rgba(0, 0, 0, 0.2);
+  --cursor-line: #757575; /* grey600 */
+}
 
-$bg_primary: #ffffff;
-$bg_inactive: #222222;
-$bg_active: rgba(255, 255, 255, 0.9);
+[data-theme="dark"] {
+  --bg-primary: #121212;
+  --bg-raised: #262626;
+  --bg-sunken: #0a0a0a;
+  --bg-selected: #123048;
+  --bg-fade-start: rgba(18, 18, 18, 0);
+  --border-selected: #1c5680;
+  --border-subtle: #2c2c2c;
+  --border-strong: #5f5f5f;
+  --border-tile: #3a3a3a;
+  --font-color-primary: #e8e8e8;
+  --font-color-faded: #a3a3a3;
+  --font-color-disabled: #616161; /* grey700 */
+  --interactive-blue: #64b5f6; /* blue300 - 8:1 on the page, where blue600 is 2.6:1 */
+  --interactive-tint: rgba(100, 181, 246, 0.5);
+  --blackout-red: #ef5350; /* red400 */
+  --blackout-tint: rgba(239, 83, 80, 0.16);
+  --delta-good: #66bb6a; /* green400 */
+  --delta-bad: #ef5350; /* red400 */
+  --mark-bg: #6d4c00;
+  --capacity-bar: #e0e0e0;
+  --shadow-ring: rgba(0, 0, 0, 0.7);
+  --tooltip-border: rgba(255, 255, 255, 0.25);
+  --cursor-line: #9e9e9e; /* grey500 */
+}
 
-$font_color_dark_primary: #ffffff;
-$bg_dark_primary: #161011;
+$font_color_primary: var(--font-color-primary);
+$font_color_faded: var(--font-color-faded);
 
-$blackout_red: #c62828; /* red800 https://material-ui.com/customization/color/ - matches blackoutColor in Theme.tsx */
-$interactive_blue: #1e88e5; /* blue 600 */
-// The two directions a number can move in. Both are the darker end of their ramp so they
-// clear 4.5:1 on white as text, since the arrow beside them is decoration rather than the
-// message -- red/green alone would leave a colourblind reader with only the arrow
-$delta_good: #2e7d32; /* green800 */
-$delta_bad: #c62828; /* red800 */
+$border_accent: 0.01in solid var(--border-strong);
+
+$bg_primary: var(--bg-primary);
+
+$blackout_red: var(--blackout-red);
+$interactive_blue: var(--interactive-blue);
+$delta_good: var(--delta-good);
+$delta_bad: var(--delta-bad);
 
 // ===============================================
 // Transitional animation classes
@@ -113,6 +172,8 @@ $absmaxdimension: 1025px;
 // Wide enough to show Facilities/Finances/Forecasts side by side -- keep in sync with
 // isDesktopScreen() in Globals.tsx. Below this, panes render too narrow to be worth it.
 $desktop_breakpoint: 1300px;
+// And wide enough for the event log beside them -- keep in sync with isUltrawideScreen()
+$ultrawide_breakpoint: 1800px;
 
 $sizemap: (
   large: 6vmin,
@@ -139,11 +200,20 @@ html {
   width: 100%;
   height: 100%;
   background: $bg_primary;
+  // Scrollbars, form controls and anything else the browser paints for us
+  color-scheme: light;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
 }
 
 body {
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
   background-color: $bg_primary;
+  // MUI colours its own components off the theme, but the plain markup between them inherits
+  // from here - and the browser default is black, which on a dark page is a blank screen
+  color: $font_color_primary;
   overflow: hidden;
   width: 100%;
   height: 100%;
@@ -188,7 +258,7 @@ body {
 .snackbar {
   .MuiSnackbarContent-root {
     background-color: $bg_primary;
-    border: 1px solid #bdbdbd; /* grey400 */
+    border: 1px solid var(--border-strong);
     border-radius: 4px;
   }
 
@@ -422,7 +492,7 @@ $pane_header_height: 40px;
 .expandable {
   &:hover {
     cursor: pointer;
-    background: #fafafa; /* grey50 */
+    background: var(--bg-raised);
   }
   .MuiCardContent-root {
     padding-top: 0;
@@ -446,10 +516,7 @@ $pane_header_height: 40px;
 
   &:after {
     content: "";
-    background-image: linear-gradient(
-      rgba(255, 255, 255, 0),
-      rgba(255, 255, 255, 255)
-    );
+    background-image: linear-gradient(var(--bg-fade-start), var(--bg-primary));
     position: absolute;
     top: 0;
     bottom: -6px;
@@ -478,7 +545,7 @@ $pane_header_height: 40px;
   display: none;
   z-index: 10;
   padding: 2px 4px;
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--tooltip-border);
   border-radius: 2px;
   background: $bg_primary;
   color: $font_color_primary;
@@ -490,7 +557,7 @@ $pane_header_height: 40px;
 
 // The crosshair marking which x the tooltip is reporting, lighter than the data it crosses
 .uplot .u-cursor-x {
-  border-right: 1px dashed #757575;
+  border-right: 1px dashed var(--cursor-line);
 }
 
 .chartLegend {
@@ -558,7 +625,7 @@ $pane_header_height: 40px;
 
 // Completion state of each tutorial in the scenario list
 .tutorialIncomplete {
-  color: #bdbdbd; /* grey400 */
+  color: var(--font-color-disabled);
 }
 
 // How far through the 101-106 sequence the player is
@@ -570,7 +637,7 @@ $pane_header_height: 40px;
 
 // The next tutorial to play, so the sequence has one obvious entry point
 .tutorialNext {
-  border-left: 4px solid #1e88e5; /* blue600, matches primary buttons */
+  border-left: 4px solid var(--interactive-blue);
 }
 
 // Units appended to numbers in tables, de-emphasized so the number still reads first
@@ -605,10 +672,10 @@ $pane_header_height: 40px;
     display: inline-block;
     min-width: 1.6em;
     padding: 1px 5px;
-    border: 1px solid #bdbdbd; /* grey400 */
+    border: 1px solid var(--border-strong);
     border-bottom-width: 2px;
     border-radius: 3px;
-    background: #fafafa; /* grey50 */
+    background: var(--bg-raised);
     font-family: monospace;
     font-size: 0.85em;
     line-height: 1.5;
@@ -661,7 +728,7 @@ $pane_header_height: 40px;
   .clickable-card {
     &:hover {
       cursor: pointer;
-      background: #fafafa; /* grey50 */
+      background: var(--bg-raised);
     }
   }
 
@@ -790,7 +857,7 @@ $pane_header_height: 40px;
 
     // Sticky so the player can still tell which section they're scrolling through
     .manual-group {
-      background: #eceff1; /* blueGray50, matches .cardList behind it */
+      background: var(--bg-sunken);
       line-height: 32px;
       font-weight: 500;
       text-transform: uppercase;
@@ -799,7 +866,7 @@ $pane_header_height: 40px;
     }
 
     mark {
-      background: #ffe082; /* amber200 */
+      background: var(--mark-bg);
       color: inherit;
     }
   }
@@ -819,12 +886,12 @@ $pane_header_height: 40px;
       padding: 0 size(base);
 
       &:hover {
-        background: #eeeeee; /* grey200 - grey50 on white was effectively invisible */
+        background: var(--bg-raised);
       }
 
       // WCAG 2.4.7: keyboard users need to see which entry they're on
       &:focus-visible {
-        background: #e3f2fd; /* blue50 */
+        background: var(--bg-selected);
         outline: 2px solid $interactive_blue;
         outline-offset: -2px;
       }
@@ -853,14 +920,14 @@ $pane_header_height: 40px;
   }
 
   .cardList {
-    background: #eceff1; /* blueGray50 */
+    background: var(--bg-sunken);
     padding-top: size(base) !important;
     padding-bottom: 20px; /* for devices with with bottom bars */
     height: 100%;
   }
 
   .facility {
-    border-top: 1px #eeeeee solid; /* grey200 */
+    border-top: 1px solid var(--border-subtle);
   }
 
   // The whole row selects, so it has to look like it does something before it is clicked
@@ -868,7 +935,7 @@ $pane_header_height: 40px;
     outline: none;
 
     &:hover .facility {
-      background: #fafafa; /* grey50 */
+      background: var(--bg-raised);
     }
 
     // WCAG 2.4.7 -- and the row is reachable by Tab, since it doubles as the drag handle
@@ -878,7 +945,7 @@ $pane_header_height: 40px;
     }
 
     &.selected {
-      background: #e3f2fd; /* blue50 */
+      background: var(--bg-selected);
       // Reads down the left edge of the list, so which row is open survives scrolling past
       // the details themselves
       box-shadow: inset 3px 0 0 0 $interactive_blue;
@@ -946,7 +1013,7 @@ $pane_header_height: 40px;
   .metricTile {
     display: block;
     padding: size(small);
-    border: 1px solid #e0e0e0; /* grey300 */
+    border: 1px solid var(--border-tile);
     border-radius: 4px;
     background: none;
     color: inherit;
@@ -955,7 +1022,7 @@ $pane_header_height: 40px;
     cursor: pointer;
 
     &:hover {
-      background: #fafafa; /* grey50 */
+      background: var(--bg-raised);
     }
 
     &:focus-visible {
@@ -965,7 +1032,7 @@ $pane_header_height: 40px;
 
     &.selected {
       border-color: $interactive_blue;
-      background: #e3f2fd; /* blue50 */
+      background: var(--bg-selected);
     }
   }
 
@@ -998,12 +1065,7 @@ $pane_header_height: 40px;
   .speedToggles {
     .MuiToggleButton-root {
       padding: 2px 8px;
-      border-color: rgba(
-        30,
-        136,
-        229,
-        0.5
-      ); /* interactive blue, matching the buttons */
+      border-color: var(--interactive-tint);
       color: $interactive_blue;
       font-size: 0.8rem;
       line-height: 1.4;
@@ -1017,6 +1079,55 @@ $pane_header_height: 40px;
         }
       }
     }
+  }
+
+  // The run's own record of itself. A list rather than a table: the lines are one clause each,
+  // and the only column they share is when they happened
+  .eventLogList {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .eventLogItem {
+    display: grid;
+    grid-template-columns: 20px 1fr;
+    gap: 0 8px;
+    align-items: start;
+    padding: size(small) size(base);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .eventLogIcon {
+    display: flex;
+    align-items: center;
+    height: 1.2em;
+    color: $font_color_faded;
+
+    .MuiSvgIcon-root {
+      font-size: 16px;
+    }
+  }
+
+  // Under the message rather than beside it: the pane is the narrowest of the four, and a date
+  // column would take a third of it to say something the eye only occasionally asks for
+  .eventLogWhen {
+    grid-column: 2;
+    font-size: 0.75rem;
+  }
+
+  // The one kind of event a player scrolls back through the log looking for
+  .eventLogItem.kind-BLACKOUT {
+    background: var(--blackout-tint);
+
+    .eventLogIcon {
+      color: $blackout_red;
+    }
+  }
+
+  .eventLogEmpty {
+    display: block;
+    padding: size(base);
   }
 
   // The change column, and the facility figures that use the same two colours
@@ -1044,8 +1155,8 @@ $pane_header_height: 40px;
   // Which money is the selected facility's, above the chart that shows the company's
   .selectedFacilitySummary {
     padding: size(small) 16px;
-    background: #e3f2fd; /* blue50 */
-    border-bottom: 1px solid #bbdefb; /* blue100 */
+    background: var(--bg-selected);
+    border-bottom: 1px solid var(--border-selected);
   }
 
   .chartLegendItem-muted {
@@ -1064,7 +1175,9 @@ $pane_header_height: 40px;
   }
 
   .outputProgressBar {
-    background: #eeeeee; /* grey200 fallback; the fuel tint is set inline per facility */
+    background: var(
+      --border-subtle
+    ); /* fallback; the fuel tint is set inline per facility */
     position: absolute;
     top: 0;
     bottom: 2px;
@@ -1080,7 +1193,7 @@ $pane_header_height: 40px;
 
     .capacityProgressBar {
       width: 12px;
-      background-color: #212121; /* grey 900 */
+      background-color: var(--capacity-bar);
       position: absolute;
       bottom: 0;
       left: 42px;
@@ -1091,7 +1204,7 @@ $pane_header_height: 40px;
       &:after {
         content: "";
         height: 39px;
-        border: 1px solid #bdbdbd; /* grey 400 */
+        border: 1px solid var(--border-strong);
         position: absolute;
         left: 0;
         right: 0;
@@ -1109,7 +1222,7 @@ $pane_header_height: 40px;
       height: 18px;
       border-radius: 50%;
       background: $bg_primary;
-      box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
+      box-shadow: 0 0 0 1px var(--shadow-ring);
       z-index: 2;
       display: flex;
       align-items: center;
@@ -1168,6 +1281,56 @@ $sizemap: (
 }
 
 // ===============================================
+// Anything wider than a phone gets columns rather than one card at a time: two of them up to
+// $desktop_breakpoint (the fleet pinned beside whichever pane the nav is on), three above it,
+// four once there is room for the event log. The grid itself comes from DesktopPanes, since the
+// player can drag it
+// ===============================================
+
+@media screen and (min-width: $abswidthmax) {
+  .desktop-layout,
+  .pane-layout {
+    height: 100%;
+    width: 100%;
+  }
+
+  .desktop-panes {
+    display: grid;
+    width: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .desktop-pane {
+    display: flex;
+    min-width: 0;
+    overflow: hidden;
+
+    > * {
+      flex: 1 1 auto;
+      min-width: 0;
+      height: 100%;
+    }
+  }
+
+  // Splitters are grid tracks of their own rather than borders on the panes, so dragging one
+  // never changes the total width the panes have to share
+  .pane-splitter {
+    cursor: col-resize;
+    border-left: $border_accent;
+    background: transparent;
+    transition: background 0.15s;
+
+    &:hover,
+    &:focus-visible {
+      background: $interactive_blue;
+      border-left-color: $interactive_blue;
+      outline: none;
+    }
+  }
+}
+
+// ===============================================
 // Above $desktop_breakpoint, let the app grow past the phone-width frame so Facilities,
 // Finances and Forecasts can render as panes side by side instead of one screen at a time.
 // The type scale comes down with it: the vertical space that buys is what fits the extra
@@ -1192,32 +1355,6 @@ $sizemap: (
     display: none;
   }
 
-  .desktop-layout {
-    height: 100%;
-    width: 100%;
-  }
-
-  // The columns themselves, and the splitter tracks between them, come from DesktopPanes --
-  // they're state, since the player can drag them
-  .desktop-panes {
-    display: grid;
-    width: 100%;
-    flex: 1 1 auto;
-    min-height: 0;
-  }
-
-  .desktop-pane {
-    display: flex;
-    min-width: 0;
-    overflow: hidden;
-
-    > * {
-      flex: 1 1 auto;
-      min-width: 0;
-      height: 100%;
-    }
-  }
-
   // There is a mouse now, so the row's actions can wait to be asked for -- which gives the
   // numbers in the details panel the width the buttons were holding. Anything that reveals
   // them has to include focus, or they'd be unreachable by keyboard
@@ -1230,20 +1367,6 @@ $sizemap: (
   .facilityRow:focus-within .facilityActions,
   .facilityRow.selected .facilityActions {
     opacity: 1;
-  }
-
-  .pane-splitter {
-    cursor: col-resize;
-    border-left: $border_accent;
-    background: transparent;
-    transition: background 0.15s;
-
-    &:hover,
-    &:focus-visible {
-      background: $interactive_blue;
-      border-left-color: $interactive_blue;
-      outline: none;
-    }
   }
 }
 

--- a/src/app.scss
+++ b/src/app.scss
@@ -933,6 +933,92 @@ $pane_header_height: 40px;
     align-items: center;
   }
 
+  // Every headline metric drawn at once, with the one on the big chart above promoted. A grid
+  // rather than a row of six, so the tiles rewrap as the pane is dragged narrower instead of
+  // being squeezed to the width of their labels
+  .metricTiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+    gap: size(small);
+    padding: size(small) size(base) 0 size(base);
+  }
+
+  .metricTile {
+    display: block;
+    padding: size(small);
+    border: 1px solid #e0e0e0; /* grey300 */
+    border-radius: 4px;
+    background: none;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover {
+      background: #fafafa; /* grey50 */
+    }
+
+    &:focus-visible {
+      outline: 2px solid $interactive_blue;
+      outline-offset: -2px;
+    }
+
+    &.selected {
+      border-color: $interactive_blue;
+      background: #e3f2fd; /* blue50 */
+    }
+  }
+
+  .metricTileLabel {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .metricTileValue {
+    font-weight: 500;
+  }
+
+  // A slider that carries tick labels needs room for the outermost ones, which otherwise hang
+  // off both ends of the pane
+  .budgetSlider {
+    padding: 0 20px;
+
+    .MuiSlider-root {
+      width: 100% !important;
+    }
+
+    .MuiSlider-markLabel {
+      font-size: 0.7rem;
+    }
+  }
+
+  // Which speed the clock is running at, said as a selection rather than as three enabled
+  // buttons and one greyed-out one - disabled reads as "you can't have this", not "you're on it"
+  .speedToggles {
+    .MuiToggleButton-root {
+      padding: 2px 8px;
+      border-color: rgba(
+        30,
+        136,
+        229,
+        0.5
+      ); /* interactive blue, matching the buttons */
+      color: $interactive_blue;
+      font-size: 0.8rem;
+      line-height: 1.4;
+
+      &.Mui-selected {
+        background: $interactive_blue;
+        color: $bg_primary;
+
+        &:hover {
+          background: $interactive_blue;
+        }
+      }
+    }
+  }
+
   // The change column, and the facility figures that use the same two colours
   .deltaCell {
     white-space: nowrap;

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -30,6 +30,8 @@ import {
 import AudioContainer from "./base/AudioContainer";
 import DesktopPanes from "./base/DesktopPanes";
 import DisplayNameDialogContainer from "./base/DisplayNameDialogContainer";
+import EventLogContainer from "./views/EventLogContainer";
+import NavigationContainer from "./base/NavigationContainer";
 import GameAppBarContainer from "./base/GameAppBar";
 import VictoryDialogContainer from "./base/VictoryDialogContainer";
 import BuildGeneratorsContainer from "./views/BuildGeneratorsContainer";
@@ -51,13 +53,17 @@ import {
   togglePauseFacility,
 } from "../reducers/Game";
 import { snackbarOpen } from "../reducers/UI";
-import { isDesktopScreen } from "../Globals";
+import { isDesktopScreen, isPaneLayout, isUltrawideScreen } from "../Globals";
 import { store } from "../Store";
 
 // All three of these cards are shown at once side by side above the desktop breakpoint (see
 // isDesktopScreen / $desktop_breakpoint), so they share one stable transition key there --
 // switching among them shouldn't slide/remount the pane group, since nothing visibly changes
 const DESKTOP_PANES_KEY = "DESKTOP_PANES";
+
+// And the same again for the two-column layout below it, where Facilities is pinned and the nav
+// swaps what is beside it -- the pinned column would otherwise slide off with the card transition
+const TABLET_PANES_KEY = "TABLET_PANES";
 
 // How many facilities the number row can reach. Nine because that is how many number keys
 // there are; a longer fleet is still reachable by mouse, and by the row actions
@@ -68,8 +74,10 @@ const FACILITY_SLOTS = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 const facilitySlotKey = (slot: number) => `shift+${slot}`;
 
 // Keep in sync with SHORTCUTS in base/KeyboardShortcuts, which is what the Manual and Settings
-// both list. react-hotkeys ignores key events from inputs, so `?` still types into a text field
-const keyMap = {
+// both list -- exported so a test can hold the two against each other rather than a comment
+// asking politely. react-hotkeys ignores key events from inputs, so `?` still types into a
+// text field
+export const keyMap = {
   PAUSED: ["`", "space", "0"],
   SLOW: "1",
   NORMAL: "2",
@@ -174,7 +182,9 @@ const shortcutHandlers = {
   },
   BUILD_GENERATOR: () => {
     if (canPlay()) {
-      store.dispatch(navigate({ name: "BUILD_GENERATORS", dontRemember: true }));
+      store.dispatch(
+        navigate({ name: "BUILD_GENERATORS", dontRemember: true }),
+      );
     }
   },
   BUILD_STORAGE: () => {
@@ -361,10 +371,11 @@ export default class Compositor extends React.Component<Props, {}> {
   }
 
   private renderCard(): React.JSX.Element {
+    const isPanes = isNavCard(this.props.card.name) && isPaneLayout();
     // Wide enough to show the fleet, P&L and forecast at once instead of tabbing between them.
     // Cash, the date, the speed controls and the year's progress are the game's state rather
     // than any one pane's, so they span all three columns instead of living in the first
-    if (isDesktopScreen() && isNavCard(this.props.card.name)) {
+    if (isPanes && isDesktopScreen()) {
       return (
         <div className="desktop-layout flexContainer">
           <GameAppBarContainer />
@@ -372,7 +383,32 @@ export default class Compositor extends React.Component<Props, {}> {
             <FacilitiesContainer />
             <FinancesContainer />
             <ForecastsContainer />
+            {/* An ultrawide window is otherwise three panes and a lot of nothing. Only here,
+                because below this a fourth column comes out of the three that carry the game */}
+            {isUltrawideScreen() ? <EventLogContainer /> : null}
           </DesktopPanes>
+        </div>
+      );
+    }
+    // Laptops and landscape tablets, which used to get a phone-width card floating in a sea of
+    // margin. There isn't room for three columns here, but there is for two: the fleet, which
+    // is the pane a player wants on screen while they read either of the others, pinned beside
+    // whichever of them the nav is on
+    if (isPanes) {
+      return (
+        <div className="pane-layout flexContainer">
+          <GameAppBarContainer />
+          <DesktopPanes>
+            <FacilitiesContainer />
+            {this.props.card.name === "FORECASTS" ? (
+              <ForecastsContainer />
+            ) : (
+              <FinancesContainer />
+            )}
+          </DesktopPanes>
+          {/* The panes supply no nav of their own in this layout, and it is still what
+              switches the second column */}
+          <NavigationContainer />
         </div>
       );
     }
@@ -432,10 +468,16 @@ export default class Compositor extends React.Component<Props, {}> {
     const { tutorialStep, ui, closeDialog, tutorialSteps, closeSnackbar } =
       this.props;
 
-    const transitionKey =
-      isDesktopScreen() && isNavCard(this.props.card.name)
+    // The pane layouts don't slide between their own cards: on desktop nothing about the screen
+    // changes, and on two columns only the second one does -- sliding the pinned fleet off the
+    // side with it would be a lie about what just happened
+    const transitionKey = !isNavCard(this.props.card.name)
+      ? this.props.card.name
+      : isDesktopScreen()
         ? DESKTOP_PANES_KEY
-        : this.props.card.name;
+        : isPaneLayout()
+          ? TABLET_PANES_KEY
+          : this.props.card.name;
     const transitionNodeRef = this.nodeRefFor(transitionKey);
 
     // See https://medium.com/lalilo/dynamic-transitions-with-react-router-and-react-transition-group-69ab795815c9

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -45,7 +45,12 @@ import NewGameContainer from "./views/NewGameContainer";
 import NewGameDetailsContainer from "./views/NewGameDetailsContainer";
 import SettingsContainer from "./views/SettingsContainer";
 import { navigate } from "../reducers/Card";
-import { setSpeed } from "../reducers/Game";
+import {
+  reprioritizeFacility,
+  setSpeed,
+  togglePauseFacility,
+} from "../reducers/Game";
+import { snackbarOpen } from "../reducers/UI";
 import { isDesktopScreen } from "../Globals";
 import { store } from "../Store";
 
@@ -53,6 +58,14 @@ import { store } from "../Store";
 // isDesktopScreen / $desktop_breakpoint), so they share one stable transition key there --
 // switching among them shouldn't slide/remount the pane group, since nothing visibly changes
 const DESKTOP_PANES_KEY = "DESKTOP_PANES";
+
+// How many facilities the number row can reach. Nine because that is how many number keys
+// there are; a longer fleet is still reachable by mouse, and by the row actions
+const FACILITY_SLOTS = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+// Shifted, because the bare number row is the speed control and has been for far longer than
+// the fleet has had shortcuts of its own
+const facilitySlotKey = (slot: number) => `shift+${slot}`;
 
 // Keep in sync with SHORTCUTS in base/KeyboardShortcuts, which is what the Manual and Settings
 // both list. react-hotkeys ignores key events from inputs, so `?` still types into a text field
@@ -64,8 +77,78 @@ const keyMap = {
   FACILITIES: "q",
   FINANCES: "w",
   FORECASTS: "e",
+  BUILD_GENERATOR: "g",
+  BUILD_STORAGE: "s",
+  PRIORITIZE_EARLIER: "[",
+  PRIORITIZE_LATER: "]",
   MANUAL: ["?", "shift+/"],
+  ...Object.fromEntries(
+    FACILITY_SLOTS.map((slot: number) => [
+      `TOGGLE_FACILITY_${slot}`,
+      facilitySlotKey(slot),
+    ]),
+  ),
 };
+
+/**
+ * Whether the keys that act on the game should do anything right now.
+ *
+ * The hotkeys are global, so they fire over the main menu and the manual too -- and a replay is
+ * somebody else's run, which the viewer does not get to reorder.
+ */
+function canPlay(): boolean {
+  const state = store.getState();
+  return (
+    state.game.inGame &&
+    !state.game.replayPlayback &&
+    isNavCard(state.card.name)
+  );
+}
+
+// Pausing from the keyboard offers the same undo the row's pause button does: the fleet is a
+// list of similar-looking rows, and a mistyped number is the likeliest way to reach one
+function togglePauseSlot(slot: number) {
+  if (!canPlay()) {
+    return;
+  }
+  const facility = store.getState().game.facilities[slot - 1];
+  if (!facility || facility.yearsToBuildLeft > 0) {
+    return;
+  }
+  const wasPaused = facility.paused;
+  store.dispatch(togglePauseFacility(facility.id));
+  store.dispatch(
+    snackbarOpen({
+      message: `${wasPaused ? "Resumed" : "Paused"} ${facility.name}`,
+      actionLabel: "Undo",
+      action: () => store.dispatch(togglePauseFacility(facility.id)),
+      open: true,
+      timeout: 6000,
+    }),
+  );
+}
+
+// Dispatch order is a core mechanic, and until now the only ways to change it were a drag and a
+// pair of buttons that appear on hover. These move the open row, which is the one the other two
+// panes are already reporting on
+function reprioritizeSelected(delta: number) {
+  if (!canPlay()) {
+    return;
+  }
+  const { game, ui } = store.getState();
+  const spotInList = game.facilities.findIndex(
+    (f) => f.id === ui.selectedFacilityId,
+  );
+  const destination = spotInList + delta;
+  if (
+    spotInList < 0 ||
+    destination < 0 ||
+    destination >= game.facilities.length
+  ) {
+    return;
+  }
+  store.dispatch(reprioritizeFacility({ spotInList, delta }));
+}
 
 const shortcutHandlers = {
   PAUSED: () => {
@@ -89,9 +172,27 @@ const shortcutHandlers = {
   FORECASTS: () => {
     store.dispatch(navigate("FORECASTS"));
   },
+  BUILD_GENERATOR: () => {
+    if (canPlay()) {
+      store.dispatch(navigate({ name: "BUILD_GENERATORS", dontRemember: true }));
+    }
+  },
+  BUILD_STORAGE: () => {
+    if (canPlay()) {
+      store.dispatch(navigate({ name: "BUILD_STORAGE", dontRemember: true }));
+    }
+  },
+  PRIORITIZE_EARLIER: () => reprioritizeSelected(-1),
+  PRIORITIZE_LATER: () => reprioritizeSelected(1),
   MANUAL: () => {
     store.dispatch(navigate("MANUAL"));
   },
+  ...Object.fromEntries(
+    FACILITY_SLOTS.map((slot: number) => [
+      `TOGGLE_FACILITY_${slot}`,
+      () => togglePauseSlot(slot),
+    ]),
+  ),
 };
 
 function Tooltip(props: TooltipRenderProps): React.JSX.Element {

--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -3,7 +3,7 @@ import uPlot from "uplot";
 import UPlotChart, { BuildContext } from "./UPlotChart";
 import { padRange, stepTicks, titlePlugin, xAxis, yAxis } from "./UPlotHelpers";
 import { formatMonthChartAxis } from "../../helpers/DateTime";
-import { demandColor } from "../../Theme";
+import { chartPalette } from "../../Theme";
 
 interface ChartData {
   month: number; // unique across years
@@ -63,13 +63,13 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
     series: [
       {},
       {
-        stroke: demandColor,
+        stroke: chartPalette().demand,
         width: 2,
         points: { show: false },
         spanGaps: false,
       },
       {
-        stroke: demandColor,
+        stroke: chartPalette().demand,
         width: 2,
         dash: [4, 4],
         points: { show: false },

--- a/src/components/base/ChartForecastFuelPrices.tsx
+++ b/src/components/base/ChartForecastFuelPrices.tsx
@@ -88,7 +88,7 @@ function buildOptions(showXLabels: boolean) {
     series: [
       {},
       ...PRICED_FUELS.map((f) => ({
-        stroke: fuelColors[f],
+        stroke: fuelColors()[f],
         width: 1.5,
         // Four overlapping lines are more than color alone can separate, so each
         // fuel also gets its own dash pattern

--- a/src/components/base/ChartForecastStorage.tsx
+++ b/src/components/base/ChartForecastStorage.tsx
@@ -15,7 +15,7 @@ import {
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
 import { formatWattHours, formatWattHoursAxis } from "../../helpers/Format";
-import { supplyColor } from "../../Theme";
+import { chartPalette } from "../../Theme";
 
 export interface Props {
   height?: number;
@@ -74,7 +74,10 @@ function buildOptions(showXLabels: boolean) {
           splits.map((t) => formatWattHoursAxis(t, splits)),
       }),
     ],
-    series: [{}, { stroke: supplyColor, width: 1, points: { show: false } }],
+    series: [
+      {},
+      { stroke: chartPalette().supply, width: 1, points: { show: false } },
+    ],
   });
 }
 

--- a/src/components/base/ChartForecastSupplyByFuel.tsx
+++ b/src/components/base/ChartForecastSupplyByFuel.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../helpers/DateTime";
 import { formatWatts, formatWattsAxis } from "../../helpers/Format";
 import { FuelNameType, TickPresentFutureType } from "../../Types";
-import { demandColor, fuelColors, withAlpha } from "../../Theme";
+import { chartPalette, fuelColors, withAlpha } from "../../Theme";
 
 export interface Props {
   height?: number;
@@ -122,17 +122,17 @@ function buildOptions(
       ...fuels.map((f) => ({
         fill:
           highlightFuel && f !== highlightFuel
-            ? withAlpha(fuelColors[f], MUTED_BAND_ALPHA)
-            : fuelColors[f],
+            ? withAlpha(fuelColors()[f], MUTED_BAND_ALPHA)
+            : fuelColors()[f],
         // A hairline of background between bands keeps them apart even where two
         // fuel colors are close, since seven series can't all be far apart
-        stroke: "#ffffff",
+        stroke: chartPalette().background,
         width: 0.5,
         points: { show: false },
       })),
       {
         // Drawn over the stack so the gap between the two reads as the shortfall
-        stroke: demandColor,
+        stroke: chartPalette().demand,
         width: 2,
         dash: [4, 2],
         points: { show: false },

--- a/src/components/base/ChartForecastSupplyDemand.tsx
+++ b/src/components/base/ChartForecastSupplyDemand.tsx
@@ -17,7 +17,7 @@ import {
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
 import { formatWatts, formatWattsAxis } from "../../helpers/Format";
-import { blackoutColor, demandColor, supplyColor } from "../../Theme";
+import { chartPalette } from "../../Theme";
 
 interface BlackoutEdges {
   minute: number;
@@ -89,10 +89,12 @@ function buildOptions(showXLabels: boolean) {
     ],
     series: [
       {},
-      { stroke: supplyColor, width: 1, points: { show: false } },
-      { stroke: demandColor, width: 2, points: { show: false } },
+      { stroke: chartPalette().supply, width: 1, points: { show: false } },
+      { stroke: chartPalette().demand, width: 2, points: { show: false } },
     ],
-    plugins: [bandsPlugin(() => getState().blackoutSpans, blackoutColor, 0.3)],
+    plugins: [
+      bandsPlugin(() => getState().blackoutSpans, chartPalette().blackout, 0.3),
+    ],
   });
 }
 

--- a/src/components/base/ChartForecastWeather.tsx
+++ b/src/components/base/ChartForecastWeather.tsx
@@ -17,7 +17,7 @@ import {
   formatMinuteAsMonthAxis,
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
-import { temperatureAxisColor, temperatureColor, windColor } from "../../Theme";
+import { chartPalette } from "../../Theme";
 import {
   formatSpeed,
   formatTemperature,
@@ -88,7 +88,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
       yAxis(scale, {
         grid: true,
         label: `Heat (${temperatureUnit(getState().units)})`,
-        stroke: temperatureAxisColor,
+        stroke: chartPalette().temperatureAxis,
         size: FORECAST_AXIS_LEFT - AXIS_LABEL_SIZE,
         values: (_u, splits) => splits.map((t) => String(Math.round(t))),
       }),
@@ -96,7 +96,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         scale: WIND_SCALE,
         side: 1,
         label: `Wind (${speedUnit(getState().units)})`,
-        stroke: windColor,
+        stroke: chartPalette().wind,
         size: FORECAST_AXIS_RIGHT - AXIS_LABEL_SIZE,
         values: (_u, splits) => splits.map((t) => String(Math.round(t))),
       }),
@@ -104,14 +104,14 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
     series: [
       {},
       {
-        stroke: temperatureColor,
+        stroke: chartPalette().temperature,
         width: 1,
         points: { show: false },
         paths: SPLINE,
       },
       {
         scale: WIND_SCALE,
-        stroke: windColor,
+        stroke: chartPalette().wind,
         width: 1,
         points: { show: false },
         paths: SPLINE,

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -8,7 +8,7 @@ import {
   LegendItem,
   padRange,
   spansFromEdges,
-  TICK_LABEL_FILL,
+  tickLabelFill,
   verticalLinePlugin,
   xAxis,
   yAxis,
@@ -21,7 +21,7 @@ import {
 } from "../../helpers/DateTime";
 import { formatWatts, formatWattsAxis } from "../../helpers/Format";
 import { getIntersectionX } from "../../helpers/Math";
-import { blackoutColor, demandColor, supplyColor } from "../../Theme";
+import { chartPalette } from "../../Theme";
 import { LocationType } from "../../Types";
 
 interface ChartData {
@@ -86,7 +86,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         // Sunrise and sunset ride a second axis so the hours stay evenly spaced and readable
         scale: "x",
         side: 2,
-        stroke: TICK_LABEL_FILL,
+        stroke: tickLabelFill(),
         font: chartFont(scale),
         grid: { show: false },
         ticks: { show: false },
@@ -103,27 +103,31 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
     series: [
       {},
       {
-        stroke: supplyColor,
+        stroke: chartPalette().supply,
         width: 1.75,
         fill: HISTORIC_FILL,
         points: { show: false },
         spanGaps: false,
       },
       {
-        stroke: supplyColor,
+        stroke: chartPalette().supply,
         width: 1,
         points: { show: false },
         spanGaps: false,
       },
       {
-        stroke: demandColor,
+        stroke: chartPalette().demand,
         width: 2.5,
         points: { show: false },
       },
     ],
     plugins: [
-      bandsPlugin(() => getState().blackoutSpans, blackoutColor, 0.3),
-      verticalLinePlugin(() => getState().currentMinute, "#000000", 0.5),
+      bandsPlugin(() => getState().blackoutSpans, chartPalette().blackout, 0.3),
+      verticalLinePlugin(
+        () => getState().currentMinute,
+        chartPalette().axis,
+        0.5,
+      ),
       // Flush with the plot's own right edge, wherever the y axis leaves it
       legendPlugin(() => getState().legendItems, 0, 18, "right"),
     ],
@@ -255,11 +259,11 @@ const ChartSupplyDemand = (props: Props): React.JSX.Element => {
   const legendItems: LegendItem[] = [];
   if (legend) {
     legendItems.push(
-      { name: "Supply", fill: supplyColor },
-      { name: "Demand", fill: demandColor },
+      { name: "Supply", fill: chartPalette().supply },
+      { name: "Demand", fill: chartPalette().demand },
     );
     if (blackoutCount > 0) {
-      legendItems.push({ name: "Blackout", fill: blackoutColor });
+      legendItems.push({ name: "Blackout", fill: chartPalette().blackout });
     }
   }
 

--- a/src/components/base/DesktopPanes.tsx
+++ b/src/components/base/DesktopPanes.tsx
@@ -13,8 +13,16 @@ import { getStorageJson, setStorageKeyValue } from "../../LocalStorage";
 
 const WEIGHTS_KEY = "desktopPaneWeights";
 
-// Facilities needs the least width, Finances and Forecasts the most
-const DEFAULT_WEIGHTS = [1, 1.15, 1.15];
+// A layout is only meaningful for the number of panes it was dragged with, and the same window
+// can be showing two of them (a laptop), three (a desktop) or four (an ultrawide) over an
+// afternoon of resizing. Three keeps the original key, so an existing saved layout still loads
+function weightsKey(count: number): string {
+  return count === 3 ? WEIGHTS_KEY : `${WEIGHTS_KEY}${count}`;
+}
+
+// Facilities needs the least width, Finances and Forecasts the most, and the event log is a
+// column of short lines that only ever gets the room left over
+const DEFAULT_WEIGHTS = [1, 1.15, 1.15, 0.75];
 
 // A pane narrower than this stops being readable, so a drag can't push one past it
 const MIN_PANE_PX = 240;
@@ -39,7 +47,7 @@ function defaultWeights(count: number): number[] {
 }
 
 function loadWeights(count: number): number[] {
-  const stored = getStorageJson<number[]>(WEIGHTS_KEY, []);
+  const stored = getStorageJson<number[]>(weightsKey(count), []);
   // A layout saved when there were a different number of panes says nothing about this one
   return isUsableWeights(stored, count) ? stored : defaultWeights(count);
 }
@@ -77,6 +85,16 @@ export default function DesktopPanes(props: Props): React.JSX.Element {
   // out, and is what the next one measures from
   const weightsRef = React.useRef(weights);
   weightsRef.current = weights;
+
+  // A window crossing the ultrawide breakpoint gains or loses a column under a mounted
+  // component, and a grid template with the wrong number of tracks in it lays out nothing at
+  // all. Reloading rather than reslicing, since each pane count has a layout of its own
+  const paneCount = panes.length;
+  React.useEffect(() => {
+    setWeights((current: number[]) =>
+      current.length === paneCount ? current : loadWeights(paneCount),
+    );
+  }, [paneCount]);
 
   // The room the panes have to share, split the way the weights currently say to
   const paneWidths = (): number[] => {
@@ -141,7 +159,7 @@ export default function DesktopPanes(props: Props): React.JSX.Element {
     }
     dragRef.current = null;
     e.currentTarget.releasePointerCapture(e.pointerId);
-    setStorageKeyValue(WEIGHTS_KEY, weightsRef.current);
+    setStorageKeyValue(weightsKey(panes.length), weightsRef.current);
   };
 
   const onKeyDown =
@@ -158,7 +176,7 @@ export default function DesktopPanes(props: Props): React.JSX.Element {
       e.preventDefault();
       const resized = resize(index, paneWidths(), step);
       if (resized) {
-        setStorageKeyValue(WEIGHTS_KEY, resized);
+        setStorageKeyValue(weightsKey(panes.length), resized);
       }
     };
 
@@ -167,12 +185,14 @@ export default function DesktopPanes(props: Props): React.JSX.Element {
     const reset = defaultWeights(panes.length);
     weightsRef.current = reset;
     setWeights(reset);
-    setStorageKeyValue(WEIGHTS_KEY, reset);
+    setStorageKeyValue(weightsKey(panes.length), reset);
   };
 
   // Splitters are grid tracks of their own rather than borders on the panes, so dragging one
   // never changes the total width the panes have to share
-  const template = weights.map((w) => `${w}fr`).join(` ${SPLITTER_PX}px `);
+  const sized =
+    weights.length === panes.length ? weights : loadWeights(panes.length);
+  const template = sized.map((w) => `${w}fr`).join(` ${SPLITTER_PX}px `);
 
   return (
     <div

--- a/src/components/base/FacilityDetails.tsx
+++ b/src/components/base/FacilityDetails.tsx
@@ -8,7 +8,7 @@ import {
   formatWattHoursOfPeak,
   formatWatts,
 } from "../../helpers/Format";
-import { fuelColors, storageColor } from "../../Theme";
+import { facilityColor } from "../../Theme";
 import {
   DateType,
   FacilityOperatingType,
@@ -107,7 +107,7 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
   const lifetime = facilityLifetime(facility);
   const fuel = (facility as Partial<GeneratorOperatingType>).fuel;
   const isStorage = facility.peakWh > 0;
-  const accentColor = (fuel && fuelColors[fuel]) || storageColor;
+  const accentColor = facilityColor(fuel);
   const underConstruction = facility.yearsToBuildLeft > 0;
 
   const trend = fuel ? fuelPriceTrend(fuel, date, seed) : [];

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -1,12 +1,21 @@
 import type { AppDispatch } from "../../Store";
 import * as React from "react";
 import { connect } from "react-redux";
-import { IconButton, Menu, MenuItem, Toolbar, Typography } from "@mui/material";
+import {
+  IconButton,
+  Menu,
+  MenuItem,
+  ToggleButton,
+  ToggleButtonGroup,
+  Toolbar,
+  Typography,
+} from "@mui/material";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import FastForwardIcon from "@mui/icons-material/FastForward";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import PauseIcon from "@mui/icons-material/Pause";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import { TICK_MS } from "../../Constants";
 import { formatHour, getTimeFromTimeline } from "../../helpers/DateTime";
 import { formatMoneyStable } from "../../helpers/Format";
 import { navigate } from "../../reducers/Card";
@@ -47,6 +56,25 @@ interface SpeedOptionsProps {
   handleSpeedClose: () => void;
 }
 
+/**
+ * The speeds, in the order the clock runs them, labelled with how many times faster than SLOW
+ * each one is. Derived from the tick rate rather than written down beside it, so the labels
+ * cannot drift from what the clock actually does -- and a player picking a speed can see what
+ * they are picking rather than inferring it from the number of chevrons on an icon.
+ */
+const RUNNING_SPEEDS: SpeedType[] = ["SLOW", "NORMAL", "FAST"];
+
+function speedMultiplier(speed: SpeedType): string {
+  return Math.round(TICK_MS.SLOW / TICK_MS[speed]) + "×";
+}
+
+const SPEED_ARIA_LABELS: { [k in SpeedType]: string } = {
+  PAUSED: "pause",
+  SLOW: "slow speed",
+  NORMAL: "normal speed",
+  FAST: "fast speed",
+};
+
 // Pulled out of the component so it can be memoised on the handful of things it actually
 // depends on, rather than rebuilt on every tick along with the cash readout beside it
 function buildSpeedOptions({
@@ -58,49 +86,37 @@ function buildSpeedOptions({
   handleSpeedClose,
 }: SpeedOptionsProps): React.JSX.Element {
   if (!smallScreen) {
+    // A group of toggles rather than four icon buttons with the current one disabled: greyed
+    // out is the universal "you cannot click this", which is the opposite of "this is the one
+    // you are on". There is room out here for the multipliers too, so the speeds say how fast
+    // they are instead of being three shades of the same triangle
     return (
-      <span>
-        <IconButton
-          onClick={() => onSpeedChange("PAUSED")}
-          disabled={speed === "PAUSED"}
-          aria-label="pause"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <PauseIcon />
-        </IconButton>
-        <IconButton
-          onClick={() => onSpeedChange("SLOW")}
-          disabled={speed === "SLOW"}
-          aria-label="slow speed"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <ChevronRightIcon />
-        </IconButton>
-        <IconButton
-          onClick={() => onSpeedChange("NORMAL")}
-          disabled={speed === "NORMAL"}
-          aria-label="normal speed"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <PlayArrowIcon />
-        </IconButton>
-        <IconButton
-          onClick={() => onSpeedChange("FAST")}
-          disabled={speed === "FAST"}
-          aria-label="fast speed"
-          edge="end"
-          color="primary"
-          size="large"
-        >
-          <FastForwardIcon />
-        </IconButton>
-      </span>
+      <ToggleButtonGroup
+        className="speedToggles"
+        exclusive
+        size="small"
+        value={speed}
+        onChange={(
+          _e: React.MouseEvent<HTMLElement>,
+          next: SpeedType | null,
+        ) => {
+          // Null is the group reporting that the button already selected was clicked again.
+          // The clock is always running at some speed, so there is nothing to deselect to
+          if (next) {
+            onSpeedChange(next);
+          }
+        }}
+        aria-label="game speed"
+      >
+        <ToggleButton value="PAUSED" aria-label={SPEED_ARIA_LABELS.PAUSED}>
+          <PauseIcon fontSize="small" />
+        </ToggleButton>
+        {RUNNING_SPEEDS.map((s: SpeedType) => (
+          <ToggleButton key={s} value={s} aria-label={SPEED_ARIA_LABELS[s]}>
+            {speedMultiplier(s)}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
     );
   }
 

--- a/src/components/base/GameCard.tsx
+++ b/src/components/base/GameCard.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Toolbar, Typography } from "@mui/material";
 import { getTimeFromTimeline } from "../../helpers/DateTime";
-import { isDesktopScreen } from "../../Globals";
+import { isPaneLayout } from "../../Globals";
 import { AppStateType, GameType } from "../../Types";
 import GameAppBarContainer from "./GameAppBar";
 import NavigationContainer from "./NavigationContainer";
@@ -11,17 +11,17 @@ import NavigationContainer from "./NavigationContainer";
  * The frame the three in-game panes sit in.
  *
  * On a phone there is one pane on screen at a time, so the card carries the app bar and the
- * bottom nav that switches between them. On desktop all three are already on screen and the app
- * bar spans them (see Compositor.renderCard), so a card is just a pane: a header naming it and
- * its own contents.
+ * bottom nav that switches between them. Anything wider puts at least two of them on screen at
+ * once with the app bar spanning them (see Compositor.renderCard), so a card is just a pane
+ * there: a header naming it and its own contents.
  */
 
 export interface GameCardProps extends React.ComponentPropsWithoutRef<"div"> {
   children?: React.JSX.Element | React.JSX.Element[] | undefined;
   className?: string | undefined;
   game: GameType;
-  // Shown as this pane's own header in the desktop layout, since there's no bottom nav there to
-  // tell the panes apart. Panes whose contents already lead with a header of their own (see
+  // Shown as this pane's own header in the side-by-side layouts, since there's no bottom nav
+  // above the desktop breakpoint to tell the panes apart. Panes whose contents already lead with a header of their own (see
   // Facilities, whose header carries the build buttons) leave this unset.
   title?: string;
 }
@@ -38,7 +38,7 @@ export function GameCard(props: Props) {
 
   const classes = ["flexContainer", props.className].filter(Boolean).join(" ");
 
-  if (isDesktopScreen()) {
+  if (isPaneLayout()) {
     return (
       // id is how tutorial steps address an individual pane, since the bottom nav they'd
       // otherwise point at is hidden in this layout

--- a/src/components/base/KeyboardShortcuts.test.tsx
+++ b/src/components/base/KeyboardShortcuts.test.tsx
@@ -1,0 +1,64 @@
+import { SHORTCUTS } from "./KeyboardShortcuts";
+import { keyMap } from "../Compositor";
+
+/**
+ * The two halves of the keyboard contract: the keys react-hotkeys actually listens for, and the
+ * table the Manual and Settings print. They live in different files and drifted before -- a key
+ * the game answers to but never mentions is only a little worse than one it advertises and
+ * ignores, and this is the cheapest way to have neither.
+ */
+
+// Every key any binding listens for, in react-hotkeys' own spelling
+const bound = new Set(
+  Object.values(keyMap)
+    .flatMap((keys: string | string[]) => (Array.isArray(keys) ? keys : [keys]))
+    .map((key: string) => key.toLowerCase()),
+);
+
+/**
+ * The printed form of a key, in that spelling. The table writes for a reader rather than for a
+ * parser: letters are capitalised, and the nine facility slots are one row reading "1-9" rather
+ * than nine rows of their own.
+ */
+function bindingsFor(shortcut: (typeof SHORTCUTS)[number]): string[] {
+  const [first, ...rest] = shortcut.keys;
+  if (first === "shift") {
+    // "shift" then "1-9": nine bindings, one row
+    return rest.flatMap((range: string) => {
+      const [from, to] = range.split("-").map(Number);
+      const keys = [];
+      for (let n = from; n <= to; n++) {
+        keys.push(`shift+${n}`);
+      }
+      return keys;
+    });
+  }
+  return shortcut.keys.map((key: string) => key.toLowerCase());
+}
+
+describe("the keyboard shortcuts", () => {
+  it("binds every key the manual and settings list", () => {
+    const unbound = SHORTCUTS.flatMap((shortcut) =>
+      bindingsFor(shortcut).filter((key: string) => !bound.has(key)),
+    );
+    expect(unbound).toEqual([]);
+  });
+
+  it("keeps the number row on the speeds, and the fleet a shift away from it", () => {
+    // The fleet shortcuts were asked for on the bare number row, which is where the speeds have
+    // lived since long before the fleet had any
+    expect(keyMap.SLOW).toEqual("1");
+    expect(keyMap.NORMAL).toEqual("2");
+    expect(keyMap.FAST).toEqual("3");
+    expect(bound.has("shift+1")).toBe(true);
+    expect(bound.has("shift+9")).toBe(true);
+  });
+
+  it("gives the desktop-only actions keys of their own", () => {
+    // Building and reordering used to be mouse-only, on the screen most likely to have a keyboard
+    expect(bound.has("g")).toBe(true);
+    expect(bound.has("s")).toBe(true);
+    expect(bound.has("[")).toBe(true);
+    expect(bound.has("]")).toBe(true);
+  });
+});

--- a/src/components/base/KeyboardShortcuts.tsx
+++ b/src/components/base/KeyboardShortcuts.tsx
@@ -15,6 +15,16 @@ export const SHORTCUTS: ShortcutType[] = [
   { keys: ["Q"], description: "Facilities tab" },
   { keys: ["W"], description: "Finances tab" },
   { keys: ["E"], description: "Forecasts tab" },
+  { keys: ["G"], description: "Build a generator" },
+  { keys: ["S"], description: "Build storage" },
+  {
+    keys: ["shift", "1-9"],
+    description: "Pause / resume that facility in the fleet",
+  },
+  {
+    keys: ["[", "]"],
+    description: "Move the selected facility up / down the dispatch order",
+  },
   { keys: ["?"], description: "Open the manual" },
 ];
 

--- a/src/components/base/MetricTiles.tsx
+++ b/src/components/base/MetricTiles.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+import { Typography } from "@mui/material";
+import Sparkline from "./Sparkline";
+import { interactiveColor, mutedSeriesColor } from "../../Theme";
+
+/**
+ * The Finances metric picker on a screen with room for one: every headline metric drawn at once,
+ * with the one being plotted promoted to the big chart above.
+ *
+ * A dropdown is what you reach for when there is only room for one number at a time -- it hides
+ * five of the six answers behind a click, and gives no hint which of them is worth looking at.
+ * Six sparklines side by side say "expenses are climbing while revenue is flat" without the
+ * player having to go looking for it, and clicking one is the same gesture the dropdown was.
+ */
+
+export interface MetricTileType {
+  metricKey: string;
+  label: string;
+  /** The metric's latest value, already formatted */
+  value: string;
+  /** Every month on the chart, oldest first, so the tile trends over the same span */
+  values: number[];
+}
+
+export interface Props {
+  tiles: MetricTileType[];
+  selectedKey: string;
+  onSelect: (metricKey: string) => void;
+  // How the walkthrough addresses the metric picker, whichever form it is taking
+  id?: string;
+}
+
+export default function MetricTiles(props: Props): React.JSX.Element {
+  const { tiles, selectedKey, onSelect } = props;
+  return (
+    <div
+      id={props.id}
+      className="metricTiles"
+      role="group"
+      aria-label="Plotted metric"
+    >
+      {tiles.map((tile: MetricTileType) => {
+        const selected = tile.metricKey === selectedKey;
+        return (
+          <button
+            key={tile.metricKey}
+            type="button"
+            className={selected ? "metricTile selected" : "metricTile"}
+            aria-pressed={selected}
+            onClick={() => onSelect(tile.metricKey)}
+          >
+            <Typography
+              variant="body2"
+              color="textSecondary"
+              className="metricTileLabel"
+            >
+              {tile.label}
+            </Typography>
+            <Typography variant="body2" className="metricTileValue">
+              {tile.value}
+            </Typography>
+            <Sparkline
+              values={tile.values}
+              color={selected ? interactiveColor : mutedSeriesColor}
+              width={80}
+              height={18}
+              ariaLabel={`${tile.label} trend`}
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/base/MetricTiles.tsx
+++ b/src/components/base/MetricTiles.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Typography } from "@mui/material";
 import Sparkline from "./Sparkline";
-import { interactiveColor, mutedSeriesColor } from "../../Theme";
+import { chartPalette } from "../../Theme";
 
 /**
  * The Finances metric picker on a screen with room for one: every headline metric drawn at once,
@@ -46,6 +46,9 @@ export default function MetricTiles(props: Props): React.JSX.Element {
             key={tile.metricKey}
             type="button"
             className={selected ? "metricTile selected" : "metricTile"}
+            // Named, because the tile reads as "Profit $6.79M" plus a picture of a line, and
+            // what the button does is plot it
+            aria-label={`Plot ${tile.label}`}
             aria-pressed={selected}
             onClick={() => onSelect(tile.metricKey)}
           >
@@ -61,7 +64,9 @@ export default function MetricTiles(props: Props): React.JSX.Element {
             </Typography>
             <Sparkline
               values={tile.values}
-              color={selected ? interactiveColor : mutedSeriesColor}
+              color={
+                selected ? chartPalette().interactive : chartPalette().muted
+              }
               width={80}
               height={18}
               ariaLabel={`${tile.label} trend`}

--- a/src/components/base/UPlotChart.tsx
+++ b/src/components/base/UPlotChart.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import uPlot from "uplot";
 import "uplot/dist/uPlot.min.css";
 import { chartScale } from "./UPlotHelpers";
+import { getThemeVersion, subscribeThemeMode } from "../../Theme";
 
 /**
  * The React shell every chart in the game sits in.
@@ -121,6 +122,15 @@ export default function UPlotChart<S>(
   const tooltipRef = React.useRef(props.tooltip);
   tooltipRef.current = props.tooltip;
 
+  // A plot's options are built once and then only fed data, so the colours in them are the
+  // ones that were in force when it was built. Switching palette therefore has to rebuild --
+  // which is what this version does, by changing below alongside width and structure
+  const themeVersion = React.useSyncExternalStore(
+    subscribeThemeMode,
+    getThemeVersion,
+    getThemeVersion,
+  );
+
   React.useLayoutEffect(() => {
     const root = rootRef.current!;
     const measure = () => setWidth(root.clientWidth);
@@ -169,9 +179,9 @@ export default function UPlotChart<S>(
       plotRef.current = null;
       drawnRef.current = null;
     };
-    // Data changes go through setData below; only size and shape rebuild
+    // Data changes go through setData below; only size, shape and palette rebuild
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [width, height, structureKey]);
+  }, [width, height, structureKey, themeVersion]);
 
   React.useLayoutEffect(() => {
     if (plotRef.current && drawnRef.current !== data) {

--- a/src/components/base/UPlotHelpers.ts
+++ b/src/components/base/UPlotHelpers.ts
@@ -1,5 +1,5 @@
 import uPlot from "uplot";
-import { chartTheme, withAlpha } from "../../Theme";
+import { chartPalette, withAlpha } from "../../Theme";
 
 /**
  * Shared pieces for the game's uPlot charts: axis styling that matches what the charts looked
@@ -32,11 +32,18 @@ export function chartScale(width: number): number {
 }
 
 export const CHART_FONT_FAMILY = `Roboto, "Helvetica Neue", Helvetica, sans-serif`;
-export const TICK_LABEL_FILL = chartTheme.tickLabels.fill;
 
-// VictoryTheme.material's colours for the parts of an axis that aren't the baseline
-const GRID_STROKE = "#ECEFF1";
-const TICK_STROKE = "#90A4AE";
+/**
+ * The colour an axis labels itself in, read at the moment it is built.
+ *
+ * A function rather than a constant because the palette can change under a running game, and a
+ * module-level constant would hold whichever one happened to be in force when the bundle loaded
+ * -- see Theme.tsx, and the rebuild UPlotChart does when it hears the palette change.
+ */
+export function tickLabelFill(): string {
+  return chartPalette().tickLabel;
+}
+
 // How far a tick pokes out of the axis, and how far the label then sits from it, in design units
 const TICK_SIZE = 5;
 const LABEL_GAP = 4;
@@ -46,9 +53,6 @@ const LABEL_GAP = 4;
 // axis was sized, a glyph with a negative left bearing, plain antialiasing - clips the first
 // character off every label.
 const LABEL_EDGE_PAD = 4;
-// Victory drew legend text in its material theme's near-black rather than the axes' grey
-const LEGEND_TEXT = "#252525";
-
 /** What an axis carrying a `label` adds to its own size, in design units. */
 export const AXIS_LABEL_SIZE = 16;
 
@@ -158,24 +162,25 @@ export function niceSplits(min: number, max: number, target = 5): number[] {
 }
 
 function axisCommon(scale: number, o: AxisOptions) {
+  const palette = chartPalette();
   return {
-    stroke: o.stroke ?? TICK_LABEL_FILL,
+    stroke: o.stroke ?? palette.tickLabel,
     font: chartFont(scale),
     grid: o.grid
       ? {
           show: true,
-          stroke: GRID_STROKE,
+          stroke: palette.grid,
           width: 1,
           dash: [10 * scale, 5 * scale],
         }
       : { show: false },
     ticks: {
       show: true,
-      stroke: TICK_STROKE,
+      stroke: palette.tick,
       width: 1,
       size: TICK_SIZE * scale,
     },
-    border: { show: true, stroke: chartTheme.axis.stroke, width: 1 },
+    border: { show: true, stroke: palette.axis, width: 1 },
     label: o.label,
     labelFont: chartFont(scale),
     labelSize: o.label ? AXIS_LABEL_SIZE * scale : undefined,
@@ -377,7 +382,7 @@ export function legendPlugin(
           u.ctx.beginPath();
           u.ctx.arc(x, y, radius, 0, Math.PI * 2);
           u.ctx.fill();
-          u.ctx.fillStyle = LEGEND_TEXT;
+          u.ctx.fillStyle = chartPalette().legendText;
           u.ctx.fillText(item.name, x + radius + gap, y);
           y += lineHeight;
         }
@@ -406,7 +411,7 @@ export function titlePlugin(
         const scale = canvasScale(u);
         u.ctx.save();
         u.ctx.font = chartFont(scale, 14);
-        u.ctx.fillStyle = chartTheme.axis.stroke;
+        u.ctx.fillStyle = chartPalette().axis;
         u.ctx.textAlign = "center";
         u.ctx.textBaseline = "middle";
         u.ctx.fillText(title, u.bbox.left + u.bbox.width / 2, designY * scale);

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { Typography } from "@mui/material";
+import AccountBalanceIcon from "@mui/icons-material/AccountBalance";
+import AddCircleIcon from "@mui/icons-material/AddCircle";
+import BuildIcon from "@mui/icons-material/Build";
+import FlashOffIcon from "@mui/icons-material/FlashOff";
+import FlashOnIcon from "@mui/icons-material/FlashOn";
+import LocalGasStationIcon from "@mui/icons-material/LocalGasStation";
+import RemoveCircleIcon from "@mui/icons-material/RemoveCircle";
+import GameCard from "../base/GameCard";
+import { GameEventKindType, GameEventType } from "../../Types";
+
+/**
+ * What has happened to the company, in the order it happened.
+ *
+ * Everything in here used to be told to the player exactly once and then thrown away: a blackout
+ * was a toolbar that pulsed until it stopped, a finished plant a toast that lasted four seconds.
+ * Look away, or look at another pane, and there was no way to find out what you had missed --
+ * which makes a simulation feel arbitrary rather than causal. This is the run's own record of it.
+ */
+
+const KIND_ICONS: { [k in GameEventKindType]: React.JSX.Element } = {
+  BLACKOUT: <FlashOffIcon fontSize="small" />,
+  BLACKOUT_OVER: <FlashOnIcon fontSize="small" />,
+  CONSTRUCTION: <BuildIcon fontSize="small" />,
+  BUILD: <AddCircleIcon fontSize="small" />,
+  SELL: <RemoveCircleIcon fontSize="small" />,
+  LOAN: <AccountBalanceIcon fontSize="small" />,
+  FUEL_PRICE: <LocalGasStationIcon fontSize="small" />,
+};
+
+export interface StateProps {
+  events: GameEventType[];
+}
+
+export interface Props extends StateProps {}
+
+export default function EventLog(props: Props): React.JSX.Element {
+  const { events } = props;
+  return (
+    <GameCard className="eventLog" title="Events" id="eventsPane">
+      <div className="scrollable">
+        {events.length === 0 && (
+          <Typography
+            className="eventLogEmpty"
+            variant="body2"
+            color="textSecondary"
+          >
+            Blackouts, finished construction, loans closing and fuel price
+            swings will show up here as they happen.
+          </Typography>
+        )}
+        <ul className="eventLogList">
+          {events.map((event: GameEventType) => (
+            <li className={`eventLogItem kind-${event.kind}`} key={event.id}>
+              <span className="eventLogIcon" aria-hidden="true">
+                {KIND_ICONS[event.kind]}
+              </span>
+              <Typography variant="body2" component="span">
+                {event.message}
+              </Typography>
+              <Typography
+                className="eventLogWhen"
+                variant="body2"
+                color="textSecondary"
+                component="span"
+              >
+                {event.label}
+              </Typography>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </GameCard>
+  );
+}

--- a/src/components/views/EventLogContainer.tsx
+++ b/src/components/views/EventLogContainer.tsx
@@ -1,0 +1,17 @@
+import { connect } from "react-redux";
+import { AppStateType, GameEventType } from "../../Types";
+import EventLog, { StateProps } from "./EventLog";
+
+// One shared array for a run with nothing in its log yet - and for a save written before the log
+// existed. A fresh [] per call would be a new prop every tick, which is a re-render every tick
+const NO_EVENTS: GameEventType[] = [];
+
+const mapStateToProps = (state: AppStateType): StateProps => {
+  return {
+    events: state.game.eventLog || NO_EVENTS,
+  };
+};
+
+const EventLogContainer = connect(mapStateToProps)(EventLog);
+
+export default EventLogContainer;

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -36,7 +36,7 @@ import {
   NotDraggingStyle,
 } from "@hello-pangea/dnd";
 import { TickThrottle } from "../../helpers/RenderThrottle";
-import { fuelColors, storageColor, withAlpha } from "../../Theme";
+import { chartPalette, facilityColor, withAlpha } from "../../Theme";
 import {
   FacilityOperatingType,
   GameType,
@@ -155,7 +155,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
   }
 
   const fuel = (facility as Partial<GeneratorOperatingType>).fuel;
-  const accentColor = (fuel && fuelColors[fuel]) || storageColor;
+  const accentColor = facilityColor(fuel);
   const outputFraction =
     facility.peakW > 0 ? Math.min(1, facility.currentW / facility.peakW) : 0;
   let secondaryText = "";
@@ -345,7 +345,9 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                     style={{
                       height: `${(facility.currentWh / facility.peakWh) * 100}%`,
                       backgroundColor:
-                        activity === "CHARGING" ? storageColor : undefined,
+                        activity === "CHARGING"
+                          ? chartPalette().storage
+                          : undefined,
                     }}
                   />
                 )}

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -60,6 +60,8 @@ import {
 import { UnitsContext } from "../base/UnitsContext";
 import ChartFinances from "../base/ChartFinances";
 import GameCard from "../base/GameCard";
+import MetricTiles, { MetricTileType } from "../base/MetricTiles";
+import { isDesktopScreen } from "../../Globals";
 import { getScenario, SCENARIOS } from "../../data/Scenarios";
 
 import numbro from "numbro";
@@ -222,6 +224,23 @@ const CHART_KEYS_BY_SYSTEM: {
 
 // The metrics on offer, which no system changes - the stored choice is checked against these
 const CHART_KEY_NAMES = Object.keys(CHART_KEYS_BY_SYSTEM.metric);
+
+/**
+ * The metrics the small multiples draw, in the order they are laid out.
+ *
+ * Six rather than all eighteen: these are the ones a player steers on, and the rest are the
+ * breakdowns underneath them, which the table below already carries. Whatever is being plotted
+ * is added to the end if it is not already here, so a metric chosen from the dropdown on a
+ * narrow screen still has a tile to be un-selected from on a wide one.
+ */
+const SMALL_MULTIPLE_KEYS: DerivedHistoryKeysType[] = [
+  "profit",
+  "revenue",
+  "expenses",
+  "kgco2e",
+  "customers",
+  "cash",
+];
 
 const CHART_KEY_STORAGE_KEY = "financesChartKey";
 // Still says year, because a stored year is still one of the options and reading it back is
@@ -443,6 +462,32 @@ function getTickFromValue(v: number) {
   return Math.floor(frontNumber + exponent * 9 - 1);
 }
 
+/**
+ * Where the marketing slider draws its ticks: one per decade of spending.
+ *
+ * Every ninth tick, because that is where the leading digit rolls over and the scale gains a
+ * zero -- the nine steps in between are $1M, $2M, ... $9M, and a mark on each of them is a row
+ * of dots too fine to aim at. Zero gets one of its own, since it sits below the scale.
+ */
+function marketingMarks(maxTick: number): { value: number; label?: string }[] {
+  const marks: { value: number; label?: string }[] = [
+    { value: -1, label: "$0" },
+  ];
+  for (let tick = 0; tick <= maxTick; tick += 9) {
+    marks.push({
+      value: tick,
+      label: formatMoneyConcise(getValueFromTick(tick)),
+    });
+  }
+  return marks;
+}
+
+// The rate slider runs $0 to $0.30/kWh, so its ticks are a fixed nickel apart
+const RATE_MARKS = [0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3].map((rate: number) => ({
+  value: rate,
+  label: formatMoneyConcise(rate),
+}));
+
 export default class Finances extends React.Component<Props, State> {
   // Context rather than a prop: shouldComponentUpdate below throttles renders against the game
   // clock, which a prop change would have to be excepted from - a context change is delivered
@@ -474,6 +519,17 @@ export default class Finances extends React.Component<Props, State> {
   // referentially stable, because that is what lets ChartFinances memoise its canvas.
   private projectionCache:
     { key: string; range: string; months: MonthlyHistoryType[] } | undefined;
+  // The tiles read the same months the chart does, one value per metric rather than one metric
+  // per month, and are rebuilt on the same terms: a month rolling over, or the range moving
+  private tileCache:
+    | {
+        chartKey: DerivedHistoryKeysType;
+        range: string;
+        historyLength: number;
+        projected: MonthlyHistoryType[];
+        tiles: MetricTileType[];
+      }
+    | undefined;
   private seriesCache:
     | {
         chartKey: DerivedHistoryKeysType;
@@ -662,6 +718,53 @@ export default class Finances extends React.Component<Props, State> {
     return series;
   }
 
+  /**
+   * One tile per headline metric: its label, its latest value and the same span of months the
+   * chart is drawing. Built from the derived months once rather than per metric, since deriving
+   * a month is the expensive half and every tile wants the same twelve.
+   */
+  private getTiles(
+    monthlyHistory: MonthlyHistoryType[],
+    projected: MonthlyHistoryType[],
+    chartKeys: { [index: string]: ChartKeyMetadataType },
+  ): MetricTileType[] {
+    const { chartKey, range } = this.state;
+    const historyLength = this.props.game.monthlyHistory.length;
+    const cached = this.tileCache;
+    if (
+      cached &&
+      cached.chartKey === chartKey &&
+      cached.range === range &&
+      cached.historyLength === historyLength &&
+      cached.projected === projected
+    ) {
+      return cached.tiles;
+    }
+
+    // game.monthlyHistory is newest first; the tiles read left to right through time
+    const months = [...monthlyHistory]
+      .reverse()
+      .concat(projected)
+      .map(deriveExpandedSummary);
+    // Whatever is plotted always has a tile, even the breakdowns that aren't headline metrics
+    const keys = SMALL_MULTIPLE_KEYS.includes(chartKey)
+      ? SMALL_MULTIPLE_KEYS
+      : [...SMALL_MULTIPLE_KEYS, chartKey];
+    const tiles = keys.map((key: DerivedHistoryKeysType) => {
+      const values = months.map((m: DerivedHistoryType) => m[key]);
+      const metadata = chartKeys[key];
+      return {
+        metricKey: key,
+        label: metadata.label,
+        value: String(metadata.format(values[values.length - 1] || 0)),
+        values,
+      };
+    });
+
+    this.tileCache = { chartKey, range, historyLength, projected, tiles };
+    return tiles;
+  }
+
   public render() {
     const { game, onDelta, selectedFacilityId } = this.props;
     const chartKeys = CHART_KEYS_BY_SYSTEM[this.context as UnitSystemType];
@@ -676,6 +779,9 @@ export default class Finances extends React.Component<Props, State> {
 
     const scenario =
       getScenario(game.scenarioId, game.customScenario) || SCENARIOS[0];
+    // Six sparklines need width the phone layout does not have, and the dropdown they replace is
+    // the right control at that size -- see MetricTiles
+    const smallMultiples = isDesktopScreen();
     const years = getPlayedYears(game);
 
     // A forward range still draws every month on the record behind its projection, so that the
@@ -766,33 +872,53 @@ export default class Finances extends React.Component<Props, State> {
                 <Typography color="primary" component="strong">
                   {formatMoneyConcise(game.monthlyMarketingSpend)}
                 </Typography>
-                /mo&nbsp; (+
-                {numbro(
-                  customersFromMarketingSpend(game.monthlyMarketingSpend),
-                ).format({ average: true })}{" "}
-                customers)
+                /mo&nbsp;&mdash;&nbsp;customers{" "}
+                {numbro(now.customers).format({ average: true })}
+                &nbsp;&rarr;&nbsp;
+                <Typography color="primary" component="strong">
+                  {numbro(
+                    now.customers +
+                      customersFromMarketingSpend(game.monthlyMarketingSpend),
+                  ).format({ average: true })}
+                </Typography>
+                &nbsp;next month
               </Typography>
             )}
             {scenario.ownership === "Investor" && (
-              <Slider
-                id="marketingSlider"
-                disabled={!!game.replayPlayback}
-                value={getTickFromValue(game.monthlyMarketingSpend)}
-                aria-labelledby="marketing monthly budget"
-                valueLabelDisplay="off"
-                min={-1}
-                step={1}
-                max={getTickFromValue(
-                  Math.max(now.cash / 12, game.monthlyMarketingSpend),
-                )}
-                onChange={(_e: Event, newTick: number | number[]) =>
-                  onDelta({
-                    monthlyMarketingSpend: getValueFromTick(
-                      Array.isArray(newTick) ? newTick[0] : newTick,
+              <div className="budgetSlider flex-newline">
+                <Slider
+                  id="marketingSlider"
+                  disabled={!!game.replayPlayback}
+                  value={getTickFromValue(game.monthlyMarketingSpend)}
+                  aria-label="Monthly marketing budget"
+                  /* On the thumb, so the budget being chosen is legible during the drag that
+                     chooses it rather than only in the line above it */
+                  valueLabelDisplay="auto"
+                  valueLabelFormat={(tick: number) =>
+                    formatMoneyConcise(getValueFromTick(tick))
+                  }
+                  getAriaValueText={(tick: number) =>
+                    `${formatMoneyConcise(getValueFromTick(tick))} per month`
+                  }
+                  marks={marketingMarks(
+                    getTickFromValue(
+                      Math.max(now.cash / 12, game.monthlyMarketingSpend),
                     ),
-                  })
-                }
-              />
+                  )}
+                  min={-1}
+                  step={1}
+                  max={getTickFromValue(
+                    Math.max(now.cash / 12, game.monthlyMarketingSpend),
+                  )}
+                  onChange={(_e: Event, newTick: number | number[]) =>
+                    onDelta({
+                      monthlyMarketingSpend: getValueFromTick(
+                        Array.isArray(newTick) ? newTick[0] : newTick,
+                      ),
+                    })
+                  }
+                />
+              </div>
             )}
             {scenario.ownership === "Public" && (
               <Typography
@@ -813,57 +939,75 @@ export default class Finances extends React.Component<Props, State> {
               </Typography>
             )}
             {scenario.ownership === "Public" && (
-              <Slider
-                id="rateSlider"
-                disabled={!!game.replayPlayback}
-                value={game.dollarsPerkWh}
-                aria-labelledby="The rate you charge for electricity generation"
-                valueLabelDisplay="off"
-                min={0}
-                step={0.01}
-                max={0.3}
-                onChange={(_e: Event, newTick: number | number[]) =>
-                  onDelta({
-                    dollarsPerkWh: Array.isArray(newTick)
-                      ? newTick[0]
-                      : newTick,
-                  })
-                }
-              />
+              <div className="budgetSlider flex-newline">
+                <Slider
+                  id="rateSlider"
+                  disabled={!!game.replayPlayback}
+                  value={game.dollarsPerkWh}
+                  aria-label="The rate you charge for electricity generation"
+                  valueLabelDisplay="auto"
+                  valueLabelFormat={(rate: number) =>
+                    `${formatMoneyConcise(rate)}/kWh`
+                  }
+                  getAriaValueText={(rate: number) =>
+                    `${formatMoneyConcise(rate)} per kilowatt hour`
+                  }
+                  marks={RATE_MARKS}
+                  min={0}
+                  step={0.01}
+                  max={0.3}
+                  onChange={(_e: Event, newTick: number | number[]) =>
+                    onDelta({
+                      dollarsPerkWh: Array.isArray(newTick)
+                        ? newTick[0]
+                        : newTick,
+                    })
+                  }
+                />
+              </div>
             )}
             <div className="flex-newline"></div>
             <Typography variant="h6" style={{ flexGrow: 0 }}>
               Plotting{" "}
             </Typography>
+            {/* The tiles below are the picker on a wide screen, so out here the metric is a
+                label rather than a control */}
+            {smallMultiples && (
+              <Typography variant="h6" style={{ flexGrow: 0 }}>
+                {chartKeys[chartKey].label}
+              </Typography>
+            )}
             {/* Controlled, so the label and the chart cannot disagree about what is plotted */}
-            <Select
-              id="plotMetric"
-              value={chartKey}
-              onChange={(e: SelectChangeEvent<string>) =>
-                this.setChartKey(e.target.value as DerivedHistoryKeysType)
-              }
-            >
-              {CHART_KEY_NAMES.map((key: string) => {
-                const k = chartKeys[key];
-                let label = k.label;
-                if (chartKey !== key && chartKeys[key].nesting) {
-                  // https://stackoverflow.com/questions/14343844/create-a-string-of-variable-length-filled-with-a-repeated-character
-                  label =
-                    new Array((chartKeys[key].nesting || 0) + 1).join(" -") +
-                    " " +
-                    label;
+            {!smallMultiples && (
+              <Select
+                id="plotMetric"
+                value={chartKey}
+                onChange={(e: SelectChangeEvent<string>) =>
+                  this.setChartKey(e.target.value as DerivedHistoryKeysType)
                 }
-                return (
-                  <MenuItem
-                    className={!k.nesting ? "bold" : `tabs-${k.nesting}`}
-                    value={key}
-                    key={key}
-                  >
-                    {label}
-                  </MenuItem>
-                );
-              })}
-            </Select>
+              >
+                {CHART_KEY_NAMES.map((key: string) => {
+                  const k = chartKeys[key];
+                  let label = k.label;
+                  if (chartKey !== key && chartKeys[key].nesting) {
+                    // https://stackoverflow.com/questions/14343844/create-a-string-of-variable-length-filled-with-a-repeated-character
+                    label =
+                      new Array((chartKeys[key].nesting || 0) + 1).join(" -") +
+                      " " +
+                      label;
+                  }
+                  return (
+                    <MenuItem
+                      className={!k.nesting ? "bold" : `tabs-${k.nesting}`}
+                      value={key}
+                      key={key}
+                    >
+                      {label}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+            )}
             <Typography variant="h6" style={{ flexGrow: 0 }}>
               {" "}
               for{" "}
@@ -907,6 +1051,16 @@ export default class Finances extends React.Component<Props, State> {
             />
           ) : (
             <span />
+          )}
+          {smallMultiples && monthly.length > 0 && (
+            <MetricTiles
+              id="plotMetric"
+              tiles={this.getTiles(monthlyHistory, projectedMonths, chartKeys)}
+              selectedKey={chartKey}
+              onSelect={(key: string) =>
+                this.setChartKey(key as DerivedHistoryKeysType)
+              }
+            />
           )}
           <div
             className={`expandable ${!expanded && "notExpanded"}`}

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -753,10 +753,14 @@ export default class Finances extends React.Component<Props, State> {
     const tiles = keys.map((key: DerivedHistoryKeysType) => {
       const values = months.map((m: DerivedHistoryType) => m[key]);
       const metadata = chartKeys[key];
+      const latest = metadata.format(values[values.length - 1] || 0);
       return {
         metricKey: key,
         label: metadata.label,
-        value: String(metadata.format(values[values.length - 1] || 0)),
+        // A number with no unit on it is a different number: "380K" of CO2e could be anything
+        value: metadata.suffix
+          ? `${latest}${metadata.suffix.startsWith("/") ? "" : " "}${metadata.suffix}`
+          : String(latest),
         values,
       };
     });
@@ -872,16 +876,22 @@ export default class Finances extends React.Component<Props, State> {
                 <Typography color="primary" component="strong">
                   {formatMoneyConcise(game.monthlyMarketingSpend)}
                 </Typography>
-                /mo&nbsp;&mdash;&nbsp;customers{" "}
-                {numbro(now.customers).format({ average: true })}
-                &nbsp;&rarr;&nbsp;
-                <Typography color="primary" component="strong">
-                  {numbro(
-                    now.customers +
-                      customersFromMarketingSpend(game.monthlyMarketingSpend),
-                  ).format({ average: true })}
-                </Typography>
-                &nbsp;next month
+                /mo&nbsp;&mdash;&nbsp;
+                {numbro(now.customers).format({ average: true })} customers
+                {game.monthlyMarketingSpend > 0 && (
+                  <>
+                    &nbsp;&rarr;&nbsp;
+                    <Typography color="primary" component="strong">
+                      {numbro(
+                        now.customers +
+                          customersFromMarketingSpend(
+                            game.monthlyMarketingSpend,
+                          ),
+                      ).format({ average: true })}
+                    </Typography>
+                    &nbsp;next month
+                  </>
+                )}
               </Typography>
             )}
             {scenario.ownership === "Investor" && (

--- a/src/components/views/FinancesSmallMultiples.test.tsx
+++ b/src/components/views/FinancesSmallMultiples.test.tsx
@@ -1,0 +1,136 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { produce } from "immer";
+import Finances from "./Finances";
+import { createGame } from "../../testing/Simulator";
+import { tickState } from "../../reducers/Game";
+import { GameType } from "../../Types";
+
+/**
+ * The Finances metric picker on a screen wide enough for small multiples, where the dropdown is
+ * replaced by a tile per headline metric. Its own file because the choice is made by measuring
+ * the window, and a module mock is the only way to be a desktop in jsdom - the sibling suite
+ * covers the same pane at phone width, where the dropdown is still the right control.
+ */
+
+jest.setTimeout(30000);
+
+jest.mock("../../Globals", () => ({
+  ...jest.requireActual("../../Globals"),
+  isDesktopScreen: () => true,
+}));
+
+jest.mock("../base/GameCard", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+const user = userEvent.setup({ delay: null });
+
+// jsdom never lays the chart out, so uPlot never builds: the accessible name of its root is the
+// only thing that says which series was passed down. The tiles are images too, and say so
+function plottedMetric(): string {
+  const chart = screen
+    .getAllByRole("img")
+    .find(
+      (el: HTMLElement) =>
+        !(el.getAttribute("aria-label") || "").endsWith("trend"),
+    );
+  return chart?.getAttribute("aria-label") || "";
+}
+
+// By label rather than by role and name: asking for a button by its accessible name makes
+// testing-library compute one for every button on the pane, which costs about a second a call
+function tile(label: string): HTMLElement {
+  return screen.getByLabelText(`Plot ${label}`);
+}
+
+function playMonths(months: number): GameType {
+  let state = createGame({ scenarioId: 100 });
+  while (state.date.monthsEllapsed < months) {
+    state = produce(state, (draft: GameType) => {
+      tickState(draft);
+    });
+  }
+  return state;
+}
+
+function renderFinances(game: GameType) {
+  render(
+    <Finances
+      game={game}
+      selectedFacilityId={null}
+      onDelta={() => undefined}
+    />,
+  );
+}
+
+describe("the Finances small multiples", () => {
+  const game = playMonths(14);
+
+  beforeEach(() => localStorage.clear());
+
+  it("draws a tile per headline metric instead of the dropdown", () => {
+    renderFinances(game);
+
+    [
+      "Profit",
+      "Revenue",
+      "Expenses",
+      "CO2e emitted",
+      "Customers",
+      "Cash",
+    ].forEach((label: string) => {
+      expect(tile(label)).toBeInTheDocument();
+    });
+    // Only the period select is left: the metric one is what the tiles replaced
+    expect(screen.getAllByRole("combobox")).toHaveLength(1);
+  });
+
+  it("promotes the tile that is clicked to the chart, and says which one that is", async () => {
+    renderFinances(game);
+    expect(plottedMetric()).toContain("Profit");
+    expect(tile("Profit")).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(tile("Revenue"));
+    expect(plottedMetric()).toContain("Revenue");
+    expect(tile("Revenue")).toHaveAttribute("aria-pressed", "true");
+    expect(tile("Profit")).toHaveAttribute("aria-pressed", "false");
+
+    // The second change is the one a render throttle would swallow, and picking a metric is a
+    // direct request rather than something the game clock did
+    await user.click(tile("Cash"));
+    expect(plottedMetric()).toContain("Cash");
+  });
+
+  it("remembers the metric across a remount, the way the dropdown did", async () => {
+    const view = render(
+      <Finances
+        game={game}
+        selectedFacilityId={null}
+        onDelta={() => undefined}
+      />,
+    );
+    await user.click(tile("Expenses"));
+    view.unmount();
+
+    renderFinances(game);
+    expect(plottedMetric()).toContain("Expenses");
+    expect(tile("Expenses")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  /**
+   * The dropdown offers every metric, including the breakdowns that aren't headline enough for a
+   * tile of their own -- so a player who chose one on a phone has to be able to see it here.
+   */
+  it("adds a tile for a metric chosen elsewhere", () => {
+    localStorage.setItem("financesChartKey", "expensesFuel");
+
+    renderFinances(game);
+    expect(plottedMetric()).toContain("Fuel");
+    expect(tile("Fuel")).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/src/components/views/Forecasts.tsx
+++ b/src/components/views/Forecasts.tsx
@@ -306,7 +306,7 @@ export default class Forecasts extends React.Component<Props, State> {
               items={[
                 ...[...fuels].reverse().map((f) => ({
                   name: f,
-                  color: fuelColors[f],
+                  color: fuelColors()[f],
                   muted: !!highlightFuel && f !== highlightFuel,
                 })),
                 { name: "Demand", color: "", rule: true },
@@ -346,7 +346,7 @@ export default class Forecasts extends React.Component<Props, State> {
               inline
               items={PRICED_FUELS.map((f) => ({
                 name: f,
-                color: fuelColors[f],
+                color: fuelColors()[f],
                 dash: fuelDashArrays[f],
               }))}
             />

--- a/src/components/views/Settings.test.tsx
+++ b/src/components/views/Settings.test.tsx
@@ -5,13 +5,14 @@ import Settings, { Props } from "./Settings";
 
 function renderSettings(overrides: Partial<Props> = {}) {
   const props: Props = {
-    settings: { units: "metric" },
+    settings: { units: "metric", theme: "system" },
     loggedIn: false,
     onLogin: () => undefined,
     onLogout: () => undefined,
     onChangeName: () => undefined,
     onAudioChange: () => undefined,
     onUnitsChange: () => undefined,
+    onThemeChange: () => undefined,
     onExportSave: () => undefined,
     onImportSave: () => undefined,
     onBack: () => undefined,

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -10,8 +10,9 @@ import {
   Typography,
 } from "@mui/material";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
-import { SettingsType, UnitSystemType } from "../../Types";
+import { SettingsType, ThemeChoiceType, UnitSystemType } from "../../Types";
 import { UNIT_SYSTEMS, UNIT_SYSTEM_LABELS } from "../../helpers/Units";
+import { THEME_CHOICES, THEME_LABELS } from "../../Theme";
 import KeyboardShortcuts from "../base/KeyboardShortcuts";
 import packageJson from "../../../package.json";
 
@@ -30,6 +31,7 @@ export interface DispatchProps {
   onChangeName: () => void;
   onAudioChange: (change: boolean) => void;
   onUnitsChange: (change: UnitSystemType) => void;
+  onThemeChange: (change: ThemeChoiceType) => void;
   onExportSave: () => void;
   onImportSave: (file: File) => void;
   onBack: () => void;
@@ -162,6 +164,27 @@ export default function Settings(props: Props): React.JSX.Element {
           {props.settings.units === "imperial"
             ? "Temperatures in °F, wind in mph, emissions in pounds and tons."
             : "Temperatures in °C, wind in km/h, emissions in kilograms and tonnes."}
+        </Typography>
+        <Typography variant="h6" style={{ marginTop: 24 }}>
+          Appearance
+        </Typography>
+        <Select
+          id="theme"
+          value={props.settings.theme}
+          onChange={(e: SelectChangeEvent<ThemeChoiceType>) =>
+            props.onThemeChange(e.target.value as ThemeChoiceType)
+          }
+        >
+          {THEME_CHOICES.map((choice: ThemeChoiceType) => (
+            <MenuItem value={choice} key={choice}>
+              {THEME_LABELS[choice]}
+            </MenuItem>
+          ))}
+        </Select>
+        <Typography variant="body2" color="textSecondary">
+          {props.settings.theme === "system"
+            ? "Follows whatever your device is set to, and changes with it."
+            : "Sessions run long; the charts are drawn for both."}
         </Typography>
         <Typography variant="h6" style={{ marginTop: 24 }}>
           Saved Game

--- a/src/components/views/SettingsContainer.tsx
+++ b/src/components/views/SettingsContainer.tsx
@@ -12,7 +12,7 @@ import {
   readSaveFile,
   resumableSave,
 } from "../../SaveFile";
-import { AppStateType, UnitSystemType } from "../../Types";
+import { AppStateType, ThemeChoiceType, UnitSystemType } from "../../Types";
 import Settings, { DispatchProps, StateProps } from "./Settings";
 import { confirmReplacingSave } from "./StartGame";
 
@@ -44,6 +44,11 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     },
     onUnitsChange: (v: UnitSystemType) => {
       dispatch(changeSettings({ units: v }));
+    },
+    // The palette itself is applied above the store, in App's ThemedApp, which is the only
+    // place that can also hear the system changing its mind while the game is open
+    onThemeChange: (v: ThemeChoiceType) => {
+      dispatch(changeSettings({ theme: v }));
     },
     onExportSave: () => {
       // Read again rather than trusting the render: the button is only enabled when there's a

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -431,6 +431,20 @@ export const SCENARIOS = [
             customers through chronic blackouts!
           </Typography>
         ),
+        // Same control, different shape: on a wide screen the metrics are all drawn at once
+        // rather than hidden behind a dropdown
+        desktop: {
+          content: (
+            <Typography variant="body1">
+              Click the Customers tile to plot it and see how they change over
+              time.
+              <br />
+              <br />
+              Beware, marketing too much too quickly may actually cost you
+              customers through chronic blackouts!
+            </Typography>
+          ),
+        },
       },
       {
         card: "FINANCES",

--- a/src/reducers/EventLog.test.tsx
+++ b/src/reducers/EventLog.test.tsx
@@ -1,0 +1,127 @@
+import cloneDeep from "lodash.clonedeep";
+import gameReducer, { buildFacility, sellFacility, tickState } from "./Game";
+import { GENERATORS } from "../data/Facilities";
+import { createGame } from "../testing/Simulator";
+import {
+  FacilityOperatingType,
+  GameEventType,
+  GameType,
+  GeneratorShoppingType,
+} from "../Types";
+
+/**
+ * The event log: the run's own record of what happened to it.
+ *
+ * Everything in here was previously announced once - a toast, or a bar that pulsed while it was
+ * true - and then forgotten, which is what these are about: not that the player was told, but
+ * that they can still find out afterwards.
+ */
+
+// Redux Toolkit freezes reducer output in development, and tickState mutates state in place
+function ticked(state: GameType, ticks: number): GameType {
+  const next = cloneDeep(state);
+  for (let i = 0; i < ticks; i++) {
+    tickState(next);
+  }
+  return next;
+}
+
+function messages(state: GameType): string[] {
+  return (state.eventLog || []).map((e: GameEventType) => e.message);
+}
+
+function kinds(state: GameType): string[] {
+  return (state.eventLog || []).map((e: GameEventType) => e.kind);
+}
+
+// A fleet that has been switched off entirely, which is the shortest road to a blackout
+function pauseEverything(state: GameType): GameType {
+  const next = cloneDeep(state);
+  next.facilities.forEach((f: FacilityOperatingType) => {
+    f.paused = true;
+  });
+  return next;
+}
+
+describe("the event log", () => {
+  it("starts empty, and stays empty while nothing happens", () => {
+    const game = createGame({ scenarioId: 100 });
+    expect(game.eventLog).toEqual([]);
+    // Half a month of a company doing exactly what it was doing before
+    expect(messages(ticked(game, 48))).toEqual([]);
+  });
+
+  it("records a blackout, and what it cost once the lights are back", () => {
+    const dark = ticked(pauseEverything(createGame({ scenarioId: 100 })), 60);
+    expect(kinds(dark)).toContain("BLACKOUT");
+
+    // Switching the fleet back on ends it, and the entry that closes it carries the bill
+    const recovered = cloneDeep(dark);
+    recovered.facilities.forEach((f: FacilityOperatingType) => {
+      f.paused = false;
+    });
+    const lit = ticked(recovered, 60);
+    const over = (lit.eventLog || []).find(
+      (e: GameEventType) => e.kind === "BLACKOUT_OVER",
+    );
+    expect(over).toBeDefined();
+    expect(over?.message).toMatch(/unserved/);
+    // Something was actually unserved, rather than the sentence being drawn around a zero
+    expect(over?.message).not.toMatch(/\b0Wh\b/);
+  });
+
+  it("stamps each entry with the month it happened in, newest first", () => {
+    const dark = ticked(pauseEverything(createGame({ scenarioId: 100 })), 200);
+    const log = dark.eventLog || [];
+    expect(log.length).toBeGreaterThan(0);
+    expect(log[0].label).toMatch(/^[A-Z][a-z]{2} \d{4}$/);
+    // Ids are handed out in order, so newest first means descending
+    const ids = log.map((e: GameEventType) => e.id);
+    expect(ids).toEqual([...ids].sort((a, b) => b - a));
+  });
+
+  it("records building a facility, and selling it again", () => {
+    const game = createGame({ scenarioId: 100 });
+    const generator = GENERATORS(game, 500000000, [], []).find(
+      (g: GeneratorShoppingType) => g.name === "Wind",
+    );
+    expect(generator).toBeDefined();
+
+    const built = cloneDeep(
+      gameReducer(
+        game,
+        buildFacility({ facility: generator!, financed: false }),
+      ),
+    );
+    expect(kinds(built)[0]).toEqual("BUILD");
+    expect(messages(built)[0]).toContain("Wind");
+
+    // Still under construction, so this is a cancellation rather than a sale
+    const underConstruction = built.facilities.find(
+      (f: FacilityOperatingType) => f.yearsToBuildLeft > 0,
+    );
+    expect(underConstruction).toBeDefined();
+    const cancelled = cloneDeep(
+      gameReducer(built, sellFacility(underConstruction!.id)),
+    );
+    expect(messages(cancelled)[0]).toContain("Cancelled construction");
+
+    const operating = built.facilities.find(
+      (f: FacilityOperatingType) => f.yearsToBuildLeft === 0,
+    );
+    expect(operating).toBeDefined();
+    const sold = cloneDeep(gameReducer(built, sellFacility(operating!.id)));
+    expect(kinds(sold)[0]).toEqual("SELL");
+    expect(messages(sold)[0]).toMatch(/^Sold /);
+  });
+
+  /**
+   * A run can go on for a century, and every one of these is also carried in the save file --
+   * so the log is a window on the recent past rather than a complete history.
+   */
+  it("keeps only the most recent hundred entries", () => {
+    const dark = ticked(pauseEverything(createGame({ scenarioId: 100 })), 400);
+    const log = dark.eventLog || [];
+    expect(log.length).toBeLessThanOrEqual(100);
+  });
+});

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -6,6 +6,7 @@ import {
   getDateFromMinute,
   getMonthYearFromMinute,
   getTimeFromTimeline,
+  MINUTES_PER_MONTH,
   summarizeHistory,
   summarizeTimeline,
   getSunriseSunset,
@@ -75,6 +76,9 @@ import {
   DateType,
   FacilityOperatingType,
   FacilityShoppingType,
+  FuelPricesType,
+  GameEventKindType,
+  GameEventType,
   LocationType,
   GameType,
   GeneratorOperatingType,
@@ -122,6 +126,98 @@ let previousMonth = "";
 // Edge-detects the blackout toast, so a sustained blackout announces itself once rather than
 // four times an hour of game time
 let previouslyInBlackout = false;
+// What the blackout currently underway has cost, so the event log can say how bad it was once
+// it's over. Reset on each edge into one; meaningless while the lights are on
+let blackoutStartMinute = 0;
+let blackoutUnservedWh = 0;
+// Last month's fuel prices, to compare this month's against. Undefined before the first
+// rollover of a run, and after resuming a save - the first month back reports no move rather
+// than inventing one against prices from whenever the game was last open
+let previousFuelPrices: FuelPricesType | undefined;
+// How much history the log keeps. Long enough to cover the run a player is likely to scroll
+// back through, short enough that it never becomes the biggest thing in a save file
+const MAX_EVENTS = 100;
+
+/**
+ * How long a blackout lasted, in whichever unit reads honestly at that length.
+ *
+ * The game simulates one day per month, so an outage that runs into a second day has already
+ * crossed a month boundary -- reporting that as "27h" reads as a bad night rather than as the
+ * quarter of a year the calendar above it just moved through.
+ */
+function blackoutLength(minutes: number): string {
+  if (minutes >= MINUTES_PER_MONTH) {
+    const months = Math.round(minutes / MINUTES_PER_MONTH);
+    return `${months} month${months === 1 ? "" : "s"}`;
+  }
+  return `${Math.max(1, Math.round(minutes / 60))}h`;
+}
+
+/**
+ * Records something that happened to the company, newest first.
+ *
+ * Only ever called from a real tick or a player action: the forecast runs the same code over
+ * months that haven't happened, and a log full of blackouts the player was never in would be
+ * worse than no log at all.
+ */
+function logGameEvent(
+  state: GameType,
+  kind: GameEventKindType,
+  message: string,
+) {
+  if (!state.eventLog) {
+    state.eventLog = [];
+  }
+  const log = state.eventLog;
+  log.unshift({
+    id: (log.length > 0 ? log[0].id : 0) + 1,
+    kind,
+    label: `${state.date.month} ${state.date.year}`,
+    message,
+  });
+  if (log.length > MAX_EVENTS) {
+    log.length = MAX_EVENTS;
+  }
+}
+
+// How far a fuel has to move in a month to be worth a line in the log. Prices wander a percent
+// or two on their own; this is the size of move that changes which plant is cheapest to run
+const FUEL_PRICE_SPIKE = 0.15;
+
+/**
+ * Logs the fuels that moved sharply this month, for the fuels the fleet actually burns.
+ *
+ * A coal spike is not news to a company running on wind, and the fuel price chart in Forecasts
+ * already draws every fuel for the player who wants them all.
+ */
+function logFuelPriceMoves(state: GameType) {
+  const prices = getFuelPricesPerMBTU(state.date, state.seed);
+  const previous = previousFuelPrices;
+  previousFuelPrices = prices;
+  if (!previous) {
+    return;
+  }
+  const burned = new Set<string>();
+  state.facilities.forEach((f: FacilityOperatingType) => {
+    const fuel = (f as Partial<GeneratorOperatingType>).fuel;
+    // Wind and sun are fuels the game names but nobody prices
+    if (fuel && previous[fuel] !== undefined && prices[fuel] !== undefined) {
+      burned.add(fuel);
+    }
+  });
+  burned.forEach((fuel: string) => {
+    const change = (prices[fuel] - previous[fuel]) / previous[fuel];
+    if (Math.abs(change) < FUEL_PRICE_SPIKE) {
+      return;
+    }
+    logGameEvent(
+      state,
+      "FUEL_PRICE",
+      `${fuel} ${change > 0 ? "up" : "down"} ${Math.round(Math.abs(change) * 100)}% to ${formatMoneyConcise(prices[fuel])}/MBTU`,
+    );
+  });
+}
+
 const initialGame: GameType = {
   seed: newSeed(),
   scenarioId: 0,
@@ -142,6 +238,7 @@ const initialGame: GameType = {
   date: getDateFromMinute(0, 2020),
   timeline: [] as TickPresentFutureType[],
   monthlyHistory: [] as MonthlyHistoryType[],
+  eventLog: [] as GameEventType[],
 };
 
 // Restarts the self-rescheduling tick() loop when leaving PAUSED, unless it's already running.
@@ -209,6 +306,9 @@ export const gameSlice = createSlice({
       // its first rollover, which also makes an otherwise identical seed produce a different run
       previousMonth = "";
       previouslyInBlackout = false;
+      blackoutUnservedWh = 0;
+      previousFuelPrices = undefined;
+      state.eventLog = [] as GameEventType[];
       state.timeline = [] as TickPresentFutureType[];
       // A game being watched is not a game being recorded; anything else starts an empty log,
       // which is also what tells serializeReplay the run was recorded from its very first minute
@@ -327,6 +427,9 @@ export const gameSlice = createSlice({
       previousMonth = restored.date.month;
       const now = getTimeFromTimeline(restored.date.minute, restored.timeline);
       previouslyInBlackout = now ? now.supplyW < now.demandW : false;
+      blackoutStartMinute = restored.date.minute;
+      blackoutUnservedWh = 0;
+      previousFuelPrices = undefined;
       speedBeforeDialog = "PAUSED";
       // Never resume mid-tick; loaded() flips inGame once the CSVs are back
       restored.speed = "PAUSED";
@@ -435,13 +538,29 @@ export default gameSlice.reducer;
  * "the player built a plant", not two that have to be kept in step.
  */
 function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
-  state = buildFacilityHelper(state, payload.facility, payload.financed);
+  const built = payload.facility;
+  logGameEvent(
+    state,
+    "BUILD",
+    `Building ${built.name}, ${built.peakWh ? formatWattHours(built.peakWh) : formatWatts(built.peakW)}${payload.financed ? " (financed)" : ""}`,
+  );
+  state = buildFacilityHelper(state, built, payload.financed);
   // Assigned rather than spread into a new object: this is an immer draft, so a fresh object
   // assigned to the parameter is discarded and the forecast would never reach state
   state.timeline = reforecastSupply(state);
 }
 
 function applySellFacility(state: GameType, id: number) {
+  const sold = state.facilities.find((g: FacilityOperatingType) => g.id === id);
+  if (sold) {
+    logGameEvent(
+      state,
+      sold.yearsToBuildLeft > 0 ? "BUILD" : "SELL",
+      sold.yearsToBuildLeft > 0
+        ? `Cancelled construction of ${sold.name}`
+        : `Sold ${sold.name}, ${sold.peakWh ? formatWattHours(sold.peakWh) : formatWatts(sold.peakW)} for ${formatMoneyConcise(facilityCashBack(sold))}`,
+    );
+  }
   // in one loop, refund cash from selling + remove from list
   state.facilities = state.facilities.filter(
     (g: GeneratorOperatingType | StorageOperatingType) => {
@@ -630,8 +749,28 @@ export function tickState(state: GameType) {
     // The pulsing top bar only tells a player who is looking at it, and by default they're
     // looking at Finances or Forecasts. Fire on the edges only, never per tick.
     const inBlackout = now.supplyW < now.demandW;
+    if (inBlackout) {
+      // What the lights being out is actually costing, in the same units the score is docked in.
+      // Accumulated per tick rather than worked out at the end, since the gap moves the whole
+      // time the blackout lasts
+      blackoutUnservedWh +=
+        ((now.demandW - now.supplyW) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+    }
     if (inBlackout !== previouslyInBlackout) {
       previouslyInBlackout = inBlackout;
+      if (inBlackout) {
+        blackoutStartMinute = state.date.minute;
+        blackoutUnservedWh = 0;
+        logGameEvent(state, "BLACKOUT", "Blackout: demand outran your supply");
+      } else {
+        // The toast that says this vanishes in four seconds and the pulsing bar stops the moment
+        // it's over, so without this a player who was looking elsewhere never learns what it cost
+        logGameEvent(
+          state,
+          "BLACKOUT_OVER",
+          `Blackout over after ${blackoutLength(state.date.minute - blackoutStartMinute)} - ${formatWattHours(blackoutUnservedWh)} unserved`,
+        );
+      }
       const message = inBlackout
         ? "Blackout! Demand is outrunning your supply."
         : "Blackout over - supply is meeting demand again.";
@@ -665,6 +804,7 @@ export function tickState(state: GameType) {
       state.interestRate =
         getPrimeRate(state.date, state.seed) * state.creditPremium;
       state.timeline = generateNewTimeline(state, cash, customers);
+      logFuelPriceMoves(state);
 
       // Pre-roll a few frames to compensate for temperature / demand jumps across months
       for (let i = 0; i < 4; i++) {
@@ -999,6 +1139,7 @@ function updateSupplyFacilitiesFinances(
       f.yearsToBuildLeft = Math.max(0, f.yearsToBuildLeft - YEARS_PER_TICK);
       if (f.yearsToBuildLeft === 0 && !simulated) {
         const message = `Construction complete: ${f.name}, ${f.peakWh ? formatWattHours(f.peakWh) : formatWatts(f.peakW)}`; // defining for functions running inside of setTimeout
+        logGameEvent(state, "CONSTRUCTION", message);
         setTimeout(() => {
           getStore().dispatch(snackbarOpen(message));
         }, 0);
@@ -1176,6 +1317,11 @@ function updateSupplyFacilitiesFinances(
         expensesInterest += paymentInterest / TICKS_PER_MONTH;
         principalRepayment += paymentPrincipal;
         g.loanAmountLeft -= paymentPrincipal;
+        // The last payment of a loan is the only interesting one, and nothing else on screen
+        // marks it: the interest line simply stops going down
+        if (!simulated && g.loanAmountLeft <= 0) {
+          logGameEvent(state, "LOAN", `Loan paid off: ${g.name}`);
+        }
         facilityExpenses += paymentInterest / TICKS_PER_MONTH;
       }
       // Only a real tick is a tick of this facility's life. The pre-roll frames after a month

--- a/src/reducers/Settings.tsx
+++ b/src/reducers/Settings.tsx
@@ -7,12 +7,16 @@ import {
 import { SettingsType } from "../Types";
 import { pause, resume } from "../data/Audio";
 import { DEFAULT_UNIT_SYSTEM, UNIT_SYSTEMS } from "../helpers/Units";
+import { THEME_CHOICES } from "../Theme";
 
 export const initialSettings: SettingsType = {
   audioEnabled: getStorageBooleanOrUndefined("audioEnabled"),
   // getStorageChoice rather than getStorageString so a hand-edited or outdated value falls back
   // to metric instead of reaching the formatters as a system that does not exist
   units: getStorageChoice("units", UNIT_SYSTEMS, DEFAULT_UNIT_SYSTEM),
+  // Following the OS is the only default that is right for both kinds of player without being
+  // asked, and it is what every other app on their machine does
+  theme: getStorageChoice("theme", THEME_CHOICES, "system"),
 };
 
 export const settingsSlice = createSlice({


### PR DESCRIPTION
Items 11-17 of #177, the second half of the desktop UX list. Items 1-10 landed in #179 and #182.

### 11. Small multiples in Finances

The metric dropdown hid five of its six headline answers behind a click, and gave no hint which
one was worth looking at. Where there's width for it, the pane now draws all six at once -
profit, revenue, expenses, emissions, customers, cash - as a sparkline each, with the one being
plotted promoted to the chart above. Clicking a tile is the same gesture the dropdown was.

The dropdown stays below the desktop breakpoint, where six tiles don't fit and hiding them is the
right call - and because it's the only way to plot the breakdowns (fuel, interest, unit revenue)
that aren't headline enough for a tile. One chosen there gets a tile of its own here, so the
setting is never stranded.

### 12. The marketing slider

Full width, unlabelled, no ticks, and its only feedback in the small print above it. It now
carries the budget on the thumb while you drag it, a mark per decade of spending, and says what
the spend buys next to what you already have: "$2M/mo - 120K customers -> 138K next month". The
rate slider is the same control doing the same job, so it got the same treatment.

### 13. Keyboard map

`g` / `s` build a generator or storage, `shift+1`-`shift+9` pause or resume that facility in the
fleet (with the same undo the row's own button offers), and `[` / `]` move the selected facility
up and down the dispatch order - which until now was a drag or a pair of buttons that only appear
on hover.

**One deviation from the issue:** it asked for the bare number row for the facility slots, but
1/2/3 have been the speed controls for far longer than the fleet has had shortcuts, so the slots
are shifted. A new test holds `keyMap` against the table the Manual and Settings print, since
those are two files that have drifted before.

### 14. Speed controls

Four icon buttons with the current one disabled reads as "you can't click this", not "this is the
one you're on". They're a `ToggleButtonGroup` now with a filled selected state, labelled with how
many times faster than slow each speed runs. The multipliers are derived from `TICK_MS` rather
than written down beside it, so they can't drift from what the clock actually does.

### 15. An event log

The biggest new thing here. A blackout was a bar that pulsed until it stopped; construction
finishing, a loan closing and a fuel price spike were a four second toast or nothing at all. Look
away and there was no way to find out what had happened to you, which is what makes a simulation
feel arbitrary rather than causal.

The game now keeps its own record - newest first, capped at a hundred entries, carried in the
save - and a blackout's closing entry says how long it ran and how much energy went unserved
(counted per tick as it happens, not estimated afterwards). It renders as a fourth column, but
only past 1800px: below that a fourth column comes out of the three panes that carry the game.

### 16. The 650-1300px gap

A laptop or a landscape tablet got one phone-width card floating in a sea of margin. It now gets
two columns - the fleet, which is the pane you want on screen while you read either of the
others, pinned beside whichever of Finances and Forecasts the nav is on. The pane grid and the
drag splitters move down to this breakpoint, and `DesktopPanes` now remembers a layout per pane
count, since two, three and four columns are genuinely different layouts of the same window.

### 17. Dark mode

Every colour in `app.scss` is now a custom property with a light and a dark value, so one
attribute on `<html>` repaints the app. The charts paint to a canvas and can't read those, so
`Theme.tsx` carries the same split for them and tells every mounted plot to rebuild when it
moves.

Dark is not light inverted: Coal at `#1a1a1a` is invisible on `#121212`, so every series moves up
its own ramp far enough to clear the contrast bar it cleared on white, keeping the luminance
spread that lets four lines on one chart be told apart. Settings offers light, dark or "match my
system", and the system option follows the OS while the game is open.

### Testing

`npm run typecheck`, `npm run lint`, `npm run format:check` and the full suite (568 tests, 43
suites) all pass. New coverage: the event log's contents and cap, the small multiples at desktop
width, and the keyboard map against its own documentation.

Driven in the browser at 420px, 1280px and 1900px, in both palettes: the phone card, the
two-column laptop layout, the three panes and the four with the event log, blackout entries
appearing as the lights go out and come back, and the charts repainting light-on-dark (verified
by sampling the canvas). The one path the local browser can't exercise is the OS flipping its
own theme mid-game - CDP's `prefers-color-scheme` emulation changes the query result without
firing the `change` event that drives it - so that half is covered by the settings picker, which
takes the same path and was driven live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
