### PR TITLE
Add enhanced geothermal generator

### DIFF
--- a/public/images/enhanced geothermal.svg
+++ b/public/images/enhanced geothermal.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:447e47787e84f89faf44acb968db63d53ac70424371328da31464999404b20fc
+size 2384

--- a/src/data/Facilities.test.tsx
+++ b/src/data/Facilities.test.tsx
@@ -1,16 +1,25 @@
 import { GENERATORS, STORAGE } from "./Facilities";
 import { getDateFromMinute } from "../helpers/DateTime";
-import { GameType, LocationType } from "../Types";
+import { FacilityOperatingType, GameType, LocationType } from "../Types";
 
-function stateAt(location: LocationType): GameType {
+function stateAt(
+  location: LocationType,
+  year = 2020,
+  facilities: FacilityOperatingType[] = [],
+): GameType {
   return {
-    date: getDateFromMinute(0, 2020),
-    difficulty: "Employee",
+    date: getDateFromMinute(0, year),
+    startingYear: year,
+    difficulty: "CEO",
     feePerKgCO2e: 0,
     seed: 1,
-    facilities: [],
+    facilities,
     location,
   } as unknown as GameType;
+}
+
+function geothermalFacility(name: string): FacilityOperatingType {
+  return { name, fuel: "Geothermal" } as FacilityOperatingType;
 }
 
 const iceland: LocationType = {
@@ -48,5 +57,76 @@ describe("location-aware facilities", () => {
     expect(fuels).not.toContain("Geothermal");
     expect(fuels).not.toContain("Hydro");
     expect(storage).not.toContain("Pumped Hydro");
+  });
+});
+
+describe("enhanced geothermal", () => {
+  const generatorAt = (
+    location: LocationType,
+    year: number,
+    name: string,
+    facilities: FacilityOperatingType[] = [],
+  ) =>
+    GENERATORS(stateAt(location, year, facilities), 100000000, [], []).find(
+      (generator) => generator.name === name,
+    );
+
+  it("unlocks in 2030 in locations without conventional geothermal", () => {
+    expect(generatorAt(france, 2029, "Enhanced Geothermal")).toBeUndefined();
+    expect(generatorAt(france, 2030, "Geothermal")).toBeUndefined();
+    expect(generatorAt(france, 2030, "Enhanced Geothermal")).toBeDefined();
+  });
+
+  it("offers both geothermal technologies in resource-rich locations", () => {
+    const names = GENERATORS(stateAt(iceland, 2030), 100000000, [], []).map(
+      (generator) => generator.name,
+    );
+
+    expect(names).toContain("Geothermal");
+    expect(names).toContain("Enhanced Geothermal");
+  });
+
+  it("does not make enhanced geothermal more expensive as its fleet grows", () => {
+    const baseline = generatorAt(france, 2030, "Enhanced Geothermal");
+    const withExistingEnhanced = generatorAt(
+      france,
+      2030,
+      "Enhanced Geothermal",
+      [
+        geothermalFacility("Enhanced Geothermal"),
+        geothermalFacility("Enhanced Geothermal"),
+      ],
+    );
+
+    expect(withExistingEnhanced?.buildCost).toBe(baseline?.buildCost);
+  });
+
+  it("only counts conventional plants for conventional geothermal scarcity", () => {
+    const baseline = generatorAt(iceland, 2030, "Geothermal");
+    const withEnhanced = generatorAt(iceland, 2030, "Geothermal", [
+      geothermalFacility("Enhanced Geothermal"),
+    ]);
+    const withConventional = generatorAt(iceland, 2030, "Geothermal", [
+      geothermalFacility("Geothermal"),
+    ]);
+
+    expect(withEnhanced?.buildCost).toBe(baseline?.buildCost);
+    expect(withConventional?.buildCost).toBe(
+      (baseline?.buildCost as number) * 1.25,
+    );
+  });
+
+  it("uses the 2030 cost and performance assumptions", () => {
+    const generator = generatorAt(france, 2030, "Enhanced Geothermal");
+
+    expect(generator).toMatchObject({
+      fuel: "Geothermal",
+      annualOperatingCost: 16000000,
+      capacityFactor: 0.83,
+      maxPeakW: 500000000,
+      yearsToBuild: 3.5,
+      lifespanYears: 30,
+    });
+    expect(generator?.buildCost).toBeCloseTo(463000000, -6);
   });
 });

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -2,12 +2,7 @@ import { LCWH } from "../helpers/Financials";
 import { hasFuelPrices } from "./FuelPrices";
 import { getInflationIndex, hasEconomy } from "./Economy";
 import { DIFFICULTIES } from "../Constants";
-import {
-  FacilityOperatingType,
-  GameType,
-  GeneratorShoppingType,
-  StorageShoppingType,
-} from "../Types";
+import { GameType, GeneratorShoppingType, StorageShoppingType } from "../Types";
 import {
   getWindCapacityFactor,
   getSolarCapacityFactor,
@@ -47,14 +42,12 @@ export function GENERATORS(
   const year = state.date.year;
 
   // only needed as a temporary hack for geothermal until https://github.com/toddmedema/electrify/issues/86 done
-  const countByFuel = state.facilities.reduce(
-    (acc: { [index: string]: number }, f: FacilityOperatingType) => {
-      if (f.fuel) {
-        acc[f.fuel] = (acc[f.fuel] || 0) + 1;
-      }
-      return acc;
-    },
-    {} as { [index: string]: number },
+  const conventionalGeothermalCount = state.facilities.filter(
+    (f) => f.name === "Geothermal",
+  ).length;
+  const enhancedGeothermalCostPerW = Math.max(
+    3,
+    5.5 * Math.pow(3 / 5.5, (year - 2028) / 7),
   );
 
   // Calculate intermittent generator capacity factors (here instead of passed in, since may eventually have different capacity factors
@@ -300,8 +293,7 @@ export function GENERATORS(
       fuel: "Geothermal",
       description: "Consistent, but few locations",
       available: hasGeothermalResource(state.location),
-      buildCost:
-        (10000000 + 4 * peakW) * (1 + (countByFuel.Geothermal || 0) / 4),
+      buildCost: (10000000 + 4 * peakW) * (1 + conventionalGeothermalCount / 4),
       // To compensate for limited locations, cost to build increases significantly with each construction
       // Future ideas: new tech in ~2000 opened up more locations at a slightly higher cost
       // Have multiplier be based on totalPeakWByFuel instead, so that you don't suffer as much from building many smaller plants
@@ -321,6 +313,23 @@ export function GENERATORS(
       // But technically availabe up to 90% of the time - https://www.energy.gov/eere/geothermal/geothermal-faqs
       lifespanYears: 40,
       // TODO
+    },
+    {
+      name: "Enhanced Geothermal",
+      fuel: "Geothermal",
+      description: "Clean, firm power nearly anywhere",
+      available: year >= 2030,
+      buildCost: enhancedGeothermalCostPerW * peakW,
+      // Fervo's $5.5/W Phase II estimate in 2028 declines to its $3/W long-term target
+      // in 2035, then stays at that floor.
+      peakW,
+      maxPeakW: 500000000,
+      btuPerWh: 0,
+      annualOperatingCost: 0.16 * peakW,
+      yearsToBuild: 3 + magnitude / 4,
+      spinMinutes: 1,
+      capacityFactor: 0.83,
+      lifespanYears: 30,
     },
     // TODO biomass
   ] as GeneratorShoppingType[];


### PR DESCRIPTION
## Summary
- add Enhanced Geothermal as a globally available generator beginning in 2030
- model the 2028-2035 cost decline with a $3/W floor and the researched performance assumptions
- keep enhanced geothermal fleet size from affecting either enhanced or conventional geothermal pricing
- add the matching generator icon and regression coverage

## Testing
- npm run check (53 suites, 640 tests)
- npm run build

Closes #100