### PR TITLE
Balance CEO scenarios and verify active playthroughs

### DIFF
--- a/scripts/sim.js
+++ b/scripts/sim.js
@@ -20,10 +20,15 @@ const FLAGS = {
   "--strategy": "SIM_STRATEGY",
   "--marketing": "SIM_MARKETING",
   "--rate": "SIM_RATE",
+  "--build": "SIM_BUILD",
+  "--build-mw": "SIM_BUILD_MW",
+  "--sell-id": "SIM_SELL_ID",
+  "--sell-month": "SIM_SELL_MONTH",
 };
 const BOOLEAN_FLAGS = {
   "--all": "SIM_ALL",
   "--full": "SIM_FULL",
+  "--finance": "SIM_FINANCE",
 };
 
 const USAGE = `
@@ -44,6 +49,11 @@ Runs the game's simulation headlessly and reports what happened.
   --strategy <name>      none (default) or keepUp, which buys generators when short on supply
   --marketing <dollars>  Monthly marketing spend (default 0)
   --rate <dollars>       $/kWh charged to customers (default: whatever a real game starts at)
+  --build <name>         Build one generator immediately (a real recorded player action)
+  --build-mw <n>         Size for --build in MW (default 300)
+  --finance              Finance --build instead of paying cash
+  --sell-id <n>          Sell one starting facility by facility id
+  --sell-month <n>       Wait until this month to apply --sell-id (default 0)
   --all                  Sweep every scenario instead of reporting on one
   --full                 Print every month rather than a sample
   --list                 List the scenarios and exit

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -523,7 +523,7 @@ export const SCENARIOS = [
     startingYear: 2020,
     cash: 330000000,
     feePerKgCO2e: 50 / 1000,
-    dollarsPerkWh: 0.07,
+    dollarsPerkWh: 0.05,
     durationMonths: 12 * 12,
     facilities: [
       { fuel: "Coal", peakW: 300000000 },
@@ -540,7 +540,7 @@ export const SCENARIOS = [
     startingYear: 2006,
     cash: 220000000,
     feePerKgCO2e: 0,
-    dollarsPerkWh: 0.07,
+    dollarsPerkWh: 0.03,
     durationMonths: 12 * 20,
     facilities: [{ fuel: "Coal", peakW: 500000000 }],
   },
@@ -572,7 +572,7 @@ export const SCENARIOS = [
     startingYear: 2002,
     cash: 220000000,
     feePerKgCO2e: 0,
-    dollarsPerkWh: 0.07,
+    dollarsPerkWh: 0.02,
     durationMonths: 12 * 12,
     facilities: [
       { fuel: "Oil", peakW: 100000000 },
@@ -589,7 +589,7 @@ export const SCENARIOS = [
     startingYear: 2000,
     cash: 220000000,
     feePerKgCO2e: 0,
-    dollarsPerkWh: 0.07,
+    dollarsPerkWh: 0.05,
     durationMonths: 12 * 20,
     facilities: [
       { fuel: "Oil", peakW: 220000000 },
@@ -607,7 +607,7 @@ export const SCENARIOS = [
     startingYear: 1980,
     cash: 198000000,
     feePerKgCO2e: 0,
-    dollarsPerkWh: 0.07,
+    dollarsPerkWh: 0.025,
     durationMonths: 12 * 20,
     facilities: [
       { fuel: "Coal", peakW: 200000000 },

--- a/src/reducers/CustomGame.test.tsx
+++ b/src/reducers/CustomGame.test.tsx
@@ -198,6 +198,9 @@ describe("a custom game", () => {
         // its first quarter -- which is what this test caught when the escalation went in.
         dollarsPerkWh: 1.1,
         feePerKgCO2e: 530 / 1000,
+        // Enough firm capacity that this weather-projection test is not cut short by the real
+        // game's chronic-blackout firing rule, which the simulator also enforces.
+        facilities: [{ name: "Natural Gas", peakW: 500000000 }],
       } as ScenarioType,
     });
 

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1125,13 +1125,7 @@ export function tickState(state: GameType) {
         }, 1);
       };
 
-      const chronicBlackouts =
-        history[1] &&
-        history[2] &&
-        history[3] &&
-        history[1].supplyWh < history[1].demandWh * 0.9 &&
-        history[2].supplyWh < history[2].demandWh * 0.9 &&
-        history[3].supplyWh < history[3].demandWh * 0.9;
+      const chronicBlackouts = hasChronicBlackouts(history);
       const failure =
         now.cash < 0
           ? ({ outcome: "bankrupt", title: "Bankrupt!" } as const)
@@ -1239,6 +1233,14 @@ export function tickState(state: GameType) {
 
   // After the tick, the way a player's click lands after the tick that brought the clock to it
   applyPendingReplayActions(state);
+}
+
+/** The same three completed-month firing rule used by the game and headless playtests. */
+export function hasChronicBlackouts(history: MonthlyHistoryType[]): boolean {
+  return (
+    history.length >= 3 &&
+    history.slice(0, 3).every((month) => month.supplyWh < month.demandWh * 0.9)
+  );
 }
 
 // Simplified customer forecast, assumes no blackouts since supply calculation depends on demand (circular depedency)

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -10,6 +10,7 @@ import { getStore } from "../StoreRegistry";
 import { createGame } from "../testing/Simulator";
 import {
   loaded,
+  hasChronicBlackouts,
   quit,
   resume,
   setSpeed,
@@ -226,6 +227,16 @@ describe("ending a scenario from inside the reducer", () => {
       { ...blackoutMonth, month: 2 },
       { ...blackoutMonth, month: 1 },
     ];
+    expect(
+      hasChronicBlackouts([
+        { ...blackoutMonth, month: 4, supplyWh: 100 },
+        ...state.monthlyHistory,
+      ]),
+    ).toBe(false);
+    state.facilities.forEach((facility) => {
+      facility.paused = true;
+      facility.currentW = 0;
+    });
 
     playOutOnTheStore(state, 1);
     jest.runOnlyPendingTimers();

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -11,8 +11,8 @@ npm run sim -- --all
 ```
   SCENARIO                  MONTHS   OUTCOME              CASH      UNSERVED  INVARIANTS
   ------------------------- -------- -------------------- --------- --------- ----------
-  Carbon Fee                144      survived             $56M      0.3%      ok
-  The Shale Boom            240      survived             $3,099M   0.7%      ok
+  Carbon Fee                144      bankrupt @ month 54  $-1M      0.3%      ok
+  The Shale Boom            240      bankrupt @ month 104 $-1M      0.7%      ok
   Paradise                  144      bankrupt @ month 43  $-3M      0.1%      ok
   ...
   All scenarios hold every invariant.
@@ -25,7 +25,9 @@ npm run sim -- --scenario 103 --strategy keepUp
 ```
 
 which prints a month by month table (customers, demand, supplied, unserved, cash, net worth,
-profit, emissions), totals for the run, the fleet it finished with, and any invariant violations.
+profit, emissions), the number of recorded player actions, totals for the run, the fleet it
+finished with, and any invariant violations. Outcomes match the real game: completed, bankrupt,
+or fired after three consecutive months below 90% supplied.
 `npm run sim -- --help` lists the flags; `--list` shows the scenario ids.
 
 `--year` and `--location` play an authored scenario somewhere or somewhen else, which is the

--- a/src/testing/Report.tsx
+++ b/src/testing/Report.tsx
@@ -159,11 +159,14 @@ export function formatReport(
   lines.push("TOTALS");
   lines.push(
     `  Outcome          ${
-      result.wentBankrupt
+      result.outcome === "bankrupt"
         ? `BANKRUPT at month ${result.bankruptAtMonth} of ${opts.months}`
-        : `survived all ${opts.months} months`
+        : result.outcome === "fired"
+          ? `FIRED at month ${result.firedAtMonth} of ${opts.months}`
+          : `completed all ${opts.months} months`
     }`,
   );
+  lines.push(`  Player actions   ${result.actionCount}`);
   if (first && last) {
     lines.push(
       `  Cash             ${formatMoneyConcise(first.cash)} -> ${formatMoneyConcise(last.cash)}`,

--- a/src/testing/SimCli.tsx
+++ b/src/testing/SimCli.tsx
@@ -53,6 +53,7 @@ function withOverrides(scenario: ScenarioType): ScenarioType | undefined {
 }
 
 function baseOptions(): Omit<SimOptionsType, "scenarioId"> {
+  const initialBuildName = process.env.SIM_BUILD;
   return {
     difficulty: (process.env.SIM_DIFFICULTY as DifficultyType) || undefined,
     months: envNumber("SIM_MONTHS"),
@@ -60,6 +61,15 @@ function baseOptions(): Omit<SimOptionsType, "scenarioId"> {
     dollarsPerkWh: envNumber("SIM_RATE"),
     monthlyMarketingSpend: envNumber("SIM_MARKETING"),
     strategy: (process.env.SIM_STRATEGY as StrategyType) || undefined,
+    initialBuild: initialBuildName
+      ? {
+          name: initialBuildName,
+          peakW: (envNumber("SIM_BUILD_MW") || 300) * 1000000,
+          financed: process.env.SIM_FINANCE === "1",
+        }
+      : undefined,
+    sellFacilityId: envNumber("SIM_SELL_ID"),
+    sellAtMonth: envNumber("SIM_SELL_MONTH"),
   };
 }
 
@@ -84,9 +94,12 @@ function runSweep() {
     const demandWh = result.months.reduce((a, m) => a + m.demandWh, 0);
     const supplyWh = result.months.reduce((a, m) => a + m.supplyWh, 0);
     const cash = result.finalCash;
-    const outcome = result.wentBankrupt
-      ? `bankrupt @ month ${result.bankruptAtMonth}`
-      : "survived";
+    const outcome =
+      result.outcome === "bankrupt"
+        ? `bankrupt @ month ${result.bankruptAtMonth}`
+        : result.outcome === "fired"
+          ? `fired @ month ${result.firedAtMonth}`
+          : "completed";
     write(
       "  " +
         scenario.name.slice(0, 25).padEnd(26) +

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -173,6 +173,83 @@ describe("simulation determinism", () => {
 });
 
 describe("simulation economics", () => {
+  // Reproducible, UI-legal playthroughs found by the CEO playtest agents. Investor scenarios use
+  // facility actions only; the one rate change belongs to the Public scenario and is checked below.
+  const CEO_WINNING_PLAYS = {
+    100: {
+      initialBuild: {
+        name: "Natural Gas",
+        peakW: 150000000,
+        financed: true,
+      },
+      sellFacilityId: 1,
+      sellAtMonth: 37,
+    },
+    101: { sellFacilityId: 1 },
+    102: {
+      initialBuild: {
+        name: "Natural Gas",
+        peakW: 200000000,
+        financed: true,
+      },
+      sellFacilityId: 1,
+      sellAtMonth: 39,
+    },
+    103: {
+      initialBuild: {
+        name: "Natural Gas",
+        peakW: 400000000,
+        financed: true,
+      },
+      sellFacilityId: 1,
+      sellAtMonth: 39,
+    },
+    104: { dollarsPerkWh: 0.08 },
+    105: {
+      initialBuild: {
+        name: "Natural Gas",
+        peakW: 300000000,
+        financed: true,
+      },
+    },
+  } as const;
+  const CEO_ACTION_COUNTS = {
+    100: 2,
+    101: 1,
+    102: 2,
+    103: 2,
+    104: 1,
+    105: 1,
+  } as Record<number, number>;
+
+  SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
+    (scenario) => {
+      it(`requires player input to win "${scenario.name}" on CEO`, () => {
+        const passive = runSimulation({
+          scenarioId: scenario.id,
+          difficulty: "CEO",
+        });
+        expectNoViolations(passive);
+        expect(passive.actionCount).toBe(0);
+        expect(passive.outcome).not.toBe("completed");
+
+        const play =
+          CEO_WINNING_PLAYS[scenario.id as keyof typeof CEO_WINNING_PLAYS];
+        expect(
+          !("dollarsPerkWh" in play) || scenario.ownership === "Public",
+        ).toBe(true);
+        const active = runSimulation({
+          scenarioId: scenario.id,
+          difficulty: "CEO",
+          ...play,
+        });
+        expectNoViolations(active);
+        expect(active.actionCount).toBe(CEO_ACTION_COUNTS[scenario.id]);
+        expect(active.outcome).toBe("completed");
+      });
+    },
+  );
+
   it("bills every customer it supplies at the going rate", () => {
     const result = runSimulation({
       scenarioId: 101,

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -7,8 +7,10 @@ import gameReducer, {
   buildFacility,
   delta,
   initGame,
+  hasChronicBlackouts,
   start,
   startReplay,
+  sellFacility,
   tickState,
 } from "../reducers/Game";
 import { DIFFICULTIES } from "../Constants";
@@ -38,6 +40,12 @@ import { loadSimData } from "./SimData";
 
 export type StrategyType = "none" | "keepUp";
 
+export interface InitialBuildType {
+  name: string;
+  peakW: number;
+  financed: boolean;
+}
+
 /**
  * Where a scenario is played, or a hard failure. The browser can put an alert on screen and go
  * back to the menu; a headless run that quietly simulated the wrong city would just print a
@@ -65,6 +73,9 @@ export interface SimOptionsType {
   dollarsPerkWh?: number;
   monthlyMarketingSpend?: number;
   strategy?: StrategyType;
+  initialBuild?: InitialBuildType;
+  sellFacilityId?: number;
+  sellAtMonth?: number;
 }
 
 export interface ResolvedSimOptionsType {
@@ -75,6 +86,9 @@ export interface ResolvedSimOptionsType {
   dollarsPerkWh: number | null; // null = left at the scenario's own rate
   monthlyMarketingSpend: number;
   strategy: StrategyType;
+  initialBuild: InitialBuildType | null;
+  sellFacilityId: number | null;
+  sellAtMonth: number;
 }
 
 export interface BuildRecordType {
@@ -93,6 +107,10 @@ export interface SimResultType {
   finalNetWorth: number;
   wentBankrupt: boolean;
   bankruptAtMonth: number | null;
+  wasFired: boolean;
+  firedAtMonth: number | null;
+  outcome: "completed" | "bankrupt" | "fired";
+  actionCount: number;
   builds: BuildRecordType[];
   // Mean fill level of the storage fleet across the run, 0 - 1, or null with no storage built
   averageStateOfCharge: number | null;
@@ -159,6 +177,35 @@ function setUpGame(
   // the rate on the Finances screen would
   if (options.dollarsPerkWh !== null) {
     state = gameReducer(state, delta({ dollarsPerkWh: options.dollarsPerkWh }));
+  }
+  if (options.initialBuild) {
+    const build = GENERATORS(
+      state,
+      options.initialBuild.peakW,
+      state.timeline.map((tick) => tick.windKph),
+      state.timeline.map((tick) => tick.solarIrradianceWM2),
+      state.timeline
+        .map((tick) => tick.windOffshoreKph)
+        .filter((wind): wind is number => wind !== undefined),
+    ).find(
+      (facility) =>
+        facility.available && facility.name === options.initialBuild?.name,
+    );
+    if (!build) {
+      throw new Error(
+        `Cannot build ${options.initialBuild.name} in ${scenario.name}`,
+      );
+    }
+    state = gameReducer(
+      state,
+      buildFacility({
+        facility: build,
+        financed: options.initialBuild.financed,
+      }),
+    );
+  }
+  if (options.sellFacilityId !== null && options.sellAtMonth === 0) {
+    state = gameReducer(state, sellFacility(options.sellFacilityId));
   }
   // Redux Toolkit freezes reducer output in development; the tick loop mutates state in place
   return cloneDeep(state);
@@ -256,6 +303,9 @@ function resolveOptions(
       options.dollarsPerkWh === undefined ? null : options.dollarsPerkWh,
     monthlyMarketingSpend: options.monthlyMarketingSpend || 0,
     strategy: options.strategy || "none",
+    initialBuild: options.initialBuild || null,
+    sellFacilityId: options.sellFacilityId ?? null,
+    sellAtMonth: options.sellAtMonth || 0,
   };
 }
 
@@ -270,11 +320,27 @@ export function runSimulation(options: SimOptionsType): SimResultType {
   let state = setUpGame(scenario, resolved);
 
   const collector = new InvariantCollector();
-  const builds: BuildRecordType[] = [];
+  const initialBuild = resolved.initialBuild
+    ? state.facilities.find(
+        (facility) =>
+          facility.name === resolved.initialBuild?.name &&
+          facility.yearsToBuildLeft > 0,
+      )
+    : undefined;
+  const builds: BuildRecordType[] = initialBuild
+    ? [
+        {
+          month: 0,
+          name: initialBuild.name,
+          buildCost: initialBuild.buildCost,
+        },
+      ]
+    : [];
   let stateOfChargeSum = 0;
   let stateOfChargeTicks = 0;
   let ticks = 0;
   let bankruptAtMonth: number | null = null;
+  let firedAtMonth: number | null = null;
   let previousMonthCount = state.monthlyHistory.length;
   let prevTick: TickPresentFutureType | null = null;
   let justBuilt = false;
@@ -282,7 +348,7 @@ export function runSimulation(options: SimOptionsType): SimResultType {
 
   // tickState fires the game's end-of-run dialogs through setTimeout, which never run here, so the
   // loop watches state directly instead and stops on the same conditions the player would hit:
-  // monthsEllapsed reaching the scenario duration, or negative cash at a month rollover.
+  // monthsEllapsed reaching the scenario duration, negative cash, or chronic blackouts.
   while (state.date.monthsEllapsed < resolved.months) {
     tickState(state);
     ticks++;
@@ -326,6 +392,21 @@ export function runSimulation(options: SimOptionsType): SimResultType {
       break; // The real game forces a restart here, so anything past it isn't a reachable state
     }
 
+    if (hasChronicBlackouts(state.monthlyHistory)) {
+      firedAtMonth = state.date.monthsEllapsed;
+      break;
+    }
+
+    if (
+      resolved.sellFacilityId !== null &&
+      resolved.sellAtMonth > 0 &&
+      state.date.monthsEllapsed === resolved.sellAtMonth
+    ) {
+      state = cloneDeep(
+        gameReducer(state, sellFacility(resolved.sellFacilityId)),
+      );
+    }
+
     if (resolved.strategy === "keepUp") {
       const toBuild = pickFacilityToBuild(state, state.monthlyHistory[0]);
       if (toBuild) {
@@ -358,6 +439,15 @@ export function runSimulation(options: SimOptionsType): SimResultType {
     finalNetWorth: lastTick ? lastTick.netWorth : 0,
     wentBankrupt: bankruptAtMonth !== null,
     bankruptAtMonth,
+    wasFired: firedAtMonth !== null,
+    firedAtMonth,
+    outcome:
+      bankruptAtMonth !== null
+        ? "bankrupt"
+        : firedAtMonth !== null
+          ? "fired"
+          : "completed",
+    actionCount: state.replayLog?.length || 0,
     builds,
     averageStateOfCharge: stateOfChargeTicks
       ? stateOfChargeSum / stateOfChargeTicks


### PR DESCRIPTION
## Summary
- rebalance all six full scenarios so passive CEO runs fail while UI-legal active strategies remain winnable
- extend the headless simulator with recorded build, finance, sale, and outcome support
- make simulator firing behavior match the game and fix the chronic-blackout window to use the latest completed months
- add regression coverage for zero-input losses and active CEO wins across every full scenario

## Verification
- npm run check
- 59 test suites passed, 664 tests passed
- passive CEO sweep: all six full scenarios fail with zero actions and no invariant violations
- active playthroughs independently verified by scenario agents, including multiple seeds where forecast randomness applies

## Balance note
Several viable strategies liquidate inherited facilities. Their sale proceeds are large because starting assets enter scenarios debt-free and at full modeled value; this existing depreciation assumption is unchanged by this PR.