### PR TITLE
Score bankrupt and fired runs

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -607,6 +607,9 @@ export interface VictoryType {
   // The player's best on this scenario BEFORE this run, read at the moment the scenario ended so
   // that "was 640" reports the run before this one rather than the one just finished
   previousBest?: number;
+  // A failed run still earns and submits a score, but the score screen must not celebrate it as a
+  // completed mission or let the terminal game resume and submit the same run again
+  outcome?: "completed" | "bankrupt" | "fired";
 }
 
 export interface UIType {

--- a/src/components/base/VictoryDialog.test.tsx
+++ b/src/components/base/VictoryDialog.test.tsx
@@ -190,6 +190,25 @@ describe("VictoryDialog", () => {
     expect(onQuit).toHaveBeenCalled();
   });
 
+  it.each([
+    ["bankrupt", "Bankrupt!"],
+    ["fired", "Fired!"],
+  ] as const)(
+    "shows a %s score without letting the terminal run resume",
+    async (outcome, title) => {
+      const onClose = jest.fn();
+      renderDialog({ victory: aVictory({ outcome }), onClose });
+
+      expect(screen.getByText("Run ended")).toBeInTheDocument();
+      expect(screen.getByText(title)).toBeInTheDocument();
+      expect(screen.getByText("How you scored")).toBeInTheDocument();
+      expect(screen.getByText(/Final score/)).toBeInTheDocument();
+      expect(screen.queryByText("Review final grid")).not.toBeInTheDocument();
+      await userEvent.keyboard("{Escape}");
+      expect(onClose).not.toHaveBeenCalled();
+    },
+  );
+
   it("uses the scenario's own ending when it has one", () => {
     renderDialog({
       victory: aVictory({

--- a/src/components/base/VictoryDialog.tsx
+++ b/src/components/base/VictoryDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import ShareIcon from "@mui/icons-material/Share";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import numbro from "numbro";
 import { VictoryType } from "../../Types";
 import { fetchGlobalRank } from "../../reducers/User";
@@ -133,10 +134,17 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
   }
 
   const { previousBest, breakdown, endTitle, endMessage } = victory;
+  const failed = victory.outcome === "bankrupt" || victory.outcome === "fired";
   const isPersonalBest =
     previousBest === undefined || victory.score > previousBest;
-  let displayTitle = endTitle || `You've retired!`;
-  if (endTitle && /^mission complete!?$/i.test(endTitle.trim())) {
+  let displayTitle =
+    endTitle ||
+    (victory.outcome === "bankrupt"
+      ? "Bankrupt!"
+      : victory.outcome === "fired"
+        ? "Fired!"
+        : `You've retired!`);
+  if (!failed && endTitle && /^mission complete!?$/i.test(endTitle.trim())) {
     displayTitle = victory.scenarioName;
   }
 
@@ -163,7 +171,9 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
     <Dialog
       open={true}
       // The run is over either way; dismissing by backdrop or Esc is the same as "Keep playing"
-      onClose={onClose}
+      // only after a completed term. A failed run is terminal and would fail and submit again on
+      // the next month if it could resume.
+      onClose={failed ? undefined : onClose}
       aria-labelledby="victory-title"
       fullWidth
       maxWidth="sm"
@@ -171,21 +181,34 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
         paper: {
           sx: {
             overflow: "hidden",
-            backgroundImage:
-              "radial-gradient(circle at 50% -20%, rgba(255, 193, 7, 0.28), transparent 45%)",
+            backgroundImage: failed
+              ? "radial-gradient(circle at 50% -20%, rgba(211, 47, 47, 0.2), transparent 45%)"
+              : "radial-gradient(circle at 50% -20%, rgba(255, 193, 7, 0.28), transparent 45%)",
           },
         },
       }}
     >
       <DialogTitle id="victory-title" sx={{ pb: 1.5 }}>
         <Stack spacing={0.5} sx={{ alignItems: "center", textAlign: "center" }}>
-          <EmojiEventsIcon color="warning" sx={{ fontSize: 52 }} aria-hidden />
+          {failed ? (
+            <ReportProblemOutlinedIcon
+              color="error"
+              sx={{ fontSize: 52 }}
+              aria-hidden
+            />
+          ) : (
+            <EmojiEventsIcon
+              color="warning"
+              sx={{ fontSize: 52 }}
+              aria-hidden
+            />
+          )}
           <Typography
             variant="overline"
-            color="warning.main"
+            color={failed ? "error.main" : "warning.main"}
             sx={{ fontWeight: 800, letterSpacing: "0.14em" }}
           >
-            Mission complete
+            {failed ? "Run ended" : "Mission complete"}
           </Typography>
           <Typography variant="h5" component="span" sx={{ fontWeight: 800 }}>
             {displayTitle}
@@ -209,7 +232,7 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
           }}
         >
           <Typography variant="overline" color="text.secondary">
-            What you accomplished
+            {failed ? "How you scored" : "What you accomplished"}
           </Typography>
           <Typography variant="body1">
             {summarizeChallenge(breakdown)}
@@ -283,9 +306,11 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
           </Button>
         )}
         <InstallAppButton label="Install for later" afterMilestone />
-        <Button color="primary" onClick={onClose}>
-          Review final grid
-        </Button>
+        {!failed && (
+          <Button color="primary" onClick={onClose}>
+            Review final grid
+          </Button>
+        )}
         <Button color="primary" onClick={onQuit}>
           Choose scenario
         </Button>

--- a/src/helpers/Scoring.test.tsx
+++ b/src/helpers/Scoring.test.tsx
@@ -1,0 +1,32 @@
+import { SCENARIOS } from "../data/Scenarios";
+import { MonthlyHistoryType, ScenarioType } from "../Types";
+import { computeScoreBreakdown, totalScore } from "./Scoring";
+
+it("gives a public utility that supplied no electricity a finite score", () => {
+  const scenario = SCENARIOS.find(
+    (candidate: ScenarioType) => candidate.ownership === "Public",
+  ) as ScenarioType;
+  const summary: MonthlyHistoryType = {
+    year: scenario.startingYear,
+    month: 1,
+    supplyWh: 0,
+    demandWh: 1000000000000,
+    cash: -1,
+    customers: 100,
+    netWorth: 0,
+    revenue: 0,
+    expensesFuel: 0,
+    expensesOM: 0,
+    expensesCarbonFee: 0,
+    expensesInterest: 0,
+    expensesMarketing: 0,
+    kgco2e: 0,
+    interestRate: 0.05,
+    inflationRate: 0.02,
+  };
+
+  const breakdown = computeScoreBreakdown(scenario, summary);
+
+  expect(Object.values(breakdown).every(Number.isFinite)).toBe(true);
+  expect(Number.isFinite(totalScore(breakdown))).toBe(true);
+});

--- a/src/helpers/Scoring.tsx
+++ b/src/helpers/Scoring.tsx
@@ -11,6 +11,13 @@ export function computeScoreBreakdown(
 ): ScoreBreakdownType {
   const blackoutsTWh =
     Math.max(0, summary.demandWh - summary.supplyWh) / 1000000000000;
+  // A public utility that fails before supplying any electricity still needs a valid final score.
+  // Its effective rate is unknowable, so leave that category neutral instead of dividing 0 / 0
+  // and sending NaN to the score screen and Firestore.
+  const effectiveRate =
+    summary.supplyWh > 0
+      ? summary.revenue / (summary.supplyWh / 1000)
+      : scenario.dollarsPerkWh;
   return scenario.ownership === "Investor"
     ? {
         supply: Math.round(summary.supplyWh / 1000000000000),
@@ -20,12 +27,7 @@ export function computeScoreBreakdown(
         blackouts: Math.round(-8 * blackoutsTWh),
       }
     : {
-        rate: Math.round(
-          80 *
-            100 *
-            (scenario.dollarsPerkWh -
-              summary.revenue / (summary.supplyWh / 1000)),
-        ),
+        rate: Math.round(80 * 100 * (scenario.dollarsPerkWh - effectiveRate)),
         supply: Math.round((10 * summary.supplyWh) / 1000000000000),
         emissions: Math.round((-5 * summary.kgco2e) / 1000000000),
         blackouts: Math.round(-10 * blackoutsTWh),

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -103,6 +103,7 @@ import {
   FuelProductionType,
   ReplayActionType,
   CardNameType,
+  VictoryType,
 } from "../Types";
 
 interface BuildFacilityAction {
@@ -1041,155 +1042,61 @@ export function tickState(state: GameType) {
       const scenarioId = state.scenarioId;
       // A replay reaches every one of these the same way the original run did, and must set off
       // none of their side effects: it is not a played game, it has no score of its own to
-      // submit, and the save it would clear belongs to whoever is watching. The dialogs still
-      // show, since a replay ending with "Bankrupt!" is the point of watching it
+      // submit, and the save it would clear belongs to whoever is watching. Its end screen still
+      // shows, since a replay ending with "Bankrupt!" is the point of watching it
       const isReplay = !!state.replayPlayback;
+      const scenario =
+        getScenario(state.scenarioId, state.customScenario) || SCENARIOS[0];
+      const isTutorial = Boolean(scenario.tutorialSteps);
+      // The leaderboard is keyed on scenario id alone, so custom runs - whatever cash, duration
+      // and rules the player gave themselves - would be scored against each other as if they
+      // were the same scenario. Replays likewise belong to the original player, not the viewer.
+      const ranked = scenario.id !== CUSTOM_SCENARIO_ID && !isReplay;
 
-      // Failure: Bankrupt
-      if (now.cash < 0) {
+      /**
+       * All non-tutorial endings use one scoring path. In particular, bankruptcy and firing used
+       * to open a plain message and skip both the score screen and submitHighscore entirely.
+       * Everything captured by the timeout is copied out of the Immer draft before it is revoked.
+       */
+      const finishScoredRun = (
+        summary: MonthlyHistoryType,
+        outcome: NonNullable<VictoryType["outcome"]>,
+        endTitle?: string,
+        endMessage?: string | (() => string),
+      ) => {
+        const score: ScoreBreakdownType = computeScoreBreakdown(
+          scenario,
+          summary,
+        );
+        const finalScore = totalScore(score);
+        const difficulty = state.difficulty;
+        const { id: scoredScenarioId, name: scenarioName } = scenario;
+        const submitsScore = ranked;
+        const replay = submitsScore ? serializeReplay(state) : undefined;
+
         if (!isReplay) {
           logEvent("scenario_end", {
-            id: scenarioId,
-            type: "bankrupt",
-            difficulty: state.difficulty,
+            id: scoredScenarioId,
+            type:
+              outcome === "completed"
+                ? "win"
+                : outcome === "fired"
+                  ? "blackouts"
+                  : "bankrupt",
+            difficulty,
+            score: finalScore,
           });
         }
-        const summary = summarizeHistory(history);
         setTimeout(() => {
           // In the timeout rather than here in the reducer: the autosave subscriber runs as soon
           // as this returns and would write the run straight back
           if (!isReplay) {
             clearSaveFor(scenarioId);
           }
-          const finished = getStore().getState().game;
-          getStore().dispatch(
-            dialogOpen({
-              title: "Bankrupt!",
-              message: `You've run out of money.
-                You survived for ${finished.date.year - finished.startingYear} years,
-                earned ${formatMoneyConcise(summary.revenue)} in revenue
-                and emitted ${formatLargeMass(summary.kgco2e, getStore().getState().settings.units)} of pollution.`,
-              open: true,
-              notCancellable: true,
-              actionLabel: "Try again",
-              action: () => getStore().dispatch(quit({ toScenarioList: true })),
-            }),
-          );
-        }, 1);
-      }
-
-      // Failure: Too many blackouts
-      if (
-        history[1] &&
-        history[2] &&
-        history[3] &&
-        history[1].supplyWh < history[1].demandWh * 0.9 &&
-        history[2].supplyWh < history[2].demandWh * 0.9 &&
-        history[3].supplyWh < history[3].demandWh * 0.9
-      ) {
-        if (!isReplay) {
-          logEvent("scenario_end", {
-            id: scenarioId,
-            type: "blackouts",
-            difficulty: state.difficulty,
-          });
-        }
-        const summary = summarizeHistory(history);
-        setTimeout(() => {
-          if (!isReplay) {
-            clearSaveFor(scenarioId);
-          }
-          const finished = getStore().getState().game;
-          getStore().dispatch(
-            dialogOpen({
-              title: "Fired!",
-              message: `You've allowed chronic blackouts for 3 months, causing shareholders to remove you from office.
-                You survived for ${finished.date.year - finished.startingYear} years,
-                earned ${formatMoneyConcise(summary.revenue)} in revenue
-                and emitted ${formatLargeMass(summary.kgco2e, getStore().getState().settings.units)} of pollution.`,
-              open: true,
-              notCancellable: true,
-              actionLabel: "Try again",
-              action: () => getStore().dispatch(quit({ toScenarioList: true })),
-            }),
-          );
-        }, 1);
-      }
-
-      const scenario =
-        getScenario(state.scenarioId, state.customScenario) || SCENARIOS[0];
-
-      // Success: Survived duration
-      if (state.date.monthsEllapsed === (scenario.durationMonths || 12 * 20)) {
-        // Every custom game shares one id, so recording it would light up a completion marker for
-        // a scenario nobody authored, and its score belongs to nothing comparable
-        const ranked = scenario.id !== CUSTOM_SCENARIO_ID && !isReplay;
-        if (ranked) {
-          // Tutorials are already marked played once their walkthrough ends, so this is a
-          // no-op for the ones the player sat all the way through
-          recordScenarioPlayed(scenarioId);
-        }
-
-        // Calculate score - This is also described in the manual; if I update the algorithm, update the manual too!
-        const summary = summarizeHistory(history);
-        const score: ScoreBreakdownType = computeScoreBreakdown(
-          scenario,
-          summary,
-        );
-        const finalScore = totalScore(score);
-        const difficulty = state.difficulty; // pulling out of state for functions running inside of setTimeout
-        // For a custom game getScenario() returns state.customScenario, which belongs to the same
-        // draft, so the fields the timeouts below read come out here too
-        const {
-          id: scoredScenarioId,
-          name: scenarioName,
-          endTitle,
-          endMessage,
-        } = scenario;
-        const isTutorial = Boolean(scenario.tutorialSteps);
-        // Read out here with everything else the timeouts need, rather than from inside them
-        const nextTutorial = getNextTutorial(scoredScenarioId);
-
-        // The leaderboard is keyed on scenario id alone, so custom runs - whatever cash, duration
-        // and rules the player gave themselves - would be scored against each other as if they
-        // were the same scenario
-        const submitsScore = !scenario.tutorialSteps && ranked;
-        // Pulled out of the draft here rather than inside the timeout, which runs after the
-        // reducer has returned and revoked it
-        const replay = submitsScore ? serializeReplay(state) : undefined;
-
-        if (!isReplay) {
-          logEvent("scenario_end", {
-            id: scoredScenarioId,
-            type: "win",
-            difficulty,
-            score: finalScore,
-          });
-        }
-        setTimeout(() => {
-          // The scenario is over even if the player takes "Keep playing"; autosave simply writes a
-          // fresh save at the next month rollover if they do
-          if (!isReplay) {
-            clearSaveFor(scenarioId);
-          }
-          if (isTutorial) {
-            return getStore().dispatch(
-              tutorialCompleteDialog({
-                title: endTitle || "Mission complete!",
-                message: endMessage,
-                nextTutorial,
-              }),
-            );
-          }
-          // Read here rather than up in the reducer: store.getState() throws while a reducer is
-          // running, and this sat in tickState, so the throw came out of the tick loop's own
-          // setTimeout - nothing rescheduled the loop and nothing opened a dialog, and the game
-          // stopped dead on the last month of every run. Still read before the submit below, so
-          // that "was 640" reports the run before this one rather than the one that just finished
+          // Read before the submit below, so "was 640" means the run before this one rather than
+          // the one that just finished. getState() cannot be called while the reducer is running.
           const previousBest =
             getStore().getState().user.bests?.[String(scoredScenarioId)]?.score;
-          // Only the numbers: the breakdown, the personal best and the rank are base/VictoryDialog's
-          // to render, so that the parts which arrive over the network can fill themselves in
           getStore().dispatch(
             victoryOpen({
               scenarioId: scoredScenarioId,
@@ -1198,9 +1105,11 @@ export function tickState(state: GameType) {
               score: finalScore,
               breakdown: score,
               endTitle,
-              endMessage,
+              endMessage:
+                typeof endMessage === "function" ? endMessage() : endMessage,
               ranked,
               previousBest,
+              outcome,
             }),
           );
           if (submitsScore) {
@@ -1215,6 +1124,116 @@ export function tickState(state: GameType) {
             );
           }
         }, 1);
+      };
+
+      const chronicBlackouts =
+        history[1] &&
+        history[2] &&
+        history[3] &&
+        history[1].supplyWh < history[1].demandWh * 0.9 &&
+        history[2].supplyWh < history[2].demandWh * 0.9 &&
+        history[3].supplyWh < history[3].demandWh * 0.9;
+      const failure =
+        now.cash < 0
+          ? ({ outcome: "bankrupt", title: "Bankrupt!" } as const)
+          : chronicBlackouts
+            ? ({ outcome: "fired", title: "Fired!" } as const)
+            : undefined;
+
+      if (failure) {
+        const summary = summarizeHistory(history);
+        const yearsSurvived = state.date.year - state.startingYear;
+        const failureMessage = () =>
+          `${
+            failure.outcome === "bankrupt"
+              ? "You've run out of money."
+              : "You've allowed chronic blackouts for 3 months, causing shareholders to remove you from office."
+          }
+                You survived for ${yearsSurvived} years,
+                earned ${formatMoneyConcise(summary.revenue)} in revenue
+                and emitted ${formatLargeMass(summary.kgco2e, getStore().getState().settings.units)} of pollution.`;
+
+        // Tutorials are intentionally unscored even when completed, so retain their guided
+        // failure dialog rather than putting one tutorial attempt on the global leaderboard.
+        if (isTutorial) {
+          if (!isReplay) {
+            logEvent("scenario_end", {
+              id: scenarioId,
+              type: failure.outcome === "fired" ? "blackouts" : "bankrupt",
+              difficulty: state.difficulty,
+            });
+          }
+          setTimeout(() => {
+            if (!isReplay) {
+              clearSaveFor(scenarioId);
+            }
+            getStore().dispatch(
+              dialogOpen({
+                title: failure.title,
+                message: failureMessage(),
+                open: true,
+                notCancellable: true,
+                actionLabel: "Try again",
+                action: () =>
+                  getStore().dispatch(quit({ toScenarioList: true })),
+              }),
+            );
+          }, 1);
+        } else {
+          finishScoredRun(
+            summary,
+            failure.outcome,
+            failure.title,
+            failureMessage,
+          );
+        }
+      } else if (
+        state.date.monthsEllapsed === (scenario.durationMonths || 12 * 20)
+      ) {
+        // Success: Survived duration
+        // Every custom game shares one id, so recording it would light up a completion marker for
+        // a scenario nobody authored, and its score belongs to nothing comparable
+        if (ranked) {
+          // Tutorials are already marked played once their walkthrough ends, so this is a
+          // no-op for the ones the player sat all the way through
+          recordScenarioPlayed(scenarioId);
+        }
+
+        const summary = summarizeHistory(history);
+        if (isTutorial) {
+          const score = computeScoreBreakdown(scenario, summary);
+          const finalScore = totalScore(score);
+          const { id: scoredScenarioId, endTitle, endMessage } = scenario;
+          const difficulty = state.difficulty;
+          const nextTutorial = getNextTutorial(scoredScenarioId);
+          if (!isReplay) {
+            logEvent("scenario_end", {
+              id: scoredScenarioId,
+              type: "win",
+              difficulty,
+              score: finalScore,
+            });
+          }
+          setTimeout(() => {
+            if (!isReplay) {
+              clearSaveFor(scenarioId);
+            }
+            return getStore().dispatch(
+              tutorialCompleteDialog({
+                title: endTitle || "Mission complete!",
+                message: endMessage,
+                nextTutorial,
+              }),
+            );
+          }, 1);
+        } else {
+          finishScoredRun(
+            summary,
+            "completed",
+            scenario.endTitle,
+            scenario.endMessage,
+          );
+        }
       }
     }
   }

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -17,7 +17,8 @@ import {
   tickState,
 } from "./Game";
 import { TICK_MS } from "../Constants";
-import { GameType, ScenarioType } from "../Types";
+import { GameType, MonthlyHistoryType, ScenarioType } from "../Types";
+import * as User from "./User";
 
 /**
  * The end of scenario triggers hand their dialogs off to setTimeout so that the autosave
@@ -81,8 +82,13 @@ function playOutOnTheStore(state: GameType, untilMonth: number) {
 }
 
 describe("ending a scenario from inside the reducer", () => {
-  beforeEach(() => jest.useFakeTimers());
-  afterEach(() => jest.useRealTimers());
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
 
   it("survives to the end of the term without reading the revoked draft", () => {
     const scenario = customScenario({ durationMonths: 2 });
@@ -157,6 +163,87 @@ describe("ending a scenario from inside the reducer", () => {
     }
     expect(state.monthlyHistory[0].cash).toBeLessThan(0);
     expect(() => jest.runOnlyPendingTimers()).not.toThrow();
+  });
+
+  it("shows and submits a score after bankruptcy", () => {
+    const submitHighscore = jest.spyOn(User, "submitHighscore");
+    getStore().dispatch(quit());
+    const scenario = SCENARIOS.find(
+      (s: ScenarioType) => s.id === 100,
+    ) as ScenarioType;
+    const state = createGame({
+      scenarioId: scenario.id,
+      monthlyMarketingSpend: 1000000000,
+    });
+
+    playOutOnTheStore(state, 1);
+    expect(getStore().getState().game.monthlyHistory[0].cash).toBeLessThan(0);
+    jest.runOnlyPendingTimers();
+
+    const victory = getStore().getState().ui.victory;
+    expect(victory).toEqual(
+      expect.objectContaining({
+        scenarioId: scenario.id,
+        outcome: "bankrupt",
+        ranked: true,
+      }),
+    );
+    expect(submitHighscore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scenarioId: scenario.id,
+        score: victory?.score,
+      }),
+    );
+  });
+
+  it("shows and submits a score after the player is fired", () => {
+    const submitHighscore = jest.spyOn(User, "submitHighscore");
+    getStore().dispatch(quit());
+    const scenario = SCENARIOS.find(
+      (s: ScenarioType) => s.id === 100,
+    ) as ScenarioType;
+    const state = createGame({ scenarioId: scenario.id });
+    const blackoutMonth: MonthlyHistoryType = {
+      year: scenario.startingYear,
+      month: 0,
+      supplyWh: 1,
+      demandWh: 100,
+      cash: scenario.cash,
+      customers: 100,
+      netWorth: scenario.cash,
+      revenue: 1,
+      expensesFuel: 0,
+      expensesOM: 0,
+      expensesCarbonFee: 0,
+      expensesInterest: 0,
+      expensesMarketing: 0,
+      kgco2e: 0,
+      interestRate: 0.05,
+      inflationRate: 0.02,
+    };
+    state.monthlyHistory = [
+      { ...blackoutMonth, month: 3 },
+      { ...blackoutMonth, month: 2 },
+      { ...blackoutMonth, month: 1 },
+    ];
+
+    playOutOnTheStore(state, 1);
+    jest.runOnlyPendingTimers();
+
+    const victory = getStore().getState().ui.victory;
+    expect(victory).toEqual(
+      expect.objectContaining({
+        scenarioId: scenario.id,
+        outcome: "fired",
+        ranked: true,
+      }),
+    );
+    expect(submitHighscore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scenarioId: scenario.id,
+        score: victory?.score,
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- route bankrupt and fired endings through the same score and leaderboard submission pipeline as completed runs
- present failed outcomes clearly and prevent terminal games from resuming and submitting repeatedly
- keep zero-supply public-utility scores finite and preserve tutorial scoring behavior

## Testing

- npm run check (712 tests passed)