### PR TITLE
Finish unified mission onboarding flow

### DIFF
--- a/src/components/views/MainMenuContainer.test.tsx
+++ b/src/components/views/MainMenuContainer.test.tsx
@@ -1,0 +1,54 @@
+import { UnknownAction } from "@reduxjs/toolkit";
+import { getPlayedScenarioIds } from "../../LocalStorage";
+import { resumableSave } from "../../SaveFile";
+import type { AppDispatch } from "../../Store";
+import { TUTORIALS } from "../../data/Scenarios";
+import { navigate } from "../../reducers/Card";
+import { start } from "../../reducers/Game";
+import { mapDispatchToProps } from "./MainMenuContainer";
+
+jest.mock("../../LocalStorage", () => ({
+  ...jest.requireActual("../../LocalStorage"),
+  getPlayedScenarioIds: jest.fn(),
+}));
+jest.mock("../../SaveFile", () => ({
+  resumableSave: jest.fn(),
+}));
+
+const mockedPlayed = getPlayedScenarioIds as jest.MockedFunction<
+  typeof getPlayedScenarioIds
+>;
+const mockedResumableSave = resumableSave as jest.MockedFunction<
+  typeof resumableSave
+>;
+
+function startFromMenu(): UnknownAction[] {
+  const actions: UnknownAction[] = [];
+  const dispatch = ((action: UnknownAction) => {
+    actions.push(action);
+    return action;
+  }) as AppDispatch;
+  mapDispatchToProps(dispatch).onStart();
+  return actions;
+}
+
+describe("MainMenuContainer onStart", () => {
+  beforeEach(() => {
+    mockedPlayed.mockReturnValue([]);
+    mockedResumableSave.mockReturnValue(null);
+  });
+
+  it("starts Mission 1 immediately for a brand-new player", () => {
+    expect(startFromMenu()).toEqual([start(TUTORIALS[0].id)]);
+  });
+
+  it("opens the mission list after any tutorial is complete", () => {
+    mockedPlayed.mockReturnValue([TUTORIALS[0].id]);
+    expect(startFromMenu()).toEqual([navigate("NEW_GAME")]);
+  });
+
+  it("opens the mission list when an unfinished save exists", () => {
+    mockedResumableSave.mockReturnValue({} as ReturnType<typeof resumableSave>);
+    expect(startFromMenu()).toEqual([navigate("NEW_GAME")]);
+  });
+});

--- a/src/components/views/MainMenuContainer.tsx
+++ b/src/components/views/MainMenuContainer.tsx
@@ -17,7 +17,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
+export const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onAudioChange: (v: boolean) => {
       dispatch(changeSettings({ audioEnabled: v }));

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CUSTOM_SCENARIO_ID, SCENARIOS, TUTORIALS } from "../../data/Scenarios";
+import { GameType, ScenarioType } from "../../Types";
+import NewGame, { Props } from "./NewGame";
+
+function props(overrides: Partial<Props> = {}): Props {
+  return {
+    game: {} as GameType,
+    onBack: jest.fn(),
+    onCustomGame: jest.fn(),
+    onDetails: jest.fn(),
+    onManual: jest.fn(),
+    onTutorial: jest.fn(),
+    ...overrides,
+  };
+}
+
+function recordPlayed(...scenarioIds: number[]) {
+  localStorage.setItem(
+    "plays",
+    JSON.stringify({
+      plays: scenarioIds.map((scenarioId) => ({
+        scenarioId,
+        date: "2026-08-27",
+      })),
+    }),
+  );
+}
+
+describe("NewGame", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("shows every authored mission in order, followed by the custom game", () => {
+    render(<NewGame {...props()} />);
+
+    const rows = screen.getAllByTestId(/^mission-row-/);
+    expect(rows).toHaveLength(SCENARIOS.length + 1);
+    SCENARIOS.forEach((scenario, index) =>
+      expect(rows[index]).toHaveTextContent(scenario.name),
+    );
+    expect(rows[rows.length - 1]).toHaveTextContent("Custom Game");
+    expect(screen.queryByText("Tutorials")).not.toBeInTheDocument();
+    expect(screen.queryByText("Scenarios")).not.toBeInTheDocument();
+  });
+
+  it("marks the first incomplete tutorial as the starting point", () => {
+    recordPlayed(TUTORIALS[0].id);
+    render(<NewGame {...props()} />);
+
+    const next = screen.getByTestId(`mission-row-${TUTORIALS[1].id}`);
+    expect(next).toHaveTextContent("Start here");
+    expect(next).toHaveTextContent(TUTORIALS[1].name);
+    expect(next).toHaveClass("tutorialNext");
+  });
+
+  it("shows completion badges for tutorials and regular missions", () => {
+    const regular = SCENARIOS.find(
+      (scenario: ScenarioType) => !scenario.tutorialSteps,
+    ) as ScenarioType;
+    recordPlayed(TUTORIALS[0].id, regular.id);
+    render(<NewGame {...props()} />);
+
+    expect(
+      screen.getByTestId(`mission-complete-${TUTORIALS[0].id}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`mission-complete-${regular.id}`),
+    ).toBeInTheDocument();
+  });
+
+  it("starts tutorials directly and opens details for regular missions", () => {
+    const onTutorial = jest.fn();
+    const onDetails = jest.fn();
+    const onCustomGame = jest.fn();
+    const regular = SCENARIOS.find(
+      (scenario: ScenarioType) => !scenario.tutorialSteps,
+    ) as ScenarioType;
+    render(<NewGame {...props({ onTutorial, onDetails, onCustomGame })} />);
+
+    fireEvent.click(screen.getByTestId(`mission-row-${TUTORIALS[0].id}`));
+    expect(onTutorial).toHaveBeenCalledWith(TUTORIALS[0].id);
+
+    fireEvent.click(screen.getByTestId(`mission-row-${regular.id}`));
+    expect(onDetails).toHaveBeenCalledWith({ scenarioId: regular.id });
+
+    fireEvent.click(screen.getByTestId(`mission-row-${CUSTOM_SCENARIO_ID}`));
+    expect(onCustomGame).toHaveBeenCalled();
+  });
+});

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -68,6 +68,7 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
     );
   return (
     <Card
+      data-testid={`mission-row-${s.id}`}
       className={`build-list-item clickable-card${next ? " tutorialNext" : ""}`}
       onClick={onSelect}
     >
@@ -80,6 +81,7 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
             badgeContent={
               completed ? (
                 <CheckCircleIcon
+                  data-testid={`mission-complete-${s.id}`}
                   className="tutorialComplete"
                   color="primary"
                   fontSize="small"

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -60,3 +60,13 @@ describe("getNextTutorial", () => {
     expect(getNextTutorial(CUSTOM_SCENARIO_ID)).toBeUndefined();
   });
 });
+
+describe("tutorial mission metadata", () => {
+  it("gives every tutorial a mission name, icon, and summary", () => {
+    TUTORIALS.forEach((tutorial, index) => {
+      expect(tutorial.name).toMatch(new RegExp(`^Mission ${index + 1}: `));
+      expect(tutorial.icon).toBeTruthy();
+      expect(tutorial.summary).toBeTruthy();
+    });
+  });
+});

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -158,7 +158,7 @@ export const SCENARIOS = [
   {
     id: 2, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
     name: "Mission 3: Storage",
-    icon: "battery",
+    icon: "pumped hydro",
     summary: "Store energy for later",
     locationId: "SF",
     ownership: "Investor",

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -708,7 +708,7 @@ function tutorialCompleteDialog({
           </span>
         )}
         <strong>
-          {completed} of {TUTORIALS.length} tutorials complete
+          {completed} of {TUTORIALS.length} missions complete
         </strong>
         {nextTutorial && (
           <span>
@@ -723,7 +723,7 @@ function tutorialCompleteDialog({
     notCancellable: true,
     secondaryLabel: "Main menu",
     secondaryAction: () => getStore().dispatch(quit()),
-    actionLabel: nextTutorial ? "Next tutorial" : "Back to tutorials",
+    actionLabel: nextTutorial ? "Next mission" : "Back to missions",
     action: () =>
       nextTutorial
         ? startTutorial(getStore().dispatch, nextTutorial.id)
@@ -957,7 +957,7 @@ export function tickState(state: GameType) {
           if (isTutorial) {
             return getStore().dispatch(
               tutorialCompleteDialog({
-                title: endTitle || "Tutorial complete!",
+                title: endTitle || "Mission complete!",
                 message: endMessage,
                 nextTutorial,
               }),

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -189,9 +189,9 @@ describe("finishing a tutorial", () => {
     expect(dialog.notCancellable).toBe(true);
   });
 
-  it("leads with the next tutorial and keeps the main menu as the way out", () => {
+  it("leads with the next mission and keeps the main menu as the way out", () => {
     const dialog = finishTutorial();
-    expect(dialog.actionLabel).toBe("Next tutorial");
+    expect(dialog.actionLabel).toBe("Next mission");
     expect(dialog.secondaryLabel).toBe("Main menu");
   });
 


### PR DESCRIPTION
## Summary

- finish the unified mission language in completion dialogs and use the approved pumped-hydro artwork for Mission 3
- add regression coverage for mission ordering, the Start here marker, completion badges, and tutorial/scenario/custom-game routing
- cover first-run Play behavior for brand-new, returning, and saved-game players

## Testing

- npm run typecheck
- npm run lint
- npm run format:check
- full Jest suite: 47 suites, 608 tests

Closes #52