### PR TITLE
Add month/year/time header to chart tooltips

### DIFF
--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -3,6 +3,7 @@ import uPlot from "uplot";
 import UPlotChart, { BuildContext } from "./UPlotChart";
 import { padRange, stepTicks, titlePlugin, xAxis, yAxis } from "./UPlotHelpers";
 import { formatMonthChartAxis } from "../../helpers/DateTime";
+import { MONTHS } from "../../Constants";
 import { chartPalette } from "../../Theme";
 
 interface ChartData {
@@ -81,7 +82,9 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
 }
 
 function tooltip(idx: number, state: State): string {
-  return state.format(state.timeline[idx].value).toString();
+  const d = state.timeline[idx];
+  const monthName = MONTHS[(d.month - 1) % 12];
+  return `${monthName} ${d.year}\n${state.format(d.value)}`;
 }
 
 const ChartFinances = (props: Props): React.JSX.Element => {

--- a/src/components/base/ChartForecastFuelPrices.tsx
+++ b/src/components/base/ChartForecastFuelPrices.tsx
@@ -14,6 +14,7 @@ import {
 } from "./UPlotHelpers";
 import {
   formatMinuteAsMonthAxis,
+  formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
 import { formatMoneyConcise, formatMoneyStable } from "../../helpers/Format";
@@ -42,6 +43,7 @@ export const PRICED_FUELS: PricedFuelType[] = [
 
 interface State {
   prices: number[][];
+  minutes: number[];
   domain: Props["domain"];
   startingYear: number;
   multiyear: boolean;
@@ -101,9 +103,16 @@ function buildOptions(showXLabels: boolean) {
 }
 
 function tooltip(idx: number, state: State): string {
-  return PRICED_FUELS.map(
-    (f, i) => `${f}: ${formatMoneyStable(state.prices[i][idx])}`,
-  ).join("\n");
+  const header = formatMinuteAsTooltipHeader(
+    state.minutes[idx],
+    state.startingYear,
+  );
+  return [
+    header,
+    ...PRICED_FUELS.map(
+      (f, i) => `${f}: ${formatMoneyStable(state.prices[i][idx])}`,
+    ),
+  ].join("\n");
 }
 
 // This is a pureComponent because its props should change much less frequently than it renders
@@ -138,7 +147,7 @@ export default class ChartForecastFuelPrices extends React.PureComponent<
         <UPlotChart<State>
           ariaLabel="Chart of forecasted fuel prices"
           height={height}
-          state={{ prices, domain, startingYear, multiyear }}
+          state={{ prices, minutes, domain, startingYear, multiyear }}
           data={[minutes, ...prices]}
           buildOptions={buildOptions(showXLabels !== false)}
           structureKey={String(showXLabels !== false)}

--- a/src/components/base/ChartForecastStorage.tsx
+++ b/src/components/base/ChartForecastStorage.tsx
@@ -12,6 +12,7 @@ import {
 import { TickPresentFutureType } from "../../Types";
 import {
   formatMinuteAsMonthAxis,
+  formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
 import { formatWattHours, formatWattHoursAxis } from "../../helpers/Format";
@@ -82,7 +83,9 @@ function buildOptions(showXLabels: boolean) {
 }
 
 function tooltip(idx: number, state: State): string {
-  return formatWattHours(state.timeline[idx].storedWh);
+  const d = state.timeline[idx];
+  const header = formatMinuteAsTooltipHeader(d.minute, state.startingYear);
+  return `${header}\n${formatWattHours(d.storedWh)}`;
 }
 
 // This is a pureComponent because its props should change much less frequently than it renders

--- a/src/components/base/ChartForecastSupplyByFuel.tsx
+++ b/src/components/base/ChartForecastSupplyByFuel.tsx
@@ -10,6 +10,7 @@ import {
 } from "./UPlotHelpers";
 import {
   formatMinuteAsMonthAxis,
+  formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
 import { formatWatts, formatWattsAxis } from "../../helpers/Format";
@@ -68,6 +69,7 @@ interface State {
   // Each fuel's own output at each x, ie before it is stacked, for the tooltip to report
   byFuel: number[][];
   demand: number[];
+  minutes: number[];
   domain: Props["domain"];
   maxY: number;
   startingYear: number;
@@ -145,7 +147,12 @@ function buildOptions(
 }
 
 function tooltip(idx: number, state: State): string {
+  const header = formatMinuteAsTooltipHeader(
+    state.minutes[idx],
+    state.startingYear,
+  );
   return [
+    header,
     ...state.fuels
       .map(
         (f: FuelNameType, i: number) =>
@@ -210,6 +217,7 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
       fuels,
       byFuel,
       demand,
+      minutes,
       domain,
       maxY,
       startingYear,

--- a/src/components/base/ChartForecastSupplyDemand.tsx
+++ b/src/components/base/ChartForecastSupplyDemand.tsx
@@ -14,6 +14,7 @@ import {
 import { TickPresentFutureType } from "../../Types";
 import {
   formatMinuteAsMonthAxis,
+  formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
 import { formatWatts, formatWattsAxis } from "../../helpers/Format";
@@ -100,7 +101,8 @@ function buildOptions(showXLabels: boolean) {
 
 function tooltip(idx: number, state: State): string {
   const d = state.timeline[idx];
-  return `Supply: ${formatWatts(d.supplyW)}\nDemand: ${formatWatts(d.demandW)}`;
+  const header = formatMinuteAsTooltipHeader(d.minute, state.startingYear);
+  return `${header}\nSupply: ${formatWatts(d.supplyW)}\nDemand: ${formatWatts(d.demandW)}`;
 }
 
 // This is a pureComponent because its props should change much less frequently than it renders

--- a/src/components/base/ChartForecastWeather.tsx
+++ b/src/components/base/ChartForecastWeather.tsx
@@ -15,6 +15,7 @@ import { TICK_MINUTES } from "../../Constants";
 import { TickPresentFutureType, UnitSystemType } from "../../Types";
 import {
   formatMinuteAsMonthAxis,
+  formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
 import { chartPalette } from "../../Theme";
@@ -122,7 +123,8 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
 
 function tooltip(idx: number, state: State): string {
   const d = state.data[idx];
-  return `Temperature: ${formatTemperature(d.temperatureC, state.units)}\nWind: ${formatSpeed(d.windKph, state.units)}`;
+  const header = formatMinuteAsTooltipHeader(d.minute, state.startingYear);
+  return `${header}\nTemperature: ${formatTemperature(d.temperatureC, state.units)}\nWind: ${formatSpeed(d.windKph, state.units)}`;
 }
 
 // This is a pureComponent because its props should change much less frequently than it renders.

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -14,6 +14,7 @@ import {
   yAxis,
 } from "./UPlotHelpers";
 import {
+  formatHour,
   formatMinuteOfDayChartAxis,
   getDateFromMinute,
   getHourTicks,
@@ -55,6 +56,7 @@ interface State {
   blackoutSpans: Array<[number, number]>;
   currentMinute: number | null;
   legendItems: LegendItem[];
+  startingYear: number;
 }
 
 const SUN_LABELS = ["🌅", "☀️ ", "🌇"];
@@ -135,7 +137,8 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
 
 function tooltip(idx: number, state: State): string {
   const d = state.timeline[idx];
-  return `Supply: ${formatWatts(d.supplyW)}\nDemand: ${formatWatts(d.demandW)}`;
+  const time = formatHour(getDateFromMinute(d.minute, state.startingYear));
+  return `${time}\nSupply: ${formatWatts(d.supplyW)}\nDemand: ${formatWatts(d.demandW)}`;
 }
 
 // TODO how to indicate history vs reality vs forecast? Perhaps current time as a prop, and then split it in the chart
@@ -275,6 +278,7 @@ const ChartSupplyDemand = (props: Props): React.JSX.Element => {
     blackoutSpans: spansFromEdges(blackouts),
     currentMinute: currentMinute === rangeMax ? null : currentMinute,
     legendItems,
+    startingYear,
   };
 
   return (

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -237,6 +237,18 @@ export function formatHour(date: DateType): string {
   return time.toLocaleString("en-US", { hour: "numeric", hour12: true });
 }
 
+/**
+ * "Jan 2030, 4 PM" -- the header line every tooltip on a minute-based chart leads with, matching
+ * the month/year/time the app bar shows for the current instant.
+ */
+export function formatMinuteAsTooltipHeader(
+  minute: number,
+  startingYear: number,
+): string {
+  const date = getDateFromMinute(minute, startingYear);
+  return `${date.month} ${date.year}, ${formatHour(date)}`;
+}
+
 // Faster subset of getDateFromMinute
 export function getMonthYearFromMinute(minute: number, startingYear: number) {
   const dayOfGame = Math.floor(minute / 1440);


### PR DESCRIPTION
## Summary
- Every chart tooltip now leads with the date/time of the hovered point (`Jan 2030, 4 PM`), matching the app bar's own format
- The Facilities chart (a single day) shows just the time of day, since month/year add no information there
- The Finances chart (a monthly series) shows just month/year, since it has no time-of-day component

## Test plan
- [x] `tsc --noEmit` passes
- [x] Full jest suite passes (43 suites, 568 tests)
- [x] Verified in-browser: hovered Facilities, Finances, and all Forecasts charts (weather, supply/demand, supply-by-fuel, fuel prices) and confirmed the new header line renders correctly