### PR TITLE
Fix bottom nav height changing between game views

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -951,6 +951,16 @@ $pane_header_height: 40px;
     & > div {
       flex: 0 1 auto;
     }
+
+    // The app bar and bottom nav are fixed chrome, not scrollable content -- only .scrollable
+    // (the pane's own body) should give up height when a pane overflows the card. Without this,
+    // a tall pane (e.g. Finances' expandable table) lets the flexbox shrink algorithm eat into
+    // BottomNavigation's automatic minimum size instead, which undercuts its real 56px height
+    // and left the nav a different height depending which pane happened to overflow.
+    & > #appbar,
+    & > #navfooter {
+      flex-shrink: 0;
+    }
   }
 
   .cardList {


### PR DESCRIPTION
## Summary
- The bottom nav (`#navfooter`) and the app bar (`#appbar`) were sharing `flex-shrink: 1` with the pane's own scrollable content as siblings inside `#gameCard`
- Whenever a pane's content overflowed the viewport (Finances/Forecasts wrap everything in one `.scrollable` div that's often taller than the screen; Facilities happened to fit more often), the flexbox shrink algorithm compressed the nav's automatic minimum size instead of leaving it fixed at its real 56px height
- Pinned `#appbar` and `#navfooter` to `flex-shrink: 0` so only the pane's own scrollable body gives up height on overflow

## Test plan
- [x] Started the dev server and measured `#navfooter`'s rendered height at mobile viewport (375x812) on Facilities, Finances, and Forecasts
  - Before: Facilities 56.8px, Finances 41.6px, Forecasts 48px (inconsistent)
  - After: 56.8px on all three views

🤖 Generated with [Claude Code](https://claude.com/claude-code)