### PR TITLE
Stop the game freezing on the last month of a run

### DIFF
--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -950,32 +950,14 @@ export function tickState(state: GameType) {
         const isTutorial = Boolean(scenario.tutorialSteps);
         // Read out here with everything else the timeouts need, rather than from inside them
         const nextTutorial = getNextTutorial(scoredScenarioId);
-        // Read now rather than inside the timeout, so that "was 640" reports the run before this
-        // one: submitHighscore below overwrites it the moment its write lands
-        const previousBest =
-          getStore().getState().user.bests?.[String(scoredScenarioId)]?.score;
 
         // The leaderboard is keyed on scenario id alone, so custom runs - whatever cash, duration
         // and rules the player gave themselves - would be scored against each other as if they
         // were the same scenario
-        if (!scenario.tutorialSteps && ranked) {
-          // Pulled out of the draft here rather than inside the timeout, which runs after the
-          // reducer has returned and revoked it
-          const replay = serializeReplay(state);
-          setTimeout(
-            () =>
-              getStore().dispatch(
-                submitHighscore({
-                  score: finalScore,
-                  scoreBreakdown: score, // For analytics purposes only
-                  scenarioId: scoredScenarioId,
-                  difficulty,
-                  replay,
-                }),
-              ),
-            1,
-          );
-        }
+        const submitsScore = !scenario.tutorialSteps && ranked;
+        // Pulled out of the draft here rather than inside the timeout, which runs after the
+        // reducer has returned and revoked it
+        const replay = submitsScore ? serializeReplay(state) : undefined;
 
         if (!isReplay) {
           logEvent("scenario_end", {
@@ -1000,6 +982,13 @@ export function tickState(state: GameType) {
               }),
             );
           }
+          // Read here rather than up in the reducer: store.getState() throws while a reducer is
+          // running, and this sat in tickState, so the throw came out of the tick loop's own
+          // setTimeout - nothing rescheduled the loop and nothing opened a dialog, and the game
+          // stopped dead on the last month of every run. Still read before the submit below, so
+          // that "was 640" reports the run before this one rather than the one that just finished
+          const previousBest =
+            getStore().getState().user.bests?.[String(scoredScenarioId)]?.score;
           // Only the numbers: the breakdown, the personal best and the rank are base/VictoryDialog's
           // to render, so that the parts which arrive over the network can fill themselves in
           getStore().dispatch(
@@ -1015,6 +1004,17 @@ export function tickState(state: GameType) {
               previousBest,
             }),
           );
+          if (submitsScore) {
+            getStore().dispatch(
+              submitHighscore({
+                score: finalScore,
+                scoreBreakdown: score, // For analytics purposes only
+                scenarioId: scoredScenarioId,
+                difficulty,
+                replay,
+              }),
+            );
+          }
         }, 1);
       }
     }

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -8,7 +8,15 @@ import {
 } from "../data/Scenarios";
 import { getStore } from "../StoreRegistry";
 import { createGame } from "../testing/Simulator";
-import { quit, tickState } from "./Game";
+import {
+  loaded,
+  quit,
+  resume,
+  setSpeed,
+  tick as tickAction,
+  tickState,
+} from "./Game";
+import { TICK_MS } from "../Constants";
 import { GameType, ScenarioType } from "../Types";
 
 /**
@@ -35,6 +43,41 @@ function tick(state: GameType): GameType {
   return produce(state, (draft: GameType) => {
     tickState(draft);
   });
+}
+
+/**
+ * Hands a part-played run to the real store and lets its own tick loop carry it to `untilMonth`.
+ *
+ * produce() above is the cheap way to cover ground, but it isn't a dispatch: everything the tick
+ * reducer is forbidden from doing while Redux is inside it - reading the store back, most of all -
+ * looks perfectly fine there. The last month of a run is where the end of scenario triggers live,
+ * so that's the stretch worth paying for.
+ */
+function playOutOnTheStore(state: GameType, untilMonth: number) {
+  // The loop paces itself off the wall clock, which stands still inside a synchronous test - so
+  // the clock is what gets driven here, one tick's worth per dispatch
+  let wallClockMs = 0;
+  const now = jest
+    .spyOn(performance, "now")
+    .mockImplementation(() => wallClockMs);
+  try {
+    getStore().dispatch(resume(state));
+    getStore().dispatch(loaded()); // Marks the game live, the way the loading screen does
+    getStore().dispatch(setSpeed("FAST"));
+    // Bounded so that a tick loop which stops advancing fails the assertion below rather than
+    // hanging the suite
+    for (
+      let i = 0;
+      i < 10000 && getStore().getState().game.date.monthsEllapsed < untilMonth;
+      i++
+    ) {
+      wallClockMs += TICK_MS.FAST * 2;
+      getStore().dispatch(tickAction());
+    }
+  } finally {
+    now.mockRestore();
+  }
+  expect(getStore().getState().game.date.monthsEllapsed).toBe(untilMonth);
 }
 
 describe("ending a scenario from inside the reducer", () => {
@@ -72,6 +115,33 @@ describe("ending a scenario from inside the reducer", () => {
     expect(victory?.ranked).toBe(false);
     // Opening the score screen stops the clock, the way any other dialog does
     expect(getStore().getState().game.speed).toBe("PAUSED");
+  });
+
+  /**
+   * The freeze this guards against: the reducer read the player's previous best straight off the
+   * store, which Redux refuses to do while a reducer is running. The throw came out of the tick
+   * loop's own setTimeout, so nothing rescheduled it and nothing opened the dialog - the game
+   * stopped dead on the last month of every run, score screen and all.
+   */
+  it("keeps the clock alive through the end of a scored run", () => {
+    getStore().dispatch(quit());
+    const scenario = SCENARIOS.find(
+      (s: ScenarioType) => s.id === 100,
+    ) as ScenarioType;
+    const duration = scenario.durationMonths as number;
+    let state = createGame({ scenarioId: scenario.id });
+    // Cheap up to the second to last month, then the store drives the one that ends the run
+    while (state.date.monthsEllapsed < duration - 1) {
+      state = tick(state);
+    }
+    playOutOnTheStore(state, duration);
+    jest.runOnlyPendingTimers();
+
+    const victory = getStore().getState().ui.victory;
+    expect(victory).not.toBeNull();
+    expect(victory?.scenarioName).toBe(scenario.name);
+    // An authored scenario is the case that reads the previous best and submits a score
+    expect(victory?.ranked).toBe(true);
   });
 
   it("goes bankrupt without reading the revoked draft", () => {


### PR DESCRIPTION
## The bug

Finishing a scenario stopped the game dead — no score screen, no tutorial completion dialog, and the speed buttons did nothing afterwards. Reproduced in the browser on a one-year custom game: the clock stopped on the final month with `Uncaught Error: You may not call store.getState() while the reducer is executing` in the console.

## Cause

The end-of-run trigger read the player's previous best straight off the store, so that "was 640" reports the run *before* this one rather than the one just finished:

```js
const previousBest =
  getStore().getState().user.bests?.[String(scoredScenarioId)]?.score;
```

That sits in `tickState`, which runs inside the `game/tick` reducer, and Redux throws on `store.getState()` during reducer execution. Three things followed:

- the throw came out of the tick loop's own `setTimeout`, so nothing rescheduled the loop — the clock stopped;
- the `setTimeout` that opens the dialog was never registered — no popup;
- `tickLoopRunning` was left `true`, so `ensureTicking` refused to restart the clock for the rest of the run — the speed buttons were dead too.

The read was unconditional, above the tutorial/custom/authored branches, so **every** completed run froze.

## Fix

Moved the read into the timeout that opens the score screen, and moved the high score submit in alongside it. Previously the submit and the dialog were two separate `setTimeout(..., 1)` callbacks whose ordering the `previousBest` semantics quietly depended on; now the read happens before the write that overwrites it, in one place, explicitly. `serializeReplay` stays in the reducer, where the Immer draft is still alive.

## Testing

`src/reducers/ScenarioEnd.test.tsx` missed this because it ticks through `produce()` rather than through a dispatch — reading the store back looks perfectly fine there. The new case hands a nearly-finished run to the real store and lets its own tick loop play out the final month; reverting the fix makes it fail with the same `getState()` error seen in the browser.

Full suite: 569 passed, 43 suites. Typecheck, lint and prettier clean. Verified in the browser end to end — the score screen appears, and "Keep playing" resumes the clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
