### PR TITLE
Fix Facilities supply/demand fill color in dark mode

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -74,6 +74,8 @@ interface ChartPaletteType {
   storage: string;
   demand: string;
   supply: string;
+  /** The wash under the supply line marking history vs. forecast on the Facilities chart */
+  historicFill: string;
   blackout: string;
   temperature: string;
   /** The temperature line's punch is too thin for the axis labels naming it */
@@ -100,6 +102,7 @@ const CHART_PALETTES: { [mode in ThemeModeType]: ChartPaletteType } = {
     storage: blue[800],
     demand: grey[900],
     supply: blue[600],
+    historicFill: blue[50],
     blackout: red[800], // darker than red[500] so the translucent band reads on white
     temperature: red[500],
     temperatureAxis: red[800],
@@ -119,6 +122,9 @@ const CHART_PALETTES: { [mode in ThemeModeType]: ChartPaletteType } = {
     storage: blue[300],
     demand: grey[100],
     supply: blue[300],
+    // Blue50 solid, as light uses, reads as a near-white glare on a near-black plot; a faint
+    // tint of the supply line itself keeps the wash subtle enough for both lines to read over it
+    historicFill: withAlpha(blue[300], 0.16),
     blackout: red[400],
     temperature: red[300],
     temperatureAxis: red[300],

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -58,7 +58,6 @@ interface State {
 }
 
 const SUN_LABELS = ["🌅", "☀️ ", "🌇"];
-const HISTORIC_FILL = "#e3f2fd"; // blue50
 
 function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
   return {
@@ -105,7 +104,7 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
       {
         stroke: chartPalette().supply,
         width: 1.75,
-        fill: HISTORIC_FILL,
+        fill: chartPalette().historicFill,
         points: { show: false },
         spanGaps: false,
       },


### PR DESCRIPTION
## Summary
- The Facilities supply/demand chart's historic-area fill was hardcoded to `#e3f2fd` (blue50), a near-white pastel tuned for a white plot area.
- In dark mode this washed out against the near-black background and reduced contrast for the light-colored supply/demand lines instead of setting them off.
- Added a `historicFill` field to `ChartPaletteType` in [Theme.tsx](src/Theme.tsx): light keeps blue50, dark uses a translucent 16%-opacity tint of the supply blue, so both lines stay legible against it.
- [ChartSupplyDemand.tsx](src/components/base/ChartSupplyDemand.tsx) now reads `chartPalette().historicFill` instead of a hardcoded constant, so it rebuilds correctly when the theme toggles (the chart already rebuilds on `themeVersion` changes).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` on changed files passes
- [x] Ran the app locally, switched to dark mode, started a tutorial game, and sampled the chart canvas pixels directly — confirmed the fill now renders as `rgba(100,181,246,~41)` (~16% opacity supply blue) instead of the old near-white pastel

🤖 Generated with [Claude Code](https://claude.com/claude-code)