### PR TITLE
Align Finances/Forecasts headers with Facilities, fix stale slider redraws

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -320,8 +320,12 @@ table {
   th {
     font-weight: bold !important;
   }
+  // A transparent border instead of extra padding-top: padding controls where the text sits
+  // inside its own row, and stretching only the top of that would leave the text sitting low --
+  // noticeably off-centre next to every nested row underneath it, which is symmetric. A border
+  // adds the same breathing room above the row without moving the text inside it.
   tr.bold td {
-    padding-top: 16px;
+    border-top: 10px solid transparent;
   }
 }
 
@@ -408,6 +412,12 @@ $pane_header_height: 40px;
 .base_main .MuiToolbar-root.paneHeader {
   min-height: $pane_header_height !important;
   border-bottom: $border_accent;
+}
+
+// A control living in a paneHeader alongside the title, pushed to the toolbar's trailing edge --
+// the flex equivalent of .manual-search, for headers with a dropdown instead of a search box
+.headerControl {
+  margin-left: auto;
 }
 
 .flex-newline {

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -159,7 +159,12 @@ function reprioritizeSelected(delta: number) {
 }
 
 const shortcutHandlers = {
-  PAUSED: () => {
+  // Space is one of this handler's own keys, and the browser's default action for it is to
+  // scroll the page -- which fires alongside the pause because react-hotkeys doesn't call
+  // preventDefault for you. Only this binding needs it: the other two (`` ` `` and `0`) have no
+  // native behaviour of their own
+  PAUSED: (e?: KeyboardEvent) => {
+    e?.preventDefault();
     store.dispatch(setSpeed("PAUSED"));
   },
   SLOW: () => {

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -53,6 +53,7 @@ import {
 } from "../../Types";
 import {
   formatLargeMassValue,
+  formatLargeMassValueConcise,
   largeMassUnit,
   massUnit,
   toDisplayMass,
@@ -180,7 +181,8 @@ function buildChartKeys(units: UnitSystemType): {
     kgco2e: {
       label: "CO2e emitted",
       higherIsBetter: false,
-      format: (n: number) => formatLargeMassValue(n, units),
+      format: (n: number) => formatLargeMassValueConcise(n, units),
+      formatTable: (n: number) => formatLargeMassValue(n, units),
       suffix: largeMassUnit(units),
       nesting: 2,
     },
@@ -837,8 +839,46 @@ export default class Finances extends React.Component<Props, State> {
     );
 
     return (
-      <GameCard className="finances" title="Finances" id="financesPane">
+      <GameCard
+        className="finances"
+        title={smallMultiples ? undefined : "Finances"}
+        id="financesPane"
+      >
         <div className="scrollable">
+          {/* On a wide screen the tiles below already say what's plotted and pick a different
+              one, so the range is the only thing left to choose -- it moves up here with the
+              title instead of sharing a row with the sliders (see Facilities, whose build
+              buttons live in the same spot) */}
+          {smallMultiples && (
+            <Toolbar className="paneHeader">
+              <Typography variant="h6">Finances</Typography>
+              <Select
+                id="plotRange"
+                value={this.state.range}
+                onChange={(e: SelectChangeEvent<string>) =>
+                  this.setRange(e.target.value)
+                }
+                className="headerControl"
+              >
+                <MenuItem value={ALL_TIME}>All time</MenuItem>
+                <MenuItem value={CURRENT_YEAR}>Current year</MenuItem>
+                {FUTURE_YEARS.map((y: number) => {
+                  return (
+                    <MenuItem value={futureRange(y)} key={futureRange(y)}>
+                      Next {y} {y === 1 ? "year" : "years"}
+                    </MenuItem>
+                  );
+                })}
+                {years.map((y: number) => {
+                  return (
+                    <MenuItem value={String(y)} key={y}>
+                      {y}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+            </Toolbar>
+          )}
           {selectedFacility && selectedLifetime && (
             // The other half of clicking a row in the fleet list: the stack in Forecasts
             // says which power is this facility's, and this says which money is
@@ -976,76 +1016,76 @@ export default class Finances extends React.Component<Props, State> {
                 />
               </div>
             )}
-            <div className="flex-newline"></div>
-            <Typography variant="h6" style={{ flexGrow: 0 }}>
-              Plotting{" "}
-            </Typography>
-            {/* The tiles below are the picker on a wide screen, so out here the metric is a
-                label rather than a control */}
-            {smallMultiples && (
-              <Typography variant="h6" style={{ flexGrow: 0 }}>
-                {chartKeys[chartKey].label}
-              </Typography>
-            )}
-            {/* Controlled, so the label and the chart cannot disagree about what is plotted */}
+            {/* On a wide screen this whole row goes away: the range moved up into the pane
+                header above, and the tiles below are the metric picker, so there is nothing
+                left here that isn't said somewhere else */}
             {!smallMultiples && (
-              <Select
-                id="plotMetric"
-                value={chartKey}
-                onChange={(e: SelectChangeEvent<string>) =>
-                  this.setChartKey(e.target.value as DerivedHistoryKeysType)
-                }
-              >
-                {CHART_KEY_NAMES.map((key: string) => {
-                  const k = chartKeys[key];
-                  let label = k.label;
-                  if (chartKey !== key && chartKeys[key].nesting) {
-                    // https://stackoverflow.com/questions/14343844/create-a-string-of-variable-length-filled-with-a-repeated-character
-                    label =
-                      new Array((chartKeys[key].nesting || 0) + 1).join(" -") +
-                      " " +
-                      label;
+              <>
+                <div className="flex-newline"></div>
+                <Typography variant="h6" style={{ flexGrow: 0 }}>
+                  Plotting{" "}
+                </Typography>
+                {/* Controlled, so the label and the chart cannot disagree about what is plotted */}
+                <Select
+                  id="plotMetric"
+                  value={chartKey}
+                  onChange={(e: SelectChangeEvent<string>) =>
+                    this.setChartKey(e.target.value as DerivedHistoryKeysType)
                   }
-                  return (
-                    <MenuItem
-                      className={!k.nesting ? "bold" : `tabs-${k.nesting}`}
-                      value={key}
-                      key={key}
-                    >
-                      {label}
-                    </MenuItem>
-                  );
-                })}
-              </Select>
+                >
+                  {CHART_KEY_NAMES.map((key: string) => {
+                    const k = chartKeys[key];
+                    let label = k.label;
+                    if (chartKey !== key && chartKeys[key].nesting) {
+                      // https://stackoverflow.com/questions/14343844/create-a-string-of-variable-length-filled-with-a-repeated-character
+                      label =
+                        new Array((chartKeys[key].nesting || 0) + 1).join(
+                          " -",
+                        ) +
+                        " " +
+                        label;
+                    }
+                    return (
+                      <MenuItem
+                        className={!k.nesting ? "bold" : `tabs-${k.nesting}`}
+                        value={key}
+                        key={key}
+                      >
+                        {label}
+                      </MenuItem>
+                    );
+                  })}
+                </Select>
+                <Typography variant="h6" style={{ flexGrow: 0 }}>
+                  {" "}
+                  for{" "}
+                </Typography>
+                <Select
+                  id="plotRange"
+                  value={this.state.range}
+                  onChange={(e: SelectChangeEvent<string>) =>
+                    this.setRange(e.target.value)
+                  }
+                >
+                  <MenuItem value={ALL_TIME}>All time</MenuItem>
+                  <MenuItem value={CURRENT_YEAR}>Current year</MenuItem>
+                  {FUTURE_YEARS.map((y: number) => {
+                    return (
+                      <MenuItem value={futureRange(y)} key={futureRange(y)}>
+                        Next {y} {y === 1 ? "year" : "years"}
+                      </MenuItem>
+                    );
+                  })}
+                  {years.map((y: number) => {
+                    return (
+                      <MenuItem value={String(y)} key={y}>
+                        {y}
+                      </MenuItem>
+                    );
+                  })}
+                </Select>
+              </>
             )}
-            <Typography variant="h6" style={{ flexGrow: 0 }}>
-              {" "}
-              for{" "}
-            </Typography>
-            <Select
-              id="plotRange"
-              value={this.state.range}
-              onChange={(e: SelectChangeEvent<string>) =>
-                this.setRange(e.target.value)
-              }
-            >
-              <MenuItem value={ALL_TIME}>All time</MenuItem>
-              <MenuItem value={CURRENT_YEAR}>Current year</MenuItem>
-              {FUTURE_YEARS.map((y: number) => {
-                return (
-                  <MenuItem value={futureRange(y)} key={futureRange(y)}>
-                    Next {y} {y === 1 ? "year" : "years"}
-                  </MenuItem>
-                );
-              })}
-              {years.map((y: number) => {
-                return (
-                  <MenuItem value={String(y)} key={y}>
-                    {y}
-                  </MenuItem>
-                );
-              })}
-            </Select>
           </Toolbar>
           {monthly.length > 0 ? (
             <ChartFinances

--- a/src/components/views/Forecasts.tsx
+++ b/src/components/views/Forecasts.tsx
@@ -86,11 +86,16 @@ export default class Forecasts extends React.Component<Props, State> {
   public shouldComponentUpdate(nextProps: Props, nextState: State) {
     // Because forecasts are computationally intense and long term, only update when the
     // month or state changes -- plus when the player selects a facility, which is a direct
-    // request to re-highlight the stack and would otherwise wait for a month rollover
+    // request to re-highlight the stack and would otherwise wait for a month rollover, or moves
+    // a slider that feeds the forecast (marketing spend drives customer growth, the rate drives
+    // revenue), which would otherwise sit frozen until the next month rolled over
     return (
       this.props.game.date.monthNumber !== nextProps.game.date.monthNumber ||
       this.props.selectedFacilityId !== nextProps.selectedFacilityId ||
-      this.state.years !== nextState.years
+      this.state.years !== nextState.years ||
+      this.props.game.monthlyMarketingSpend !==
+        nextProps.game.monthlyMarketingSpend ||
+      this.props.game.dollarsPerkWh !== nextProps.game.dollarsPerkWh
     );
   }
 
@@ -230,26 +235,31 @@ export default class Forecasts extends React.Component<Props, State> {
         : undefined;
 
     return (
-      <GameCard className="Forecasts" title="Forecasts" id="forecastsPane">
+      <GameCard className="Forecasts" id="forecastsPane">
         <div className="scrollable">
+          {/* The pane's own header rather than GameCard's plain one, so the horizon picker --
+              which governs every chart in the stack below, not just the first -- sits with the
+              title instead of floating inside "Supply & Demand" (see Facilities, whose build
+              buttons live here the same way) */}
+          <Toolbar className="paneHeader">
+            <Typography variant="h6">Forecasts</Typography>
+            <Select
+              id="forecastYears"
+              value={years}
+              onChange={(e: SelectChangeEvent<number>) =>
+                this.setYears(e.target.value as number)
+              }
+              className="headerControl"
+            >
+              {FORECAST_YEARS_OPTIONS.map((y: number) => (
+                <MenuItem value={y} key={y}>
+                  {y} year{y > 1 ? "s" : ""}
+                </MenuItem>
+              ))}
+            </Select>
+          </Toolbar>
           <Toolbar>
-            <Typography variant="h6">
-              Supply & Demand
-              <Select
-                id="forecastYears"
-                value={years}
-                onChange={(e: SelectChangeEvent<number>) =>
-                  this.setYears(e.target.value as number)
-                }
-                sx={{ float: "right" }}
-              >
-                {FORECAST_YEARS_OPTIONS.map((y: number) => (
-                  <MenuItem value={y} key={y}>
-                    {y} year{y > 1 ? "s" : ""}
-                  </MenuItem>
-                ))}
-              </Select>
-            </Typography>
+            <Typography variant="h6">Supply & Demand</Typography>
           </Toolbar>
           <ChartForecastSupplyDemand
             height={140}

--- a/src/helpers/Units.tsx
+++ b/src/helpers/Units.tsx
@@ -102,6 +102,20 @@ export function formatLargeMassValue(
   });
 }
 
+/**
+ * The same value as formatLargeMassValue, but rounded to K/M/etc rather than spelled out to the
+ * kilogram - for the chart and its sparkline tile, which have room for three or four characters
+ * and not the seven a full tonne count runs to.
+ */
+export function formatLargeMassValueConcise(
+  kg: number,
+  units: UnitSystemType,
+): string {
+  return numbro(toDisplayLargeMass(kg, units))
+    .format({ average: true, totalLength: 3, trimMantissa: true })
+    .toUpperCase();
+}
+
 export function formatLargeMass(kg: number, units: UnitSystemType): string {
   return `${formatLargeMassValue(kg, units)} ${largeMassUnit(units)}`;
 }


### PR DESCRIPTION
## Summary
- Move the range/year picker into the pane header next to the title on Finances and Forecasts, matching the Generator/Storage buttons on Facilities — drops the redundant "Plotting X for Y" line on desktop (which also fixes a missing-space rendering bug) and the `float:right` hack that scrunched the Forecasts picker against the top
- Format CO2e emitted concisely (K/M) on the chart and tile so it no longer wraps to three lines; the expanded table still shows the exact figure
- Prevent the browser's default scroll-the-page behavior when the spacebar pause shortcut fires
- Fix Forecasts not redrawing when the marketing/rate slider moves — `shouldComponentUpdate` never checked `monthlyMarketingSpend`/`dollarsPerkWh`, so the Supply & Demand forecast sat stale while Finances (which redraws for other reasons) looked live
- Fix asymmetric row padding in the Finances summary table that threw off vertical centering, most visible when the table is collapsed

## Test plan
- [x] `tsc --noEmit` and `eslint` clean on all touched files
- [x] Finances test suites pass (`Finances.test.tsx`, `FinancesSmallMultiples.test.tsx` — 40 tests)
- [x] Verified in-browser at desktop/tablet/mobile widths: header layout, CO2e tile text, table row heights/padding, spacebar `preventDefault`, and pause toggling
- [ ] Visual screenshot review (couldn't get pixel screenshots in this session's Browser pane — verified via DOM/computed-style inspection instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)