### PR TITLE
Add clear cache action to settings

### DIFF
--- a/src/components/views/Settings.test.tsx
+++ b/src/components/views/Settings.test.tsx
@@ -1,7 +1,16 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Settings, { Props } from "./Settings";
+import { clearAppCache } from "../../helpers/Cache";
+
+jest.mock("../../helpers/Cache", () => ({
+  clearAppCache: jest.fn(async () => undefined),
+}));
+
+const mockedClearAppCache = clearAppCache as jest.MockedFunction<
+  typeof clearAppCache
+>;
 
 function renderSettings(overrides: Partial<Props> = {}) {
   const props: Props = {
@@ -105,5 +114,19 @@ describe("Settings", () => {
 
     // Picking the same file again still counts, for the player who went and fixed a bad one
     expect(fileInput().value).toBe("");
+  });
+
+  it("offers a subtle cache reset at the bottom", async () => {
+    renderSettings();
+
+    const button = screen.getByRole("button", { name: "Clear cache" });
+    expect(
+      within(screen.getByRole("contentinfo")).getByRole("button", {
+        name: "Clear cache",
+      }),
+    ).toBe(button);
+    await userEvent.click(button);
+
+    expect(mockedClearAppCache).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -23,6 +23,7 @@ import { THEME_CHOICES, THEME_LABELS } from "../../Theme";
 import KeyboardShortcuts from "../base/KeyboardShortcuts";
 import InstallAppButton from "../base/InstallAppButton";
 import packageJson from "../../../package.json";
+import { clearAppCache } from "../../helpers/Cache";
 
 export interface StateProps {
   settings: SettingsType;
@@ -317,6 +318,24 @@ export default function Settings(props: Props): React.JSX.Element {
             <Typography>
               <a href="/privacy.html">Privacy</a>
             </Typography>
+            <Button
+              variant="text"
+              size="small"
+              onClick={() => void clearAppCache()}
+              sx={{
+                color: "text.secondary",
+                display: "block",
+                fontSize: "0.75rem",
+                minWidth: 0,
+                mx: "auto",
+                mt: 0.5,
+                opacity: 0.75,
+                px: 0.5,
+                textTransform: "none",
+              }}
+            >
+              Clear cache
+            </Button>
           </Box>
         </Stack>
       </Box>

--- a/src/helpers/Cache.test.ts
+++ b/src/helpers/Cache.test.ts
@@ -1,0 +1,51 @@
+import { clearAppCache } from "./Cache";
+
+describe("clearAppCache", () => {
+  it("deletes every app cache before reloading", async () => {
+    const events: string[] = [];
+    const cacheStorage = {
+      keys: jest.fn(async () => ["electrify-v1", "electrify-old"]),
+      delete: jest.fn(async (name: string) => {
+        events.push(`delete ${name}`);
+        return true;
+      }),
+    };
+    const reload = jest.fn(() => events.push("reload"));
+
+    await clearAppCache(cacheStorage, reload);
+
+    expect(cacheStorage.delete).toHaveBeenCalledWith("electrify-v1");
+    expect(cacheStorage.delete).toHaveBeenCalledWith("electrify-old");
+    expect(events[events.length - 1]).toBe("reload");
+  });
+
+  it("still reloads in a browser without Cache Storage", async () => {
+    const reload = jest.fn();
+
+    await clearAppCache(undefined, reload);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reloads when clearing is refused", async () => {
+    const error = new Error("storage blocked");
+    const warn = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const reload = jest.fn();
+
+    await clearAppCache(
+      {
+        keys: jest.fn(async () => {
+          throw error;
+        }),
+        delete: jest.fn(),
+      },
+      reload,
+    );
+
+    expect(warn).toHaveBeenCalledWith("Couldn't clear the app cache:", error);
+    expect(reload).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+});

--- a/src/helpers/Cache.ts
+++ b/src/helpers/Cache.ts
@@ -1,0 +1,27 @@
+type AppCacheStorage = Pick<CacheStorage, "keys" | "delete">;
+
+function getAppCacheStorage(): AppCacheStorage | undefined {
+  return typeof caches === "undefined" ? undefined : caches;
+}
+
+/**
+ * Removes this origin's service-worker caches without touching localStorage, where saves and
+ * settings live. Reload only after every deletion settles so the service worker refills the cache
+ * from the current deployment rather than racing the clear.
+ */
+export async function clearAppCache(
+  cacheStorage: AppCacheStorage | undefined = getAppCacheStorage(),
+  reload: () => void = () => window.location.reload(),
+): Promise<void> {
+  if (cacheStorage) {
+    try {
+      const names = await cacheStorage.keys();
+      await Promise.all(names.map((name) => cacheStorage.delete(name)));
+    } catch (error) {
+      // A reload is still worthwhile if storage is unavailable or one stale entry disappeared
+      // between listing and deletion.
+      console.warn("Couldn't clear the app cache:", error);
+    }
+  }
+  reload();
+}


### PR DESCRIPTION
## Summary
- add a subtle Clear cache text action to the Settings footer
- clear this origin's service-worker Cache Storage and reload without touching local saves or preferences
- handle unavailable or blocked cache storage and cover the behavior with focused tests

## Testing
- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false Settings.test Cache.test
- npm test -- --watchAll=false (711 tests)
- npm run build