### PR TITLE
Add deterministic simulation events and fuel crossovers

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -446,7 +446,10 @@ export type GameEventKindType =
   | "BUILD"
   | "SELL"
   | "LOAN"
-  | "FUEL_PRICE";
+  | "FUEL_PRICE"
+  | "FUEL_CROSSOVER";
+
+export type GameEventImportanceType = "ROUTINE" | "NOTABLE" | "CRITICAL";
 
 /**
  * One line of the company's history.
@@ -462,6 +465,34 @@ export interface GameEventType {
   // When it happened, as the game clock read it at the time ("Mar 2024")
   label: string;
   message: string;
+  // Most entries are passive history. Important entries can interrupt the clock, stand out in
+  // the log and take the player to the screen where the consequence can be investigated.
+  importance?: GameEventImportanceType;
+  actionTarget?: CardNameType;
+}
+
+export interface WorldEventEffectsType {
+  fuelPriceMultipliers?: Partial<FuelPricesType>;
+  temperatureOffsetC?: number;
+  demandMultiplier?: number;
+}
+
+/** One deterministic, time-bounded occurrence created by the world-event engine. */
+export interface ActiveWorldEventType {
+  // Definition id plus location/date, stable across a replay of the same run
+  key: string;
+  definitionId: string;
+  startsMinute: number;
+  endsMinute: number;
+  attributes: Record<string, string | number>;
+  effects: WorldEventEffectsType;
+}
+
+export interface WorldEventStateType {
+  active: ActiveWorldEventType[];
+  // A bounded record of month/definition checks prevents a save resumed in the same month from
+  // drawing (and announcing) the same occurrence twice.
+  checkedKeys: string[];
 }
 
 export interface GameType {
@@ -491,6 +522,13 @@ export interface GameType {
   // Newest first, capped at MAX_EVENTS. Optional because a save written before the log existed
   // has none, and an empty log and a missing one mean the same thing to everything that reads it
   eventLog?: GameEventType[];
+  // Keys outlive the capped event log: a once-per-run lesson must not repeat just because its
+  // original row was the 101st one and fell off the visible history.
+  reportedEventKeys?: string[];
+  eventLogReadThroughId?: number;
+  // All-in $/MWh by fuel at the last monthly rollover, used to edge-detect cost-order changes.
+  fuelCostSnapshot?: Partial<Record<FuelNameType, number>>;
+  worldEvents?: WorldEventStateType;
   facilities: Array<StorageOperatingType | GeneratorOperatingType>;
   // Every simulation-affecting thing the player has done this run, for the replay attached to a
   // high score. Undefined means the run isn't being recorded: before a game starts, while one is

--- a/src/app.scss
+++ b/src/app.scss
@@ -1456,6 +1456,25 @@ $pane_header_height: 40px;
     align-items: start;
     padding: size(small) size(base);
     border-bottom: 1px solid var(--border-subtle);
+
+    &.actionable {
+      cursor: pointer;
+
+      &:hover,
+      &:focus-visible {
+        background: var(--interactive-tint);
+        outline: none;
+      }
+    }
+
+    &.importance-NOTABLE {
+      border-left: 3px solid $interactive_blue;
+    }
+
+    &.importance-CRITICAL {
+      border-left: 3px solid $blackout_red;
+      background: var(--blackout-tint);
+    }
   }
 
   .eventLogIcon {

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -486,7 +486,11 @@ export default class Compositor extends React.Component<Props, {}> {
           <DesktopPanes>
             <FacilitiesContainer />
             <FinancesContainer />
-            <ForecastsContainer />
+            {this.props.card.name === "EVENTS" && !isUltrawideScreen() ? (
+              <EventLogContainer />
+            ) : (
+              <ForecastsContainer />
+            )}
             {/* An ultrawide window is otherwise three panes and a lot of nothing. Only here,
                 because below this a fourth column comes out of the three that carry the game */}
             {isUltrawideScreen() ? <EventLogContainer /> : null}

--- a/src/components/base/GameAppBar.test.tsx
+++ b/src/components/base/GameAppBar.test.tsx
@@ -15,6 +15,7 @@ function renderAppBar(overrides: Partial<Props> = {}) {
     game: { ...game, inGame: true },
     audioEnabled: true,
     onAudioChange: () => undefined,
+    onEvents: () => undefined,
     onManual: () => undefined,
     onNextTutorial: () => undefined,
     onQuit: () => undefined,

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -40,6 +40,7 @@ export interface StateProps {
 }
 
 export interface DispatchProps {
+  onEvents: () => void;
   onManual: () => void;
   onSettings: () => void;
   onSpeedChange: (speed: SpeedType) => void;
@@ -114,6 +115,7 @@ export function GameAppBar(props: Props) {
     game,
     audioEnabled,
     onAudioChange,
+    onEvents,
     onManual,
     onNextTutorial,
     onQuit,
@@ -141,6 +143,8 @@ export function GameAppBar(props: Props) {
   // gets the "Save & Quit" reminder that leaving keeps it around to come back to
   const isTutorial = !!getScenario(game.scenarioId, game.customScenario)
     ?.tutorialSteps;
+  const hasUnreadEvents =
+    (game.eventLog?.[0]?.id || 0) > (game.eventLogReadThroughId || 0);
 
   const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
     setMenuAnchorEl(event.currentTarget);
@@ -183,6 +187,9 @@ export function GameAppBar(props: Props) {
           open={Boolean(menuAnchorEl)}
           onClose={handleMenuClose}
         >
+          <MenuItem onClick={onEvents}>
+            Events{hasUnreadEvents ? " •" : ""}
+          </MenuItem>
           <MenuItem onClick={onManual}>Manual</MenuItem>
           <MenuItem onClick={onSettings}>Options</MenuItem>
           <MenuItem
@@ -220,6 +227,8 @@ export function GameAppBar(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       menuAnchorEl,
+      onEvents,
+      hasUnreadEvents,
       onManual,
       onSettings,
       onNextTutorial,
@@ -310,6 +319,9 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onManual: () => {
       dispatch(navigate("MANUAL"));
+    },
+    onEvents: () => {
+      dispatch(navigate("EVENTS"));
     },
     onSettings: () => {
       dispatch(navigate("SETTINGS"));

--- a/src/components/base/Navigation.tsx
+++ b/src/components/base/Navigation.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { BottomNavigation, BottomNavigationAction } from "@mui/material";
+import { Badge, BottomNavigation, BottomNavigationAction } from "@mui/material";
 import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
 import FlashOnIcon from "@mui/icons-material/FlashOn";
 import HistoryIcon from "@mui/icons-material/History";
@@ -17,6 +17,10 @@ export interface Props extends StateProps {}
 export default function Navigation() {
   const dispatch = useAppDispatch();
   const cardName = useAppSelector(selectCardName);
+  const unreadEvents = useAppSelector((state) => {
+    const latest = state.game.eventLog?.[0]?.id || 0;
+    return latest > (state.game.eventLogReadThroughId || 0);
+  });
   return (
     <BottomNavigation
       id="navfooter"
@@ -48,7 +52,11 @@ export default function Navigation() {
         id="eventsNav"
         label="Events"
         value="EVENTS"
-        icon={<HistoryIcon />}
+        icon={
+          <Badge color="primary" variant="dot" invisible={!unreadEvents}>
+            <HistoryIcon />
+          </Badge>
+        }
       />
     </BottomNavigation>
   );

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -21,16 +21,23 @@ const KIND_CONCEPTS: { [k in GameEventKindType]: ConceptNameType } = {
   SELL: "money",
   LOAN: "finances",
   FUEL_PRICE: "fuel",
+  FUEL_CROSSOVER: "fuel",
 };
 
 export interface StateProps {
   events: GameEventType[];
 }
 
-export interface Props extends StateProps {}
+export interface DispatchProps {
+  onOpen: () => void;
+  onSelect: (event: GameEventType) => void;
+}
+
+export interface Props extends StateProps, DispatchProps {}
 
 export default function EventLog(props: Props): React.JSX.Element {
-  const { events } = props;
+  const { events, onOpen, onSelect } = props;
+  React.useEffect(() => onOpen(), [onOpen]);
   return (
     <GameCard className="eventLog" title="Events" id="eventsPane">
       <div className="scrollable">
@@ -46,7 +53,22 @@ export default function EventLog(props: Props): React.JSX.Element {
         )}
         <ul className="eventLogList">
           {events.map((event: GameEventType) => (
-            <li className={`eventLogItem kind-${event.kind}`} key={event.id}>
+            <li
+              className={`eventLogItem kind-${event.kind} importance-${event.importance || "ROUTINE"}${event.actionTarget ? " actionable" : ""}`}
+              key={event.id}
+              onClick={() => onSelect(event)}
+              onKeyDown={(e: React.KeyboardEvent<HTMLLIElement>) => {
+                if (
+                  event.actionTarget &&
+                  (e.key === "Enter" || e.key === " ")
+                ) {
+                  e.preventDefault();
+                  onSelect(event);
+                }
+              }}
+              role={event.actionTarget ? "button" : undefined}
+              tabIndex={event.actionTarget ? 0 : undefined}
+            >
               <span className="eventLogIcon">
                 <ConceptIcon
                   concept={KIND_CONCEPTS[event.kind]}

--- a/src/components/views/EventLogContainer.tsx
+++ b/src/components/views/EventLogContainer.tsx
@@ -1,6 +1,9 @@
 import { connect } from "react-redux";
 import { AppStateType, GameEventType } from "../../Types";
-import EventLog, { StateProps } from "./EventLog";
+import EventLog, { DispatchProps, StateProps } from "./EventLog";
+import type { AppDispatch } from "../../Store";
+import { markEventsRead } from "../../reducers/Game";
+import { navigate } from "../../reducers/Card";
 
 // One shared array for a run with nothing in its log yet - and for a save written before the log
 // existed. A fresh [] per call would be a new prop every tick, which is a re-render every tick
@@ -12,6 +15,18 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   };
 };
 
-const EventLogContainer = connect(mapStateToProps)(EventLog);
+const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => ({
+  onOpen: () => dispatch(markEventsRead()),
+  onSelect: (event: GameEventType) => {
+    if (event.actionTarget) {
+      dispatch(navigate(event.actionTarget));
+    }
+  },
+});
+
+const EventLogContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EventLog);
 
 export default EventLogContainer;

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -436,6 +436,38 @@ export const SCENARIOS = [
       },
       {
         card: "FACILITIES",
+        target: "#speedChangeButtons",
+        advanceOn: (s: AppStateType) =>
+          (s.game.eventLog || []).some((event) => event.kind === "BLACKOUT"),
+        content: (
+          <TutorialPrompt
+            concepts={["play", "blackout"]}
+            text="Tap 1× and let the forecasted blackout begin."
+            action={["play"]}
+          />
+        ),
+      },
+      {
+        card: "EVENTS",
+        target: ".eventLogItem",
+        content: (
+          <TutorialPrompt
+            concepts={["time", "blackout"]}
+            text="This dated event explains what changed. Fuel cost crossovers appear here too, and only interrupt you the first time each fuel crosses."
+          />
+        ),
+        desktop: {
+          target: "#eventsPane",
+          content: (
+            <TutorialPrompt
+              concepts={["time", "blackout"]}
+              text="This pane keeps dated explanations of important changes. Fuel cost crossovers appear here too, and only interrupt you the first time each fuel crosses."
+            />
+          ),
+        },
+      },
+      {
+        card: "FACILITIES",
         target: ".facility",
         advanceOn: (s: AppStateType) =>
           s.game.facilities.every((f) => !f.paused),

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -1,0 +1,43 @@
+import { getDateFromMinute } from "../helpers/DateTime";
+import { LOCATIONS } from "../Constants";
+import { resolveWorldEvent, WorldEventDefinitionType } from "./WorldEvents";
+
+const definition: WorldEventDefinitionType = {
+  id: "test-storm",
+  probabilityPerMonth: 1,
+  durationMonths: 1,
+  describe: (_context, random) => {
+    const size = Math.round(10 + random("size") * 90);
+    return {
+      kind: "FUEL_PRICE",
+      message: `Test storm ${size}`,
+      attributes: { size },
+      effects: { demandMultiplier: 1 + size / 1000 },
+    };
+  },
+};
+
+function occurrence(seed: number, location = LOCATIONS.SF, minute = 0) {
+  return resolveWorldEvent(definition, {
+    seed,
+    location,
+    date: getDateFromMinute(minute, 2020),
+  }).occurrence;
+}
+
+describe("deterministic world events", () => {
+  it("replays the same occurrence and attributes for the same seed, place and time", () => {
+    expect(occurrence(12345)).toEqual(occurrence(12345));
+  });
+
+  it("addresses randomness by location, time and seed", () => {
+    const baseline = occurrence(12345);
+    expect(occurrence(54321)?.attributes).not.toEqual(baseline?.attributes);
+    expect(occurrence(12345, LOCATIONS.PIT)?.attributes).not.toEqual(
+      baseline?.attributes,
+    );
+    expect(occurrence(12345, LOCATIONS.SF, 43200)?.attributes).not.toEqual(
+      baseline?.attributes,
+    );
+  });
+});

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -1,0 +1,140 @@
+import {
+  ActiveWorldEventType,
+  CardNameType,
+  DateType,
+  GameEventImportanceType,
+  GameEventKindType,
+  LocationType,
+  WorldEventEffectsType,
+} from "../Types";
+import { MINUTES_PER_MONTH } from "../helpers/DateTime";
+import { randomAt, RANDOM_STREAM } from "../helpers/Math";
+
+export interface WorldEventContextType {
+  seed: number;
+  date: DateType;
+  location: LocationType;
+}
+
+export type WorldEventRandomType = (attribute: string) => number;
+
+export interface WorldEventDescriptionType {
+  message: string;
+  kind: GameEventKindType;
+  importance?: GameEventImportanceType;
+  actionTarget?: CardNameType;
+  attributes: Record<string, string | number>;
+  effects?: WorldEventEffectsType;
+}
+
+/**
+ * Authored rule for a discrete occurrence. No rule ships yet: this is the engine contract future
+ * wildfire, hail and policy content plugs into without taking randomness from a running sequence.
+ */
+export interface WorldEventDefinitionType {
+  id: string;
+  probabilityPerMonth: number;
+  durationMonths: number;
+  applies?: (context: WorldEventContextType) => boolean;
+  describe: (
+    context: WorldEventContextType,
+    random: WorldEventRandomType,
+  ) => WorldEventDescriptionType;
+}
+
+export interface ResolvedWorldEventType {
+  checkedKey: string;
+  occurrence?: ActiveWorldEventType & WorldEventDescriptionType;
+}
+
+// Deliberately empty for this first slice. Adding a phenomenon is content, balancing and a new
+// icon/message contract; the engine can now support it without pretending one exists yet.
+export const WORLD_EVENT_DEFINITIONS: WorldEventDefinitionType[] = [];
+
+/** A stable 32-bit address for a string, independent of array order or other event definitions. */
+function hash(value: string): number {
+  let result = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    result ^= value.charCodeAt(i);
+    result = Math.imul(result, 16777619);
+  }
+  return result | 0;
+}
+
+function locationKey(location: LocationType): string {
+  // Coordinates disambiguate custom locations whose user-facing id may have been reused.
+  return `${location.id}|${location.lat.toFixed(5)}|${location.long.toFixed(5)}`;
+}
+
+export function worldEventCheckKey(
+  context: WorldEventContextType,
+  definitionId: string,
+): string {
+  return `${definitionId}|${locationKey(context.location)}|${context.date.year}-${context.date.monthNumber}`;
+}
+
+/**
+ * Checks one event rule for one month. Every draw is addressed by seed + location + month + rule
+ * + attribute, so replaying that world produces the same occurrence and the same size/details,
+ * even if unrelated event rules are inserted or reordered later.
+ */
+export function resolveWorldEvent(
+  definition: WorldEventDefinitionType,
+  context: WorldEventContextType,
+): ResolvedWorldEventType {
+  const checkedKey = worldEventCheckKey(context, definition.id);
+  const draw = (attribute: string) =>
+    randomAt(
+      context.seed,
+      RANDOM_STREAM.worldEvents,
+      hash(`${checkedKey}|${attribute}`),
+    );
+  if (
+    (definition.applies && !definition.applies(context)) ||
+    draw("occurs") >= definition.probabilityPerMonth
+  ) {
+    return { checkedKey };
+  }
+  const description = definition.describe(context, draw);
+  return {
+    checkedKey,
+    occurrence: {
+      key: checkedKey,
+      definitionId: definition.id,
+      startsMinute: context.date.minute,
+      endsMinute:
+        context.date.minute + definition.durationMonths * MINUTES_PER_MONTH,
+      ...description,
+      effects: description.effects || {},
+    },
+  };
+}
+
+export function activeWorldEventEffects(
+  events: ActiveWorldEventType[] | undefined,
+  minute: number,
+): WorldEventEffectsType {
+  const effects: WorldEventEffectsType = {};
+  (events || []).forEach((event: ActiveWorldEventType) => {
+    if (minute < event.startsMinute || minute >= event.endsMinute) {
+      return;
+    }
+    effects.temperatureOffsetC =
+      (effects.temperatureOffsetC || 0) +
+      (event.effects.temperatureOffsetC || 0);
+    effects.demandMultiplier =
+      (effects.demandMultiplier || 1) * (event.effects.demandMultiplier || 1);
+    if (event.effects.fuelPriceMultipliers) {
+      effects.fuelPriceMultipliers = effects.fuelPriceMultipliers || {};
+      Object.entries(event.effects.fuelPriceMultipliers).forEach(
+        ([fuel, multiplier]) => {
+          if (multiplier !== undefined) {
+            effects.fuelPriceMultipliers![fuel] =
+              (effects.fuelPriceMultipliers![fuel] || 1) * multiplier;
+          }
+        },
+      );
+    }
+  });
+  return effects;
+}

--- a/src/helpers/Math.tsx
+++ b/src/helpers/Math.tsx
@@ -41,6 +41,7 @@ export const RANDOM_STREAM = {
   fuelPrices: 2, // normalAt only
   economy: 3, // randomAt only
   weatherShape: 4, // randomAt only -- which recorded day a forecast borrows its shape from
+  worldEvents: 5, // randomAt only -- discrete occurrences and each occurrence's attributes
 };
 
 // https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript

--- a/src/reducers/EventLog.test.tsx
+++ b/src/reducers/EventLog.test.tsx
@@ -1,9 +1,15 @@
 import cloneDeep from "lodash.clonedeep";
-import gameReducer, { buildFacility, sellFacility, tickState } from "./Game";
+import gameReducer, {
+  buildFacility,
+  logFuelCrossovers,
+  sellFacility,
+  tickState,
+} from "./Game";
 import { GENERATORS } from "../data/Facilities";
 import { createGame } from "../testing/Simulator";
 import {
   FacilityOperatingType,
+  FuelNameType,
   GameEventType,
   GameType,
   GeneratorShoppingType,
@@ -123,5 +129,48 @@ describe("the event log", () => {
     const dark = ticked(pauseEverything(createGame({ scenarioId: 100 })), 400);
     const log = dark.eventLog || [];
     expect(log.length).toBeLessThanOrEqual(100);
+  });
+
+  it("reports a fuel cost crossover only once for the fuel that became dearer", () => {
+    const scenario = {
+      id: 9991,
+      name: "Crossover fixture",
+      icon: "coal",
+      locationId: "SF",
+      ownership: "Investor" as const,
+      startingYear: 2020,
+      cash: 500000000,
+      feePerKgCO2e: 0,
+      dollarsPerkWh: 0.1,
+      durationMonths: 24,
+      facilities: [
+        { fuel: "Coal" as const, peakW: 300000000 },
+        { fuel: "Natural Gas" as const, peakW: 300000000 },
+      ],
+    };
+    const game = createGame({ scenarioId: scenario.id, scenario, seed: 2468 });
+    const costs = game.fuelCostSnapshot || {};
+    const ordered: FuelNameType[] = ["Coal", "Natural Gas"];
+    ordered.sort((a, b) => (costs[b] || 0) - (costs[a] || 0));
+    const dearer = ordered[0];
+    const cheaper = ordered[1];
+    expect((costs[dearer] || 0) - (costs[cheaper] || 0)).toBeGreaterThan(1);
+
+    // Reverse the prior ordering so today's deterministic prices form a real crossing edge.
+    game.fuelCostSnapshot = { [dearer]: 1, [cheaper]: 1000 };
+    game.speed = "FAST";
+    logFuelCrossovers(game);
+    expect(kinds(game)).toContain("FUEL_CROSSOVER");
+    expect(messages(game)[0]).toContain(`${dearer} is now more expensive`);
+    expect(game.eventLog?.[0].importance).toEqual("NOTABLE");
+    expect(game.eventLog?.[0].actionTarget).toEqual("FACILITIES");
+    expect(game.speed).toEqual("PAUSED");
+
+    // Even after recreating the same edge, the persistent per-fuel key suppresses it.
+    game.fuelCostSnapshot = { [dearer]: 1, [cheaper]: 1000 };
+    logFuelCrossovers(game);
+    expect(
+      kinds(game).filter((kind) => kind === "FUEL_CROSSOVER"),
+    ).toHaveLength(1);
   });
 });

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -30,6 +30,11 @@ import { computeScoreBreakdown, totalScore } from "../helpers/Scoring";
 import { formatLargeMass } from "../helpers/Units";
 import { getSolarOutputFactor, getWindOutputFactor } from "../helpers/Energy";
 import { getFuelPricesPerMBTU } from "../data/FuelPrices";
+import {
+  activeWorldEventEffects,
+  resolveWorldEvent,
+  WORLD_EVENT_DEFINITIONS,
+} from "../data/WorldEvents";
 import { getWeather, getRawSolarIrradianceWM2 } from "../data/Weather";
 import {
   dialogOpen,
@@ -78,7 +83,9 @@ import {
   FacilityOperatingType,
   FacilityShoppingType,
   FuelPricesType,
+  FuelNameType,
   GameEventKindType,
+  GameEventImportanceType,
   GameEventType,
   LocationType,
   GameType,
@@ -91,6 +98,7 @@ import {
   TickPresentFutureType,
   FuelProductionType,
   ReplayActionType,
+  CardNameType,
 } from "../Types";
 
 interface BuildFacilityAction {
@@ -165,7 +173,19 @@ function logGameEvent(
   state: GameType,
   kind: GameEventKindType,
   message: string,
-) {
+  options: {
+    importance?: GameEventImportanceType;
+    actionTarget?: CardNameType;
+    reportedKey?: string;
+    pause?: boolean;
+  } = {},
+): boolean {
+  if (
+    options.reportedKey &&
+    (state.reportedEventKeys || []).includes(options.reportedKey)
+  ) {
+    return false;
+  }
   if (!state.eventLog) {
     state.eventLog = [];
   }
@@ -175,10 +195,22 @@ function logGameEvent(
     kind,
     label: `${state.date.month} ${state.date.year}`,
     message,
+    importance: options.importance,
+    actionTarget: options.actionTarget,
   });
+  if (options.reportedKey) {
+    state.reportedEventKeys = state.reportedEventKeys || [];
+    state.reportedEventKeys.push(options.reportedKey);
+  }
   if (log.length > MAX_EVENTS) {
     log.length = MAX_EVENTS;
   }
+  // An important event creates a decision point. Replays remain passive records, and an already
+  // paused player stays deliberately paused rather than acquiring a speed to restore later.
+  if (options.pause && !state.replayPlayback) {
+    state.speed = "PAUSED";
+  }
+  return true;
 }
 
 // How far a fuel has to move in a month to be worth a line in the log. Prices wander a percent
@@ -192,7 +224,7 @@ const FUEL_PRICE_SPIKE = 0.15;
  * already draws every fuel for the player who wants them all.
  */
 function logFuelPriceMoves(state: GameType) {
-  const prices = getFuelPricesPerMBTU(state.date, state.seed, state.location);
+  const prices = getEffectiveFuelPrices(state.date, state);
   const previous = previousFuelPrices;
   previousFuelPrices = prices;
   if (!previous) {
@@ -217,6 +249,175 @@ function logFuelPriceMoves(state: GameType) {
       `${fuel} ${change > 0 ? "up" : "down"} ${Math.round(Math.abs(change) * 100)}% to ${formatMoneyConcise(prices[fuel])}/MBTU`,
     );
   });
+}
+
+const HOURS_PER_YEAR = 8760;
+const WH_PER_MWH = 1000000;
+const FUEL_CROSSOVER_MINIMUM_DIFFERENCE = 1;
+
+/** All-in operating cost at expected annual output, excluding financing and sunk build cost. */
+function generatorCostPerMWh(
+  generator: GeneratorOperatingType,
+  prices: FuelPricesType,
+  feePerKgCO2e: number,
+): number | undefined {
+  if (
+    generator.yearsToBuildLeft > 0 ||
+    generator.peakW <= 0 ||
+    generator.capacityFactor <= 0
+  ) {
+    return undefined;
+  }
+  const annualMWh =
+    (generator.peakW * generator.capacityFactor * HOURS_PER_YEAR) / WH_PER_MWH;
+  const fuelPrice = prices[generator.fuel];
+  const fuelCost =
+    generator.btuPerWh > 0 && fuelPrice !== undefined
+      ? generator.btuPerWh * fuelPrice
+      : 0;
+  const carbonCost =
+    generator.btuPerWh *
+    WH_PER_MWH *
+    (FUELS[generator.fuel]?.kgCO2ePerBtu || 0) *
+    feePerKgCO2e;
+  return generator.annualOperatingCost / annualMWh + fuelCost + carbonCost;
+}
+
+function currentFuelCosts(
+  state: GameType,
+): Partial<Record<FuelNameType, number>> {
+  const costs: Partial<Record<FuelNameType, number>> = {};
+  const prices = getEffectiveFuelPrices(state.date, state);
+  state.facilities.forEach((facility: FacilityOperatingType) => {
+    const generator = facility as Partial<GeneratorOperatingType>;
+    if (!generator.fuel) {
+      return;
+    }
+    const cost = generatorCostPerMWh(
+      facility as GeneratorOperatingType,
+      prices,
+      state.feePerKgCO2e,
+    );
+    if (cost === undefined) {
+      return;
+    }
+    // A fuel can have several plants. The cheapest one is the one dispatch order can actually
+    // choose at the margin, and avoids plant size turning the comparison into an average.
+    costs[generator.fuel] = Math.min(costs[generator.fuel] ?? Infinity, cost);
+  });
+  return costs;
+}
+
+/** Reports only the first cheaper-to-dearer ordering change for each fuel in a run. */
+export function logFuelCrossovers(state: GameType) {
+  const current = currentFuelCosts(state);
+  const previous = state.fuelCostSnapshot;
+  state.fuelCostSnapshot = current;
+  if (!previous) {
+    return;
+  }
+  (Object.entries(current) as [FuelNameType, number][]).forEach(
+    ([fuel, cost]) => {
+      if (cost === undefined || (FUELS[fuel]?.kgCO2ePerBtu || 0) <= 0) {
+        return;
+      }
+      const previousCost = previous[fuel];
+      if (previousCost === undefined) {
+        return;
+      }
+      const crossed = (Object.entries(current) as [FuelNameType, number][])
+        .filter(([otherFuel, otherCost]) => {
+          const previousOther = previous[otherFuel];
+          return (
+            otherFuel !== fuel &&
+            otherCost !== undefined &&
+            previousOther !== undefined &&
+            previousCost <= previousOther &&
+            cost - otherCost >= FUEL_CROSSOVER_MINIMUM_DIFFERENCE
+          );
+        })
+        // If one fuel passed several in the same month, name the cheapest comparator: that is
+        // the clearest dispatch consequence and the largest gap the player can act on.
+        .sort((a, b) => a[1] - b[1])[0];
+      if (!crossed || crossed[1] === undefined) {
+        return;
+      }
+      const otherFuel = crossed[0];
+      logGameEvent(
+        state,
+        "FUEL_CROSSOVER",
+        `${fuel} is now more expensive than ${otherFuel}: ${formatMoneyConcise(cost)}/MWh vs ${formatMoneyConcise(crossed[1])}/MWh`,
+        {
+          importance: "NOTABLE",
+          actionTarget: "FACILITIES",
+          reportedKey: `fuel-crossover:${fuel}`,
+          pause: true,
+        },
+      );
+    },
+  );
+}
+
+const MAX_WORLD_EVENT_CHECKS = 2400;
+
+/** Starts/ends authored events before this month's forecast is built. */
+function updateWorldEvents(state: GameType) {
+  state.worldEvents = state.worldEvents || { active: [], checkedKeys: [] };
+  state.worldEvents.active = state.worldEvents.active.filter(
+    (event) => event.endsMinute > state.date.minute,
+  );
+  WORLD_EVENT_DEFINITIONS.forEach((definition) => {
+    const resolved = resolveWorldEvent(definition, {
+      seed: state.seed,
+      date: state.date,
+      location: state.location,
+    });
+    if (state.worldEvents!.checkedKeys.includes(resolved.checkedKey)) {
+      return;
+    }
+    state.worldEvents!.checkedKeys.push(resolved.checkedKey);
+    if (resolved.occurrence) {
+      state.worldEvents!.active.push(resolved.occurrence);
+      logGameEvent(
+        state,
+        resolved.occurrence.kind,
+        resolved.occurrence.message,
+        {
+          importance: resolved.occurrence.importance,
+          actionTarget: resolved.occurrence.actionTarget,
+          reportedKey: `world-event:${resolved.occurrence.key}`,
+          pause: resolved.occurrence.importance === "CRITICAL",
+        },
+      );
+    }
+  });
+  if (state.worldEvents.checkedKeys.length > MAX_WORLD_EVENT_CHECKS) {
+    state.worldEvents.checkedKeys.splice(
+      0,
+      state.worldEvents.checkedKeys.length - MAX_WORLD_EVENT_CHECKS,
+    );
+  }
+}
+
+function getEffectiveFuelPrices(
+  date: DateType,
+  state: GameType,
+): FuelPricesType {
+  const prices = getFuelPricesPerMBTU(date, state.seed, state.location);
+  const multipliers = activeWorldEventEffects(
+    state.worldEvents?.active,
+    date.minute,
+  ).fuelPriceMultipliers;
+  if (!multipliers) {
+    return prices;
+  }
+  const effective = { ...prices };
+  Object.entries(multipliers).forEach(([fuel, multiplier]) => {
+    if (multiplier !== undefined && effective[fuel] !== undefined) {
+      effective[fuel] *= multiplier;
+    }
+  });
+  return effective;
 }
 
 const initialGame: GameType = {
@@ -310,6 +511,10 @@ export const gameSlice = createSlice({
       blackoutUnservedWh = 0;
       previousFuelPrices = undefined;
       state.eventLog = [] as GameEventType[];
+      state.reportedEventKeys = [];
+      state.eventLogReadThroughId = 0;
+      state.worldEvents = { active: [], checkedKeys: [] };
+      state.fuelCostSnapshot = undefined;
       state.timeline = [] as TickPresentFutureType[];
       // A game being watched is not a game being recorded; anything else starts an empty log,
       // which is also what tells serializeReplay the run was recorded from its very first minute
@@ -383,6 +588,9 @@ export const gameSlice = createSlice({
         );
       }
       state.timeline = reforecastSupply(state);
+      // Establish the comparison before time moves. A fleet that was already dearer on day one
+      // has not crossed anything; the first monthly ordering change is the event.
+      state.fuelCostSnapshot = currentFuelCosts(state);
       // Anything the player did before the clock first moved -- setting a rate or a marketing
       // budget on the way in. tickState picks up everything after this
       applyPendingReplayActions(state);
@@ -409,6 +617,9 @@ export const gameSlice = createSlice({
     setSpeed: (state, action: PayloadAction<SpeedType>) => {
       state.speed = action.payload;
       ensureTicking(state);
+    },
+    markEventsRead: (state) => {
+      state.eventLogReadThroughId = state.eventLog?.[0]?.id || 0;
     },
   },
   // start, loaded and quit are declared in GameActions so that Card and UI can react to them
@@ -522,6 +733,7 @@ export const {
   togglePauseFacility,
   reprioritizeFacility,
   setSpeed,
+  markEventsRead,
 } = gameSlice.actions;
 
 // Re-exported so that everything still imports the game's actions from one place
@@ -804,8 +1016,10 @@ export function tickState(state: GameType) {
       );
       state.interestRate =
         getPrimeRate(state.date, state.seed) * state.creditPremium;
+      updateWorldEvents(state);
       state.timeline = generateNewTimeline(state, cash, customers);
       logFuelPriceMoves(state);
+      logFuelCrossovers(state);
 
       // Pre-roll a few frames to compensate for temperature / demand jumps across months
       for (let i = 0; i < 4; i++) {
@@ -1049,7 +1263,11 @@ function getDemandW(
     40 * minutesFrom9amLogistics +
     30 * minutesFromDarkLogistics -
     65 * minutesFrom5pmLogistics;
-  return demandMultiple * now.customers;
+  const effects = activeWorldEventEffects(
+    game.worldEvents?.active,
+    date.minute,
+  );
+  return demandMultiple * now.customers * (effects.demandMultiplier || 1);
 }
 
 const KG_PER_MEGATON = 1000000000;
@@ -1079,7 +1297,11 @@ function reforecastWeatherAndPrices(
     if (t.minute >= state.date.minute) {
       const date = getDateFromMinute(t.minute, state.startingYear);
       const weather = getWeather(date, state.seed, cumulativeMegatons);
-      const fuelPrices = getFuelPricesPerMBTU(date, state.seed, state.location);
+      const fuelPrices = getEffectiveFuelPrices(date, state);
+      const effects = activeWorldEventEffects(
+        state.worldEvents?.active,
+        date.minute,
+      );
       return {
         ...t,
         ...fuelPrices,
@@ -1089,7 +1311,7 @@ function reforecastWeatherAndPrices(
           weather.CLOUD_PCT,
         ),
         windKph: OUTSKIRTS_WIND_MULTIPLIER * weather.WIND_KPH,
-        temperatureC: weather.TEMP_C,
+        temperatureC: weather.TEMP_C + (effects.temperatureOffsetC || 0),
         storedWh: 0,
         supplyByFuel: {} as FuelProductionType,
       } as TickPresentFutureType;
@@ -1261,7 +1483,7 @@ function updateSupplyFacilitiesFinances(
   let principalRepayment = 0;
   // Hoisted out of the loop below, the way the demand pass at the top of this file already does
   // it: prices move by the month, and this is per facility per tick
-  const fuelPrices = getFuelPricesPerMBTU(date, state.seed, state.location);
+  const fuelPrices = getEffectiveFuelPrices(date, state);
   // What one facility earns is its share of what the company actually sold, so the row can say
   // whether it has paid for itself. Curtailed output earns nothing, which pro-rating against the
   // served total is exactly what expresses


### PR DESCRIPTION
Adds one-time fuel cost crossover events using monthly all-in operating costs, with persistent deduplication per fuel. Introduces deterministic world-event plumbing keyed by seed, location, month, event definition, and attribute, with composable fuel-price, temperature, and demand effects but no new weather-event content yet. Extends the Events UI with importance, auto-pause, unread indicators, contextual navigation, desktop access, and a Mission 6 tutorial using a real blackout entry. Testing: npm run check (635 tests), plus a successful production build.