### PR TITLE
Adopt concept symbols across the game UI

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -759,6 +759,53 @@ $pane_header_height: 40px;
 
 // For things that use size() / get recalulcated on larger displays
 @mixin styling() {
+  // The vocabulary introduced by the missions stays attached to the same concepts in the live
+  // interface. Text remains beside it for first-time recognition and screen magnification.
+  .gameStatus,
+  .gameStatusValue,
+  .gameStatusBlackout,
+  .iconLabel,
+  .scoreBreakdownRow {
+    display: flex;
+    align-items: center;
+  }
+
+  .gameStatus {
+    gap: size(small);
+    min-width: 0;
+  }
+
+  .gameStatusValue,
+  .iconLabel,
+  .scoreBreakdownRow {
+    gap: size(tiny);
+  }
+
+  .gameStatusBlackout {
+    color: $blackout_red;
+  }
+
+  .scoreBreakdownRow {
+    min-height: 24px;
+  }
+
+  .conceptLegend {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: size(small);
+    margin-top: size(base);
+  }
+
+  .conceptLegendItem {
+    display: flex;
+    align-items: center;
+    gap: size(small);
+    padding: size(small);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    background: var(--bg-raised);
+  }
+
   .clickable-card {
     &:hover {
       cursor: pointer;

--- a/src/components/base/ConceptIcon.test.tsx
+++ b/src/components/base/ConceptIcon.test.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import ConceptIcon, {
+  CONCEPT_LABELS,
+  CONCEPT_NAMES,
+  ConceptNameType,
+} from "./ConceptIcon";
+
+describe("ConceptIcon", () => {
+  it.each(CONCEPT_NAMES)("gives %s its shared accessible label", (concept) => {
+    const view = render(<ConceptIcon concept={concept} />);
+    const icon = screen.getByLabelText(CONCEPT_LABELS[concept]);
+    expect(icon).toHaveAttribute("data-concept", concept);
+    view.unmount();
+  });
+
+  it("keeps the vocabulary list and label catalog in sync", () => {
+    expect(new Set(CONCEPT_NAMES)).toHaveProperty(
+      "size",
+      Object.keys(CONCEPT_LABELS).length,
+    );
+    expect(CONCEPT_NAMES).toEqual(
+      expect.arrayContaining(Object.keys(CONCEPT_LABELS) as ConceptNameType[]),
+    );
+  });
+});

--- a/src/components/base/ConceptIcon.tsx
+++ b/src/components/base/ConceptIcon.tsx
@@ -46,6 +46,30 @@ export type ConceptNameType =
   | "danger"
   | "goal";
 
+export const CONCEPT_NAMES: ConceptNameType[] = [
+  "money",
+  "supply",
+  "demand",
+  "blackout",
+  "customers",
+  "generator",
+  "storage",
+  "build",
+  "buy",
+  "reorder",
+  "pause",
+  "play",
+  "time",
+  "construction",
+  "finances",
+  "forecast",
+  "marketing",
+  "fuel",
+  "weather",
+  "danger",
+  "goal",
+];
+
 // The one place each concept gets its spoken/read name - and the seed of a future
 // localization catalog, since screen readers are the only consumer of these words
 export const CONCEPT_LABELS: Record<ConceptNameType, string> = {
@@ -113,11 +137,13 @@ const IMG_SIZES = { small: 20, medium: 24, large: 35 };
 export interface ConceptIconProps {
   concept: ConceptNameType;
   fontSize?: "small" | "medium" | "large";
+  style?: React.CSSProperties;
 }
 
 export default function ConceptIcon({
   concept,
   fontSize = "medium",
+  style,
 }: ConceptIconProps): React.JSX.Element {
   const label = CONCEPT_LABELS[concept];
   if (concept === "storage") {
@@ -126,8 +152,10 @@ export default function ConceptIcon({
       <img
         src="/images/battery.svg"
         alt={label}
+        aria-label={label}
+        data-concept={concept}
         className="conceptIcon"
-        style={{ width: px, height: px }}
+        style={{ width: px, height: px, ...style }}
       />
     );
   }
@@ -135,9 +163,11 @@ export default function ConceptIcon({
   return (
     <Icon
       className="conceptIcon"
-      titleAccess={label}
+      aria-label={label}
+      data-concept={concept}
       fontSize={fontSize}
       color={CONCEPT_COLORS[concept]}
+      style={style}
     />
   );
 }

--- a/src/components/base/ConceptLegend.tsx
+++ b/src/components/base/ConceptLegend.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { Typography } from "@mui/material";
+import ConceptIcon, {
+  CONCEPT_LABELS,
+  CONCEPT_NAMES,
+  ConceptNameType,
+} from "./ConceptIcon";
+
+/**
+ * The visible key for the vocabulary introduced by the first missions. Keeping the legend driven
+ * by the same names and labels as every in-game glyph means adding a concept cannot leave the
+ * Manual's explanation silently out of date.
+ */
+export default function ConceptLegend(): React.JSX.Element {
+  return (
+    <div className="conceptLegend" data-testid="concept-legend">
+      {CONCEPT_NAMES.map((concept: ConceptNameType) => (
+        <div className="conceptLegendItem" key={concept}>
+          <ConceptIcon concept={concept} fontSize="large" />
+          <Typography variant="body2">{CONCEPT_LABELS[concept]}</Typography>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -24,6 +24,7 @@ import { getNextTutorial, getScenario } from "../../data/Scenarios";
 import { quit, setSpeed, startTutorial } from "../../reducers/Game";
 import { AppStateType, GameType, SpeedType } from "../../Types";
 import ScenarioDetailsDialog from "./ScenarioDetailsDialog";
+import ConceptIcon from "./ConceptIcon";
 
 /**
  * The game's global state: cash, the date, how fast time is running, how far through the year it
@@ -327,12 +328,21 @@ export function GameAppBar(props: Props) {
       <div id="topbar">
         <Toolbar className={inBlackout ? "blackout-pulsing" : ""}>
           {menu}
-          <Typography variant="h6">
-            {formatMoneyStable(now.cash)}&nbsp;
-            <span className="weak">
+          <Typography variant="h6" className="gameStatus">
+            <span className="gameStatusValue">
+              <ConceptIcon concept="money" fontSize="small" />
+              {formatMoneyStable(now.cash)}
+            </span>
+            <span className="weak gameStatusValue">
+              <ConceptIcon concept="time" fontSize="small" />
               {date.month} {date.year}
               {bigScreen ? `, ${formatHour(date)}` : ""}
             </span>
+            {inBlackout && (
+              <span className="gameStatusBlackout">
+                <ConceptIcon concept="blackout" fontSize="small" />
+              </span>
+            )}
             {isReplay && <span className="replayBadge">REPLAY</span>}
           </Typography>
           <div id="speedChangeButtons">{speedOptions}</div>

--- a/src/components/base/VictoryDialog.tsx
+++ b/src/components/base/VictoryDialog.tsx
@@ -13,6 +13,7 @@ import numbro from "numbro";
 import { VictoryType } from "../../Types";
 import { fetchGlobalRank } from "../../reducers/User";
 import { buildShareText, canShare, shareText } from "../../helpers/Share";
+import ConceptIcon, { ConceptNameType } from "./ConceptIcon";
 
 // What each scored category is called on the score screen. The breakdown's keys differ by
 // ownership (see reducers/Game), so this is a lookup rather than a fixed list -- a scenario type
@@ -24,6 +25,15 @@ export const SCORE_LABELS: { [key: string]: string } = {
   rate: "electric rates",
   emissions: "emissions",
   blackouts: "blackouts",
+};
+
+const SCORE_CONCEPTS: { [key: string]: ConceptNameType | undefined } = {
+  supply: "supply",
+  netWorth: "money",
+  customers: "customers",
+  rate: "money",
+  emissions: "danger",
+  blackouts: "blackout",
 };
 
 export interface StateProps {
@@ -124,7 +134,8 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
       onClose={onClose}
       aria-labelledby="victory-title"
     >
-      <DialogTitle id="victory-title">
+      <DialogTitle id="victory-title" className="iconLabel">
+        <ConceptIcon concept="goal" />
         {endTitle || `You've retired!`}
       </DialogTitle>
       <DialogContent>
@@ -137,12 +148,16 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
           Your final score is <strong>{formatScore(victory.score)}</strong>:
         </Typography>
         <div style={{ margin: "8px 0" }}>
-          {Object.keys(breakdown).map((category: string) => (
-            <div key={category}>
-              {breakdown[category]} pts from{" "}
-              {SCORE_LABELS[category] || category}
-            </div>
-          ))}
+          {Object.keys(breakdown).map((category: string) => {
+            const concept = SCORE_CONCEPTS[category];
+            return (
+              <div key={category} className="scoreBreakdownRow">
+                {concept && <ConceptIcon concept={concept} fontSize="small" />}
+                {breakdown[category]} pts from{" "}
+                {SCORE_LABELS[category] || category}
+              </div>
+            );
+          })}
         </div>
         {ranked && loggedIn && (
           <Typography variant="body1" style={{ marginTop: 12 }}>

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -53,6 +53,7 @@ import { MANUAL_ENTRY } from "../../data/Manual";
 import { formatMass } from "../../helpers/Units";
 import ManualLink from "../base/ManualLink";
 import { useUnits } from "../base/UnitsContext";
+import ConceptIcon from "../base/ConceptIcon";
 
 interface GeneratorBuildItemProps {
   cash: number;
@@ -127,6 +128,7 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
               color="primary"
               onClick={toggleOpen}
               disabled={downpayment > cash || !buildable}
+              startIcon={<ConceptIcon concept="buy" fontSize="small" />}
             >
               {formatMoneyConcise(generator.buildCost)}
             </Button>
@@ -342,6 +344,7 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
               props.onBuild(false);
               toggleOpen(e);
             }}
+            startIcon={<ConceptIcon concept="money" fontSize="small" />}
           >
             Pay cash
           </Button>
@@ -352,6 +355,7 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
               props.onBuild(true);
               toggleOpen(e);
             }}
+            startIcon={<ConceptIcon concept="finances" fontSize="small" />}
           >
             Take loan
           </Button>
@@ -457,7 +461,10 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
       <Toolbar className="bottomBorder">
         <Typography variant="h6">
           {formatMoneyStable(cash)}{" "}
-          <span className="weak">Build Generator</span>
+          <span className="weak gameStatusValue">
+            <ConceptIcon concept="generator" fontSize="small" />
+            Build Generator
+          </span>
         </Typography>
         {game.speed !== "PAUSED" && (
           <IconButton

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -38,6 +38,7 @@ import { DOWNPAYMENT_PERCENT, LOAN_MONTHS } from "../../Constants";
 import { STORAGE } from "../../data/Facilities";
 import { MANUAL_ENTRY } from "../../data/Manual";
 import ManualLink from "../base/ManualLink";
+import ConceptIcon from "../base/ConceptIcon";
 import { GameType, SpeedType, StorageShoppingType } from "../../Types";
 
 interface StorageBuildItemProps {
@@ -101,6 +102,7 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
               color="primary"
               onClick={toggleOpen}
               disabled={downpayment > cash || !buildable}
+              startIcon={<ConceptIcon concept="buy" fontSize="small" />}
             >
               {formatMoneyConcise(storage.buildCost)}
             </Button>
@@ -236,6 +238,7 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
               props.onBuild(false);
               toggleOpen(e);
             }}
+            startIcon={<ConceptIcon concept="money" fontSize="small" />}
           >
             Pay cash
           </Button>
@@ -246,6 +249,7 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
               props.onBuild(true);
               toggleOpen(e);
             }}
+            startIcon={<ConceptIcon concept="finances" fontSize="small" />}
           >
             Take loan
           </Button>
@@ -335,7 +339,11 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
     <div id="topbar" className="flexContainer">
       <Toolbar className="bottomBorder">
         <Typography variant="h6">
-          {formatMoneyStable(cash)} <span className="weak">Build Storage</span>
+          {formatMoneyStable(cash)}{" "}
+          <span className="weak gameStatusValue">
+            <ConceptIcon concept="storage" fontSize="small" />
+            Build Storage
+          </span>
         </Typography>
         {game.speed !== "PAUSED" && (
           <IconButton

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -1,14 +1,8 @@
 import * as React from "react";
 import { Typography } from "@mui/material";
-import AccountBalanceIcon from "@mui/icons-material/AccountBalance";
-import AddCircleIcon from "@mui/icons-material/AddCircle";
-import BuildIcon from "@mui/icons-material/Build";
-import FlashOffIcon from "@mui/icons-material/FlashOff";
-import FlashOnIcon from "@mui/icons-material/FlashOn";
-import LocalGasStationIcon from "@mui/icons-material/LocalGasStation";
-import RemoveCircleIcon from "@mui/icons-material/RemoveCircle";
 import GameCard from "../base/GameCard";
 import { GameEventKindType, GameEventType } from "../../Types";
+import ConceptIcon, { ConceptNameType } from "../base/ConceptIcon";
 
 /**
  * What has happened to the company, in the order it happened.
@@ -19,14 +13,14 @@ import { GameEventKindType, GameEventType } from "../../Types";
  * which makes a simulation feel arbitrary rather than causal. This is the run's own record of it.
  */
 
-const KIND_ICONS: { [k in GameEventKindType]: React.JSX.Element } = {
-  BLACKOUT: <FlashOffIcon fontSize="small" />,
-  BLACKOUT_OVER: <FlashOnIcon fontSize="small" />,
-  CONSTRUCTION: <BuildIcon fontSize="small" />,
-  BUILD: <AddCircleIcon fontSize="small" />,
-  SELL: <RemoveCircleIcon fontSize="small" />,
-  LOAN: <AccountBalanceIcon fontSize="small" />,
-  FUEL_PRICE: <LocalGasStationIcon fontSize="small" />,
+const KIND_CONCEPTS: { [k in GameEventKindType]: ConceptNameType } = {
+  BLACKOUT: "blackout",
+  BLACKOUT_OVER: "supply",
+  CONSTRUCTION: "construction",
+  BUILD: "build",
+  SELL: "money",
+  LOAN: "finances",
+  FUEL_PRICE: "fuel",
 };
 
 export interface StateProps {
@@ -53,8 +47,11 @@ export default function EventLog(props: Props): React.JSX.Element {
         <ul className="eventLogList">
           {events.map((event: GameEventType) => (
             <li className={`eventLogItem kind-${event.kind}`} key={event.id}>
-              <span className="eventLogIcon" aria-hidden="true">
-                {KIND_ICONS[event.kind]}
+              <span className="eventLogIcon">
+                <ConceptIcon
+                  concept={KIND_CONCEPTS[event.kind]}
+                  fontSize="small"
+                />
               </span>
               <Typography variant="body2" component="span">
                 {event.message}

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -15,13 +15,9 @@ import {
   Toolbar,
   Typography,
 } from "@mui/material";
-import PauseIcon from "@mui/icons-material/Pause";
-import PlayIcon from "@mui/icons-material/PlayArrow";
 import CancelIcon from "@mui/icons-material/Cancel";
 import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
-import BoltIcon from "@mui/icons-material/Bolt";
-import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 import PowerSettingsNewIcon from "@mui/icons-material/PowerSettingsNew";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
@@ -53,6 +49,7 @@ import {
 import ChartSupplyDemand from "../base/ChartSupplyDemand";
 import FacilityDetails from "../base/FacilityDetails";
 import GameCard from "../base/GameCard";
+import ConceptIcon from "../base/ConceptIcon";
 
 interface FacilityListItemProps {
   facility: FacilityOperatingType;
@@ -89,9 +86,9 @@ function activityIcon(activity: FacilityActivityType, color: string) {
   const style = { color };
   switch (activity) {
     case "BUILDING":
-      return <HourglassEmptyIcon style={style} />;
+      return <ConceptIcon concept="construction" style={style} />;
     case "PAUSED":
-      return <PauseIcon style={style} />;
+      return <ConceptIcon concept="pause" style={style} />;
     case "IDLE":
       return <PowerSettingsNewIcon style={style} />;
     case "CHARGING":
@@ -99,7 +96,7 @@ function activityIcon(activity: FacilityActivityType, color: string) {
     case "DISCHARGING":
       return <ArrowDownwardIcon style={style} />;
     default:
-      return <BoltIcon style={style} />;
+      return <ConceptIcon concept="supply" style={style} />;
   }
 }
 
@@ -267,7 +264,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                       color="primary"
                       size="small"
                     >
-                      <PauseIcon />
+                      <ConceptIcon concept="pause" />
                     </IconButton>
                   )}
                 {!readOnly && facility.paused && (
@@ -281,7 +278,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                     color="primary"
                     size="small"
                   >
-                    <PlayIcon />
+                    <ConceptIcon concept="play" />
                   </IconButton>
                 )}
                 {!readOnly && !underConstruction && props.listLength > 1 && (
@@ -507,6 +504,7 @@ export default class Facilities extends React.Component<Props, {}> {
                 color="primary"
                 onClick={onGeneratorBuild}
                 className="button-buildGenerator"
+                startIcon={<ConceptIcon concept="generator" fontSize="small" />}
               >
                 + Generator
               </Button>
@@ -517,6 +515,7 @@ export default class Facilities extends React.Component<Props, {}> {
                 color="primary"
                 onClick={onStorageBuild}
                 className="button-buildStorage"
+                startIcon={<ConceptIcon concept="storage" fontSize="small" />}
               >
                 + Storage
               </Button>

--- a/src/components/views/Manual.test.tsx
+++ b/src/components/views/Manual.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Manual, { clearManualMemory } from "./Manual";
 import { MANUAL_ENTRY } from "../../data/Manual";
+import { CONCEPT_LABELS, CONCEPT_NAMES } from "../base/ConceptIcon";
 
 function renderManual(focusEntry?: string) {
   return render(<Manual onBack={() => undefined} focusEntry={focusEntry} />);
@@ -73,6 +74,17 @@ describe("Manual", () => {
       await search(term);
       expect(listedTitles().length).toBeGreaterThan(0);
     }
+  });
+
+  it("includes every shared game symbol in the symbol guide", async () => {
+    renderManual();
+    await userEvent.click(entryHeader(MANUAL_ENTRY.SYMBOLS));
+    const legend = screen.getByTestId("concept-legend");
+    CONCEPT_NAMES.forEach((concept) => {
+      expect(
+        within(legend).getByLabelText(CONCEPT_LABELS[concept]),
+      ).toHaveAttribute("data-concept", concept);
+    });
   });
 
   it("expands matched entries and highlights the match", async () => {

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import KeyboardShortcuts, {
   SHORTCUTS_SEARCH_TEXT,
 } from "../components/base/KeyboardShortcuts";
+import ConceptLegend from "../components/base/ConceptLegend";
 import { useUnits } from "../components/base/UnitsContext";
 import {
   formatLargeMassApprox,
@@ -60,6 +61,7 @@ export const MANUAL_ENTRY = {
   RATES: "Rates",
   ROUND_TRIP_EFFICIENCY: "Round-trip Efficiency",
   SCORE: "Score",
+  SYMBOLS: "Symbol Guide",
   TOTAL_COST_OF_ENERGY: "Total Cost of Energy",
 } as const;
 
@@ -169,6 +171,21 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           something expensive that starts quickly. The rest of this manual
           explains the terms you'll meet along the way.
         </p>
+      </div>
+    ),
+  },
+  {
+    title: MANUAL_ENTRY.SYMBOLS,
+    group: "Gameplay",
+    keywords:
+      "icons glyphs legend key money supply demand blackout customers generator storage build buy reorder pause play time construction finances forecast marketing fuel weather danger goal",
+    entry: (
+      <div>
+        <p>
+          These symbols mean the same thing in missions, controls, events and
+          results. Learn one once, then follow it everywhere.
+        </p>
+        <ConceptLegend />
       </div>
     ),
   },


### PR DESCRIPTION
## Summary

- reuse the mission concept vocabulary in the game status bar, facility controls and states, and generator/storage build flows
- use the same symbols for event history and victory score breakdowns
- add a generated Symbol Guide to the Manual so every shared glyph can teach itself
- centralize the vocabulary ordering and strengthen accessible labels for every concept icon

## Verification

- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false --runInBand --testMatch "**/src/**/*.test.tsx" (45 suites, 600 tests)
- npm run build

Refs #52