### PR TITLE
Save & Quit label, Options in the in-game menu

### DIFF
--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -20,7 +20,7 @@ import { formatHour, getTimeFromTimeline } from "../../helpers/DateTime";
 import { formatMoneyStable } from "../../helpers/Format";
 import { navigate } from "../../reducers/Card";
 import { isBigScreen, isSmallScreen, openWindow } from "../../Globals";
-import { getNextTutorial } from "../../data/Scenarios";
+import { getNextTutorial, getScenario } from "../../data/Scenarios";
 import { quit, setSpeed, startTutorial } from "../../reducers/Game";
 import { AppStateType, GameType, SpeedType } from "../../Types";
 
@@ -40,6 +40,7 @@ export interface StateProps {
 
 export interface DispatchProps {
   onManual: () => void;
+  onSettings: () => void;
   onSpeedChange: (speed: SpeedType) => void;
   onNextTutorial: (scenarioId: number) => void;
   onQuit: () => void;
@@ -200,7 +201,8 @@ function buildSpeedOptions({
 }
 
 export function GameAppBar(props: Props) {
-  const { game, onManual, onNextTutorial, onQuit, onSpeedChange } = props;
+  const { game, onManual, onNextTutorial, onQuit, onSettings, onSpeedChange } =
+    props;
   const date = game.date;
   const now = getTimeFromTimeline(date.minute, game.timeline);
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<HTMLElement | null>(
@@ -220,6 +222,10 @@ export function GameAppBar(props: Props) {
   // tutorial to offer?" for the menu item below. Also undefined throughout a replay, since a
   // tutorial never sets a score and so never has one to watch
   const nextTutorial = getNextTutorial(game.scenarioId);
+  // A tutorial's progress isn't worth resuming, so its menu item stays "Quit" - only a real run
+  // gets the "Save & Quit" reminder that leaving keeps it around to come back to
+  const isTutorial = !!getScenario(game.scenarioId, game.customScenario)
+    ?.tutorialSteps;
 
   const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
     setMenuAnchorEl(event.currentTarget);
@@ -269,6 +275,7 @@ export function GameAppBar(props: Props) {
           onClose={handleMenuClose}
         >
           <MenuItem onClick={onManual}>Manual</MenuItem>
+          <MenuItem onClick={onSettings}>Options</MenuItem>
           <MenuItem onClick={() => openWindow("mailto:todd@fabricate.io")}>
             Send feedback
           </MenuItem>
@@ -280,13 +287,22 @@ export function GameAppBar(props: Props) {
             </MenuItem>
           )}
           <MenuItem onClick={onQuit}>
-            {isReplay ? "Exit replay" : "Quit"}
+            {isReplay ? "Exit replay" : isTutorial ? "Quit" : "Save & Quit"}
           </MenuItem>
         </Menu>
       </>
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [menuAnchorEl, onManual, onNextTutorial, onQuit, nextTutorial, isReplay],
+    [
+      menuAnchorEl,
+      onManual,
+      onSettings,
+      onNextTutorial,
+      onQuit,
+      nextTutorial,
+      isReplay,
+      isTutorial,
+    ],
   );
 
   if (!game.inGame || !now) {
@@ -329,6 +345,9 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onManual: () => {
       dispatch(navigate("MANUAL"));
+    },
+    onSettings: () => {
+      dispatch(navigate("SETTINGS"));
     },
     onSpeedChange: (speed: SpeedType) => {
       dispatch(setSpeed(speed));

--- a/src/components/views/SettingsContainer.tsx
+++ b/src/components/views/SettingsContainer.tsx
@@ -1,6 +1,6 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
-import { navigate } from "../../reducers/Card";
+import { navigateBack } from "../../reducers/Card";
 import { resume } from "../../reducers/Game";
 import { change as changeSettings } from "../../reducers/Settings";
 import { snackbarOpen } from "../../reducers/UI";
@@ -75,8 +75,10 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
         );
       });
     },
+    // Mirrors Manual: Options can now be reached mid-game too, so back has to return wherever
+    // the player came from rather than always dropping them at the main menu
     onBack: () => {
-      dispatch(navigate("MAIN_MENU"));
+      dispatch(navigateBack());
     },
   };
 };


### PR DESCRIPTION
## Summary
- Rename "Quit" to "Save & Quit" in the top menu bar when playing a non-tutorial game (tutorials and replays keep their existing labels).
- Add an "Options" item to the in-game menu, right after "Manual".
- Fix Options' back button to return to wherever the player came from (`navigateBack()`) instead of always the main menu, so it works correctly when opened mid-game.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed files
- [x] Manually verified in browser: continued a saved (non-tutorial) game, opened the menu, confirmed "Options" and "Save & Quit" appear
- [x] Opened Options mid-game and confirmed "back" returns to the game rather than the main menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)