### PR TITLE
Turn tutorials into action-gated missions

### DIFF
--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -4,6 +4,7 @@ import { registerStore } from "./StoreRegistry";
 import cardReducer from "./reducers/Card";
 import gameReducer from "./reducers/Game";
 import settingsReducer from "./reducers/Settings";
+import { tutorialGateMiddleware } from "./reducers/Tutorial";
 import uiReducer from "./reducers/UI";
 import userReducer from "./reducers/User";
 
@@ -15,6 +16,8 @@ export const store = configureStore({
     ui: uiReducer,
     user: userReducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(tutorialGateMiddleware),
 });
 
 export type AppStore = typeof store;

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -354,6 +354,16 @@ export interface TutorialStepType {
   onNext?: () => Redux.Action;
   target: string;
   content: React.JSX.Element;
+  // Present = the step is action-gated ("play, don't tell"): the tooltip shows a "do it"
+  // affordance instead of a Next button, and the walkthrough advances the moment this
+  // returns true. Evaluated after every dispatch - including every tick - so keep it to
+  // cheap field reads. Tutorial scenarios have fixed authored starting states, so
+  // predicates are absolute (e.g. facilities.length >= 2), never relative to step entry
+  advanceOn?: (state: AppStateType) => boolean;
+  // Gate for deeds that leave no distinguishable state behind (a drag re-order, a pause
+  // toggle): advance when an action with one of these types is dispatched. Either gate
+  // field alone makes the step gated; both may be combined (OR)
+  advanceOnAction?: string | string[];
   // Above the desktop breakpoint the bottom nav is hidden and Facilities / Finances /
   // Forecasts render side by side, so a step whose target lives in that nav - or whose
   // selector matches more than one pane - needs a different target there, and usually
@@ -362,6 +372,20 @@ export interface TutorialStepType {
     target: string;
     content?: React.JSX.Element;
   };
+}
+
+export function isGatedStep(step: TutorialStepType): boolean {
+  return !!(step.advanceOn || step.advanceOnAction);
+}
+
+// A walkthrough moving between two steps. Both ends are named because Back and Next need
+// telling apart: a step's onNext only applies to leaving it forwards
+export interface TutorialStepChangeType {
+  fromStep: number;
+  toStep: number;
+  tutorialSteps: TutorialStepType[] | undefined;
+  scenarioId: number;
+  currentCard: CardNameType;
 }
 
 export interface ScenarioType {

--- a/src/app.scss
+++ b/src/app.scss
@@ -820,6 +820,55 @@ $pane_header_height: 40px;
       opacity: 0.6;
       font-size: 0.85em;
     }
+
+    // Stands in for the Next button on action-gated steps: doing the highlighted thing is
+    // what advances, so the affordance pulses instead of being clickable
+    .tutorialDoIt {
+      display: inline-flex;
+      align-items: center;
+      padding: size(tiny);
+      animation: tutorialDoItPulse 1.5s ease-in-out infinite;
+    }
+  }
+
+  // Icon-led step content: symbols on top, one confirming line of text, and for gated
+  // steps a "do this" chip naming the deed in the same symbols
+  .tutorialPrompt {
+    text-align: center;
+
+    .tutorialPromptConcepts {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: size(small);
+      margin-bottom: size(small);
+    }
+
+    .tutorialPromptArrow {
+      opacity: 0.5;
+    }
+
+    .tutorialPromptAction {
+      display: inline-flex;
+      align-items: center;
+      gap: size(tiny);
+      margin-top: size(small);
+      padding: size(tiny) size(small);
+      border: 1px solid var(--border-strong);
+      border-radius: 100px;
+    }
+  }
+
+  @keyframes tutorialDoItPulse {
+    0%,
+    100% {
+      transform: scale(1);
+      opacity: 0.7;
+    }
+    50% {
+      transform: scale(1.25);
+      opacity: 1;
+    }
   }
 
   // ===============================================

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -7,6 +7,7 @@ import {
   Snackbar,
   Typography,
 } from "@mui/material";
+import TouchAppIcon from "@mui/icons-material/TouchApp";
 import * as React from "react";
 import { GlobalHotKeys, configure } from "react-hotkeys";
 import {
@@ -24,8 +25,10 @@ import {
   CardType,
   SettingsType,
   TransitionClassType,
+  TutorialStepChangeType,
   TutorialStepType,
   UIType,
+  isGatedStep,
 } from "../Types";
 import AudioContainer from "./base/AudioContainer";
 import DesktopPanes from "./base/DesktopPanes";
@@ -279,6 +282,10 @@ function Tooltip(props: TooltipRenderProps): React.JSX.Element {
     isLastStep,
   } = props;
   const isString = typeof step.content === "string";
+  // Presentation flags baked in by stepsForViewport: a gated step has no Next button -
+  // doing the highlighted deed is what advances it - and Back is hidden next to a gate,
+  // since backing into a satisfied one would instantly re-advance
+  const flags = (step.data || {}) as { gated?: boolean; hideBack?: boolean };
   // tooltipProps carries role="alertdialog" + aria-modal, which require an accessible name;
   // without one screen readers announce an anonymous dialog
   return (
@@ -298,14 +305,23 @@ function Tooltip(props: TooltipRenderProps): React.JSX.Element {
         <span className="tutorialProgress">
           Step {index + 1} of {size}
         </span>
-        {index > 0 && (
+        {index > 0 && !flags.hideBack && (
           <Button {...backProps} color="primary">
             Back
           </Button>
         )}
-        <Button {...primaryProps} variant="contained" color="primary">
-          {isLastStep ? "Play" : "Next"}
-        </Button>
+        {flags.gated ? (
+          <span
+            className="tutorialDoIt"
+            aria-label="Do the highlighted action to continue"
+          >
+            <TouchAppIcon color="primary" />
+          </span>
+        ) : (
+          <Button {...primaryProps} variant="contained" color="primary">
+            {isLastStep ? "Play" : "Next"}
+          </Button>
+        )}
       </div>
     </div>
   );
@@ -321,15 +337,9 @@ export interface StateProps {
   tutorialSteps?: TutorialStepType[];
 }
 
-// A walkthrough moving between two steps. Both ends are named because Back and Next need
-// telling apart: a step's onNext only applies to leaving it forwards
-export interface TutorialStepChangeType {
-  fromStep: number;
-  toStep: number;
-  tutorialSteps: TutorialStepType[] | undefined;
-  scenarioId: number;
-  currentCard: CardNameType;
-}
+// Moved to Types so the tutorial gate middleware can share it without a component import;
+// re-exported here for existing consumers
+export type { TutorialStepChangeType } from "../Types";
 
 export interface DispatchProps {
   closeDialog: () => void;
@@ -375,9 +385,24 @@ export default class Compositor extends React.Component<Props, {}> {
     if (cache && cache.source === steps && cache.desktop === desktop) {
       return cache.resolved;
     }
-    const resolved = steps.map((step) => {
-      const { desktop: override, ...rest } = step;
-      return (desktop && override ? { ...rest, ...override } : rest) as Step;
+    const resolved = steps.map((step, i) => {
+      // The gate fields and onNext are engine concerns; Joyride only needs the
+      // presentation, plus flags telling the tooltip which buttons make sense here
+      const {
+        desktop: override,
+        advanceOn: _advanceOn,
+        advanceOnAction: _advanceOnAction,
+        onNext: _onNext,
+        ...rest
+      } = step;
+      const merged = desktop && override ? { ...rest, ...override } : rest;
+      return {
+        ...merged,
+        data: {
+          gated: isGatedStep(step),
+          hideBack: isGatedStep(step) || (i > 0 && isGatedStep(steps[i - 1])),
+        },
+      } as Step;
     });
     this.stepsCache = { source: steps, desktop, resolved };
     return resolved;
@@ -406,6 +431,17 @@ export default class Compositor extends React.Component<Props, {}> {
     // scenario list. Has to come first, since closing also reports STEP_AFTER
     if (action === ACTIONS.CLOSE) {
       this.props.onTutorialEnd(this.props.tutorialSteps);
+      return;
+    }
+    // A gated step advances only by its deed. Skipping it on a missing target would wave
+    // the player past the very thing the step exists to make them do - and the deed itself
+    // often removes the target for a frame (buying closes the build screen), which Joyride
+    // reports as TARGET_NOT_FOUND while the gate middleware is already landing the next step
+    const current =
+      this.props.tutorialStep >= 0 && this.props.tutorialSteps
+        ? this.props.tutorialSteps[this.props.tutorialStep]
+        : undefined;
+    if (type === EVENTS.TARGET_NOT_FOUND && current && isGatedStep(current)) {
       return;
     }
     const advancingEvents: string[] = [

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -1,12 +1,13 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as React from "react";
-import type { UnknownAction } from "redux";
-import { ACTIONS, EVENTS, type EventData } from "react-joyride";
+import { UnknownAction } from "redux";
+import { ACTIONS, EVENTS, EventData } from "react-joyride";
 import type { AppDispatch } from "../Store";
 import { SCENARIOS } from "../data/Scenarios";
+import { reprioritizeFacility, togglePauseFacility } from "../reducers/Game";
 import { CardNameType, NavigateActionType, TutorialStepType } from "../Types";
-import Compositor, { type Props as CompositorProps } from "./Compositor";
+import Compositor, { Props as CompositorProps } from "./Compositor";
 import { mapDispatchToProps } from "./CompositorContainer";
 
 // Where `loaded` drops the player, and so where every walkthrough starts
@@ -70,7 +71,7 @@ function navigatedTo(dispatched: UnknownAction[]): CardNameType | undefined {
 }
 
 describe("onTutorialStep", () => {
-  const generators = walkthrough("102: Generators");
+  const generators = walkthrough("Mission 2: Generators");
 
   it("moves the walkthrough to the new step", () => {
     const dispatched = step({
@@ -113,15 +114,20 @@ describe("onTutorialStep", () => {
     );
   });
 
-  // The mirror of the case above: the last step closes the build screen, so stepping back into
-  // it has to reopen it
+  // The mirror of the case above: a later step closes the build screen, so stepping back into
+  // the preceding shop step has to reopen it
   it("navigates back into a screen a later step closed", () => {
-    const last = generators.length - 1;
-    expect(cardOf(generators[last])).toBe(STARTING_CARD);
+    const facilitiesStep = generators.findIndex(
+      (candidate, index) =>
+        index > 0 &&
+        cardOf(candidate) === STARTING_CARD &&
+        cardOf(generators[index - 1]) === "BUILD_GENERATORS",
+    );
+    expect(facilitiesStep).toBeGreaterThan(0);
     const dispatched = step({
       steps: generators,
-      fromStep: last,
-      toStep: last - 1,
+      fromStep: facilitiesStep,
+      toStep: facilitiesStep - 1,
       currentCard: STARTING_CARD,
     });
     expect(navigatedTo(dispatched)).toBe("BUILD_GENERATORS");
@@ -210,9 +216,25 @@ function declares(simple: string): boolean {
 
 describe("walkthrough steps", () => {
   const tutorials = SCENARIOS.filter((s) => s.tutorialSteps);
+  const actionGateTypes = new Set<string>([
+    reprioritizeFacility.type,
+    togglePauseFacility.type,
+  ]);
 
   it("covers every walkthrough", () => {
     expect(tutorials.length).toBeGreaterThan(0);
+  });
+
+  it("uses real game actions for every action gate", () => {
+    const declared = tutorials.flatMap(
+      (scenario) =>
+        scenario.tutorialSteps?.flatMap((tutorialStep) =>
+          tutorialStep.advanceOnAction
+            ? ([] as string[]).concat(tutorialStep.advanceOnAction)
+            : [],
+        ) || [],
+    );
+    expect(declared.filter((type) => !actionGateTypes.has(type))).toEqual([]);
   });
 
   tutorials.forEach((scenario) => {
@@ -272,7 +294,7 @@ describe("walkthrough steps", () => {
 });
 
 describe("handleJoyrideCallback", () => {
-  const steps = walkthrough("102: Generators");
+  const steps = walkthrough("Mission 2: Generators");
 
   function fire(tutorialStep: number, event: Partial<EventData>) {
     const onTutorialStep = jest.fn();
@@ -290,12 +312,21 @@ describe("handleJoyrideCallback", () => {
   }
 
   it("advances past a target that never turns up mid-walkthrough", () => {
+    const { onTutorialStep } = fire(1, {
+      action: ACTIONS.NEXT,
+      index: 1,
+      type: EVENTS.TARGET_NOT_FOUND,
+    });
+    expect(onTutorialStep).toHaveBeenCalled();
+  });
+
+  it("does not skip a gated deed when its target is temporarily missing", () => {
     const { onTutorialStep } = fire(2, {
       action: ACTIONS.NEXT,
       index: 2,
       type: EVENTS.TARGET_NOT_FOUND,
     });
-    expect(onTutorialStep).toHaveBeenCalled();
+    expect(onTutorialStep).not.toHaveBeenCalled();
   });
 
   // Quitting takes the targets out of the DOM, which Joyride reports the same way. Acting on it

--- a/src/components/CompositorContainer.tsx
+++ b/src/components/CompositorContainer.tsx
@@ -1,22 +1,17 @@
 import type { AppDispatch } from "../Store";
 import { connect } from "react-redux";
 import { delta, quit } from "../reducers/Game";
+import { changeTutorialStep } from "../reducers/Tutorial";
 import { dialogClose, snackbarClose, snackbarOpen } from "../reducers/UI";
-import { recordScenarioPlayed } from "../LocalStorage";
 import { getScenario } from "../data/Scenarios";
-import { navigate } from "../reducers/Card";
 import {
   AppStateType,
   ScenarioType,
   TransitionClassType,
+  TutorialStepChangeType,
   TutorialStepType,
 } from "../Types";
-import Compositor, {
-  DispatchProps,
-  isNavCard,
-  StateProps,
-  TutorialStepChangeType,
-} from "./Compositor";
+import Compositor, { DispatchProps, isNavCard, StateProps } from "./Compositor";
 
 const mapStateToProps = (state: AppStateType): StateProps => {
   let transition: TransitionClassType = "next";
@@ -57,53 +52,10 @@ export const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     closeSnackbar(): void {
       dispatch(snackbarClose());
     },
-    onTutorialStep({
-      fromStep,
-      toStep,
-      tutorialSteps,
-      scenarioId,
-      currentCard,
-    }: TutorialStepChangeType): void {
-      const steps = tutorialSteps || [];
-
-      // Only leaving a step forwards runs its one-way side effects - Back has no way to undo
-      // them, and replaying the previous step's would fire an effect nobody triggered
-      const leaving = toStep > fromStep ? steps[fromStep] : undefined;
-      if (leaving && leaving.onNext) {
-        dispatch(leaving.onNext());
-      }
-
-      // Steps declare the card their target lives on, and every step change navigates there
-      // regardless of direction. Otherwise Back leaves the player on whatever card the
-      // forward step navigated to, where Joyride can't find the target and shows no tooltip
-      const destination = steps[toStep] && steps[toStep].card;
-      if (destination) {
-        const name =
-          typeof destination === "string" ? destination : destination.name;
-        if (name !== currentCard) {
-          dispatch(navigate(destination));
-        }
-      }
-
-      dispatch(delta({ tutorialStep: toStep }));
-
-      if (toStep < steps.length) {
-        return;
-      }
-
-      // Finishing the walkthrough is what counts as doing the tutorial - the rest of the
-      // scenario is optional practice, and requiring it meant a checkmark cost up to four
-      // minutes of watching the sim run
-      recordScenarioPlayed(scenarioId);
-      dispatch(
-        snackbarOpen({
-          message: "Walkthrough complete - keep practicing, or move on",
-          actionLabel: "Tutorials",
-          action: () => dispatch(quit({ toScenarioList: true })),
-          open: true,
-          timeout: 6000,
-        }),
-      );
+    onTutorialStep(change: TutorialStepChangeType): void {
+      // Shared with the gate middleware, so a tooltip button and a satisfied gate fire
+      // identical side effects
+      changeTutorialStep(dispatch, change);
     },
     onTutorialEnd(tutorialSteps: TutorialStepType[] | undefined): void {
       // Past the last step, which is how a finished walkthrough is represented too
@@ -112,9 +64,8 @@ export const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
       // a paused scenario with no idea what happened - so say so, and offer the way out
       dispatch(
         snackbarOpen({
-          message:
-            "Walkthrough closed - keep playing, or pick another tutorial",
-          actionLabel: "Tutorials",
+          message: "Walkthrough closed - keep playing, or pick another mission",
+          actionLabel: "Missions",
           action: () => dispatch(quit({ toScenarioList: true })),
           open: true,
           timeout: 6000,

--- a/src/components/base/ConceptIcon.tsx
+++ b/src/components/base/ConceptIcon.tsx
@@ -1,0 +1,143 @@
+import AccountBalanceIcon from "@mui/icons-material/AccountBalance";
+import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
+import BoltIcon from "@mui/icons-material/Bolt";
+import BuildIcon from "@mui/icons-material/Build";
+import CampaignIcon from "@mui/icons-material/Campaign";
+import ConstructionIcon from "@mui/icons-material/Construction";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import FactoryIcon from "@mui/icons-material/Factory";
+import FlashOffIcon from "@mui/icons-material/FlashOff";
+import FlashOnIcon from "@mui/icons-material/FlashOn";
+import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
+import LocalGasStationIcon from "@mui/icons-material/LocalGasStation";
+import PauseCircleIcon from "@mui/icons-material/PauseCircle";
+import PeopleIcon from "@mui/icons-material/People";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import QueryStatsIcon from "@mui/icons-material/QueryStats";
+import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
+import WarningIcon from "@mui/icons-material/Warning";
+import WbSunnyIcon from "@mui/icons-material/WbSunny";
+import * as React from "react";
+
+// The game's symbol vocabulary: one glyph per concept, everywhere a concept appears.
+// Consistency is what lets the symbols teach themselves - a player who met "blackout"
+// in Mission 1 recognizes it in an event row or a dialog without reading anything.
+export type ConceptNameType =
+  | "money"
+  | "supply"
+  | "demand"
+  | "blackout"
+  | "customers"
+  | "generator"
+  | "storage"
+  | "build"
+  | "buy"
+  | "reorder"
+  | "pause"
+  | "play"
+  | "time"
+  | "construction"
+  | "finances"
+  | "forecast"
+  | "marketing"
+  | "fuel"
+  | "weather"
+  | "danger"
+  | "goal";
+
+// The one place each concept gets its spoken/read name - and the seed of a future
+// localization catalog, since screen readers are the only consumer of these words
+export const CONCEPT_LABELS: Record<ConceptNameType, string> = {
+  money: "Money",
+  supply: "Supply",
+  demand: "Demand",
+  blackout: "Blackout",
+  customers: "Customers",
+  generator: "Generator",
+  storage: "Storage",
+  build: "Build",
+  buy: "Buy",
+  reorder: "Re-order",
+  pause: "Pause",
+  play: "Play",
+  time: "Time",
+  construction: "Under construction",
+  finances: "Finances",
+  forecast: "Forecast",
+  marketing: "Marketing",
+  fuel: "Fuel",
+  weather: "Weather",
+  danger: "Danger",
+  goal: "Goal",
+};
+
+// Storage renders the battery illustration the fleet list already uses, so it's absent here
+const CONCEPT_ICONS: Record<
+  Exclude<ConceptNameType, "storage">,
+  React.ElementType
+> = {
+  money: AttachMoneyIcon,
+  supply: FlashOnIcon,
+  demand: BoltIcon,
+  blackout: FlashOffIcon,
+  customers: PeopleIcon,
+  generator: FactoryIcon,
+  build: BuildIcon,
+  buy: ShoppingCartIcon,
+  reorder: SwapVertIcon,
+  pause: PauseCircleIcon,
+  play: PlayArrowIcon,
+  time: HourglassEmptyIcon,
+  construction: ConstructionIcon,
+  finances: AccountBalanceIcon,
+  forecast: QueryStatsIcon,
+  marketing: CampaignIcon,
+  fuel: LocalGasStationIcon,
+  weather: WbSunnyIcon,
+  danger: WarningIcon,
+  goal: EmojiEventsIcon,
+};
+
+// Colour reinforces the meanings the app already assigns: green supply, red blackout
+const CONCEPT_COLORS: Partial<
+  Record<ConceptNameType, "success" | "error" | "warning">
+> = {
+  supply: "success",
+  blackout: "error",
+  danger: "warning",
+};
+
+const IMG_SIZES = { small: 20, medium: 24, large: 35 };
+
+export interface ConceptIconProps {
+  concept: ConceptNameType;
+  fontSize?: "small" | "medium" | "large";
+}
+
+export default function ConceptIcon({
+  concept,
+  fontSize = "medium",
+}: ConceptIconProps): React.JSX.Element {
+  const label = CONCEPT_LABELS[concept];
+  if (concept === "storage") {
+    const px = IMG_SIZES[fontSize];
+    return (
+      <img
+        src="/images/battery.svg"
+        alt={label}
+        className="conceptIcon"
+        style={{ width: px, height: px }}
+      />
+    );
+  }
+  const Icon = CONCEPT_ICONS[concept];
+  return (
+    <Icon
+      className="conceptIcon"
+      titleAccess={label}
+      fontSize={fontSize}
+      color={CONCEPT_COLORS[concept]}
+    />
+  );
+}

--- a/src/components/base/TutorialPrompt.tsx
+++ b/src/components/base/TutorialPrompt.tsx
@@ -1,0 +1,49 @@
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import TouchAppIcon from "@mui/icons-material/TouchApp";
+import { Typography } from "@mui/material";
+import * as React from "react";
+import ConceptIcon, { ConceptNameType } from "./ConceptIcon";
+
+export interface TutorialPromptProps {
+  // The idea, told in symbols: a large icon row read left to right, arrows between
+  concepts: ConceptNameType[];
+  // At most one short sentence - the symbols carry the teaching, the words only confirm it
+  text?: string;
+  // For gated steps: the deed being asked for, as a "do this" chip matching the pulsing
+  // affordance in the tooltip footer
+  action?: ConceptNameType[];
+}
+
+export default function TutorialPrompt({
+  concepts,
+  text,
+  action,
+}: TutorialPromptProps): React.JSX.Element {
+  return (
+    <div className="tutorialPrompt">
+      <div className="tutorialPromptConcepts">
+        {concepts.map((concept, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && (
+              <ArrowForwardIcon
+                className="tutorialPromptArrow"
+                fontSize="small"
+                aria-hidden
+              />
+            )}
+            <ConceptIcon concept={concept} fontSize="large" />
+          </React.Fragment>
+        ))}
+      </div>
+      {text && <Typography variant="body2">{text}</Typography>}
+      {action && (
+        <div className="tutorialPromptAction">
+          <TouchAppIcon fontSize="small" color="primary" aria-hidden />
+          {action.map((concept, i) => (
+            <ConceptIcon key={i} concept={concept} fontSize="small" />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/views/MainMenuContainer.tsx
+++ b/src/components/views/MainMenuContainer.tsx
@@ -1,8 +1,10 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { AppStateType } from "../../Types";
+import { TUTORIALS } from "../../data/Scenarios";
+import { getPlayedScenarioIds } from "../../LocalStorage";
 import { navigate } from "../../reducers/Card";
-import { resume } from "../../reducers/Game";
+import { resume, start } from "../../reducers/Game";
 import { change as changeSettings } from "../../reducers/Settings";
 import { resumableSave } from "../../SaveFile";
 import MainMenu, { DispatchProps, StateProps } from "./MainMenu";
@@ -34,7 +36,18 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
       dispatch(navigate("SETTINGS"));
     },
     onStart: () => {
-      dispatch(navigate("NEW_GAME"));
+      // A brand-new player jumps straight into Mission 1 - "play, don't tell" starts at
+      // the menu. The save guard keeps Continue meaningful: someone mid-scenario isn't
+      // new, even if they skipped the missions
+      const played = getPlayedScenarioIds();
+      const anyTutorialDone = TUTORIALS.some(
+        (t) => played.indexOf(t.id) !== -1,
+      );
+      if (!anyTutorialDone && !resumableSave()) {
+        dispatch(start(TUTORIALS[0].id));
+      } else {
+        dispatch(navigate("NEW_GAME"));
+      }
     },
   };
 };

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import {
   Avatar,
+  Badge,
   Button,
   Card,
   CardHeader,
   IconButton,
-  LinearProgress,
   List,
   Toolbar,
   Typography,
@@ -14,7 +14,6 @@ import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutlineOutlined";
-import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import { getPlayedScenarioIds } from "../../LocalStorage";
 import { getScenarioLocation } from "../../helpers/Locations";
 import {
@@ -39,65 +38,23 @@ export interface DispatchProps {
 
 export interface Props extends StateProps, DispatchProps {}
 
-interface TutorialListItemProps {
+interface MissionListItemProps {
+  s: ScenarioType;
   completed: boolean;
-  // The first tutorial the player hasn't done yet, called out so the sequence has an
-  // obvious entry point instead of six equal-looking rows
+  // The first mission the player hasn't done yet, called out so the single list has an
+  // obvious entry point instead of a dozen equal-looking rows
   next: boolean;
-  s: ScenarioType;
-  onTutorial: DispatchProps["onTutorial"];
-}
-
-function TutorialListItem(props: TutorialListItemProps): React.JSX.Element {
-  const { s, onTutorial, completed, next } = props;
-  return (
-    <Card className={`build-list-item${next ? " tutorialNext" : ""}`}>
-      <CardHeader
-        style={{ opacity: completed ? 0.6 : 1 }}
-        avatar={
-          completed ? (
-            <CheckCircleIcon
-              className="tutorialComplete"
-              color="primary"
-              titleAccess={`${s.name} completed`}
-            />
-          ) : (
-            <RadioButtonUncheckedIcon
-              className="tutorialIncomplete"
-              titleAccess={`${s.name} not yet completed`}
-            />
-          )
-        }
-        action={
-          <Button
-            size="small"
-            variant={completed ? "outlined" : "contained"}
-            color="primary"
-            onClick={() => onTutorial(s.id)}
-            autoFocus={next}
-          >
-            {completed ? "Replay" : "Play"}
-          </Button>
-        }
-        title={s.name}
-        subheader={next ? "Start here" : undefined}
-      />
-    </Card>
-  );
-}
-
-interface ScenarioListItemProps {
-  s: ScenarioType;
-  // The custom game row opens its own setup screen rather than the scenario details one, so the
-  // row doesn't get to assume what selecting it does
   onSelect: () => void;
 }
 
-function ScenarioListItem(props: ScenarioListItemProps): React.JSX.Element {
-  const { s, onSelect } = props;
+// One row for everything: tutorial missions, scenarios, and the custom game all share the
+// list now - the only differences are the action control and what the subheader shows
+function MissionListItem(props: MissionListItemProps): React.JSX.Element {
+  const { s, completed, next, onSelect } = props;
+  const isTutorial = !!s.tutorialSteps;
   const location = getScenarioLocation(s) || { name: "UNKNOWN" };
   const summary =
-    s.id === CUSTOM_SCENARIO_ID ? (
+    isTutorial || s.id === CUSTOM_SCENARIO_ID ? (
       s.summary
     ) : (
       <span>
@@ -110,15 +67,59 @@ function ScenarioListItem(props: ScenarioListItemProps): React.JSX.Element {
       </span>
     );
   return (
-    <Card className="build-list-item clickable-card" onClick={onSelect}>
+    <Card
+      className={`build-list-item clickable-card${next ? " tutorialNext" : ""}`}
+      onClick={onSelect}
+    >
       <CardHeader
-        avatar={<Avatar src={`/images/${s.icon.toLowerCase()}.svg`} />}
+        style={{ opacity: completed ? 0.6 : 1 }}
+        avatar={
+          <Badge
+            overlap="circular"
+            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            badgeContent={
+              completed ? (
+                <CheckCircleIcon
+                  className="tutorialComplete"
+                  color="primary"
+                  fontSize="small"
+                  titleAccess={`${s.name} completed`}
+                />
+              ) : undefined
+            }
+          >
+            <Avatar src={`/images/${s.icon.toLowerCase()}.svg`} />
+          </Badge>
+        }
         title={s.name}
-        subheader={summary}
+        subheader={next ? "Start here" : summary}
         action={
-          <IconButton color="primary" onClick={onSelect} size="large">
-            <ArrowRightIcon />
-          </IconButton>
+          isTutorial ? (
+            <Button
+              size="small"
+              variant={completed ? "outlined" : "contained"}
+              color="primary"
+              onClick={(e) => {
+                // The whole card is clickable too - don't start the mission twice
+                e.stopPropagation();
+                onSelect();
+              }}
+              autoFocus={next}
+            >
+              {completed ? "Replay" : "Play"}
+            </Button>
+          ) : (
+            <IconButton
+              color="primary"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSelect();
+              }}
+              size="large"
+            >
+              <ArrowRightIcon />
+            </IconButton>
+          )
         }
       />
     </Card>
@@ -127,9 +128,6 @@ function ScenarioListItem(props: ScenarioListItemProps): React.JSX.Element {
 
 export default function NewGame(props: Props): React.JSX.Element {
   const ids = getPlayedScenarioIds();
-  const completedTutorials = TUTORIALS.filter(
-    (s) => ids.indexOf(s.id) !== -1,
-  ).length;
   const nextTutorial = TUTORIALS.find((s) => ids.indexOf(s.id) === -1);
 
   return (
@@ -145,7 +143,7 @@ export default function NewGame(props: Props): React.JSX.Element {
           >
             <ArrowBackIosIcon />
           </IconButton>
-          <Typography variant="h6">Select a Scenario</Typography>
+          <Typography variant="h6">Missions</Typography>
           {/* Otherwise the Manual is only reachable from the title screen and the in-game
               overflow menu, so players who stop partway through never find out it exists.
               Auto margin rather than absolute positioning, so it can't sit on top of the
@@ -162,49 +160,25 @@ export default function NewGame(props: Props): React.JSX.Element {
         </Toolbar>
       </div>
       <List dense className="scrollable cardList">
-        <Typography variant="h5" sx={{ paddingLeft: 1, paddingTop: 1 }}>
-          Tutorials
-        </Typography>
-        <Typography
-          variant="body2"
-          color="textSecondary"
-          sx={{ paddingLeft: 1, paddingBottom: 1 }}
-        >
-          {completedTutorials} of {TUTORIALS.length} complete
-        </Typography>
-        <LinearProgress
-          variant="determinate"
-          value={(completedTutorials / TUTORIALS.length) * 100}
-          className="tutorialProgressBar"
-          aria-label={`Tutorials: ${completedTutorials} of ${TUTORIALS.length} complete`}
-        />
-        {TUTORIALS.map((s) => {
-          return (
-            <TutorialListItem
-              key={s.id}
-              onTutorial={props.onTutorial}
-              s={s}
-              completed={ids.indexOf(s.id) !== -1}
-              next={nextTutorial !== undefined && s.id === nextTutorial.id}
-            />
-          );
-        })}
-        <Typography variant="h5" sx={{ paddingLeft: 1, paddingTop: 1 }}>
-          Scenarios
-        </Typography>
-        {SCENARIOS.filter((s: ScenarioType) => !s.tutorialSteps).map((s) => {
-          return (
-            <ScenarioListItem
-              key={s.id}
-              onSelect={() => props.onDetails({ scenarioId: s.id })}
-              s={s}
-            />
-          );
-        })}
-        <ScenarioListItem
+        {SCENARIOS.map((s) => (
+          <MissionListItem
+            key={s.id}
+            s={s}
+            completed={ids.indexOf(s.id) !== -1}
+            next={nextTutorial !== undefined && s.id === nextTutorial.id}
+            onSelect={
+              s.tutorialSteps
+                ? () => props.onTutorial(s.id)
+                : () => props.onDetails({ scenarioId: s.id })
+            }
+          />
+        ))}
+        <MissionListItem
           key={CUSTOM_SCENARIO_ID}
-          onSelect={props.onCustomGame}
           s={DEFAULT_CUSTOM_SCENARIO}
+          completed={false}
+          next={false}
+          onSelect={props.onCustomGame}
         />
       </List>
     </div>

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -1,13 +1,14 @@
-import { Typography } from "@mui/material";
 import * as React from "react";
 
-import { setSpeed } from "../reducers/Game";
-import { ScenarioType } from "../Types";
+import TutorialPrompt from "../components/base/TutorialPrompt";
+import { AppStateType, ScenarioType } from "../Types";
 
 export const SCENARIOS = [
   {
     id: 0, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
-    name: "101: Electricity",
+    name: "Mission 1: Electricity",
+    icon: "solar",
+    summary: "Meet your grid",
     locationId: "SF",
     ownership: "Investor",
     startingYear: 2019,
@@ -15,8 +16,8 @@ export const SCENARIOS = [
     feePerKgCO2e: 0,
     dollarsPerkWh: 0.07,
     durationMonths: 1,
-    endTitle: "Tutorial complete!",
-    endMessage: "Just a few tutorials to go",
+    endTitle: "Mission complete!",
+    endMessage: "Just a few missions to go",
     facilities: [
       { fuel: "Natural Gas", peakW: 410000000 },
       { fuel: "Sun", peakW: 300000000 },
@@ -27,76 +28,62 @@ export const SCENARIOS = [
         card: "FACILITIES",
         target: "#topbar",
         content: (
-          <Typography variant="body1">
-            Welcome! You're the new CEO of a regional power generation company.
-            <br />
-            <br />
-            Your goal: Make as much money as possible. You lose if you run out
-            of cash or cause too many blackouts.
-          </Typography>
+          <TutorialPrompt
+            concepts={["money", "goal"]}
+            text="Earn money - don't go broke or black out."
+          />
         ),
       },
       {
         card: "FACILITIES",
         target: "#chartSupplyDemand",
         content: (
-          <Typography variant="body1">
-            Make money by supplying demand for electricity, measured in
-            Megawatts (MW).
-            <br />
-            <br />
-            This graph represents an <strong>average day</strong> for the month.
-            <br />
-            <br />
-            Demand is driven by a variety of factors, including the weather and
-            how many customers you have.
-          </Typography>
-        ),
-      },
-      {
-        card: "FACILITIES",
-        target: "#chartSupplyDemand",
-        content: (
-          <Typography variant="body1">
-            Your generators automatically spin up to meet demand as best they
-            can.
-            <br />
-            <br />
-            If you don't supply enough power, you'll cause blackouts that cost
-            you customers.
-          </Typography>
+          <TutorialPrompt
+            concepts={["supply", "demand"]}
+            text="Keep supply above demand - this is one average day."
+          />
         ),
       },
       {
         card: "FACILITIES",
         target: ".facility",
         content: (
-          <Typography variant="body1">
-            Your facilities indicate how much power they're currently
-            producting.
-            <br />
-            <br />
-            For example, your solar plant isn't producing because it's night
-            time, so your natural gas is picking up the slack.
-          </Typography>
+          <TutorialPrompt
+            concepts={["generator"]}
+            text="Your power plants - the bar shows what each is producing."
+          />
         ),
       },
       {
         card: "FACILITIES",
         target: "#speedChangeButtons",
-        onNext: () => setSpeed("SLOW"),
+        advanceOn: (s: AppStateType) => s.game.speed !== "PAUSED",
         content: (
-          <Typography variant="body1">
-            This tutorial will run for 1 month. See how demand and your supply
-            changes over that time!
-          </Typography>
+          <TutorialPrompt
+            concepts={["play"]}
+            text="Press play."
+            action={["play"]}
+          />
+        ),
+      },
+      {
+        card: "FACILITIES",
+        target: "#chartSupplyDemand",
+        advanceOn: (s: AppStateType) => s.game.date.minute >= 1440,
+        content: (
+          <TutorialPrompt
+            concepts={["weather", "time"]}
+            text="Watch one full day go by."
+          />
         ),
       },
     ],
   },
   {
     id: 1, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
-    name: "102: Generators",
+    name: "Mission 2: Generators",
+    icon: "natural gas",
+    summary: "Build a generator",
     locationId: "SF",
     ownership: "Investor",
     startingYear: 2019,
@@ -104,99 +91,75 @@ export const SCENARIOS = [
     feePerKgCO2e: 0,
     dollarsPerkWh: 0.07,
     durationMonths: 12,
-    endTitle: "Tutorial complete!",
+    endTitle: "Mission complete!",
     endMessage:
-      "You now know enough to run a company on Intern difficulty - or, continue tutorials to build your skills",
+      "You now know enough to run a company on Intern difficulty - or, continue missions to build your skills",
     facilities: [{ fuel: "Natural Gas", peakW: 500000000 }],
     tutorialSteps: [
       {
         skipBeacon: true, // causes tutorial to auto-start
         card: "FACILITIES",
         target: ".button-buildGenerator",
+        advanceOn: (s: AppStateType) => s.card.name === "BUILD_GENERATORS",
         content: (
-          <Typography variant="body1">
-            Build generators to produce additional electricity when you're
-            having blackouts - or in anticipation of future growth.
-          </Typography>
-        ),
-      },
-      {
-        card: { name: "BUILD_GENERATORS", dontRemember: true },
-        target: "#peak-output",
-        content: (
-          <Typography variant="body1">
-            Slide to change the size of generator you want to build.
-          </Typography>
-        ),
-      },
-      {
-        card: { name: "BUILD_GENERATORS", dontRemember: true },
-        target: "#sort",
-        content: (
-          <Typography variant="body1">Sort by different properties.</Typography>
-        ),
-      },
-      {
-        card: { name: "BUILD_GENERATORS", dontRemember: true },
-        target: ".action-seconday-text",
-        content: (
-          <Typography variant="body1">
-            See how long it will take to build, the total cost of electricity
-            across its lifetime, and how much greenhouse gas it releases per
-            unit generated.
-          </Typography>
+          <TutorialPrompt
+            concepts={["build", "generator"]}
+            text="Open the generator shop."
+            action={["build"]}
+          />
         ),
       },
       {
         card: { name: "BUILD_GENERATORS", dontRemember: true },
         target: ".build-list-item",
         content: (
-          <Typography variant="body1">
-            Click on a generator to see more detailed information.
-          </Typography>
+          <TutorialPrompt
+            concepts={["money", "time", "fuel"]}
+            text="Compare cost, build time and fuel."
+          />
         ),
       },
       {
         card: { name: "BUILD_GENERATORS", dontRemember: true },
         target: ".buy-button",
+        advanceOn: (s: AppStateType) => s.game.facilities.length >= 2,
         content: (
-          <Typography variant="body1">
-            Click on the price to buy it, either in cash or with a loan.
-            <br />
-            <br />A loan's interest rate depends on the economy and on your
-            company's own finances - and once you sign, that rate is fixed for
-            the life of the loan.
-          </Typography>
+          <TutorialPrompt
+            concepts={["buy", "generator"]}
+            text="Buy one - cash or loan."
+            action={["buy"]}
+          />
         ),
       },
       {
-        card: { name: "BUILD_GENERATORS", dontRemember: true },
-        target: "#close-button",
+        card: "FACILITIES",
+        target: ".facility",
         content: (
-          <Typography variant="body1">
-            Tap X to close the buy screen.
-          </Typography>
+          <TutorialPrompt
+            concepts={["construction", "time"]}
+            text="It's being built."
+          />
         ),
       },
       {
         card: "FACILITIES",
         target: "#speedChangeButtons",
+        advanceOn: (s: AppStateType) => s.game.speed !== "PAUSED",
         content: (
-          <Typography variant="body1">
-            Start the game by unpausing it. Hotkeys are in a row: `/1/2/3. Space
-            and 0 also pause.
-            <br />
-            <br />
-            This tutorial will run for 1 year. Try building different types of
-            generators!
-          </Typography>
+          <TutorialPrompt
+            concepts={["play"]}
+            text="Run the year."
+            action={["play"]}
+          />
         ),
       },
     ],
   },
   {
     id: 2, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
-    name: "103: Storage",
+    name: "Mission 3: Storage",
+    icon: "battery",
+    summary: "Store energy for later",
     locationId: "SF",
     ownership: "Investor",
     startingYear: 2019,
@@ -204,9 +167,9 @@ export const SCENARIOS = [
     feePerKgCO2e: 0,
     dollarsPerkWh: 0.07,
     durationMonths: 6,
-    endTitle: "Tutorial complete!",
+    endTitle: "Mission complete!",
     endMessage:
-      "You now know enough to run a company on Employee difficulty - or, continue tutorials to build your skills",
+      "You now know enough to run a company on Employee difficulty - or, continue missions to build your skills",
     facilities: [
       { name: "Pumped Hydro", peakWh: 500000000 },
       { fuel: "Coal", peakW: 480000000 },
@@ -216,77 +179,68 @@ export const SCENARIOS = [
         skipBeacon: true, // causes tutorial to auto-start
         card: "FACILITIES",
         target: ".button-buildStorage",
+        advanceOn: (s: AppStateType) => s.card.name === "BUILD_STORAGE",
         content: (
-          <Typography variant="body1">
-            When you're getting blackouts, generators aren't your only option.
-            <br />
-            <br />
-            If you have power at other times of day, it's often cheaper to store
-            that energy than build more generators.
-          </Typography>
+          <TutorialPrompt
+            concepts={["build", "storage"]}
+            text="Storage banks spare power for when you need it - open the storage shop."
+            action={["build"]}
+          />
         ),
       },
       {
         card: { name: "BUILD_STORAGE", dontRemember: true },
         target: ".build-list-item",
+        advanceOn: (s: AppStateType) => s.game.facilities.length >= 3,
         content: (
-          <Typography variant="body1">
-            Moving the slider changes their capacity and peak output.
-          </Typography>
-        ),
-      },
-      {
-        card: { name: "BUILD_STORAGE", dontRemember: true },
-        target: "#close-button",
-        content: (
-          <Typography variant="body1">
-            Tap X to close the build screen.
-          </Typography>
+          <TutorialPrompt
+            concepts={["buy", "storage"]}
+            text="Buy one."
+            action={["buy"]}
+          />
         ),
       },
       {
         card: "FACILITIES",
         target: ".capacityProgressBar",
         content: (
-          <Typography variant="body1">
-            Like generators, the horizontal bar indicates how much electricity
-            it's outputting.
-            <br />
-            <br />
-            In addition, storage units have a vertical bar indicating how much
-            energy is stored.
-          </Typography>
+          <TutorialPrompt
+            concepts={["storage"]}
+            text="The vertical bar is how much energy it holds."
+          />
         ),
       },
       {
         card: "FACILITIES",
         target: ".facility",
+        advanceOnAction: "game/reprioritizeFacility",
         content: (
-          <Typography variant="body1">
-            Hold and drag to re-order your generators and storage.
-            <br />
-            <br />
-            Generators at the top produce first and only charge storage below
-            them.
-          </Typography>
+          <TutorialPrompt
+            concepts={["reorder"]}
+            text="Drag to re-order - the top runs first and charges storage below it."
+            action={["reorder"]}
+          />
         ),
       },
       {
         card: "FACILITIES",
-        target: ".facility",
-        onNext: () => setSpeed("SLOW"),
+        target: "#speedChangeButtons",
+        advanceOn: (s: AppStateType) => s.game.speed !== "PAUSED",
         content: (
-          <Typography variant="body1">
-            This tutorial will run for 6 months. Try changing the order of
-            storage and generators to see how it affects their output!
-          </Typography>
+          <TutorialPrompt
+            concepts={["play"]}
+            text="Run it."
+            action={["play"]}
+          />
         ),
       },
     ],
   },
   {
     id: 4, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
-    name: "104: Finances",
+    name: "Mission 4: Finances",
+    icon: "coal",
+    summary: "Read the books",
     locationId: "SF",
     ownership: "Investor",
     startingYear: 2019,
@@ -294,9 +248,9 @@ export const SCENARIOS = [
     feePerKgCO2e: 0,
     dollarsPerkWh: 0.07,
     durationMonths: 1,
-    endTitle: "Tutorial complete!",
+    endTitle: "Mission complete!",
     endMessage:
-      "You now know enough to run a company on Manager difficulty - or, continue tutorials to build your skills",
+      "You now know enough to run a company on Manager difficulty - or, continue missions to build your skills",
     facilities: [
       { name: "Pumped Hydro", peakWh: 1000000000 },
       { fuel: "Coal", peakW: 600000000 },
@@ -307,18 +261,18 @@ export const SCENARIOS = [
         card: "FACILITIES",
         target: "#financesNav",
         content: (
-          <Typography variant="body1">
-            To run a profitable business, you'll need to understand the Finances
-            tab. (Hotkey: W)
-          </Typography>
+          <TutorialPrompt
+            concepts={["finances", "money"]}
+            text="Your money lives in the Finances tab."
+          />
         ),
         desktop: {
           target: "#financesPane",
           content: (
-            <Typography variant="body1">
-              To run a profitable business, you'll need to understand the
-              Finances pane.
-            </Typography>
+            <TutorialPrompt
+              concepts={["finances", "money"]}
+              text="Your money lives in the Finances pane."
+            />
           ),
         },
       },
@@ -326,54 +280,41 @@ export const SCENARIOS = [
         card: "FINANCES",
         target: "#chartFinances",
         content: (
-          <Typography variant="body1">
-            You can plot a variety of metrics by changing the dropdowns above
-            the chart. You can also plot previous years to analyze long term
-            strategies.
-          </Typography>
+          <TutorialPrompt
+            concepts={["forecast", "money"]}
+            text="Chart any metric, any year."
+          />
         ),
       },
       {
         card: "FINANCES",
         target: ".MuiTable-root",
         content: (
-          <Typography variant="body1">
-            The table shows you the high level numbers for your business for the
-            selected year. Click on the table to get a more detailed breakdown
-            of the numbers, and click it again to collapse it.
-          </Typography>
-        ),
-      },
-      {
-        card: "FINANCES",
-        target: ".MuiTable-root",
-        content: (
-          <Typography variant="body1">
-            The expanded table includes your <strong>interest rate</strong> -
-            what a new loan would cost you today. It moves with the economy, and
-            with how healthy your own books look.
-            <br />
-            <br />
-            Both it and inflation can be charted, like any other metric.
-          </Typography>
+          <TutorialPrompt
+            concepts={["finances"]}
+            text="Tap the table to expand it - including your loan interest rate."
+          />
         ),
       },
       {
         card: "FINANCES",
         target: "#speedChangeButtons",
-        onNext: () => setSpeed("SLOW"),
+        advanceOn: (s: AppStateType) => s.game.speed !== "PAUSED",
         content: (
-          <Typography variant="body1">
-            This tutorial will run for 1 month - try playing around with the
-            chart.
-          </Typography>
+          <TutorialPrompt
+            concepts={["play", "money"]}
+            text="Run a month - watch the numbers."
+            action={["play"]}
+          />
         ),
       },
     ],
   },
   {
     id: 3, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
-    name: "105: Marketing",
+    name: "Mission 5: Marketing",
+    icon: "wind",
+    summary: "Grow your customers",
     locationId: "SF",
     ownership: "Investor",
     startingYear: 2019,
@@ -381,9 +322,9 @@ export const SCENARIOS = [
     feePerKgCO2e: 0,
     dollarsPerkWh: 0.07,
     durationMonths: 12,
-    endTitle: "Tutorial complete!",
+    endTitle: "Mission complete!",
     endMessage:
-      "You now know enough to run a company on VP difficulty - or, continue tutorials to build your skills",
+      "You now know enough to run a company on VP difficulty - or, continue missions to build your skills",
     facilities: [
       { name: "Pumped Hydro", peakWh: 1000000000 },
       { fuel: "Coal", peakW: 600000000 },
@@ -394,75 +335,73 @@ export const SCENARIOS = [
         card: "FACILITIES",
         target: "#financesNav",
         content: (
-          <Typography variant="body1">
-            When you have spare capacity, you can use marketing to grow your
-            business by heading to the "Finances" tab. (Hotkey: W)
-          </Typography>
+          <TutorialPrompt
+            concepts={["marketing", "customers"]}
+            text="Marketing lives in the Finances tab."
+          />
         ),
         desktop: {
           target: "#financesPane",
           content: (
-            <Typography variant="body1">
-              When you have spare capacity, you can use marketing to grow your
-              business - look for it in the Finances pane.
-            </Typography>
+            <TutorialPrompt
+              concepts={["marketing", "customers"]}
+              text="Marketing lives in the Finances pane."
+            />
           ),
         },
       },
       {
         card: "FINANCES",
         target: "#marketingSlider",
+        advanceOn: (s: AppStateType) => s.game.monthlyMarketingSpend > 0,
         content: (
-          <Typography variant="body1">
-            Slide to increase your marketing budget, growing your customer base
-            and demand.
-          </Typography>
+          <TutorialPrompt
+            concepts={["marketing", "customers"]}
+            text="Raise the marketing budget."
+            action={["marketing"]}
+          />
         ),
       },
       {
         card: "FINANCES",
         target: "#plotMetric",
         content: (
-          <Typography variant="body1">
-            Change the graph to plot Customers to see how they change over time.
-            <br />
-            <br />
-            Beware, marketing too much too quickly may actually cost you
-            customers through chronic blackouts!
-          </Typography>
+          <TutorialPrompt
+            concepts={["customers", "forecast"]}
+            text="Plot Customers to watch them grow - but grow too fast and blackouts will cost you them."
+          />
         ),
         // Same control, different shape: on a wide screen the metrics are all drawn at once
         // rather than hidden behind a dropdown
         desktop: {
+          target: "#plotMetric",
           content: (
-            <Typography variant="body1">
-              Click the Customers tile to plot it and see how they change over
-              time.
-              <br />
-              <br />
-              Beware, marketing too much too quickly may actually cost you
-              customers through chronic blackouts!
-            </Typography>
+            <TutorialPrompt
+              concepts={["customers", "forecast"]}
+              text="Click the Customers tile to watch them grow - but grow too fast and blackouts will cost you them."
+            />
           ),
         },
       },
       {
         card: "FINANCES",
         target: "#speedChangeButtons",
-        onNext: () => setSpeed("SLOW"),
+        advanceOn: (s: AppStateType) => s.game.speed !== "PAUSED",
         content: (
-          <Typography variant="body1">
-            This tutorial will run for 1 year - see how changing your marketing
-            budget changes your demand.
-          </Typography>
+          <TutorialPrompt
+            concepts={["play"]}
+            text="Run the year."
+            action={["play"]}
+          />
         ),
       },
     ],
   },
-
   {
     id: 5, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
-    name: "106: Forecasting",
+    name: "Mission 6: Forecasting",
+    icon: "geothermal",
+    summary: "See what's coming",
     locationId: "SF",
     ownership: "Investor",
     startingYear: 2020,
@@ -470,87 +409,76 @@ export const SCENARIOS = [
     feePerKgCO2e: 0,
     dollarsPerkWh: 0.07,
     durationMonths: 12,
-    endTitle: "Tutorial complete!",
+    endTitle: "Mission complete!",
     endMessage: `That's all we can teach you - the rest you'll have to learn by doing!`,
     facilities: [{ fuel: "Coal", peakW: 450000000 }],
     tutorialSteps: [
       {
         skipBeacon: true, // causes tutorial to auto-start
         card: "FACILITIES",
-        target: "#forecastsNav",
+        target: ".facility",
+        advanceOnAction: "game/togglePauseFacility",
         content: (
-          <Typography variant="body1">
-            To truly succeed, you'll need to plan ahead - let's check out the
-            Forecasts tab. (Hotkey: E)
-          </Typography>
+          <TutorialPrompt
+            concepts={["pause", "generator"]}
+            text="Pause your only plant - see what the future thinks."
+            action={["pause"]}
+          />
         ),
-        desktop: {
-          target: "#forecastsPane",
-          content: (
-            <Typography variant="body1">
-              To truly succeed, you'll need to plan ahead - let's check out the
-              Forecasts pane.
-            </Typography>
-          ),
-        },
       },
       {
         card: "FORECASTS",
         target: "#chartForecastSupplyDemand",
         content: (
-          <Typography variant="body1">
-            This chart shows forecasted supply and demand over the next year -
-            including any upcoming blackouts. Try pausing a generator to see how
-            it affects your ability to meet demand.
-          </Typography>
+          <TutorialPrompt
+            concepts={["forecast", "blackout"]}
+            text="Blackouts ahead - forecasts show the year to come."
+          />
         ),
       },
       {
-        card: "FORECASTS",
-        target: "#chartForecastSupplyByFuel",
+        card: "FACILITIES",
+        target: ".facility",
+        advanceOn: (s: AppStateType) =>
+          s.game.facilities.every((f) => !f.paused),
         content: (
-          <Typography variant="body1">
-            This chart shows what fuels are supplying your electricity. Try
-            dragging to re-order your facilities to see how it affects your fuel
-            consumption.
-          </Typography>
+          <TutorialPrompt
+            concepts={["play", "generator"]}
+            text="Turn it back on."
+            action={["play"]}
+          />
         ),
       },
       {
         card: "FORECASTS",
         target: "#chartForecastFuelPrices",
         content: (
-          <Typography variant="body1">
-            This chart shows forecasted fuel prices, based on real data. Fuel
-            prices can change suddenly and significantly, affecting the
-            profitability of your fuel-based generators.
-          </Typography>
+          <TutorialPrompt
+            concepts={["fuel", "money"]}
+            text="Fuel prices move - and move your profits with them."
+          />
         ),
       },
       {
         card: "FORECASTS",
         target: "#chartForecastWeather",
         content: (
-          <Typography variant="body1">
-            This chart shows forecasted weather, which affects demand (such as
-            heating and air conditioning) - and the output of solar and wind
-            generators.
-          </Typography>
+          <TutorialPrompt
+            concepts={["weather", "demand"]}
+            text="Weather drives demand - and solar and wind output."
+          />
         ),
       },
       {
         card: "FORECASTS",
         target: "#speedChangeButtons",
-        onNext: () => setSpeed("FAST"),
+        advanceOn: (s: AppStateType) => s.game.speed !== "PAUSED",
         content: (
-          <Typography variant="body1">
-            To learn more about concepts, select "Manual" from the top left
-            menu.
-            <br />
-            <br />
-            This tutorial will run for 1 year so that you can see how the
-            forecasts change over time.
-          </Typography>
+          <TutorialPrompt
+            concepts={["play"]}
+            text="Run the year - the Manual (top-left menu) has the deep dives."
+            action={["play"]}
+          />
         ),
       },
     ],
@@ -659,7 +587,7 @@ export const SCENARIOS = [
   // TODO more public-ownership scenarios, such as in LA or Nebraska
 ] as ScenarioType[];
 
-// The numbered 101-106 walkthroughs, in the order a new player should work through them
+// The opening missions, in the order a new player should work through them
 export const TUTORIALS = SCENARIOS.filter((s) => s.tutorialSteps);
 
 /**

--- a/src/reducers/Tutorial.test.tsx
+++ b/src/reducers/Tutorial.test.tsx
@@ -1,0 +1,194 @@
+import { configureStore, UnknownAction } from "@reduxjs/toolkit";
+import * as React from "react";
+import { getPlayedScenarioIds } from "../LocalStorage";
+import { AppStateType, CardNameType, TutorialStepType } from "../Types";
+import { DEFAULT_CUSTOM_SCENARIO, CUSTOM_SCENARIO_ID } from "../data/Scenarios";
+import cardReducer from "./Card";
+import gameReducer from "./Game";
+import settingsReducer from "./Settings";
+import { tutorialGateMiddleware } from "./Tutorial";
+import uiReducer from "./UI";
+import userReducer from "./User";
+
+function informational(card: "FACILITIES" | "FINANCES" = "FACILITIES") {
+  return {
+    card,
+    target: "#information",
+    content: <span />,
+  } as TutorialStepType;
+}
+
+function initialState(
+  steps: TutorialStepType[],
+  options: { marketingSpend?: number; tutorialStep?: number } = {},
+): AppStateType {
+  const init = { type: "test/init" };
+  return {
+    card: {
+      ...cardReducer(undefined, init),
+      name: "FACILITIES",
+    },
+    game: {
+      ...gameReducer(undefined, init),
+      scenarioId: CUSTOM_SCENARIO_ID,
+      customScenario: {
+        ...DEFAULT_CUSTOM_SCENARIO,
+        tutorialSteps: steps,
+      },
+      monthlyMarketingSpend: options.marketingSpend || 0,
+      tutorialStep: options.tutorialStep || 0,
+    },
+    settings: settingsReducer(undefined, init),
+    ui: uiReducer(undefined, init),
+    user: userReducer(undefined, init),
+  };
+}
+
+function reducer(
+  state: AppStateType = initialState([]),
+  action: UnknownAction,
+): AppStateType {
+  if (action.type === "test/satisfy-predicate") {
+    return {
+      ...state,
+      game: { ...state.game, monthlyMarketingSpend: 1 },
+    };
+  }
+  if (action.type === "game/delta") {
+    return {
+      ...state,
+      game: {
+        ...state.game,
+        ...(action.payload as Partial<AppStateType["game"]>),
+      },
+    };
+  }
+  if (action.type === "card/navigate") {
+    const payload = action.payload as
+      string | { name: AppStateType["card"]["name"] };
+    return {
+      ...state,
+      card: {
+        ...state.card,
+        name:
+          typeof payload === "string"
+            ? (payload as CardNameType)
+            : payload.name,
+      },
+    };
+  }
+  if (action.type === "ui/snackbarOpen") {
+    return {
+      ...state,
+      ui: {
+        ...state.ui,
+        snackbar: action.payload as AppStateType["ui"]["snackbar"],
+      },
+    };
+  }
+  return state;
+}
+
+function tutorialStore(
+  steps: TutorialStepType[],
+  options?: { marketingSpend?: number; tutorialStep?: number },
+) {
+  return configureStore({
+    reducer,
+    preloadedState: initialState(steps, options),
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false }).concat(
+        tutorialGateMiddleware,
+      ),
+  });
+}
+
+describe("tutorialGateMiddleware", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("advances a predicate gate after the action updates state", () => {
+    const steps: TutorialStepType[] = [
+      {
+        ...informational(),
+        advanceOn: (state) => state.game.monthlyMarketingSpend > 0,
+      },
+      informational("FINANCES"),
+    ];
+    const store = tutorialStore(steps);
+
+    store.dispatch({ type: "test/satisfy-predicate" });
+
+    expect(store.getState().game.tutorialStep).toBe(1);
+    expect(store.getState().card.name).toBe("FINANCES");
+  });
+
+  it("advances an action gate only for a declared action type", () => {
+    const steps: TutorialStepType[] = [
+      { ...informational(), advanceOnAction: ["test/do-it", "test/also"] },
+      informational(),
+    ];
+    const store = tutorialStore(steps);
+
+    store.dispatch({ type: "test/unrelated" });
+    expect(store.getState().game.tutorialStep).toBe(0);
+
+    store.dispatch({ type: "test/do-it" });
+    expect(store.getState().game.tutorialStep).toBe(1);
+  });
+
+  it("chains through a newly reached predicate gate that is already satisfied", () => {
+    const steps: TutorialStepType[] = [
+      { ...informational(), advanceOnAction: "test/do-it" },
+      {
+        ...informational(),
+        advanceOn: (state) => state.game.monthlyMarketingSpend > 0,
+      },
+      informational(),
+    ];
+    const store = tutorialStore(steps, { marketingSpend: 1 });
+
+    store.dispatch({ type: "test/do-it" });
+
+    expect(store.getState().game.tutorialStep).toBe(2);
+  });
+
+  it("never moves an informational step", () => {
+    const store = tutorialStore([informational()]);
+
+    store.dispatch({ type: "test/satisfy-predicate" });
+
+    expect(store.getState().game.tutorialStep).toBe(0);
+  });
+
+  it("contains a broken predicate without killing its dispatch", () => {
+    const steps: TutorialStepType[] = [
+      {
+        ...informational(),
+        advanceOn: () => {
+          throw new Error("broken gate");
+        },
+      },
+    ];
+    const store = tutorialStore(steps);
+
+    expect(() => store.dispatch({ type: "test/action" })).not.toThrow();
+    expect(store.getState().game.tutorialStep).toBe(0);
+  });
+
+  it("records completion and opens the completion snackbar", () => {
+    const steps: TutorialStepType[] = [
+      { ...informational(), advanceOnAction: "test/finish" },
+    ];
+    const store = tutorialStore(steps);
+
+    store.dispatch({ type: "test/finish" });
+
+    expect(store.getState().game.tutorialStep).toBe(1);
+    expect(getPlayedScenarioIds()).toContain(CUSTOM_SCENARIO_ID);
+    expect(store.getState().ui.snackbar).toEqual(
+      expect.objectContaining({ open: true, actionLabel: "Missions" }),
+    );
+  });
+});

--- a/src/reducers/Tutorial.tsx
+++ b/src/reducers/Tutorial.tsx
@@ -1,0 +1,147 @@
+import type { Middleware } from "@reduxjs/toolkit";
+import { recordScenarioPlayed } from "../LocalStorage";
+import { getScenario } from "../data/Scenarios";
+import type { AppDispatch } from "../Store";
+import {
+  AppStateType,
+  TutorialStepChangeType,
+  TutorialStepType,
+  isGatedStep,
+} from "../Types";
+import { navigate } from "./Card";
+import { delta, quit } from "./Game";
+import { snackbarOpen } from "./UI";
+
+// Moves a live walkthrough between two steps, whether a tooltip button or a satisfied gate
+// asked for it - both paths need the same side effects, in the same order
+export function changeTutorialStep(
+  dispatch: AppDispatch,
+  {
+    fromStep,
+    toStep,
+    tutorialSteps,
+    scenarioId,
+    currentCard,
+  }: TutorialStepChangeType,
+): void {
+  const steps = tutorialSteps || [];
+
+  // Only leaving a step forwards runs its one-way side effects - Back has no way to undo
+  // them, and replaying the previous step's would fire an effect nobody triggered
+  const leaving = toStep > fromStep ? steps[fromStep] : undefined;
+  if (leaving && leaving.onNext) {
+    dispatch(leaving.onNext());
+  }
+
+  // Steps declare the card their target lives on, and every step change navigates there
+  // regardless of direction. Otherwise Back leaves the player on whatever card the
+  // forward step navigated to, where Joyride can't find the target and shows no tooltip
+  const destination = steps[toStep] && steps[toStep].card;
+  if (destination) {
+    const name =
+      typeof destination === "string" ? destination : destination.name;
+    if (name !== currentCard) {
+      dispatch(navigate(destination));
+    }
+  }
+
+  dispatch(delta({ tutorialStep: toStep }));
+
+  if (toStep < steps.length) {
+    return;
+  }
+
+  // Finishing the walkthrough is what counts as doing the tutorial - the rest of the
+  // scenario is optional practice, and requiring it meant a checkmark cost up to four
+  // minutes of watching the sim run
+  recordScenarioPlayed(scenarioId);
+  dispatch(
+    snackbarOpen({
+      message: "Walkthrough complete - keep practicing, or move on",
+      actionLabel: "Missions",
+      action: () => dispatch(quit({ toScenarioList: true })),
+      open: true,
+      timeout: 6000,
+    }),
+  );
+}
+
+function matchesActionGate(
+  step: TutorialStepType,
+  actionType: string | undefined,
+): boolean {
+  if (step.advanceOnAction === undefined || actionType === undefined) {
+    return false;
+  }
+  return ([] as string[]).concat(step.advanceOnAction).includes(actionType);
+}
+
+// True while a gate-driven advance is mid-flight. changeTutorialStep's own dispatches
+// (onNext, navigate, delta, snackbar) re-enter this middleware before tutorialStep has
+// moved off the satisfied step, which would re-advance the same step without end - the
+// loop below does the chaining deliberately instead.
+let advancing = false;
+
+// The "play, don't tell" engine: after every dispatch, a gated step advances the moment
+// its deed is done. A middleware rather than the tick loop because deeds happen while
+// paused too (buying, re-ordering), and rather than store.subscribe because subscribers
+// never see action types, which advanceOnAction needs.
+export const tutorialGateMiddleware: Middleware =
+  (api) => (next) => (action) => {
+    const result = next(action);
+    if (advancing) {
+      return result;
+    }
+    const actionType =
+      typeof action === "object" && action !== null && "type" in action
+        ? String((action as { type: unknown }).type)
+        : undefined;
+    advancing = true;
+    try {
+      // The dispatched action can only satisfy the step it landed on; steps reached by
+      // chaining advance solely on state predicates that are already true - a player who
+      // did a deed early skips its step the moment they arrive on it
+      let freshAction = true;
+      for (;;) {
+        const state = api.getState() as AppStateType;
+        const stepIndex = state.game.tutorialStep;
+        if (stepIndex < 0) {
+          break;
+        }
+        const scenario = getScenario(
+          state.game.scenarioId,
+          state.game.customScenario,
+        );
+        const steps = scenario && scenario.tutorialSteps;
+        const step = steps && steps[stepIndex];
+        if (!step || !isGatedStep(step)) {
+          break;
+        }
+        const byAction = freshAction && matchesActionGate(step, actionType);
+        let byState = false;
+        try {
+          byState = !!(step.advanceOn && step.advanceOn(state));
+        } catch {
+          // A broken gate must not kill the dispatch it rides on
+        }
+        if (!byAction && !byState) {
+          break;
+        }
+        changeTutorialStep(api.dispatch as AppDispatch, {
+          fromStep: stepIndex,
+          toStep: stepIndex + 1,
+          tutorialSteps: steps,
+          scenarioId: state.game.scenarioId,
+          currentCard: state.card.name,
+        });
+        freshAction = false;
+        // Bail rather than spin if the step somehow didn't move
+        if ((api.getState() as AppStateType).game.tutorialStep === stepIndex) {
+          break;
+        }
+      }
+    } finally {
+      advancing = false;
+    }
+    return result;
+  };


### PR DESCRIPTION
## Summary

- add predicate- and action-gated walkthrough steps that advance when the player completes the highlighted deed
- replace tutorial paragraphs with a shared concept-icon vocabulary and concise mission prompts
- unify tutorials and scenarios as missions, with Mission 1 starting directly for new players
- preserve completion recording, navigation, keyboard behavior, and missing-target safeguards

## Verification

- npm run typecheck
- npm run lint
- npm run format:check
- full test suite: 44 suites and 577 tests passed
- npm run build

Refs #52