### PR TITLE
Restore direct mobile speed controls

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -444,9 +444,37 @@ $topbar_height: 56px;
 
 #topbar .MuiToolbar-root {
   min-height: $topbar_height !important;
+  flex-wrap: nowrap;
   padding-top: env(safe-area-inset-top);
   padding-left: max(16px, env(safe-area-inset-left)) !important;
   padding-right: max(16px, env(safe-area-inset-right)) !important;
+}
+
+// Four direct speed choices still fit beside the live status at phone width. The currency and
+// date already name their concepts in text, so their duplicate glyphs are omitted in the
+// component and the remaining chrome tightens just enough for a 320px viewport.
+@media screen and (max-width: 599px) {
+  #topbar .MuiToolbar-root {
+    padding-left: max(4px, env(safe-area-inset-left)) !important;
+    padding-right: max(4px, env(safe-area-inset-right)) !important;
+  }
+
+  #topbar .gameMenuButton {
+    margin-left: 0;
+    padding: 10px;
+  }
+
+  #topbar .gameStatus {
+    flex: 1 1 auto;
+    overflow: hidden;
+    gap: 2px;
+    font-size: clamp(0.65rem, 3.2vw, 0.875rem);
+    white-space: nowrap;
+  }
+
+  #speedChangeButtons {
+    flex: 0 0 auto;
+  }
 }
 
 #navfooter {

--- a/src/components/base/GameAppBar.test.tsx
+++ b/src/components/base/GameAppBar.test.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { createGame } from "../../testing/Simulator";
+import { GameAppBar, Props } from "./GameAppBar";
+
+jest.mock("../../Globals", () => ({
+  ...jest.requireActual("../../Globals"),
+  isBigScreen: () => false,
+  isSmallScreen: () => true,
+}));
+
+function renderAppBar(overrides: Partial<Props> = {}) {
+  const game = createGame({ scenarioId: 101 });
+  const props: Props = {
+    game: { ...game, inGame: true },
+    audioEnabled: true,
+    onAudioChange: () => undefined,
+    onManual: () => undefined,
+    onNextTutorial: () => undefined,
+    onQuit: () => undefined,
+    onSettings: () => undefined,
+    onSpeedChange: () => undefined,
+    ...overrides,
+  };
+  return render(<GameAppBar {...props} />);
+}
+
+describe("GameAppBar mobile speed controls", () => {
+  it("keeps all four speeds one tap away", () => {
+    const onSpeedChange = jest.fn();
+    renderAppBar({ onSpeedChange });
+
+    const speedControls = screen.getByRole("group", { name: "game speed" });
+    expect(within(speedControls).getAllByRole("button")).toHaveLength(4);
+
+    fireEvent.click(
+      within(speedControls).getByRole("button", { name: "fast speed" }),
+    );
+    expect(onSpeedChange).toHaveBeenCalledWith("FAST");
+  });
+
+  it("omits the redundant money and time icons", () => {
+    renderAppBar();
+    expect(screen.queryByLabelText("Money")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Time")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -10,11 +10,8 @@ import {
   Toolbar,
   Typography,
 } from "@mui/material";
-import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import FastForwardIcon from "@mui/icons-material/FastForward";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import PauseIcon from "@mui/icons-material/Pause";
-import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import { TICK_MS } from "../../Constants";
 import { formatHour, getTimeFromTimeline } from "../../helpers/DateTime";
 import { formatMoneyStable, formatWatts } from "../../helpers/Format";
@@ -54,12 +51,8 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 interface SpeedOptionsProps {
-  smallScreen: boolean;
   speed: SpeedType;
   onSpeedChange: (speed: SpeedType) => void;
-  speedAnchorEl: HTMLElement | null;
-  handleSpeedClick: (event: React.MouseEvent<HTMLElement>) => void;
-  handleSpeedClose: () => void;
 }
 
 /**
@@ -84,124 +77,35 @@ const SPEED_ARIA_LABELS: { [k in SpeedType]: string } = {
 // Pulled out of the component so it can be memoised on the handful of things it actually
 // depends on, rather than rebuilt on every tick along with the cash readout beside it
 function buildSpeedOptions({
-  smallScreen,
   speed,
   onSpeedChange,
-  speedAnchorEl,
-  handleSpeedClick,
-  handleSpeedClose,
 }: SpeedOptionsProps): React.JSX.Element {
-  if (!smallScreen) {
-    // A group of toggles rather than four icon buttons with the current one disabled: greyed
-    // out is the universal "you cannot click this", which is the opposite of "this is the one
-    // you are on". There is room out here for the multipliers too, so the speeds say how fast
-    // they are instead of being three shades of the same triangle
-    return (
-      <ToggleButtonGroup
-        className="speedToggles"
-        exclusive
-        size="small"
-        value={speed}
-        onChange={(
-          _e: React.MouseEvent<HTMLElement>,
-          next: SpeedType | null,
-        ) => {
-          // Null is the group reporting that the button already selected was clicked again.
-          // The clock is always running at some speed, so there is nothing to deselect to
-          if (next) {
-            onSpeedChange(next);
-          }
-        }}
-        aria-label="game speed"
-      >
-        <ToggleButton value="PAUSED" aria-label={SPEED_ARIA_LABELS.PAUSED}>
-          <PauseIcon fontSize="small" />
-        </ToggleButton>
-        {RUNNING_SPEEDS.map((s: SpeedType) => (
-          <ToggleButton key={s} value={s} aria-label={SPEED_ARIA_LABELS[s]}>
-            {speedMultiplier(s)}
-          </ToggleButton>
-        ))}
-      </ToggleButtonGroup>
-    );
-  }
-
-  let speedIcon = <PlayArrowIcon />;
-  switch (speed) {
-    case "PAUSED":
-      speedIcon = <PlayArrowIcon />;
-      break;
-    case "SLOW":
-      speedIcon = <ChevronRightIcon />;
-      break;
-    case "NORMAL":
-      speedIcon = <PlayArrowIcon />;
-      break;
-    case "FAST":
-      speedIcon = <FastForwardIcon />;
-      break;
-    default:
-      break;
-  }
+  // Keep every speed one tap away at every viewport width. The selected treatment says where
+  // the clock is now without turning the current speed into a misleading disabled control.
   return (
-    <span>
-      {speed !== "PAUSED" && (
-        <IconButton
-          onClick={() => onSpeedChange("PAUSED")}
-          aria-label="pause"
-          size="large"
-        >
-          <PauseIcon color="primary" />
-        </IconButton>
-      )}
-      <IconButton
-        onClick={handleSpeedClick}
-        aria-label="change speed"
-        edge="end"
-        color="primary"
-        size="large"
-      >
-        {speedIcon}
-      </IconButton>
-      <Menu
-        id="speedMenu"
-        anchorEl={speedAnchorEl}
-        keepMounted
-        open={Boolean(speedAnchorEl)}
-        onClose={handleSpeedClose}
-      >
-        <MenuItem
-          onClick={() => {
-            onSpeedChange("SLOW");
-            handleSpeedClose();
-          }}
-          disabled={speed === "SLOW"}
-          aria-label="slow-speed"
-        >
-          <ChevronRightIcon color="primary" />
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            onSpeedChange("NORMAL");
-            handleSpeedClose();
-          }}
-          disabled={speed === "NORMAL"}
-          aria-label="normal-speed"
-        >
-          <PlayArrowIcon color="primary" />
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            onSpeedChange("FAST");
-            handleSpeedClose();
-          }}
-          disabled={speed === "FAST"}
-          aria-label="fast-speed"
-        >
-          <FastForwardIcon color="primary" />
-        </MenuItem>
-      </Menu>
-    </span>
+    <ToggleButtonGroup
+      className="speedToggles"
+      exclusive
+      size="small"
+      value={speed}
+      onChange={(_e: React.MouseEvent<HTMLElement>, next: SpeedType | null) => {
+        // Null is the group reporting that the button already selected was clicked again.
+        // The clock is always running at some speed, so there is nothing to deselect to.
+        if (next) {
+          onSpeedChange(next);
+        }
+      }}
+      aria-label="game speed"
+    >
+      <ToggleButton value="PAUSED" aria-label={SPEED_ARIA_LABELS.PAUSED}>
+        <PauseIcon fontSize="small" />
+      </ToggleButton>
+      {RUNNING_SPEEDS.map((s: SpeedType) => (
+        <ToggleButton key={s} value={s} aria-label={SPEED_ARIA_LABELS[s]}>
+          {speedMultiplier(s)}
+        </ToggleButton>
+      ))}
+    </ToggleButtonGroup>
   );
 }
 
@@ -219,9 +123,6 @@ export function GameAppBar(props: Props) {
   const date = game.date;
   const now = getTimeFromTimeline(date.minute, game.timeline);
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<HTMLElement | null>(
-    null,
-  );
-  const [speedAnchorEl, setSpeedAnchorEl] = React.useState<HTMLElement | null>(
     null,
   );
   const [scenarioDetailsOpen, setScenarioDetailsOpen] = React.useState(false);
@@ -244,35 +145,29 @@ export function GameAppBar(props: Props) {
   const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
     setMenuAnchorEl(event.currentTarget);
   const handleMenuClose = () => setMenuAnchorEl(null);
-  const handleSpeedClick = (event: React.MouseEvent<HTMLElement>) =>
-    setSpeedAnchorEl(event.currentTarget);
-  const handleSpeedClose = () => setSpeedAnchorEl(null);
 
   /**
    * The bar has to re-render every tick to keep the cash and the clock honest, which at FAST is
-   * a hundred times a second. Everything else in it -- five icon buttons and a kept-mounted menu
-   * -- only changes when the player clicks something, so those subtrees are built once per actual
-   * change and handed back as the same elements. React then skips them entirely on the frames in
-   * between, which is where a good quarter of the frame budget went.
+   * a hundred times a second. Everything else in it -- the speed toggles, menu button and
+   * kept-mounted menu -- only changes when the player clicks something, so those subtrees are
+   * built once per actual change and handed back as the same elements. React then skips them
+   * entirely on the frames in between, which is where a good quarter of the frame budget went.
    */
   const speedOptions = React.useMemo(
     () =>
       buildSpeedOptions({
-        smallScreen,
         speed,
         onSpeedChange,
-        speedAnchorEl,
-        handleSpeedClick,
-        handleSpeedClose,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [smallScreen, speed, onSpeedChange, speedAnchorEl],
+    [speed, onSpeedChange],
   );
 
   const menu = React.useMemo(
     () => (
       <>
         <IconButton
+          className="gameMenuButton"
           onClick={handleMenuClick}
           aria-label="menu"
           edge="start"
@@ -361,11 +256,11 @@ export function GameAppBar(props: Props) {
           {menu}
           <Typography variant="h6" className="gameStatus">
             <span className="gameStatusValue">
-              <ConceptIcon concept="money" fontSize="small" />
+              {!smallScreen && <ConceptIcon concept="money" fontSize="small" />}
               {formatMoneyStable(now.cash)}
             </span>
             <span className="weak gameStatusValue">
-              <ConceptIcon concept="time" fontSize="small" />
+              {!smallScreen && <ConceptIcon concept="time" fontSize="small" />}
               {date.month} {date.year}
               {bigScreen ? `, ${formatHour(date)}` : ""}
             </span>


### PR DESCRIPTION
Shows pause and all three running speeds directly in the mobile navbar, removes the redundant money and time glyphs at phone widths, and tightens responsive spacing so the toolbar remains on one row down to 320px. Adds regression coverage for the four controls and direct speed changes. Verified with typecheck, lint, formatting, the full 615-test existing suite, the new focused tests, and browser layout checks at 320px and 390px.