### PR TITLE
Fix playtest UI, offline sync, and facility depreciation

### DIFF
--- a/docs/facilities-economics.md
+++ b/docs/facilities-economics.md
@@ -75,6 +75,40 @@ midpoint of NREL's $2,205-$4,434/kW closed-loop site range), equivalent to $332/
 Fixed O&M becomes $19/kW-year. NREL projects no cost or efficiency improvement for this mature
 technology.
 
+## Lifetimes and depreciation
+
+Facility resale value now follows straight-line physical depreciation from commercial operation:
+`build cost × max(0, 1 - operating age / lifespan)`. Construction time is not asset age. Cancelling
+construction returns the cash-funded portion of the purchase and closes any construction loan;
+selling an operating facility returns its depreciated gross value after settling the remaining
+loan. A fully depreciated asset may still operate, but has no resale value.
+
+These are technology-specific operating lives, not tax schedules. Tax depreciation (for example,
+five-year MACRS for several renewable technologies) is an accounting convention and would make a
+poor proxy for the physical value the player can sell:
+
+| Facility            |     Life | Basis                                                            |
+| ------------------- | -------: | ---------------------------------------------------------------- |
+| Coal                | 40 years | EIA AEO2025 standardized plant operating life                    |
+| Nuclear             | 40 years | EIA AEO2025 new-build economic operating life                    |
+| Natural gas         | 40 years | EIA AEO2025 H-class simple-cycle operating life                  |
+| Oil                 | 30 years | NREL technology-comparison economic life for combustion turbines |
+| Onshore wind        | 25 years | EIA AEO2025 large-plant operating life                           |
+| Offshore wind       | 25 years | EIA AEO2025 fixed-bottom operating life                          |
+| Solar PV            | 35 years | EIA AEO2025 single-axis PV operating life                        |
+| Hydropower          | 50 years | EIA AEO2025 reference operating life                             |
+| Geothermal          | 40 years | EIA AEO2025 dual-flash operating life                            |
+| Enhanced geothermal | 30 years | NREL EGS resource and plant-life assumption                      |
+| Lithium-ion battery | 20 years | EIA AEO2025 7,300-cycle service life                             |
+| Pumped hydro        | 75 years | Midpoint of DOE's typical 65-85 year hydropower range            |
+
+The EIA study is the most internally consistent current primary source because it specifies life,
+lead time, plant configuration, and cost together. DOE/NREL sources fill the technologies it does
+not distinguish. Actual plants can outlive these economic lives after refurbishment—DOE notes
+65-85 years as typical for hydropower, and the NRC can license nuclear units out to 80 years—but
+the game needs one reference life for predictable resale rather than trying to price future major
+overhauls.
+
 ## Commercial technology review
 
 No additional facility type is added in this pass:
@@ -99,5 +133,9 @@ No additional facility type is added in this pass:
 - [IRENA, Renewable Power Generation Costs in 2020](https://www.irena.org/Publications/2021/Jun/Renewable-Power-Costs-in-2020)
 - [NREL, Cost Projections for Utility-Scale Battery Storage: 2021 Update](https://docs.nrel.gov/docs/fy21osti/79236.pdf)
 - [NREL, 2024 Annual Technology Baseline: Pumped Storage Hydropower](https://atb.nrel.gov/electricity/2024b/pumped_storage_hydropower)
+- [NREL, Cost and Performance Data for Power Generation Technologies](https://docs.nrel.gov/docs/fy11osti/48595.pdf)
+- [NREL, Update to Enhanced Geothermal System Resource Potential Estimate](https://docs.nrel.gov/docs/fy17osti/66428.pdf)
+- [DOE, Hydropower Basics](https://www.energy.gov/cmei/water/hydropower-basics)
+- [EIA, age and license extensions of U.S. nuclear plants](https://www.eia.gov/tools/faqs/faq.php?id=228&t=1)
 - [BLS, annual CPI-U indexes](https://www.bls.gov/regions/mid-atlantic/data/ConsumerPriceIndexAnnualandSemiAnnual_Table.htm)
 - [DOE, Long-Duration Energy Storage portfolio](https://www.energy.gov/cmei/oced/long-duration-energy-storage)

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,13 +1,52 @@
-const CACHE_VERSION = "electrify-v1";
+const CACHE_VERSION = "electrify-v2";
+const WEATHER_INDEX = "/data/weather/index.json";
+const MARKET_DATA = ["/data/FuelPricesRaw.csv", "/data/EconomyRaw.csv"];
 const APP_SHELL = [
   "/",
   "/manifest.json",
   "/images/logo.svg",
   "/images/icon/192x192.png",
   "/images/icon/512x512.png",
-  "/data/FuelPricesRaw.csv",
-  "/data/EconomyRaw.csv",
+  WEATHER_INDEX,
+  ...MARKET_DATA,
 ];
+
+async function fetchAndCache(cache, url) {
+  const response = await fetch(url, { cache: "no-cache" });
+  if (!response.ok) {
+    throw new Error(`${response.status} fetching ${url}`);
+  }
+  await cache.put(url, response.clone());
+  return response;
+}
+
+/**
+ * An installed app asks for this after launch has gone idle. Compare the catalog first: an
+ * unchanged one only fills holes, while a changed catalog refreshes every location because its
+ * update date means the packed records may have changed in place.
+ */
+async function syncOfflineData() {
+  const cache = await caches.open(CACHE_VERSION);
+  const cachedIndex = await cache.match(WEATHER_INDEX);
+  const cachedText = cachedIndex ? await cachedIndex.clone().text() : "";
+  const indexResponse = await fetchAndCache(cache, WEATHER_INDEX);
+  const indexText = await indexResponse.clone().text();
+  const index = JSON.parse(indexText);
+  const weatherUrls = Object.keys(index.cities || {}).map(
+    (id) => `/data/weather/${id}.bin`,
+  );
+  const cachedUrls = new Set(
+    (await cache.keys()).map((request) => new URL(request.url).pathname),
+  );
+  const weatherToFetch =
+    cachedText !== indexText
+      ? weatherUrls
+      : weatherUrls.filter((url) => !cachedUrls.has(url));
+
+  await Promise.allSettled(
+    [...MARKET_DATA, ...weatherToFetch].map((url) => fetchAndCache(cache, url)),
+  );
+}
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
@@ -28,6 +67,12 @@ self.addEventListener("activate", (event) => {
       )
       .then(() => self.clients.claim()),
   );
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data?.type === "SYNC_OFFLINE_DATA") {
+    event.waitUntil(syncOfflineData());
+  }
 });
 
 self.addEventListener("fetch", (event) => {

--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -140,7 +140,6 @@ export const TICK_MS = {
 export const INFLATION = 0.03;
 export const ORGANIC_GROWTH_MAX_ANNUAL = 0.015; // Includes organic / non-blackout attrition; Duke Energy grew 1.6% 2018 -> 2019, and that's with some marketing spending
 export const RESERVE_MARGIN = 0.05;
-export const GENERATOR_SELL_MULTIPLIER = 0.5;
 export const DOWNPAYMENT_PERCENT = 0.2;
 export const INTEREST_RATE_YEARLY = 0.04;
 export const LOAN_MONTHS = 30 * 12;

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -289,6 +289,9 @@ export interface GeneratorOperatingType
   currentW: number;
   yearsToBuildLeft: number;
   minuteCreated: number; // That the user clicked buy, not construction complete
+  // Set when construction completes. Optional so saves made before depreciation existed still
+  // load; the first real tick establishes their remaining lifetime from that point onward.
+  minuteOperational?: number;
   paused: boolean;
 }
 
@@ -298,6 +301,7 @@ export interface StorageOperatingType
   currentWh: number;
   yearsToBuildLeft: number;
   minuteCreated: number; // That the user clicked buy, not construction complete
+  minuteOperational?: number;
 }
 
 /**

--- a/src/app.scss
+++ b/src/app.scss
@@ -302,6 +302,12 @@ button,
   }
 }
 
+@media screen and (max-width: ($desktop_breakpoint - 1px)) {
+  .snackbar-above-nav {
+    bottom: calc(56px + env(safe-area-inset-bottom) + 8px) !important;
+  }
+}
+
 .draggable-indicator {
   position: absolute;
   left: -4px;
@@ -520,13 +526,14 @@ $topbar_height: 56px;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  min-height: 24px;
-  padding: 2px max(12px, env(safe-area-inset-left));
+  min-height: 18px;
+  padding: 0 max(12px, env(safe-area-inset-left));
   border-top: 1px solid var(--border-subtle);
   border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-raised);
   color: $font_color_primary;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
+  line-height: 18px;
   text-align: center;
 
   &.gridHealth-blackout {
@@ -607,7 +614,7 @@ $pane_header_height: 40px;
   }
 
   #yearProgressBar {
-    margin-top: -5px;
+    margin-top: 0;
     height: 2px;
     background: $font_color_faded;
     z-index: 100;
@@ -691,6 +698,9 @@ $pane_header_height: 40px;
   .scrollable {
     flex: 1 1 auto !important;
     overflow-y: auto;
+    overflow-x: hidden;
+    min-width: 0;
+    max-width: 100%;
   }
 }
 

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -361,6 +361,7 @@ export function isNavCard(name: CardNameType) {
 
 export default class Compositor extends React.Component<Props, {}> {
   private resizeTimeout: ReturnType<typeof setTimeout> | undefined;
+  private tutorialScrollTimeout: ReturnType<typeof setTimeout> | undefined;
   private stepsCache:
     | { source: TutorialStepType[]; desktop: boolean; resolved: Step[] }
     | undefined;
@@ -423,11 +424,42 @@ export default class Compositor extends React.Component<Props, {}> {
 
   public componentDidMount() {
     window.addEventListener("resize", this.handleResize);
+    this.scrollTutorialTargetIntoView();
+  }
+
+  public componentDidUpdate(prevProps: Props) {
+    if (
+      prevProps.tutorialStep !== this.props.tutorialStep ||
+      prevProps.card.name !== this.props.card.name
+    ) {
+      this.scrollTutorialTargetIntoView();
+    }
   }
 
   public componentWillUnmount() {
     window.removeEventListener("resize", this.handleResize);
     clearTimeout(this.resizeTimeout);
+    clearTimeout(this.tutorialScrollTimeout);
+  }
+
+  /** Joyride scrolling hangs inside card panes, so move their real scroll container ourselves. */
+  private scrollTutorialTargetIntoView() {
+    clearTimeout(this.tutorialScrollTimeout);
+    this.tutorialScrollTimeout = setTimeout(() => {
+      const steps = this.props.tutorialSteps;
+      const index = this.props.tutorialStep;
+      if (!steps || index < 0 || index >= steps.length) {
+        return;
+      }
+      const target = this.stepsForViewport(steps)[index]?.target;
+      if (typeof target !== "string") {
+        return;
+      }
+      const element = document.querySelector(target);
+      if (element && typeof element.scrollIntoView === "function") {
+        element.scrollIntoView({ block: "center", inline: "nearest" });
+      }
+    }, 50);
   }
 
   public handleJoyrideCallback = (data: EventData) => {
@@ -693,7 +725,7 @@ export default class Compositor extends React.Component<Props, {}> {
           </DialogActions>
         </Dialog>
         <Snackbar
-          className="snackbar"
+          className={`snackbar ${isNavCard(this.props.card.name) ? "snackbar-above-nav" : ""}`}
           // Bottom left is the MUI default, which on a wide screen leaves the toast hanging
           // off the side of the centered app frame
           anchorOrigin={{ vertical: "bottom", horizontal: "center" }}

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -237,6 +237,22 @@ describe("walkthrough steps", () => {
     expect(declared.filter((type) => !actionGateTypes.has(type))).toEqual([]);
   });
 
+  it("uses the same symbols as the generator and storage buttons it highlights", () => {
+    const actionOf = (step: TutorialStepType) =>
+      React.isValidElement<{ action?: string[] }>(step.content)
+        ? step.content.props.action
+        : undefined;
+    const generatorStep = walkthrough("Mission 2: Generators").find(
+      (step) => step.target === ".button-buildGenerator",
+    )!;
+    const storageStep = walkthrough("Mission 3: Storage").find(
+      (step) => step.target === ".button-buildStorage",
+    )!;
+
+    expect(actionOf(generatorStep)).toEqual(["generator"]);
+    expect(actionOf(storageStep)).toEqual(["storage"]);
+  });
+
   tutorials.forEach((scenario) => {
     const steps = scenario.tutorialSteps as TutorialStepType[];
 

--- a/src/components/base/GameAppBar.test.tsx
+++ b/src/components/base/GameAppBar.test.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { createGame } from "../../testing/Simulator";
-import { GameAppBar, Props } from "./GameAppBar";
+import { GameAppBar, Props, reserveCapacityW } from "./GameAppBar";
+import { getTimeFromTimeline } from "../../helpers/DateTime";
+import { FacilityOperatingType } from "../../Types";
 
 jest.mock("../../Globals", () => ({
   ...jest.requireActual("../../Globals"),
@@ -38,6 +40,23 @@ describe("GameAppBar mobile speed controls", () => {
       within(speedControls).getByRole("button", { name: "fast speed" }),
     );
     expect(onSpeedChange).toHaveBeenCalledWith("FAST");
+  });
+
+  it("reports unused available capacity in MW and grows when a plant is added", () => {
+    const game = createGame({ scenarioId: 101 });
+    const now = getTimeFromTimeline(game.date.minute, game.timeline)!;
+    const plant = game.facilities.find(
+      (facility: FacilityOperatingType) =>
+        facility.fuel &&
+        !["Sun", "Wind", "Offshore Wind"].includes(facility.fuel),
+    )!;
+    const before = reserveCapacityW(game, now);
+    game.facilities.push({ ...plant, id: 999 });
+
+    expect(reserveCapacityW(game, now) - before).toBe(plant.peakW);
+    renderAppBar({ game: { ...game, inGame: true } });
+    expect(screen.getByText(/Grid OK · .*W reserve/)).toBeInTheDocument();
+    expect(screen.queryByText(/% reserve/)).not.toBeInTheDocument();
   });
 
   it("omits the redundant money and time icons", () => {

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import PauseIcon from "@mui/icons-material/Pause";
-import { TICK_MS } from "../../Constants";
+import { TICKS_PER_HOUR, TICK_MS } from "../../Constants";
 import { formatHour, getTimeFromTimeline } from "../../helpers/DateTime";
 import { formatMoneyStable, formatWatts } from "../../helpers/Format";
 import { navigate } from "../../reducers/Card";
@@ -20,7 +20,13 @@ import { isBigScreen, isSmallScreen, openWindow } from "../../Globals";
 import { getNextTutorial, getScenario } from "../../data/Scenarios";
 import { quit, setSpeed, startTutorial } from "../../reducers/Game";
 import { change as changeSettings } from "../../reducers/Settings";
-import { AppStateType, GameType, SpeedType } from "../../Types";
+import {
+  AppStateType,
+  FacilityOperatingType,
+  GameType,
+  SpeedType,
+  TickPresentFutureType,
+} from "../../Types";
 import ScenarioDetailsDialog from "./ScenarioDetailsDialog";
 import ConceptIcon from "./ConceptIcon";
 
@@ -66,6 +72,39 @@ const RUNNING_SPEEDS: SpeedType[] = ["SLOW", "NORMAL", "FAST"];
 
 function speedMultiplier(speed: SpeedType): string {
   return Math.round(TICK_MS.SLOW / TICK_MS[speed]) + "×";
+}
+
+const WEATHER_DRIVEN_FUELS = new Set(["Sun", "Wind", "Offshore Wind"]);
+
+/** Capacity that could serve demand now, rather than the deliberately dispatched output. */
+export function reserveCapacityW(
+  game: GameType,
+  now: TickPresentFutureType,
+): number {
+  const available = game.facilities.reduce(
+    (total: number, facility: FacilityOperatingType) => {
+      if (facility.paused || facility.yearsToBuildLeft > 0) {
+        return total;
+      }
+      if (facility.peakWh) {
+        return (
+          total +
+          Math.min(
+            facility.peakW,
+            Math.max(0, facility.currentWh) * TICKS_PER_HOUR,
+          )
+        );
+      }
+      return (
+        total +
+        (WEATHER_DRIVEN_FUELS.has(facility.fuel)
+          ? Math.max(0, facility.currentW)
+          : facility.peakW)
+      );
+    },
+    0,
+  );
+  return available - now.demandW;
 }
 
 const SPEED_ARIA_LABELS: { [k in SpeedType]: string } = {
@@ -247,16 +286,10 @@ export function GameAppBar(props: Props) {
   }
 
   const inBlackout = now.supplyW < now.demandW;
-  const reservePercent =
-    now.demandW > 0
-      ? Math.max(
-          0,
-          Math.round(((now.supplyW - now.demandW) / now.demandW) * 100),
-        )
-      : 0;
+  const reserveW = Math.max(0, reserveCapacityW(game, now));
   const gridHealth = inBlackout
     ? `Blackout · ${formatWatts(now.demandW - now.supplyW)} short`
-    : `Grid OK · ${reservePercent}% reserve`;
+    : `Grid OK · ${formatWatts(reserveW)} reserve`;
 
   return (
     <div id="appbar">

--- a/src/components/base/InstallAppButton.tsx
+++ b/src/components/base/InstallAppButton.tsx
@@ -38,6 +38,10 @@ const InstallContext = React.createContext<InstallContextType>({
   snooze: () => undefined,
 });
 
+export function useIsInstalledApp(): boolean {
+  return React.useContext(InstallContext).installed || standalone();
+}
+
 const INSTALL_SNOOZE_KEY = "installPromptSnoozedAt";
 const INSTALL_VISITS_KEY = "installVisits";
 const INSTALL_VISIT_COUNTED_KEY = "installVisitCounted";

--- a/src/components/base/VictoryDialog.test.tsx
+++ b/src/components/base/VictoryDialog.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import VictoryDialog, { Props, summarizeChallenge } from "./VictoryDialog";
+import VictoryDialog, { Props } from "./VictoryDialog";
 import { VictoryType } from "../../Types";
 
 const mockFetchGlobalRank = jest.fn();
@@ -72,21 +72,7 @@ describe("VictoryDialog", () => {
       screen.getByText(/800 pts from electricity supplied/),
     ).toBeInTheDocument();
     expect(screen.getByText(/-18 pts from blackouts/)).toBeInTheDocument();
-    expect(screen.getByText("What you accomplished")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "You practiced balancing electricity supplied, emissions and blackouts.",
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it("summarizes whichever scoring categories a scenario provides", () => {
-    expect(summarizeChallenge({ customers: 100 })).toBe(
-      "You practiced managing final customers.",
-    );
-    expect(summarizeChallenge({})).toBe(
-      "You completed the scenario and kept the grid moving.",
-    );
+    expect(screen.queryByText("What you accomplished")).not.toBeInTheDocument();
   });
 
   it("uses the scenario name instead of repeating a generic completion title", () => {
@@ -201,7 +187,7 @@ describe("VictoryDialog", () => {
 
       expect(screen.getByText("Run ended")).toBeInTheDocument();
       expect(screen.getByText(title)).toBeInTheDocument();
-      expect(screen.getByText("How you scored")).toBeInTheDocument();
+      expect(screen.queryByText("How you scored")).not.toBeInTheDocument();
       expect(screen.getByText(/Final score/)).toBeInTheDocument();
       expect(screen.queryByText("Review final grid")).not.toBeInTheDocument();
       await userEvent.keyboard("{Escape}");

--- a/src/components/base/VictoryDialog.tsx
+++ b/src/components/base/VictoryDialog.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {
-  Box,
   Button,
   Dialog,
   DialogActions,
@@ -64,24 +63,6 @@ export interface Props extends StateProps, DispatchProps {}
 
 export function formatScore(score: number): string {
   return numbro(score).format({ thousandSeparated: true, mantissa: 0 });
-}
-
-export function summarizeChallenge(
-  breakdown: VictoryType["breakdown"],
-): string {
-  const practiced = Object.keys(breakdown)
-    .map((category) => SCORE_LABELS[category] || category)
-    .slice(0, 3);
-
-  if (practiced.length === 0) {
-    return "You completed the scenario and kept the grid moving.";
-  }
-  if (practiced.length === 1) {
-    return `You practiced managing ${practiced[0]}.`;
-  }
-
-  const last = practiced.pop();
-  return `You practiced balancing ${practiced.join(", ")} and ${last}.`;
 }
 
 /**
@@ -221,23 +202,6 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
             {endMessage}
           </Typography>
         )}
-        <Box
-          sx={{
-            my: 2,
-            p: 2,
-            borderRadius: 2,
-            bgcolor: "action.hover",
-            border: 1,
-            borderColor: "divider",
-          }}
-        >
-          <Typography variant="overline" color="text.secondary">
-            {failed ? "How you scored" : "What you accomplished"}
-          </Typography>
-          <Typography variant="body1">
-            {summarizeChallenge(breakdown)}
-          </Typography>
-        </Box>
         <Typography variant="body1" sx={{ fontWeight: 600 }}>
           Final score: <strong>{formatScore(victory.score)}</strong>
         </Typography>

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -373,7 +373,9 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                 <DialogContent>
                   <DialogContentText>
                     You will receive{" "}
-                    {formatMoneyConcise(facilityCashBack(facility))}
+                    {formatMoneyConcise(
+                      facilityCashBack(facility, game.date.minute),
+                    )}
                     {facility.loanAmountLeft > 0
                       ? ` and the rest will go towards paying off the remaining loan balance of ${formatMoneyConcise(facility.loanAmountLeft)}`
                       : ""}

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -27,15 +27,23 @@ describe("MainMenu", () => {
     expect(screen.queryByText(/no energy or gaming experience/i)).toBeNull();
   });
 
-  it("starts a new game from the primary guided-missions action", async () => {
+  it("starts a new game from the primary play action", async () => {
     const onStart = jest.fn();
     render(<MainMenu {...props({ onStart })} />);
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Start guided missions" }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Play" }));
     expect(onStart).toHaveBeenCalled();
     expect(screen.queryByText("Continue")).not.toBeInTheDocument();
+  });
+
+  it("only advertises account-free play before sign-in", () => {
+    const { rerender } = render(<MainMenu {...props({ uid: undefined })} />);
+    expect(screen.getByText("Free · no account needed")).toBeInTheDocument();
+
+    rerender(<MainMenu {...props({ uid: "player" })} />);
+    expect(
+      screen.queryByText("Free · no account needed"),
+    ).not.toBeInTheDocument();
   });
 
   it("prioritizes continuing a save while offering mission selection", () => {

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -29,9 +29,7 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 const MainMenu = (props: Props): React.JSX.Element => {
-  const startLabel = props.hasSavedGame
-    ? "Choose a mission"
-    : "Start guided missions";
+  const startLabel = props.hasSavedGame ? "Choose a mission" : "Play";
   const [shareStatus, setShareStatus] = React.useState("");
 
   const onShare = async () => {
@@ -87,7 +85,7 @@ const MainMenu = (props: Props): React.JSX.Element => {
           >
             {startLabel}
           </Button>
-          {!props.hasSavedGame && (
+          {!props.hasSavedGame && !props.uid && (
             <Typography variant="caption">Free · no account needed</Typography>
           )}
         </Stack>

--- a/src/components/views/NewGameDetails.test.tsx
+++ b/src/components/views/NewGameDetails.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { GameType } from "../../Types";
 import NewGameDetails, { Props } from "./NewGameDetails";
 
@@ -71,5 +71,20 @@ describe("NewGameDetails leaderboard", () => {
     await waitFor(() =>
       expect(mockWhere).toHaveBeenCalledWith("difficulty", "==", "CEO"),
     );
+  });
+
+  it("puts the player's best score in the score column", async () => {
+    mockGetDocs.mockResolvedValueOnce({ docs: [] }).mockResolvedValueOnce({
+      docs: [{ data: () => ({ score: 432, uid: "player" }) }],
+    });
+
+    render(<NewGameDetails {...props({ uid: "player" })} />);
+
+    await screen.findByText("Your best");
+    const row = screen.getByRole("row", { name: /Your best 432/ });
+    const cells = within(row).getAllByRole("cell");
+    expect(cells[1]).toHaveTextContent("Your best");
+    expect(cells[2]).toHaveTextContent("432");
+    expect(cells[1]).not.toHaveTextContent("432");
   });
 });

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -433,9 +433,8 @@ export default class NewGameDetails extends React.Component<Props, State> {
                     sx={{ fontWeight: "bold", bgcolor: "action.selected" }}
                   >
                     <TableCell className="rank" />
-                    <TableCell colSpan={2}>
-                      Your best: {formatScore(myTopScore.score)}
-                    </TableCell>
+                    <TableCell>Your best</TableCell>
+                    <TableCell>{formatScore(myTopScore.score)}</TableCell>
                     {this.renderReplayCell(myTopScore)}
                   </TableRow>
                 )}

--- a/src/components/views/Settings.test.tsx
+++ b/src/components/views/Settings.test.tsx
@@ -106,4 +106,25 @@ describe("Settings", () => {
     // Picking the same file again still counts, for the player who went and fixed a bad one
     expect(fileInput().value).toBe("");
   });
+
+  it("hides installation controls when already running as an installed app", () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = jest.fn().mockReturnValue({
+      matches: true,
+      media: "(display-mode: standalone)",
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    });
+
+    renderSettings();
+
+    expect(
+      screen.queryByRole("region", { name: "App" }),
+    ).not.toBeInTheDocument();
+    window.matchMedia = originalMatchMedia;
+  });
 });

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -2,8 +2,6 @@ import * as React from "react";
 import {
   Box,
   Button,
-  Card,
-  CardContent,
   Checkbox,
   FormControl,
   FormControlLabel,
@@ -21,7 +19,7 @@ import { SettingsType, ThemeChoiceType, UnitSystemType } from "../../Types";
 import { UNIT_SYSTEMS, UNIT_SYSTEM_LABELS } from "../../helpers/Units";
 import { THEME_CHOICES, THEME_LABELS } from "../../Theme";
 import KeyboardShortcuts from "../base/KeyboardShortcuts";
-import InstallAppButton from "../base/InstallAppButton";
+import InstallAppButton, { useIsInstalledApp } from "../base/InstallAppButton";
 import packageJson from "../../../package.json";
 
 export interface StateProps {
@@ -59,20 +57,39 @@ function SettingsSection({
   children,
 }: SettingsSectionProps): React.JSX.Element {
   return (
-    <Card component="section" variant="outlined" aria-labelledby={id}>
-      <CardContent>
-        <Typography id={id} component="h2" variant="h6" sx={{ mb: 1.5 }}>
-          {title}
-        </Typography>
-        <Stack spacing={1.5} sx={{ alignItems: "flex-start" }}>
-          {children}
-        </Stack>
-      </CardContent>
-    </Card>
+    <Box
+      component="section"
+      aria-labelledby={id}
+      sx={{
+        display: "grid",
+        gridTemplateColumns: {
+          xs: "88px minmax(0, 1fr)",
+          sm: "160px minmax(0, 1fr)",
+        },
+        gap: { xs: 1.5, sm: 2 },
+        alignItems: "start",
+        py: 1.25,
+        borderBottom: 1,
+        borderColor: "divider",
+      }}
+    >
+      <Typography
+        id={id}
+        component="h2"
+        variant="subtitle2"
+        sx={{ pt: 0.75, fontWeight: 700 }}
+      >
+        {title}
+      </Typography>
+      <Stack spacing={0.75} sx={{ alignItems: "flex-start", minWidth: 0 }}>
+        {children}
+      </Stack>
+    </Box>
   );
 }
 
 export default function Settings(props: Props): React.JSX.Element {
+  const installedApp = useIsInstalledApp();
   // TODO: enable / disable music, font size, auto-pause while looking at build options, keyboard shortcuts, ...?
   // const fontSizeIdx = fontSizeValues.indexOf(props.settings.fontSize);
 
@@ -130,12 +147,12 @@ export default function Settings(props: Props): React.JSX.Element {
           maxWidth: 720,
           mx: "auto",
           px: { xs: 2, sm: 3 },
-          py: 2,
+          py: 0.5,
           boxSizing: "border-box",
           overflowY: "auto",
         }}
       >
-        <Stack spacing={2}>
+        <Stack spacing={0}>
           <SettingsSection id="sound-settings" title="Sound">
             <FormControlLabel
               control={
@@ -251,13 +268,16 @@ export default function Settings(props: Props): React.JSX.Element {
             </Typography>
           </SettingsSection>
 
-          <SettingsSection id="app-settings" title="App">
-            <InstallAppButton />
-            <Typography variant="body2" color="textSecondary">
-              Install availability depends on your browser. Once installed,
-              Electrify opens like an app and cached game data can load offline.
-            </Typography>
-          </SettingsSection>
+          {!installedApp && (
+            <SettingsSection id="app-settings" title="App">
+              <InstallAppButton />
+              <Typography variant="body2" color="textSecondary">
+                Install availability depends on your browser. Once installed,
+                Electrify opens like an app and caches every location for
+                offline play.
+              </Typography>
+            </SettingsSection>
+          )}
 
           <SettingsSection id="saved-game-settings" title="Saved Game">
             <Stack
@@ -301,11 +321,17 @@ export default function Settings(props: Props): React.JSX.Element {
             <KeyboardShortcuts />
           </SettingsSection>
 
-          <Box component="footer" sx={{ textAlign: "center", pb: 1 }}>
-            <Typography className="version">
+          <Stack
+            component="footer"
+            direction="row"
+            spacing={2}
+            useFlexGap
+            sx={{ justifyContent: "center", flexWrap: "wrap", py: 1.5 }}
+          >
+            <Typography variant="caption">
               Electrify App v{packageJson.version}
             </Typography>
-            <Typography className="github">
+            <Typography variant="caption">
               <a
                 href="https://github.com/toddmedema/electrify"
                 target="_blank"
@@ -314,10 +340,10 @@ export default function Settings(props: Props): React.JSX.Element {
                 GitHub
               </a>
             </Typography>
-            <Typography>
+            <Typography variant="caption">
               <a href="/privacy.html">Privacy</a>
             </Typography>
-          </Box>
+          </Stack>
         </Stack>
       </Box>
     </div>

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -104,7 +104,7 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["build", "generator"]}
             text="Open the generator shop."
-            action={["build"]}
+            action={["generator"]}
           />
         ),
       },
@@ -183,7 +183,7 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["build", "storage"]}
             text="Storage banks spare power for when you need it - open the storage shop."
-            action={["build"]}
+            action={["storage"]}
           />
         ),
       },

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -12,11 +12,7 @@ import {
   MAX_CREDIT_POINTS,
   LCWH,
 } from "./Financials";
-import {
-  GENERATOR_SELL_MULTIPLIER,
-  HOURS_PER_YEAR_REAL,
-  LOAN_MONTHS,
-} from "../Constants";
+import { DAYS_PER_YEAR, HOURS_PER_YEAR_REAL, LOAN_MONTHS } from "../Constants";
 import { FacilityOperatingType, GeneratorShoppingType } from "../Types";
 import { getDateFromMinute } from "./DateTime";
 import { formatMoneyConcise } from "./Format";
@@ -31,6 +27,9 @@ function aFacility(
     loanAmountLeft: 0,
     yearsToBuild: 4,
     yearsToBuildLeft: 0,
+    lifespanYears: 40,
+    minuteCreated: 0,
+    minuteOperational: 0,
     ...overrides,
   } as FacilityOperatingType;
 }
@@ -102,39 +101,34 @@ describe("facilityCashBack", () => {
     ).toBe(1000000);
   });
 
-  it("takes the sell multiplier off a finished facility", () => {
-    expect(facilityCashBack(aFacility())).toBeCloseTo(
-      1000000 * (1 - GENERATOR_SELL_MULTIPLIER),
-      6,
-    );
+  it("starts a finished facility at its full unfinanced value", () => {
+    expect(facilityCashBack(aFacility())).toBe(1000000);
   });
 
-  it("pays back less the further construction has progressed", () => {
-    // 2.5% and 5% of a four year build
-    const early = facilityCashBack(aFacility({ yearsToBuildLeft: 3.9 }));
-    const later = facilityCashBack(aFacility({ yearsToBuildLeft: 3.8 }));
-    expect(early).toBeGreaterThan(later);
-    expect(later).toBeGreaterThan(facilityCashBack(aFacility()));
+  it("depreciates linearly over the facility's own lifespan", () => {
+    const minute = (years: number) => years * DAYS_PER_YEAR * 24 * 60;
+    expect(facilityCashBack(aFacility(), minute(20))).toBeCloseTo(500000, 6);
+    expect(facilityCashBack(aFacility(), minute(40))).toBe(0);
+    expect(facilityCashBack(aFacility(), minute(60))).toBe(0);
   });
 
-  /**
-   * The taper is sqrt(percentBuilt * 10), capped at 1, so it reaches the full penalty at 10% built
-   * and everything past that refunds the same. Worth knowing before reading the "refund slightly
-   * more if construction isn't complete" comment as a smooth curve across the whole build.
-   */
-  it("charges the full penalty from 10% built onwards", () => {
-    const tenPercent = facilityCashBack(aFacility({ yearsToBuildLeft: 3.6 }));
-    expect(tenPercent).toBeCloseTo(facilityCashBack(aFacility()), 6);
-    expect(facilityCashBack(aFacility({ yearsToBuildLeft: 0.5 }))).toBeCloseTo(
-      facilityCashBack(aFacility()),
-      6,
-    );
+  it("uses a conservative life for a legacy save with no lifespan", () => {
+    const currentMinute = 15 * DAYS_PER_YEAR * 24 * 60;
+    expect(
+      facilityCashBack(aFacility({ lifespanYears: undefined }), currentMinute),
+    ).toBeCloseTo(500000, 6);
+  });
+
+  it("refunds the same committed equity throughout construction", () => {
+    [0.1, 1, 2, 3.5, 4].forEach((yearsToBuildLeft) => {
+      expect(facilityCashBack(aFacility({ yearsToBuildLeft }))).toBe(1000000);
+    });
   });
 
   it("nets out what is still owed on the loan", () => {
     const owed = 400000;
     expect(facilityCashBack(aFacility({ loanAmountLeft: owed }))).toBeCloseTo(
-      (1000000 - owed) * (1 - GENERATOR_SELL_MULTIPLIER),
+      1000000 - owed,
       6,
     );
   });

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -1,8 +1,4 @@
-import {
-  FUELS,
-  GENERATOR_SELL_MULTIPLIER,
-  HOURS_PER_YEAR_REAL,
-} from "../Constants";
+import { DAYS_PER_YEAR, FUELS, HOURS_PER_YEAR_REAL } from "../Constants";
 import {
   DateType,
   FacilityOperatingType,
@@ -203,16 +199,45 @@ export function facilityLifetime(
   };
 }
 
-// Returns how much cash the user recieves if they sell / cancel the facility
-export function facilityCashBack(g: FacilityOperatingType): number {
-  // Refund slightly more if construction isn't complete - after all, that money hasn't been spent yet
-  // But lose more upfront from material purchases: https://www.wolframalpha.com/input/?i=10*x+%5E+1%2F2+from+0+to+100
-  const percentBuilt = (g.yearsToBuild - g.yearsToBuildLeft) / g.yearsToBuild;
-  const lostFromSelling =
-    (g.buildCost - g.loanAmountLeft) *
-    GENERATOR_SELL_MULTIPLIER *
-    Math.min(1, Math.pow(percentBuilt * 10, 1 / 2));
-  return g.buildCost - lostFromSelling - g.loanAmountLeft;
+const MINUTES_PER_GAME_YEAR = DAYS_PER_YEAR * 24 * 60;
+
+/** The time a completed facility has spent operating, excluding its construction period. */
+export function facilityAgeYears(
+  g: FacilityOperatingType,
+  currentMinute: number,
+): number {
+  return g.minuteOperational === undefined
+    ? 0
+    : Math.max(
+        0,
+        (currentMinute - g.minuteOperational) / MINUTES_PER_GAME_YEAR,
+      );
+}
+
+// Returns how much cash the user receives if they sell / cancel the facility. Construction
+// refunds committed equity; an operating asset depreciates linearly to zero over the
+// technology-specific life in Facilities.tsx. Any outstanding loan is settled on sale.
+export function facilityCashBack(
+  g: FacilityOperatingType,
+  currentMinute = g.minuteOperational ?? g.minuteCreated,
+): number {
+  if (g.yearsToBuildLeft === 0) {
+    // Saves from before technology-specific lives were added do not have this field. Thirty years
+    // is the conservative common economic-life assumption; the facility's researched value wins
+    // for every new game and save written by current code.
+    const lifespanYears =
+      Number.isFinite(g.lifespanYears) && g.lifespanYears > 0
+        ? g.lifespanYears
+        : 30;
+    const remainingLife = Math.max(
+      0,
+      1 - facilityAgeYears(g, currentMinute) / lifespanYears,
+    );
+    return g.buildCost * remainingLife - g.loanAmountLeft;
+  }
+  // Cancellation unwinds the committed purchase. For a financed build this returns only the
+  // down payment/equity because the outstanding loan is settled at the same time.
+  return g.buildCost - g.loanAmountLeft;
 }
 
 // CAC $100->150, increasing as you spend more - https://woodlawnassociates.com/electrical-potential-solar-and-competitive-electricity/

--- a/src/helpers/Format.test.tsx
+++ b/src/helpers/Format.test.tsx
@@ -121,6 +121,14 @@ describe("money formatting of values that are not numbers", () => {
     expect(formatMoneyStable(1500000)).toEqual("$1.50M");
   });
 
+  it("does not promote an amount before it reaches the next tier", () => {
+    expect(formatMoneyConcise(700000000)).toEqual("$700M");
+    expect(formatMoneyStable(700000000)).toEqual("$700M");
+    expect(formatMoneyConcise(999000000)).toEqual("$999M");
+    expect(formatMoneyConcise(999999999)).toEqual("$999M");
+    expect(formatMoneyConcise(1000000000)).toEqual("$1B");
+  });
+
   it("shows a dash rather than a word for a value it cannot express", () => {
     [Infinity, -Infinity, NaN].forEach((value) => {
       expect(formatMoneyConcise(value)).toEqual(NO_ESTIMATE);

--- a/src/helpers/Format.tsx
+++ b/src/helpers/Format.tsx
@@ -42,20 +42,54 @@ export function formatMoneyStable(i: number): string {
   if (!Number.isFinite(i)) {
     return NO_ESTIMATE;
   }
-  return (
-    "$" + numbro(i).format({ average: true, totalLength: 3 }).toUpperCase()
-  );
+  return "$" + formatMoneyAmount(i, false);
 }
 
 export function formatMoneyConcise(i: number): string {
   if (!Number.isFinite(i)) {
     return NO_ESTIMATE;
   }
+  return "$" + formatMoneyAmount(i, true);
+}
+
+interface MoneyUnitType {
+  suffix: string;
+  divisor: number;
+}
+
+const MONEY_UNITS: MoneyUnitType[] = [
+  { suffix: "T", divisor: 1e12 },
+  { suffix: "B", divisor: 1e9 },
+  { suffix: "M", divisor: 1e6 },
+  { suffix: "k", divisor: 1e3 },
+  { suffix: "", divisor: 1 },
+];
+
+/**
+ * Pick units from the amount itself, never from the formatter's desired character count. That
+ * keeps $700M as $700M instead of promoting it to $0.70B; a suffix only changes once the amount
+ * actually reaches one of the next unit.
+ */
+function formatMoneyAmount(i: number, trimMantissa: boolean): string {
+  const abs = Math.abs(i);
+  const unit =
+    MONEY_UNITS.find((candidate) => abs >= candidate.divisor) ||
+    MONEY_UNITS[MONEY_UNITS.length - 1];
+  let scaled = i / unit.divisor;
+  const scaledAbs = Math.abs(scaled);
+  // Rounding 999.9M to 1,000M would violate the chosen tier even though the source value is still
+  // below $1B. At that narrow boundary, truncate to the largest valid whole value for the tier.
+  if (scaledAbs >= 999.5 && unit.divisor > 1) {
+    scaled = Math.sign(scaled) * 999;
+  }
+  const displayAbs = Math.abs(scaled);
+  const mantissa = displayAbs < 10 ? 2 : displayAbs < 100 ? 1 : 0;
   return (
-    "$" +
-    numbro(i)
-      .format({ average: true, totalLength: 3, trimMantissa: true })
-      .toUpperCase()
+    numbro(scaled).format({
+      mantissa,
+      trimMantissa,
+      thousandSeparated: false,
+    }) + unit.suffix
   );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,21 @@ if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
   window.addEventListener("load", () => {
     navigator.serviceWorker
       .register("/service-worker.js")
+      .then(() => {
+        const installed = Boolean(
+          (navigator as Navigator & { standalone?: boolean }).standalone ||
+          window.matchMedia?.("(display-mode: standalone)").matches,
+        );
+        if (installed) {
+          // Give the app shell, current screen and first interaction priority. The service worker
+          // then fills every weather location and refreshes market data in the background.
+          window.setTimeout(() => {
+            navigator.serviceWorker.ready.then((registration) =>
+              registration.active?.postMessage({ type: "SYNC_OFFLINE_DATA" }),
+            );
+          }, 3000);
+        }
+      })
       .catch((error) => console.warn("Couldn't enable offline play:", error));
   });
 }

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -53,7 +53,6 @@ import {
   DOWNPAYMENT_PERCENT,
   FUELS,
   GAME_TO_REAL_YEARS,
-  GENERATOR_SELL_MULTIPLIER,
   INTEREST_RATE_YEARLY,
   LOAN_MONTHS,
   ORGANIC_GROWTH_MAX_ANNUAL,
@@ -776,7 +775,7 @@ function applySellFacility(state: GameType, id: number) {
       sold.yearsToBuildLeft > 0 ? "BUILD" : "SELL",
       sold.yearsToBuildLeft > 0
         ? `Cancelled construction of ${sold.name}`
-        : `Sold ${sold.name}, ${sold.peakWh ? formatWattHours(sold.peakWh) : formatWatts(sold.peakW)} for ${formatMoneyConcise(facilityCashBack(sold))}`,
+        : `Sold ${sold.name}, ${sold.peakWh ? formatWattHours(sold.peakWh) : formatWatts(sold.peakW)} for ${formatMoneyConcise(facilityCashBack(sold, state.date.minute))}`,
     );
   }
   // in one loop, refund cash from selling + remove from list
@@ -785,7 +784,7 @@ function applySellFacility(state: GameType, id: number) {
       if (g.id === id) {
         const now = getTimeFromTimeline(state.date.minute, state.timeline);
         if (now) {
-          now.cash += facilityCashBack(g);
+          now.cash += facilityCashBack(g, state.date.minute);
         }
         return false;
       }
@@ -1376,13 +1375,20 @@ function updateSupplyFacilitiesFinances(
   facilities.forEach((f: FacilityOperatingType) => {
     if (f.yearsToBuildLeft > 0) {
       f.yearsToBuildLeft = Math.max(0, f.yearsToBuildLeft - YEARS_PER_TICK);
-      if (f.yearsToBuildLeft === 0 && !simulated) {
-        const message = `Construction complete: ${f.name}, ${f.peakWh ? formatWattHours(f.peakWh) : formatWatts(f.peakW)}`; // defining for functions running inside of setTimeout
-        logGameEvent(state, "CONSTRUCTION", message);
-        setTimeout(() => {
-          getStore().dispatch(snackbarOpen(message));
-        }, 0);
+      if (f.yearsToBuildLeft === 0) {
+        f.minuteOperational = now.minute;
+        if (!simulated) {
+          const message = `Construction complete: ${f.name}, ${f.peakWh ? formatWattHours(f.peakWh) : formatWatts(f.peakW)}`; // defining for functions running inside of setTimeout
+          logGameEvent(state, "CONSTRUCTION", message);
+          setTimeout(() => {
+            getStore().dispatch(snackbarOpen(message));
+          }, 0);
+        }
       }
+    } else if (f.minuteOperational === undefined && !simulated) {
+      // A save from before depreciation has no commissioning timestamp. Start its clock now
+      // rather than guessing that every inherited plant is already worn out.
+      f.minuteOperational = now.minute;
     }
   });
 
@@ -1633,7 +1639,7 @@ function updateSupplyFacilitiesFinances(
       expensesMarketing -
       principalRepayment,
   );
-  now.netWorth = getNetWorth(facilities, now.cash);
+  now.netWorth = getNetWorth(facilities, now.cash, now.minute);
   now.revenue = revenue;
   now.expensesOM = expensesOM;
   now.expensesFuel = expensesFuel;
@@ -1664,10 +1670,25 @@ function reforecastSupply(
   // its end-of-horizon state -- resuming a paused nuclear plant snapped straight to full output
   // instead of ramping, and every reforecast silently aged construction and loans by a whole day.
   const newState = { ...state, facilities: cloneDeep(state.facilities) };
+  const current = getTimeFromTimeline(state.date.minute, state.timeline);
+  const currentCash = current?.cash;
+  const currentCustomers = current?.customers;
   let prev = newState.timeline[0];
   return newState.timeline.map((t: TickPresentFutureType) => {
     if (t.minute >= state.date.minute) {
       t = updateSupplyFacilitiesFinances(newState, prev, { ...t }, simulated);
+      // The current tick already happened. Reforecast its supply against the player's action,
+      // but keep the transaction and customer balance that caused this reforecast. Otherwise
+      // rebuilding from the previous tick erases a purchase refund (and, symmetrically, a cost).
+      if (t.minute === state.date.minute) {
+        if (currentCash !== undefined) {
+          t.cash = currentCash;
+        }
+        if (currentCustomers !== undefined) {
+          t.customers = currentCustomers;
+        }
+        t.netWorth = getNetWorth(newState.facilities, t.cash, t.minute);
+      }
     }
     prev = t;
     return t;
@@ -1697,7 +1718,7 @@ export function generateNewTimeline(
   );
   // Loop invariant: the fleet is fixed across the horizon and the cash is a parameter, so this
   // was the same number recomputed for every one of up to a year's worth of ticks
-  const netWorth = getNetWorth(state.facilities, cash);
+  const netWorth = getNetWorth(state.facilities, cash, state.date.minute);
   for (let i = 0; i < ticks; i++) {
     state.timeline[i] = {
       minute: state.date.minute + i * TICK_MINUTES,
@@ -1795,6 +1816,7 @@ function buildFacilityHelper(
       currentW: newGame && g.peakWh === undefined ? g.peakW : 0,
       yearsToBuildLeft: newGame ? 0 : g.yearsToBuild,
       minuteCreated: state.date.minute,
+      minuteOperational: newGame ? state.date.minute : undefined,
     } as FacilityOperatingType;
     if (g.peakWh) {
       facility.currentWh = 0;
@@ -1807,17 +1829,17 @@ function buildFacilityHelper(
   return state;
 }
 
-// TODO account for generator current value better - get rid of SELL_MULTIPLIER everywhere and depreciate buildCost over time
 function getNetWorth(
   facilities: FacilityOperatingType[],
   cash: number,
+  currentMinute: number,
 ): number {
   let netWorth = cash;
   facilities.forEach((g: FacilityOperatingType) => {
-    if (g.yearsToBuildLeft === 0) {
-      netWorth += g.buildCost * GENERATOR_SELL_MULTIPLIER - g.loanAmountLeft;
-    } else {
+    if (g.yearsToBuildLeft > 0) {
       netWorth += g.buildCost * DOWNPAYMENT_PERCENT;
+    } else {
+      netWorth += facilityCashBack(g, currentMinute);
     }
   });
   return netWorth;

--- a/src/reducers/SellFacility.test.tsx
+++ b/src/reducers/SellFacility.test.tsx
@@ -1,0 +1,74 @@
+import cloneDeep from "lodash.clonedeep";
+import { TICKS_PER_DAY } from "../Constants";
+import { GENERATORS } from "../data/Facilities";
+import { getTimeFromTimeline } from "../helpers/DateTime";
+import { facilityCashBack } from "../helpers/Financials";
+import { createGame } from "../testing/Simulator";
+import {
+  FacilityOperatingType,
+  GameType,
+  GeneratorShoppingType,
+} from "../Types";
+import gameReducer, { buildFacility, sellFacility, tickState } from "./Game";
+
+function playTicks(state: GameType, ticks: number): GameType {
+  const played = cloneDeep(state);
+  for (let i = 0; i < ticks; i++) {
+    tickState(played);
+  }
+  return played;
+}
+
+function cashNow(state: GameType): number {
+  return getTimeFromTimeline(state.date.minute, state.timeline)!.cash;
+}
+
+describe("sellFacility cash transactions", () => {
+  it("credits a completed facility sale after the month is underway", () => {
+    const before = playTicks(
+      createGame({ scenarioId: 103 }),
+      TICKS_PER_DAY / 2,
+    );
+    const sold = before.facilities.find(
+      (facility: FacilityOperatingType) => facility.yearsToBuildLeft === 0,
+    )!;
+    const cashBefore = cashNow(before);
+    const expectedProceeds = facilityCashBack(sold, before.date.minute);
+
+    const after = gameReducer(before, sellFacility(sold.id));
+
+    expect(cashNow(after)).toBeCloseTo(cashBefore + expectedProceeds, 6);
+    expect(after.facilities.some((facility) => facility.id === sold.id)).toBe(
+      false,
+    );
+  });
+
+  it("returns committed equity when construction is cancelled", () => {
+    const before = playTicks(
+      createGame({ scenarioId: 103 }),
+      TICKS_PER_DAY / 2,
+    );
+    const generator = GENERATORS(before, 500000000, [20], [500]).find(
+      (facility: GeneratorShoppingType) => facility.fuel === "Natural Gas",
+    )!;
+    const built = gameReducer(
+      before,
+      buildFacility({ facility: generator, financed: true }),
+    );
+    const underConstruction = built.facilities.find(
+      (facility) => facility.yearsToBuildLeft > 0,
+    )!;
+    const cashAfterBuild = cashNow(built);
+    const expectedRefund = facilityCashBack(
+      underConstruction,
+      built.date.minute,
+    );
+
+    const after = gameReducer(built, sellFacility(underConstruction.id));
+
+    expect(cashNow(after)).toBeCloseTo(cashAfterBuild + expectedRefund, 6);
+    expect(
+      after.facilities.some((facility) => facility.id === underConstruction.id),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- polish signed-in home copy, mission success, tutorial targeting, mobile toasts/layout, compact settings, and high-score placement
- show stable cash abbreviations and real-time reserve capacity in MW
- prefetch all weather and market data for installed-app offline play
- preserve cash from facility sales/cancellations and add straight-line, technology-specific depreciation with documented EIA/DOE/NREL research

## Verification
- npm run check (58 suites, 721 tests)
- node --check public/service-worker.js
- npm run build
- mobile browser verification at 390x844 for tutorial scrolling, toast clearance, grid bar, settings, and construction-screen overflow