### PR TITLE
Show marketing impact as customer growth

### DIFF
--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -2,7 +2,12 @@ import * as React from "react";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { produce } from "immer";
-import Finances, { getComparison, parseRange, projectMonths } from "./Finances";
+import Finances, {
+  formatMarketingCustomerGrowth,
+  getComparison,
+  parseRange,
+  projectMonths,
+} from "./Finances";
 import { createGame } from "../../testing/Simulator";
 import { tickState } from "../../reducers/Game";
 import { MINUTES_PER_MONTH, summarizeTimeline } from "../../helpers/DateTime";
@@ -94,6 +99,18 @@ function renderFinances(
     />,
   );
 }
+
+describe("the marketing forecast", () => {
+  it("shows customer growth as a delta and percent when compact totals would look equal", () => {
+    expect(formatMarketingCustomerGrowth(1000000, 1000000)).toEqual(
+      "+9.9k (+1.0%)",
+    );
+  });
+
+  it("omits an undefined growth percent when there are no existing customers", () => {
+    expect(formatMarketingCustomerGrowth(1000000, 0)).toEqual("+9.9k");
+  });
+});
 
 describe("the Finances chart selectors", () => {
   // Two years in, so that the period select has past years to offer and each one covers a

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -490,6 +490,25 @@ const RATE_MARKS = [0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3].map((rate: number) => ({
   label: formatMoneyConcise(rate),
 }));
 
+/**
+ * The useful part of the marketing forecast is its change, not its resulting total. At large
+ * customer counts, formatting both totals compactly can turn `1m -> 1m` and hide the effect.
+ */
+export function formatMarketingCustomerGrowth(
+  marketingSpend: number,
+  customers: number,
+): string {
+  const gained = customersFromMarketingSpend(marketingSpend);
+  const formattedGain = numbro(gained).format({
+    average: true,
+    mantissa: 1,
+    trimMantissa: true,
+  });
+  const percent =
+    customers > 0 ? ` (+${((gained / customers) * 100).toFixed(1)}%)` : "";
+  return `+${formattedGain}${percent}`;
+}
+
 export default class Finances extends React.Component<Props, State> {
   // Context rather than a prop: shouldComponentUpdate below throttles renders against the game
   // clock, which a prop change would have to be excepted from - a context change is delivered
@@ -922,12 +941,10 @@ export default class Finances extends React.Component<Props, State> {
                   <>
                     &nbsp;&rarr;&nbsp;
                     <Typography color="primary" component="strong">
-                      {numbro(
-                        now.customers +
-                          customersFromMarketingSpend(
-                            game.monthlyMarketingSpend,
-                          ),
-                      ).format({ average: true })}
+                      {formatMarketingCustomerGrowth(
+                        game.monthlyMarketingSpend,
+                        now.customers,
+                      )}
                     </Typography>
                     &nbsp;next month
                   </>


### PR DESCRIPTION
## Summary
- replace the rounded next-month customer total with the customer delta
- show the marketing-driven percentage growth alongside the delta
- handle zero existing customers without displaying an undefined percentage

## Verification
- npm test -- --watchAll=false --runInBand src/components/views/Finances.test.tsx
- npm run typecheck
- npm run lint -- --no-cache
- npx prettier --check src/components/views/Finances.tsx src/components/views/Finances.test.tsx