### PR TITLE
Add biomass generation

### DIFF
--- a/public/images/biomass.svg
+++ b/public/images/biomass.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b61e9eff0873bde63f1d701e781656a3592d6ebc731ab2d096d1306eb29a83e
-size 967
+oid sha256:c206141399d1b2a79214e2e6b9545225e7cf976eb6f5830861f3b09d86b0b0f3
+size 1096

--- a/public/images/biomass.svg
+++ b/public/images/biomass.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b61e9eff0873bde63f1d701e781656a3592d6ebc731ab2d096d1306eb29a83e
+size 967

--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -179,6 +179,12 @@ export const FUELS = {
   Coal: {
     kgCO2ePerBtu: 0.000112, // https://www.epa.gov/sites/production/files/2015-08/documents/aberdeen-merged-deter-ltr.pdf
   },
+  Biomass: {
+    // 195 lb CO2/MMBtu for biomass, converted to kg/Btu. This is direct combustion CO2:
+    // net biogenic emissions depend on the feedstock and regrowth and cannot be assumed zero.
+    // https://www.eia.gov/outlooks/capitalcost/pdf/updated_capcost.pdf
+    kgCO2ePerBtu: 0.000088451,
+  },
   "Natural Gas": {
     kgCO2ePerBtu: 0.000068, // https://www.epa.gov/sites/production/files/2015-08/documents/aberdeen-merged-deter-ltr.pdf
   },

--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -21,7 +21,7 @@ import { FuelNameType, ThemeChoiceType, ThemeModeType } from "./Types";
  * four lines on one chart be told apart.
  */
 
-// Seven series can never all clear WCAG's 3:1 non-text contrast against each other - the
+// Nine series can never all clear WCAG's 3:1 non-text contrast against each other - the
 // luminance ladder runs out at about four - so these are tuned for two things that are achievable:
 // every fuel clears 3:1 against the plot area, and the pairs that share a line chart
 // (the four priced fuels) are spread as far apart in luminance as that constraint allows.
@@ -31,6 +31,7 @@ import { FuelNameType, ThemeChoiceType, ThemeModeType } from "./Types";
 const FUEL_COLORS: { [mode in ThemeModeType]: { [fuel: string]: string } } = {
   light: {
     Coal: "#1a1a1a", // 17.4:1 on white
+    Biomass: "#356b20",
     Uranium: "#0f5b63", // 7.8:1
     Oil: "#ac4e13", // 5.5:1
     "Natural Gas": "#bb79e6", // 3.0:1
@@ -42,6 +43,7 @@ const FUEL_COLORS: { [mode in ThemeModeType]: { [fuel: string]: string } } = {
   },
   dark: {
     Coal: "#d0d0d0", // 11.9:1 on #121212 - the darkest fuel has to become the lightest
+    Biomass: "#9ccc65",
     Uranium: "#4dd0e1", // 9.9:1
     Oil: "#ffa726", // 10.6:1
     "Natural Gas": "#ce93d8", // 7.7:1
@@ -68,6 +70,7 @@ export function facilityColor(fuel?: FuelNameType): string {
 // a dash pattern reads the same on either palette.
 export const fuelDashArrays = {
   Coal: undefined, // solid
+  Biomass: "12,3",
   "Natural Gas": "6,3",
   Oil: "2,3",
   Uranium: "9,3,2,3",

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -52,6 +52,7 @@ export interface LocationType {
 
 export type FuelNameType =
   | "Coal"
+  | "Biomass"
   | "Wind"
   | "Offshore Wind"
   | "Sun"
@@ -62,6 +63,7 @@ export type FuelNameType =
   | "Hydro";
 export interface FuelPricesType {
   [index: string]: number;
+  Biomass: number; // $/btu
   "Natural Gas": number; // $/btu
   Coal: number; // $/btu
   Uranium: number; // $/btu
@@ -69,6 +71,7 @@ export interface FuelPricesType {
 }
 export interface FuelProductionType {
   [index: string]: number | undefined;
+  Biomass?: number; // wh
   "Natural Gas"?: number; // wh
   Coal?: number; // wh
   Uranium?: number; // wh

--- a/src/components/base/ChartForecastFuelPrices.tsx
+++ b/src/components/base/ChartForecastFuelPrices.tsx
@@ -33,8 +33,10 @@ export interface Props {
   syncKey?: string;
 }
 
-export type PricedFuelType = "Coal" | "Natural Gas" | "Oil" | "Uranium";
+export type PricedFuelType =
+  "Biomass" | "Coal" | "Natural Gas" | "Oil" | "Uranium";
 export const PRICED_FUELS: PricedFuelType[] = [
+  "Biomass",
   "Coal",
   "Natural Gas",
   "Oil",
@@ -92,7 +94,7 @@ function buildOptions(showXLabels: boolean) {
       ...PRICED_FUELS.map((f) => ({
         stroke: fuelColors()[f],
         width: 1.5,
-        // Four overlapping lines are more than color alone can separate, so each
+        // Five overlapping lines are more than color alone can separate, so each
         // fuel also gets its own dash pattern
         dash: dashArray(fuelDashArrays[f]),
         points: { show: false },
@@ -132,7 +134,7 @@ export default class ChartForecastFuelPrices extends React.PureComponent<
     } = this.props;
 
     const minutes = new Array<number>(timeline.length);
-    // Every tick carries all four prices; the fallback is only here because the fuel prices
+    // Every tick carries all five prices; the fallback is only here because the fuel prices
     // are optional on the tick type
     const prices = PRICED_FUELS.map(() => new Array<number>(timeline.length));
     timeline.forEach((t: TickPresentFutureType, i: number) => {

--- a/src/data/Facilities.test.tsx
+++ b/src/data/Facilities.test.tsx
@@ -177,3 +177,33 @@ describe("offshore wind", () => {
     expect(cost2010).toBeGreaterThan(cost2023);
   });
 });
+
+describe("biomass", () => {
+  it("offers a priced, dispatchable 50 MW reference plant", () => {
+    const generator = GENERATORS(stateAt(france, 2019), 50000000, [], []).find(
+      (candidate) => candidate.name === "Biomass",
+    );
+
+    expect(generator).toMatchObject({
+      fuel: "Biomass",
+      annualOperatingCost: 7235500,
+      btuPerWh: 13.3,
+      capacityFactor: 0.602,
+      maxPeakW: 50000000,
+      spinMinutes: 240,
+      yearsToBuild: 5,
+      lifespanYears: 30,
+    });
+    expect(generator?.buildCost).toBe(188870594);
+  });
+
+  it("is available in every location", () => {
+    [iceland, france].forEach((location) => {
+      expect(
+        GENERATORS(stateAt(location, 1980), 10000000, [], []).some(
+          (generator) => generator.name === "Biomass",
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -189,6 +189,35 @@ export function GENERATORS(
       lifespanYears: 30,
       // TODO
     },
+    {
+      name: "Biomass",
+      fuel: "Biomass",
+      description: "Renewable and dispatchable, but fuel-hungry",
+      available: true,
+      // EIA's 50 MW fluidized-bed reference plant costs $4,843/kW in 2025 dollars. Converted
+      // to the table's 2018 base with CPI-U (251.107 / 321.943), then split into the same
+      // one-quarter fixed / three-quarter variable shape used by the other thermal plants, so
+      // small biomass plants retain the real technology's poor economies of scale.
+      // https://www.eia.gov/outlooks/aeo/assumptions/pdf/EMM_Assumptions.pdf
+      // https://www.bls.gov/regions/mid-atlantic/data/ConsumerPriceIndexAnnualandSemiAnnual_Table.htm
+      buildCost: 47217644 + 2.833059 * peakW,
+      peakW,
+      // DOE's project-screening guidance describes 10-50 MW as the economic range; larger
+      // fleets can still be assembled as several plants with separate feedstock logistics.
+      // https://www.energy.gov/indianenergy/transcript-may-2019-tribal-energy-webinar-series-initial-scoping-energy-projects-back
+      maxPeakW: 50000000,
+      btuPerWh: 13.3,
+      spinMinutes: 240,
+      // EIA gives $154.26/kW-year fixed plus $5.93/MWh variable O&M in 2025 dollars. The engine
+      // has one annual O&M field, so both are converted to 2018 dollars and variable O&M is
+      // annualized at the observed 60.2% capacity factor.
+      annualOperatingCost: 0.14471 * peakW,
+      yearsToBuild: 5,
+      // 2022 U.S. "other biomass" fleet average; wood was 57.9% in the same table.
+      // https://www.eia.gov/electricity/annual/table.php?t=epa_04_08_b.html
+      capacityFactor: 0.602,
+      lifespanYears: 30,
+    },
     // {
     //   name: 'Trash Incinerator',
     //   fuel: 'Trash',
@@ -374,7 +403,6 @@ export function GENERATORS(
       capacityFactor: 0.83,
       lifespanYears: 30,
     },
-    // TODO biomass
   ] as GeneratorShoppingType[];
 
   // update with calculations that occur across all entries, like difficulty multipliers

--- a/src/data/FuelPrices.test.tsx
+++ b/src/data/FuelPrices.test.tsx
@@ -27,6 +27,13 @@ interface FixtureFuelType {
   swing: number;
 }
 const FIXTURE_FUELS: FixtureFuelType[] = [
+  {
+    column: "biomass",
+    name: "Biomass",
+    base: 1.5,
+    trendYearly: 0.025,
+    swing: 0.15,
+  },
   { column: "coal", name: "Coal", base: 2, trendYearly: 0.03, swing: 0.2 },
   {
     column: "naturalgas",
@@ -44,8 +51,8 @@ const FIXTURE_FUELS: FixtureFuelType[] = [
   },
   { column: "oil", name: "Oil", base: 10, trendYearly: 0.035, swing: 0.45 },
 ];
-const COAL = FIXTURE_FUELS[0];
-const NATURAL_GAS = FIXTURE_FUELS[1];
+const COAL = FIXTURE_FUELS.find((fuel) => fuel.name === "Coal")!;
+const NATURAL_GAS = FIXTURE_FUELS.find((fuel) => fuel.name === "Natural Gas")!;
 
 // A trend with a slow cycle riding on it, which is the shape a fuel price actually has -- and,
 // unlike the flat series this fixture used to be, something the projection can measure a spread
@@ -60,7 +67,7 @@ function fixturePrice(fuel: FixtureFuelType, monthsIn: number): number {
 }
 
 function fixtureCsv(): string {
-  const rows = ["year,month,naturalgas,coal,uranium,oil"];
+  const rows = ["year,month,biomass,naturalgas,coal,uranium,oil"];
   for (let year = FIXTURE_STARTING_YEAR; year <= FIXTURE_ENDING_YEAR; year++) {
     for (let month = 1; month <= 12; month++) {
       const monthsIn = (year - FIXTURE_STARTING_YEAR) * 12 + (month - 1);
@@ -73,6 +80,7 @@ function fixtureCsv(): string {
         [
           year,
           month,
+          by("biomass"),
           by("naturalgas"),
           by("coal"),
           by("uranium"),
@@ -86,10 +94,10 @@ function fixtureCsv(): string {
 
 // A flat record, for the degenerate case: a fuel that never moved has no spread to reproduce
 function flatCsv(): string {
-  const rows = ["year,month,naturalgas,coal,uranium,oil"];
+  const rows = ["year,month,biomass,naturalgas,coal,uranium,oil"];
   for (let year = FIXTURE_STARTING_YEAR; year <= FIXTURE_ENDING_YEAR; year++) {
     for (let month = 1; month <= 12; month++) {
-      rows.push([year, month, 3, 2, 0.7, 10].join(","));
+      rows.push([year, month, 1.5, 3, 2, 0.7, 10].join(","));
     }
   }
   return rows.join("\n");
@@ -131,6 +139,13 @@ describe("getFuelPricesPerMBTU", () => {
     FIXTURE_FUELS.forEach((fuel: FixtureFuelType) => {
       expect(prices[fuel.name]).toBeCloseTo(fixturePrice(fuel, 5), 5);
     });
+  });
+
+  it("fills biomass from EIA's annual history when the legacy CSV has no column", () => {
+    initFuelPricesFromCsv(
+      "year,month,naturalgas,coal,uranium,oil\n2018,1,3,2,0.7,10",
+    );
+    expect(getFuelPricesPerMBTU(dateIn(2018, 1), SEED).Biomass).toBe(2.15);
   });
 
   it("keeps the US history but applies regional fuel-price levels", () => {
@@ -201,7 +216,7 @@ describe("getFuelPricesPerMBTU", () => {
   });
 
   it("explains itself rather than hanging when nothing has been loaded", () => {
-    initFuelPricesFromCsv("year,month,naturalgas,coal,uranium,oil");
+    initFuelPricesFromCsv("year,month,biomass,naturalgas,coal,uranium,oil");
     expect(() => pricesIn(FIXTURE_STARTING_YEAR, 1)).toThrow(
       /No fuel prices loaded/,
     );
@@ -365,7 +380,7 @@ describe("initFuelPrices", () => {
       ok: true,
       text: () =>
         Promise.resolve(
-          "month,year,coal,naturalgas,uranium,oil\n12,2019,2.9,1.09,0.0011,9.76",
+          "month,year,biomass,coal,naturalgas,uranium,oil\n12,2019,2.28,2.9,1.09,0.0011,9.76",
         ),
     }) as unknown as typeof fetch;
     const failure = await new Promise((resolve) => initFuelPrices(resolve));

--- a/src/data/FuelPrices.tsx
+++ b/src/data/FuelPrices.tsx
@@ -28,8 +28,62 @@ const EARLIEST_DATA_YEAR = 1975;
 export const LATEST_DATA_YEAR = 2019;
 
 // Fixed so that each fuel always draws from the same slot of the fuel stream, whatever order
-// the CSV's columns happen to arrive in
-const FUEL_KEYS = ["Natural Gas", "Coal", "Uranium", "Oil"];
+// the CSV's columns happen to arrive in. New fuels belong at the end so adding one cannot shift
+// the established simulations for every fuel before it.
+const FUEL_KEYS = ["Natural Gas", "Coal", "Uranium", "Oil", "Biomass"];
+
+// Annual U.S. wood-and-waste prices for electric power, repeated across the twelve months because
+// EIA publishes this series annually. Kept beside the older four-fuel CSV until that sheet grows a
+// biomass column; collectFuelPriceRow prefers such a column if one is present.
+// Series WWEID, state US, dollars per million Btu:
+// https://www.eia.gov/opendata/browser/seds
+const BIOMASS_PRICES_PER_MBTU: Record<number, number> = {
+  1975: 0.92,
+  1976: 0.98,
+  1977: 1.04,
+  1978: 1.12,
+  1979: 1.56,
+  1980: 1.74,
+  1981: 1.24,
+  1982: 1.28,
+  1983: 1.12,
+  1984: 1.28,
+  1985: 0.79,
+  1986: 0.32,
+  1987: 0.95,
+  1988: 0.87,
+  1989: 0.53,
+  1990: 0.34,
+  1991: 0.41,
+  1992: 0.42,
+  1993: 0.52,
+  1994: 1.09,
+  1995: 1.13,
+  1996: 0.75,
+  1997: 0.53,
+  1998: 0.66,
+  1999: 0.54,
+  2000: 0.68,
+  2001: 1.3,
+  2002: 1.66,
+  2003: 1.69,
+  2004: 1.61,
+  2005: 2.31,
+  2006: 2.56,
+  2007: 3.22,
+  2008: 2.53,
+  2009: 2.4,
+  2010: 2.63,
+  2011: 2.66,
+  2012: 2.31,
+  2013: 2.26,
+  2014: 2.72,
+  2015: 2.59,
+  2016: 2.52,
+  2017: 2.37,
+  2018: 2.15,
+  2019: 2.28,
+};
 
 // How fast the trend a projected price is tied to climbs, in that year's dollars. The recorded
 // series run between 1.8%/yr (natural gas) and 3.6%/yr (oil) across 1975-2019, so this sits just
@@ -73,6 +127,7 @@ interface FuelTrendType extends DepartureType {
 type RawFuelPricesType = {
   month: string;
   year: string;
+  biomass?: string;
   naturalgas: string;
   coal: string;
   uranium: string;
@@ -264,6 +319,11 @@ function collectFuelPriceRow(data: RawFuelPricesType) {
   // Frozen because getFuelPricesPerMBTU hands the cached object straight to its callers rather
   // than copying it per tick, and a caller that wrote to one would be rewriting the record
   fuelPrices[+data.year][+data.month] = Object.freeze({
+    Biomass:
+      data.biomass !== undefined && data.biomass !== ""
+        ? +data.biomass
+        : BIOMASS_PRICES_PER_MBTU[+data.year] ||
+          BIOMASS_PRICES_PER_MBTU[LATEST_DATA_YEAR],
     "Natural Gas": +data.naturalgas,
     Coal: +data.coal,
     Uranium: +data.uranium,

--- a/src/reducers/CustomGame.test.tsx
+++ b/src/reducers/CustomGame.test.tsx
@@ -99,6 +99,31 @@ describe("a custom game", () => {
     expect(offshore.currentW).toBeLessThanOrEqual(offshore.peakW);
   });
 
+  it("runs a biomass starting facility with finite fuel costs and emissions", () => {
+    const state = createGame({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: {
+        ...CUSTOM,
+        startingYear: 2019,
+        facilities: [{ name: "Biomass", peakW: 50000000 }],
+      },
+    });
+    const now = getTimeFromTimeline(state.date.minute, state.timeline)!;
+
+    expect(state.facilities[0]).toMatchObject({
+      name: "Biomass",
+      fuel: "Biomass",
+      peakW: 50000000,
+      yearsToBuildLeft: 0,
+    });
+    expect(now.supplyByFuel.Biomass).toBeGreaterThan(0);
+    expect(now.expensesFuel).toBeGreaterThan(0);
+    expect(now.kgco2e).toBeGreaterThan(0);
+    expect(Number.isFinite(now.cash)).toBe(true);
+    expect(Number.isFinite(now.expensesFuel)).toBe(true);
+    expect(Number.isFinite(now.kgco2e)).toBe(true);
+  });
+
   it("runs on the seed the player pinned, and replays identically from it", () => {
     const first = createGame({
       scenarioId: CUSTOM_SCENARIO_ID,


### PR DESCRIPTION
## Summary
- add Biomass as a priced, dispatchable generator and facility, including dedicated artwork and chart styling
- model a 50 MW fluidized-bed plant from EIA and DOE cost, performance, construction, capacity-factor, and emissions data
- add EIA's 1975-2019 wood-and-waste fuel-price history to the deterministic fuel forecast, with projected prices after 2019
- cover the facility catalog, fuel-price fallback/projection, and an end-to-end biomass simulation with tests

## Research and modeling notes
- EIA AEO 2026's reference biomass fluidized-bed plant is 50 MW, takes 5 years to build, has a 13,300 Btu/kWh heat rate, and costs $4,843/kW in 2025 dollars. Its fixed and variable O&M are $154.26/kW-year and $5.93/MWh: https://www.eia.gov/outlooks/aeo/assumptions/pdf/EMM_Assumptions.pdf
- EIA's Electric Power Annual reports 60.2% capacity factor for other biomass in 2022; DOE gives a broader 50-70% range and notes 10-50 MW as the typical economic project scale: https://www.eia.gov/electricity/annual/table.php?t=epa_04_08_b.html and https://www.energy.gov/indianenergy/transcript-may-2019-tribal-energy-webinar-series-initial-scoping-energy-projects-back
- The cost inputs are normalized from 2025 dollars to the game's 2018-dollar base using BLS CPI-U annual averages: https://www.bls.gov/regions/mid-atlantic/data/ConsumerPriceIndexAnnualandSemiAnnual_Table.htm
- Historical biomass fuel prices use EIA SEDS series WWEID (wood and waste, electric power sector): https://www.eia.gov/opendata/browser/seds
- The model uses EIA's direct combustion coefficient of 195 lb CO2/MMBtu. Net biogenic lifecycle emissions depend on feedstock and regrowth, so they are not assumed to be automatically zero: https://www.eia.gov/outlooks/capitalcost/pdf/updated_capcost.pdf and https://www.epa.gov/sites/default/files/2016-08/documents/biogenic-co2-accounting-framework-report-sept-2011.pdf

## Validation
- `npm run check` (typecheck, lint, formatting, 55 test suites / 695 tests)
- manually verified the Biomass card, economics, emissions, and SVG rendering in the running app

Closes #207