### PR TITLE
Polish mobile gameplay and facility building

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -472,6 +472,14 @@ $topbar_height: 56px;
     white-space: nowrap;
   }
 
+  // Modern large phones have room to make the two most important readouts substantially easier
+  // to scan. Keep the compressed scale below 360px, where the four speed controls need it.
+  @media screen and (min-width: 360px) {
+    #topbar .gameStatus {
+      font-size: clamp(0.95rem, 4vw, 1.125rem);
+    }
+  }
+
   #speedChangeButtons {
     flex: 0 0 auto;
   }
@@ -807,19 +815,6 @@ $pane_header_height: 40px;
   border-left: 4px solid var(--interactive-blue);
 }
 
-.recommendedChip {
-  margin-left: 8px;
-  height: 24px !important;
-  vertical-align: middle;
-}
-
-.missionCompleteText {
-  display: block;
-  color: $font_color_primary;
-  font-size: 0.75rem;
-  font-weight: 700;
-}
-
 .leaderboardDisclosure {
   margin: 20px auto;
   max-width: 760px;
@@ -1024,11 +1019,11 @@ $pane_header_height: 40px;
     }
   }
 
-  .expand-icon {
-    position: absolute;
-    bottom: -6px;
-    left: 50%;
-    transform: translatex(-50%);
+  .expand-details.MuiButton-root {
+    width: calc(100% - 32px);
+    margin: 0 16px size(small);
+    border-top: 1px solid var(--border-subtle);
+    border-radius: 0;
   }
 
   #tutorial-tooltip {

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -172,9 +172,7 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
         <GeneratorMetric
           label="Emissions"
           value={
-            kgCO2ePerMWh > 0
-              ? `${formatMass(kgCO2ePerMWh, units)} CO2e/MWh`
-              : "No CO2e"
+            kgCO2ePerMWh > 0 ? `${formatMass(kgCO2ePerMWh, units)}/MWh` : "None"
           }
         />
       </Box>
@@ -188,29 +186,20 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
           {formatMoneyConcise(downpayment)} loan down payment.
         </Typography>
       )}
-      {buildable && financingGap === 0 && cash < generator.buildCost && (
-        <Typography
-          variant="body2"
-          color="textSecondary"
-          sx={{ px: 2, pb: 1.5 }}
-        >
-          Financing available with a {formatMoneyConcise(downpayment)} down
-          payment.
-        </Typography>
-      )}
-      <IconButton
+      <Button
         color="primary"
-        className="expand-icon"
+        className="expand-details"
         size="small"
         aria-label={`${expanded ? "Hide" : "Show"} ${generator.name} details`}
         aria-expanded={expanded}
+        endIcon={expanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
         onClick={(event) => {
           event.stopPropagation();
           toggleExpand();
         }}
       >
-        {expanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
-      </IconButton>
+        {expanded ? "Hide details" : "Show details"}
+      </Button>
 
       <Collapse in={expanded} timeout="auto" unmountOnExit>
         <TableContainer>
@@ -318,7 +307,9 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
                   </Typography>
                 </TableCell>
                 <TableCell align="right">
-                  {formatMass(kgCO2ePerMWh, units)} CO2e/MWh
+                  {kgCO2ePerMWh > 0
+                    ? `${formatMass(kgCO2ePerMWh, units)}/MWh`
+                    : "None"}
                 </TableCell>
               </TableRow>
             </TableBody>

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -116,16 +116,17 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
         title={storage.name}
         subheader={secondaryText}
       />
-      <IconButton
+      <Button
         color="primary"
-        className="expand-icon"
+        className="expand-details"
         size="small"
         aria-label={`${expanded ? "Hide" : "Show"} ${storage.name} details`}
         aria-expanded={expanded}
+        endIcon={expanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
         onClick={toggleExpand}
       >
-        {expanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
-      </IconButton>
+        {expanded ? "Hide details" : "Show details"}
+      </Button>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
         <TableContainer>
           <Table size="small" aria-label="storage properties">

--- a/src/components/views/EventLog.test.tsx
+++ b/src/components/views/EventLog.test.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import EventLog from "./EventLog";
+
+jest.mock("../base/GameCard", () => (props: { children: React.ReactNode }) => (
+  <div>{props.children}</div>
+));
+
+describe("EventLog", () => {
+  it("marks events read without returning the dispatched action as an effect cleanup", () => {
+    const dispatchedAction = { type: "game/markEventsRead" };
+    const onOpen = jest.fn(() => dispatchedAction) as unknown as () => void;
+    const view = render(
+      <React.StrictMode>
+        <EventLog events={[]} onOpen={onOpen} onSelect={jest.fn()} />
+      </React.StrictMode>,
+    );
+
+    expect(onOpen).toHaveBeenCalled();
+    expect(screen.getByText(/Blackouts, finished construction/)).toBeVisible();
+    expect(() => view.unmount()).not.toThrow();
+  });
+});

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -37,7 +37,12 @@ export interface Props extends StateProps, DispatchProps {}
 
 export default function EventLog(props: Props): React.JSX.Element {
   const { events, onOpen, onSelect } = props;
-  React.useEffect(() => onOpen(), [onOpen]);
+  // An effect may only return a cleanup function. Redux dispatch returns the dispatched action,
+  // so the expression-bodied form returned an object here; React later tried to call that object
+  // while unmounting this phone-only pane and crashed the app to a blank screen.
+  React.useEffect(() => {
+    onOpen();
+  }, [onOpen]);
   return (
     <GameCard className="eventLog" title="Events" id="eventsPane">
       <div className="scrollable">

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -23,8 +23,7 @@ jest.mock("../base/GameCard", () => ({
 const user = userEvent.setup({ delay: null });
 
 function playedGame(ticks: number): GameType {
-  // Carbon Fee, which starts with two generators - a fleet of one hides every row action, since
-  // there is nothing to reorder it against and nothing to fall back on if it is paused or sold
+  // Carbon Fee, which starts with two generators.
   const state = createGame({ scenarioId: 100 });
   for (let i = 0; i < ticks; i++) {
     tickState(state);
@@ -33,6 +32,7 @@ function playedGame(ticks: number): GameType {
 }
 
 interface Handlers {
+  onPause: jest.Mock;
   onSelect: jest.Mock;
   onReprioritize: jest.Mock;
 }
@@ -42,6 +42,7 @@ function renderFacilities(
   selectedFacilityId: number | null,
 ): Handlers {
   const handlers: Handlers = {
+    onPause: jest.fn(),
     onSelect: jest.fn(),
     onReprioritize: jest.fn(),
   };
@@ -53,7 +54,7 @@ function renderFacilities(
       onStorageBuild={() => undefined}
       onSell={() => undefined}
       onTogglePause={() => undefined}
-      onPause={() => undefined}
+      onPause={handlers.onPause}
       onReprioritize={handlers.onReprioritize}
       onSelect={handlers.onSelect}
     />,
@@ -143,6 +144,15 @@ describe("the fleet list", () => {
       ),
     );
     expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("can pause the only facility in a fleet", async () => {
+    const onePlant = createGame({ scenarioId: 5 });
+    const { onPause } = renderFacilities(onePlant, null);
+    const facility = onePlant.facilities[0];
+
+    await user.click(screen.getByLabelText(`Pause ${facility.name}`));
+    expect(onPause).toHaveBeenCalledWith(facility.id, facility.name);
   });
 
   it("hides the player's controls while a replay is being watched", () => {

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -250,23 +250,20 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                     </IconButton>
                   </>
                 )}
-                {!readOnly &&
-                  !underConstruction &&
-                  props.listLength > 1 &&
-                  !facility.paused && (
-                    <IconButton
-                      onClick={(e: React.MouseEvent) => {
-                        e.stopPropagation();
-                        onPause(facility.id, facility.name);
-                      }}
-                      aria-label={`Pause ${facility.name}`}
-                      edge="end"
-                      color="primary"
-                      size="small"
-                    >
-                      <ConceptIcon concept="pause" />
-                    </IconButton>
-                  )}
+                {!readOnly && !underConstruction && !facility.paused && (
+                  <IconButton
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      onPause(facility.id, facility.name);
+                    }}
+                    aria-label={`Pause ${facility.name}`}
+                    edge="end"
+                    color="primary"
+                    size="small"
+                  >
+                    <ConceptIcon concept="pause" />
+                  </IconButton>
+                )}
                 {!readOnly && facility.paused && (
                   <IconButton
                     onClick={(e: React.MouseEvent) => {

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -56,8 +56,12 @@ describe("NewGame", () => {
     expect(TUTORIALS[1].summary).toBeDefined();
     expect(next).toHaveTextContent(TUTORIALS[1].summary as string);
     expect(next).not.toHaveTextContent("Start here");
+    expect(next).not.toHaveTextContent("Recommended next");
     expect(next).toHaveTextContent(TUTORIALS[1].name);
     expect(next).toHaveClass("tutorialNext");
+    expect(within(next).getByRole("button")).toHaveAccessibleName(
+      `Play ${TUTORIALS[1].name}`,
+    );
   });
 
   it("shows completion badges for tutorials and regular missions", () => {
@@ -73,6 +77,7 @@ describe("NewGame", () => {
     expect(
       screen.getByTestId(`mission-complete-${regular.id}`),
     ).toBeInTheDocument();
+    expect(screen.queryByText("Completed")).toBeNull();
   });
 
   it("starts tutorials directly and opens details for regular missions", () => {

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -78,7 +78,7 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
         autoFocus={next}
         aria-label={
           isTutorial
-            ? `${completed ? "Replay" : "Play"} ${s.name}${next ? ", recommended next" : ""}`
+            ? `${completed ? "Replay" : "Play"} ${s.name}`
             : `View ${s.name} details`
         }
       >
@@ -102,27 +102,8 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
               <Avatar src={`/images/${s.icon.toLowerCase()}.svg`} />
             </Badge>
           }
-          title={
-            <span>
-              {s.name}
-              {next && (
-                <Chip
-                  className="recommendedChip"
-                  label="Recommended next"
-                  size="small"
-                  color="primary"
-                />
-              )}
-            </span>
-          }
-          subheader={
-            <span>
-              {summary}
-              {completed && (
-                <span className="missionCompleteText">Completed</span>
-              )}
-            </span>
-          }
+          title={<span>{s.name}</span>}
+          subheader={<span>{summary}</span>}
           action={
             isTutorial ? (
               <Chip


### PR DESCRIPTION
## Summary

- simplify mission-list status labels and enlarge cash/date text on larger phones
- let a single facility be paused so Mission 6 can start, and streamline generator/storage build rows
- fix the Event Log effect cleanup crash that blanked the app when leaving the pane

## Testing

- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false --runInBand (53 suites, 674 tests)
- npm test -- --watchAll=false --runInBand src/components/views/EventLog.test.tsx src/components/views/NewGame.test.tsx src/components/views/Facilities.test.tsx
- npm run build
- in-app browser at 412 x 915: header fits at 16.48px, build emissions/disclosure copy verified, Event Log crash reproduced before fix and absent after fix