### PR TITLE
Declutter homepage sharing and filter leaderboards

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -5,6 +5,25 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "scenarioId", "order": "ASCENDING" },
+        { "fieldPath": "difficulty", "order": "ASCENDING" },
+        { "fieldPath": "score", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "scores",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "scenarioId", "order": "ASCENDING" },
+        { "fieldPath": "difficulty", "order": "ASCENDING" },
+        { "fieldPath": "uid", "order": "ASCENDING" },
+        { "fieldPath": "score", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "scores",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "scenarioId", "order": "ASCENDING" },
         { "fieldPath": "score", "order": "DESCENDING" }
       ]
     },

--- a/src/app.scss
+++ b/src/app.scss
@@ -815,19 +815,9 @@ $pane_header_height: 40px;
   border-left: 4px solid var(--interactive-blue);
 }
 
-.leaderboardDisclosure {
+.leaderboard {
   margin: 20px auto;
   max-width: 760px;
-
-  summary {
-    width: fit-content;
-    margin: 0 auto 8px;
-    padding: 10px 12px;
-    color: $interactive_blue;
-    font-weight: 700;
-    cursor: pointer;
-    touch-action: manipulation;
-  }
 }
 
 // Units appended to numbers in tables, de-emphasized so the number still reads first

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MainMenu, { Props } from "./MainMenu";
 
@@ -53,5 +53,16 @@ describe("MainMenu", () => {
     expect(screen.getByRole("region", { name: "Primary actions" })).toHaveStyle(
       { gap: "10px" },
     );
+  });
+
+  it("keeps sharing as a compact footer icon", () => {
+    render(<MainMenu {...props()} />);
+
+    expect(
+      within(screen.getByRole("contentinfo")).getByRole("button", {
+        name: "Share Electrify",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Share game" })).toBeNull();
   });
 });

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -123,11 +123,6 @@ const MainMenu = (props: Props): React.JSX.Element => {
           sx={{ flexWrap: "wrap", justifyContent: "center" }}
         >
           <InstallAppButton />
-          {canShare() && (
-            <Button color="primary" startIcon={<ShareIcon />} onClick={onShare}>
-              Share game
-            </Button>
-          )}
           {props.audioEnabled === undefined && (
             <Button
               color="primary"
@@ -152,6 +147,16 @@ const MainMenu = (props: Props): React.JSX.Element => {
           opacity: 0.7,
         }}
       >
+        {canShare() && (
+          <IconButton
+            color="primary"
+            onClick={onShare}
+            aria-label="Share Electrify"
+            size="large"
+          >
+            <ShareIcon />
+          </IconButton>
+        )}
         <IconButton
           color="primary"
           href="mailto:todd@fabricate.io"

--- a/src/components/views/NewGameDetails.test.tsx
+++ b/src/components/views/NewGameDetails.test.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { GameType } from "../../Types";
+import NewGameDetails, { Props } from "./NewGameDetails";
+
+const mockGetDocs = jest.fn();
+const mockWhere = jest.fn((field: string, op: string, value: unknown) => ({
+  field,
+  op,
+  value,
+}));
+
+jest.mock("firebase/firestore", () => ({
+  collection: jest.fn(() => "scores"),
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+  query: jest.fn((...args: unknown[]) => args),
+  where: (...args: [string, string, unknown]) => mockWhere(...args),
+  orderBy: jest.fn((...args: unknown[]) => args),
+  limit: jest.fn((...args: unknown[]) => args),
+}));
+
+jest.mock("../../Globals", () => ({
+  getDb: jest.fn(() => ({})),
+  getLocalStorage: jest.fn(() => globalThis.localStorage),
+  login: jest.fn(),
+}));
+
+function game(difficulty: GameType["difficulty"]): GameType {
+  return { scenarioId: 100, difficulty } as GameType;
+}
+
+function props(overrides: Partial<Props> = {}): Props {
+  return {
+    game: game("Employee"),
+    onBack: jest.fn(),
+    onDelta: jest.fn(),
+    onStart: jest.fn(),
+    onWatchReplay: jest.fn(),
+    onReplayError: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("NewGameDetails leaderboard", () => {
+  beforeEach(() => {
+    mockGetDocs.mockResolvedValue({ docs: [] });
+    mockWhere.mockClear();
+  });
+
+  it("is always visible and follows the selected difficulty", async () => {
+    const { rerender } = render(<NewGameDetails {...props()} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Global High Scores — Easy" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("See global leaderboard")).toBeNull();
+    expect(
+      screen.queryByRole("columnheader", { name: "Difficulty" }),
+    ).toBeNull();
+    await waitFor(() =>
+      expect(mockWhere).toHaveBeenCalledWith("difficulty", "==", "Employee"),
+    );
+
+    rerender(<NewGameDetails {...props({ game: game("CEO") })} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Global High Scores — Expert" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockWhere).toHaveBeenCalledWith("difficulty", "==", "CEO"),
+    );
+  });
+});

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -90,6 +90,9 @@ interface State {
 export interface Props extends StateProps, DispatchProps {}
 
 export default class NewGameDetails extends React.Component<Props, State> {
+  private boardRequestId = 0;
+  private myBestRequestId = 0;
+
   constructor(props: Props) {
     super(props);
     const scenario =
@@ -110,15 +113,22 @@ export default class NewGameDetails extends React.Component<Props, State> {
     if (!scenario) {
       return;
     }
+    const requestId = ++this.boardRequestId;
+    const difficulty = this.props.game.difficulty;
+    this.setState({ scores: undefined, boardFailed: false });
     try {
       const querySnapshot = await getDocs(
         query(
           collection(getDb(), "scores"),
           where("scenarioId", "==", scenario.id),
+          where("difficulty", "==", difficulty),
           orderBy("score", "desc"),
           limit(50),
         ),
       );
+      if (requestId !== this.boardRequestId) {
+        return;
+      }
       // Set in one go rather than once per document: fifty setStates to draw one table meant
       // laying out a table that grew by a row each time
       this.setState({
@@ -126,7 +136,9 @@ export default class NewGameDetails extends React.Component<Props, State> {
       });
     } catch (err) {
       console.warn("Couldn't load the high scores: ", err);
-      this.setState({ scores: [], boardFailed: true });
+      if (requestId === this.boardRequestId) {
+        this.setState({ scores: [], boardFailed: true });
+      }
     }
   }
 
@@ -136,19 +148,25 @@ export default class NewGameDetails extends React.Component<Props, State> {
     if (!scenario) {
       return;
     }
+    const requestId = ++this.myBestRequestId;
+    const difficulty = this.props.game.difficulty;
+    this.setState({ myTopScore: undefined });
     try {
       const querySnapshot = await getDocs(
         query(
           collection(getDb(), "scores"),
           where("scenarioId", "==", scenario.id),
+          where("difficulty", "==", difficulty),
           where("uid", "==", uid),
           orderBy("score", "desc"),
           limit(1),
         ),
       );
-      querySnapshot.forEach((doc) => {
-        this.setState({ myTopScore: doc.data() as ScoreType });
-      });
+      if (requestId === this.myBestRequestId) {
+        this.setState({
+          myTopScore: querySnapshot.docs[0]?.data() as ScoreType | undefined,
+        });
+      }
     } catch (err) {
       console.warn("Couldn't load your best score: ", err);
     }
@@ -217,9 +235,19 @@ export default class NewGameDetails extends React.Component<Props, State> {
   }
 
   public componentDidUpdate(prevProps: Props) {
+    if (this.props.game.difficulty !== prevProps.game.difficulty) {
+      this.loadBoard();
+      if (this.props.uid) {
+        this.loadMyBest(this.props.uid);
+      }
+      return;
+    }
     // Logging in from the button below the board is what makes "your best" answerable
     if (this.props.uid && this.props.uid !== prevProps.uid) {
       this.loadMyBest(this.props.uid);
+    } else if (!this.props.uid && prevProps.uid) {
+      ++this.myBestRequestId;
+      this.setState({ myTopScore: undefined });
     }
   }
 
@@ -382,20 +410,20 @@ export default class NewGameDetails extends React.Component<Props, State> {
             </DialogActions>
           </Dialog>
 
-          <details className="leaderboardDisclosure">
-            <summary>See global leaderboard</summary>
+          <div className="leaderboard">
             <Table id="HighScores">
               <TableHead>
                 <TableRow>
-                  <TableCell colSpan={5}>
-                    <Typography variant="h6">Global High Scores</Typography>
+                  <TableCell colSpan={4}>
+                    <Typography variant="h6">
+                      Global High Scores — {DIFFICULTY_LABELS[game.difficulty]}
+                    </Typography>
                   </TableCell>
                 </TableRow>
                 <TableRow>
                   <TableCell className="rank">#</TableCell>
                   <TableCell>Name</TableCell>
                   <TableCell>Score</TableCell>
-                  <TableCell>Difficulty</TableCell>
                   <TableCell className="replay">Replay</TableCell>
                 </TableRow>
               </TableHead>
@@ -408,13 +436,12 @@ export default class NewGameDetails extends React.Component<Props, State> {
                     <TableCell colSpan={2}>
                       Your best: {formatScore(myTopScore.score)}
                     </TableCell>
-                    <TableCell>{myTopScore.difficulty}</TableCell>
                     {this.renderReplayCell(myTopScore)}
                   </TableRow>
                 )}
                 {!scores && (
                   <TableRow>
-                    <TableCell colSpan={5}>
+                    <TableCell colSpan={4}>
                       <Typography variant="body2" color="textSecondary">
                         Loading...
                       </Typography>
@@ -423,7 +450,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                 )}
                 {scores && scores.length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={5}>
+                    <TableCell colSpan={4}>
                       <Typography variant="body2" color="textSecondary">
                         {boardFailed
                           ? "Couldn't load the high scores right now."
@@ -450,14 +477,13 @@ export default class NewGameDetails extends React.Component<Props, State> {
                           {score.displayName || "Anonymous"}
                         </TableCell>
                         <TableCell>{formatScore(score.score)}</TableCell>
-                        <TableCell>{score.difficulty}</TableCell>
                         {this.renderReplayCell(score)}
                       </TableRow>
                     );
                   })}
               </TableBody>
             </Table>
-          </details>
+          </div>
           {/* Below the board rather than in place of it: the board is the reason to log in */}
           {!uid && (
             <div style={{ textAlign: "center", margin: "12px 0 24px" }}>


### PR DESCRIPTION
Moves the homepage share action into the footer as an icon. Keeps scenario leaderboards always visible, filters global and personal scores to the selected difficulty, removes the difficulty column, and adds the required Firestore indexes. Validation: npm run check (693 tests passed).