### PR TITLE
Make Events its own top-level nav tab

### DIFF
--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -170,6 +170,7 @@ export const NAV_CARDS = [
   "FACILITIES",
   "FINANCES",
   "FORECASTS",
+  "EVENTS",
 ] as CardNameType[];
 export const CARD_TRANSITION_ANIMATION_MS = 300;
 export const NAVIGATION_DEBOUNCE_MS = 600;

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -72,6 +72,7 @@ export type CardNameType =
   | "FACILITIES"
   | "FINANCES"
   | "FORECASTS"
+  | "EVENTS"
   | "LOADING"
   | "MAIN_MENU"
   | "NEW_GAME"

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -129,6 +129,7 @@ export const keyMap = {
   FACILITIES: "q",
   FINANCES: "w",
   FORECASTS: "e",
+  EVENTS: "r",
   BUILD_GENERATOR: "g",
   BUILD_STORAGE: "s",
   PRIORITIZE_EARLIER: "[",
@@ -229,6 +230,9 @@ const shortcutHandlers = {
   },
   FORECASTS: () => {
     store.dispatch(navigate("FORECASTS"));
+  },
+  EVENTS: () => {
+    store.dispatch(navigate("EVENTS"));
   },
   BUILD_GENERATOR: () => {
     if (canPlay()) {
@@ -461,6 +465,8 @@ export default class Compositor extends React.Component<Props, {}> {
             <FacilitiesContainer />
             {this.props.card.name === "FORECASTS" ? (
               <ForecastsContainer />
+            ) : this.props.card.name === "EVENTS" ? (
+              <EventLogContainer />
             ) : (
               <FinancesContainer />
             )}
@@ -480,6 +486,8 @@ export default class Compositor extends React.Component<Props, {}> {
         return <FinancesContainer />;
       case "FORECASTS":
         return <ForecastsContainer />;
+      case "EVENTS":
+        return <EventLogContainer />;
       case "FACILITIES":
         return <FacilitiesContainer />;
       case "SETTINGS":

--- a/src/components/base/KeyboardShortcuts.tsx
+++ b/src/components/base/KeyboardShortcuts.tsx
@@ -15,6 +15,7 @@ export const SHORTCUTS: ShortcutType[] = [
   { keys: ["Q"], description: "Facilities tab" },
   { keys: ["W"], description: "Finances tab" },
   { keys: ["E"], description: "Forecasts tab" },
+  { keys: ["R"], description: "Events tab" },
   { keys: ["G"], description: "Build a generator" },
   { keys: ["S"], description: "Build storage" },
   {

--- a/src/components/base/Navigation.tsx
+++ b/src/components/base/Navigation.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { BottomNavigation, BottomNavigationAction } from "@mui/material";
 import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
 import FlashOnIcon from "@mui/icons-material/FlashOn";
+import HistoryIcon from "@mui/icons-material/History";
 import InsertChartIcon from "@mui/icons-material/InsertChart";
 import { useAppSelector, useAppDispatch } from "../../Store";
 import { CardNameType, CardType } from "../../Types";
@@ -42,6 +43,12 @@ export default function Navigation() {
         label="Forecasts"
         value="FORECASTS"
         icon={<InsertChartIcon />}
+      />
+      <BottomNavigationAction
+        id="eventsNav"
+        label="Events"
+        value="EVENTS"
+        icon={<HistoryIcon />}
       />
     </BottomNavigation>
   );


### PR DESCRIPTION
## Summary
- Adds `EVENTS` as a `CardNameType` / `NAV_CARDS` entry, so the event log is a full nav destination rather than something only visible inline on ultrawide desktop.
- Adds it as the farthest-right item in the bottom nav (`Navigation.tsx`), with a `History` icon.
- Wires it into the tablet pane-layout's swappable second column and the mobile/standalone card switch in `Compositor.tsx`.
- Adds the `r` keyboard shortcut (continuing the q/w/e row used by Facilities/Finances/Forecasts), documented in `KeyboardShortcuts.tsx` (shown in Settings/Manual).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `eslint` on changed files
- [x] `prettier --check` on changed files
- [x] Full test suite (569 tests, 43 suites) passes
- [x] Manually verified in browser: Events tab renders farthest right in the bottom nav, clicking it navigates to the event log, and the `r` shortcut navigates to it from another tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)