### PR TITLE
Keep cash finite when hydro construction completes

### DIFF
--- a/src/reducers/BuildFacility.test.tsx
+++ b/src/reducers/BuildFacility.test.tsx
@@ -1,8 +1,9 @@
-import gameReducer, { buildFacility } from "./Game";
+import gameReducer, { buildFacility, generateNewTimeline } from "./Game";
 import { GENERATORS } from "../data/Facilities";
 import { getTimeFromTimeline } from "../helpers/DateTime";
 import { GameType, GeneratorShoppingType } from "../Types";
 import { createGame } from "../testing/Simulator";
+import { TICKS_PER_MONTH } from "../Constants";
 
 function aGeneratorToBuild(state: GameType): GeneratorShoppingType {
   const generator = GENERATORS(state, 500000000, [20], [500]).find(
@@ -80,5 +81,35 @@ describe("buildFacility", () => {
         .filter((t) => t.minute < after.date.minute)
         .map((t) => t.cash),
     ).toEqual(pastBefore);
+  });
+
+  it("keeps a long cash forecast finite when hydro finishes construction", () => {
+    const before = createGame({ scenarioId: 103 });
+    const hydro = GENERATORS(before, 50000000, [20], [500]).find(
+      (g: GeneratorShoppingType) => g.name === "Hydro",
+    );
+    expect(hydro).toBeDefined();
+
+    const after = gameReducer(
+      before,
+      buildFacility({ facility: hydro!, financed: true }),
+    );
+    const now = getTimeFromTimeline(after.date.minute, after.timeline)!;
+    const forecast = generateNewTimeline(
+      after,
+      now.cash,
+      now.customers,
+      TICKS_PER_MONTH * 24,
+    );
+
+    // Hydro finishes inside this horizon. It has an emissions entry but no purchased-fuel price;
+    // that combination used to turn its first fuel expense, and then the Cash chart, into NaN.
+    expect(
+      after.facilities.find((f) => f.name === "Hydro")!.yearsToBuildLeft,
+    ).toBeGreaterThan(0);
+    expect(forecast.every((tick) => Number.isFinite(tick.cash))).toBe(true);
+    expect(forecast.every((tick) => Number.isFinite(tick.expensesFuel))).toBe(
+      true,
+    );
   });
 });

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1520,7 +1520,12 @@ function updateSupplyFacilitiesFinances(
         const fuelBtu =
           ((g.currentW * (g.btuPerWh || 0)) / TICKS_PER_HOUR) *
           GAME_TO_REAL_YEARS; // Output-dependent #'s converted to real months, since we don't simulate every day
-        const facilityFuel = (fuelBtu * fuelPrices[g.fuel]) / 1000000;
+        // Hydro and geothermal carry a zero-emission FUELS entry so carbon accounting can name
+        // them, but they do not buy a fuel and therefore have no entry in the price table. In
+        // JavaScript even zero times undefined is NaN; the first operating tick after construction
+        // used to feed that through expenses into cash, where saving or charting exposed it as
+        // null. An unpriced resource costs zero here, matching generatorCostPerMWh above.
+        const facilityFuel = (fuelBtu * (fuelPrices[g.fuel] ?? 0)) / 1000000;
         const facilityKgco2e = fuelBtu * FUELS[g.fuel].kgCO2ePerBtu;
         expensesFuel += facilityFuel;
         kgco2e += facilityKgco2e;


### PR DESCRIPTION
## Summary
- treat facilities without a purchased-fuel price as having zero fuel cost
- prevent hydro and geothermal completion from turning fuel expense, cash, and net worth into NaN/null
- cover the 24-month cash forecast path with a hydro construction regression

## Root cause
Hydro and geothermal have entries in `FUELS` for emissions accounting, but no entries in the purchased-fuel price table. Their first operating tick multiplied zero fuel use by an undefined price. JavaScript evaluates that as `NaN`, which then propagated into the finance chart and serialized as `null`.

## Validation
- `npm run typecheck`
- ESLint on the changed files
- Prettier check on the changed files
- full test suite: 55 suites, 696 tests passing