### PR TITLE
Replace investor marketing with rate competition

### DIFF
--- a/scripts/sim.js
+++ b/scripts/sim.js
@@ -18,7 +18,6 @@ const FLAGS = {
   "--months": "SIM_MONTHS",
   "--seed": "SIM_SEED",
   "--strategy": "SIM_STRATEGY",
-  "--marketing": "SIM_MARKETING",
   "--rate": "SIM_RATE",
   "--build": "SIM_BUILD",
   "--build-mw": "SIM_BUILD_MW",
@@ -47,7 +46,6 @@ Runs the game's simulation headlessly and reports what happened.
   --months <n>           Override the scenario's own duration
   --seed <n>             Pin the run's randomness (default 12345)
   --strategy <name>      none (default) or keepUp, which buys generators when short on supply
-  --marketing <dollars>  Monthly marketing spend (default 0)
   --rate <dollars>       $/kWh charged to customers (default: whatever a real game starts at)
   --build <name>         Build one generator immediately (a real recorded player action)
   --build-mw <n>         Size for --build in MW (default 300)

--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -142,7 +142,7 @@ export const TICK_MS = {
 // Fallbacks for the screens that run before any economic data has been loaded, and the anchor
 // the projected cycles rest near. The played game reads its rates from data/Economy instead.
 export const INFLATION = 0.03;
-export const ORGANIC_GROWTH_MAX_ANNUAL = 0.015; // Includes organic / non-blackout attrition; Duke Energy grew 1.6% 2018 -> 2019, and that's with some marketing spending
+export const ORGANIC_GROWTH_MAX_ANNUAL = 0.015; // Includes organic / non-blackout attrition; Duke Energy grew 1.6% from 2018 to 2019
 export const RESERVE_MARGIN = 0.05;
 export const DOWNPAYMENT_PERCENT = 0.2;
 export const INTEREST_RATE_YEARLY = 0.04;

--- a/src/Replay.test.tsx
+++ b/src/Replay.test.tsx
@@ -38,9 +38,9 @@ function aReplay(overrides: Partial<ReplayType> = {}): ReplayType {
 
 describe("recordedDelta", () => {
   it("keeps the fields the simulation reads", () => {
-    expect(
-      recordedDelta({ dollarsPerkWh: 0.11, monthlyMarketingSpend: 5000 }),
-    ).toEqual({ dollarsPerkWh: 0.11, monthlyMarketingSpend: 5000 });
+    expect(recordedDelta({ dollarsPerkWh: 0.11 })).toEqual({
+      dollarsPerkWh: 0.11,
+    });
   });
 
   it("ignores a delta that changes nothing about the run", () => {
@@ -48,6 +48,11 @@ describe("recordedDelta", () => {
     // scenario, the difficulty picked before the game began
     expect(recordedDelta({ tutorialStep: 3 })).toBeNull();
     expect(recordedDelta({ difficulty: "CEO" })).toBeNull();
+  });
+
+  it("rejects an invalid rate from an untrusted replay", () => {
+    expect(recordedDelta({ dollarsPerkWh: Number.NaN })).toBeNull();
+    expect(recordedDelta({ dollarsPerkWh: -0.01 })).toBeNull();
   });
 });
 
@@ -81,12 +86,11 @@ describe("recordReplayAction", () => {
     const game = aGame(60, []);
     recordReplayAction(game, "delta", { dollarsPerkWh: 0.1 });
     recordReplayAction(game, "delta", { dollarsPerkWh: 0.2 });
-    recordReplayAction(game, "delta", { monthlyMarketingSpend: 100 });
     expect(game.replayLog).toEqual([
       {
         minute: 60,
         type: "delta",
-        payload: { dollarsPerkWh: 0.2, monthlyMarketingSpend: 100 },
+        payload: { dollarsPerkWh: 0.2 },
       },
     ]);
   });

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -29,10 +29,12 @@ import {
  */
 
 // Bump on any breaking schema change. Mismatched replays are ignored rather than migrated.
+// 4 replaces investor marketing with price-driven customer switching; older replays would grow a
+// different customer base even if they contain no explicit marketing action.
 // 3 adds offshore wind weather and generation; an older replay would simulate a different grid.
 // 2 added `location`: a v1 replay names only a scenario, and a scenario no longer pins down
 // where it is played, so there is no safe way to migrate one.
-export const REPLAY_VERSION = 3;
+export const REPLAY_VERSION = 4;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few
@@ -53,10 +55,7 @@ export const MAX_REPLAY_BYTES = 800000;
 // Only the fields of a `delta` that change how the simulation runs. Everything else the action
 // carries -- the tutorial step, the custom scenario, the difficulty picked before the game began
 // -- either doesn't affect the sim or is already in the replay header.
-export const RECORDED_DELTA_KEYS = [
-  "dollarsPerkWh",
-  "monthlyMarketingSpend",
-] as const;
+export const RECORDED_DELTA_KEYS = ["dollarsPerkWh"] as const;
 
 export type RecordedDeltaType = Partial<
   Pick<GameType, (typeof RECORDED_DELTA_KEYS)[number]>
@@ -77,22 +76,17 @@ const REPLAY_ACTION_NAMES: ReplayActionNameType[] = [
 export function recordedDelta(
   payload: Partial<GameType>,
 ): RecordedDeltaType | null {
-  const recorded: RecordedDeltaType = {};
-  let any = false;
-  RECORDED_DELTA_KEYS.forEach((key) => {
-    if (payload[key] !== undefined) {
-      recorded[key] = payload[key];
-      any = true;
-    }
-  });
-  return any ? recorded : null;
+  const rate = payload.dollarsPerkWh;
+  return typeof rate === "number" && Number.isFinite(rate) && rate >= 0
+    ? { dollarsPerkWh: rate }
+    : null;
 }
 
 /**
  * Appends an action to the run's log, if the run is being recorded at all.
  *
- * Consecutive deltas within the same game minute are merged rather than appended: the rate and
- * marketing sliders fire an action per pixel dragged, and since nothing reads either value until
+ * Consecutive deltas within the same game minute are merged rather than appended: the rate slider
+ * fires an action per pixel dragged, and since nothing reads the intermediate values until
  * the next tick, only the one the player let go on ever mattered. Merging is exact, and it's the
  * difference between a few dozen entries and a few thousand.
  */

--- a/src/SaveFile.test.tsx
+++ b/src/SaveFile.test.tsx
@@ -18,6 +18,8 @@ function fakeGame(overrides: Partial<GameType> = {}): GameType {
     scenarioId: 101, // Rise of Renewables
     seed: 31337,
     startingYear: 2020,
+    customerMarketSize: 2_000_000,
+    customerRate: 0.07,
     location: LOCATIONS.PIT,
     date: { minute: 1000, year: 2035, month: 6 },
     facilities: [],

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -74,6 +74,13 @@ describe("SaveGame", () => {
     ).toBeNull();
   });
 
+  it("rejects a current-version save without customer-market state", () => {
+    const save = serializeSave(game);
+    const withoutMarket = { ...save.game } as Partial<GameType>;
+    delete withoutMarket.customerMarketSize;
+    expect(parseSave({ ...save, game: withoutMarket })).toBeNull();
+  });
+
   it("ignores corrupt JSON", () => {
     window.localStorage.setItem(SAVE_KEY, "{not json");
     expect(readSave()).toBeNull();

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -25,11 +25,12 @@ import type { AppStore } from "./Store";
 
 export const SAVE_KEY = "savedGame";
 // Bump on any breaking schema change. Mismatched saves are ignored rather than migrated.
+// 5: investor customers respond to rate history and a finite market instead of marketing spend.
 // 4: conventional hydro carries a reservoir water balance and storage applies hourly losses.
 // 3: timeline rows may carry offshore wind, which changes the output of an offshore fleet.
 // 2: facilities carry the rate their loan was signed at, and the game carries the rate a new one
 // would cost. A version 1 save has neither, and a loan with no rate cannot be repaid.
-export const SAVE_VERSION = 4;
+export const SAVE_VERSION = 5;
 
 export interface SaveGameType {
   version: number;
@@ -74,6 +75,12 @@ export function parseSave(raw: unknown): SaveGameType | null {
     typeof game.scenarioId !== "number" ||
     typeof game.seed !== "number" ||
     typeof game.startingYear !== "number" ||
+    typeof game.customerMarketSize !== "number" ||
+    !Number.isFinite(game.customerMarketSize) ||
+    game.customerMarketSize <= 0 ||
+    typeof game.customerRate !== "number" ||
+    !Number.isFinite(game.customerRate) ||
+    game.customerRate < 0 ||
     // Checked in full rather than trusted, the same way decodeReplay checks a replay's: the
     // location's id becomes the path of the weather file the loading screen fetches, and its
     // lat/long and time zone drive the sun model. A save is hand-editable too

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -251,6 +251,8 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     hydroSpillWh: number; // Water above reservoir capacity lost during this tick
     hydroMandatedReleaseW: number; // Must-run water-rights flow through turbines
     storageLossWh: number; // Self-discharge / evaporation during this simulated tick
+    // The exponentially smoothed bill customers respond to, rather than the slider's latest value
+    customerRate: number;
     supplyByFuel: FuelProductionType;
   };
 
@@ -280,7 +282,6 @@ interface HistoryForecastShared {
   expensesOM: number; // total
   expensesCarbonFee: number; // total
   expensesInterest: number; // total - only the interest payments count as an expense, the rest is just a settling of balances between cash and liability
-  expensesMarketing: number; // total
   kgco2e: number; // total
   // Point in time rather than totals: what a new loan would cost, and what prices were doing,
   // as of this tick / the end of this month. Summing them would be meaningless, so reduceHistories
@@ -543,7 +544,10 @@ export interface GameType {
   inGame: boolean;
   feePerKgCO2e: number;
   dollarsPerkWh: number;
-  monthlyMarketingSpend: number;
+  // Customer price competition starts from the scenario's rate and half of this addressable pool.
+  // customerRate is the three-month bill average carried between monthly forecast windows.
+  customerMarketSize: number;
+  customerRate: number;
   // What a loan signed right now would cost, and the multiplier on prime that gets there.
   // Both recomputed once a month. The premium is kept separately so that a forecast can price
   // future months against where prime is heading while holding the company's own creditworthiness

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -78,8 +78,8 @@ const FACILITY_SLOTS = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 const facilitySlotKey = (slot: number) => `shift+${slot}`;
 
 // react-hotkeys' default ignoreEventsCondition treats every <input> as a text field and drops
-// the keydown entirely -- but the capacity sliders on the build screens and the marketing
-// spend slider in Finances are MUI Sliders, which render as a bare <input type="range">. Just
+// the keydown entirely -- but the capacity sliders on the build screens and the rate slider in
+// Finances are MUI Sliders, which render as a bare <input type="range">. Just
 // clicking one leaves it focused, and from then on every shortcut silently did nothing until
 // the player happened to click something else -- the "some element is pulling focus" bug.
 // These types don't take character input, so there's nothing for a shortcut key to clobber.

--- a/src/components/base/ConceptIcon.tsx
+++ b/src/components/base/ConceptIcon.tsx
@@ -2,7 +2,6 @@ import AccountBalanceIcon from "@mui/icons-material/AccountBalance";
 import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
 import BoltIcon from "@mui/icons-material/Bolt";
 import BuildIcon from "@mui/icons-material/Build";
-import CampaignIcon from "@mui/icons-material/Campaign";
 import ConstructionIcon from "@mui/icons-material/Construction";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import FactoryIcon from "@mui/icons-material/Factory";
@@ -13,6 +12,7 @@ import LocalGasStationIcon from "@mui/icons-material/LocalGasStation";
 import PauseCircleIcon from "@mui/icons-material/PauseCircle";
 import PeopleIcon from "@mui/icons-material/People";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import PriceChangeIcon from "@mui/icons-material/PriceChange";
 import QueryStatsIcon from "@mui/icons-material/QueryStats";
 import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
@@ -40,7 +40,7 @@ export type ConceptNameType =
   | "construction"
   | "finances"
   | "forecast"
-  | "marketing"
+  | "rate"
   | "fuel"
   | "weather"
   | "danger"
@@ -63,7 +63,7 @@ export const CONCEPT_NAMES: ConceptNameType[] = [
   "construction",
   "finances",
   "forecast",
-  "marketing",
+  "rate",
   "fuel",
   "weather",
   "danger",
@@ -89,7 +89,7 @@ export const CONCEPT_LABELS: Record<ConceptNameType, string> = {
   construction: "Under construction",
   finances: "Finances",
   forecast: "Forecast",
-  marketing: "Marketing",
+  rate: "Electricity rate",
   fuel: "Fuel",
   weather: "Weather",
   danger: "Danger",
@@ -116,7 +116,7 @@ const CONCEPT_ICONS: Record<
   construction: ConstructionIcon,
   finances: AccountBalanceIcon,
   forecast: QueryStatsIcon,
-  marketing: CampaignIcon,
+  rate: PriceChangeIcon,
   fuel: LocalGasStationIcon,
   weather: WbSunnyIcon,
   danger: WarningIcon,

--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { produce } from "immer";
 import Finances, {
-  formatMarketingCustomerGrowth,
+  formatCustomerChange,
   getComparison,
   parseRange,
   projectMonths,
@@ -27,6 +27,10 @@ jest.mock("../base/GameCard", () => ({
   default: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
+}));
+jest.mock("../base/ManualLink", () => ({
+  __esModule: true,
+  default: () => null,
 }));
 
 /**
@@ -100,15 +104,25 @@ function renderFinances(
   );
 }
 
-describe("the marketing forecast", () => {
+describe("the customer forecast", () => {
   it("shows customer growth as a delta and percent when compact totals would look equal", () => {
-    expect(formatMarketingCustomerGrowth(1000000, 1000000)).toEqual(
-      "+9.9k (+1.0%)",
-    );
+    expect(formatCustomerChange(9900, 1000000)).toEqual("+9.9k (+1.0%)");
   });
 
-  it("omits an undefined growth percent when there are no existing customers", () => {
-    expect(formatMarketingCustomerGrowth(1000000, 0)).toEqual("+9.9k");
+  it("formats losses and omits an undefined percent with no existing customers", () => {
+    expect(formatCustomerChange(-9900, 1000000)).toEqual("-9.9k (-1.0%)");
+    expect(formatCustomerChange(9900, 0)).toEqual("+9.9k");
+  });
+
+  it("shows investor players the market benchmark and a rate control", () => {
+    renderFinances(createGame({ scenarioId: 101 }), "PAUSED");
+    expect(
+      screen.getByRole("slider", {
+        name: "The rate you charge for electricity generation",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/market \$/)).toBeInTheDocument();
+    cleanup();
   });
 });
 

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -14,21 +14,24 @@ import {
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
-import { MONTHS, TICKS_PER_MONTH } from "../../Constants";
+import { MONTHS, TICK_MINUTES, TICKS_PER_MONTH } from "../../Constants";
 import { TickThrottle } from "../../helpers/RenderThrottle";
 import {
   deriveExpandedSummary,
   EMPTY_HISTORY,
+  getDateFromMinute,
   getTimeFromTimeline,
   reduceHistories,
   summarizeHistory,
   summarizeTimeline,
   summarizeTimelineByMonth,
 } from "../../helpers/DateTime";
+import { facilityLifetime } from "../../helpers/Financials";
 import {
-  customersFromMarketingSpend,
-  facilityLifetime,
-} from "../../helpers/Financials";
+  customerMarketSizeAt,
+  getMarketRate,
+  projectCustomerChange,
+} from "../../helpers/Customers";
 import {
   formatMoneyConcise,
   formatMoneyStable,
@@ -75,8 +78,8 @@ interface ChartKeyMetadataType {
   nesting?: number; // default 0 / unnested
   /**
    * Which direction of the change column is good news, so the arrow can be coloured. Left
-   * unset for the metrics that are neither: marketing spend is a decision rather than a
-   * result, and inflation is weather. Those get an arrow with no colour on it.
+   * unset for metrics such as inflation that are neither good nor bad. Those get an arrow with no
+   * colour on it.
    */
   higherIsBetter?: boolean;
 }
@@ -148,12 +151,6 @@ function buildChartKeys(units: UnitSystemType): {
     expensesOM: {
       label: "Operations",
       higherIsBetter: false,
-      format: formatMoneyConcise,
-      formatTable: formatMoneyStable,
-      nesting: 1,
-    },
-    expensesMarketing: {
-      label: "Marketing",
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
       nesting: 1,
@@ -445,45 +442,6 @@ function DeltaCell(props: DeltaCellProps): React.JSX.Element {
   );
 }
 
-// -1:0 -> 0:$100k, each tick increments the front number - when it overflows, instead add a 0 (i.e. 1->2M, 9->10M, 10->20M)
-function getValueFromTick(tick: number) {
-  if (tick === -1) {
-    return 0;
-  }
-  const exponent = Math.floor(tick / 9) + 5;
-  const frontNumber = (tick % 9) + 1;
-  return Math.round(frontNumber * Math.pow(10, exponent));
-}
-
-function getTickFromValue(v: number) {
-  if (v === 0) {
-    return -1;
-  }
-  const exponent = Math.floor(Math.log10(v)) - 5;
-  const frontNumber = +v.toString().charAt(0);
-  return Math.floor(frontNumber + exponent * 9 - 1);
-}
-
-/**
- * Where the marketing slider draws its ticks: one per decade of spending.
- *
- * Every ninth tick, because that is where the leading digit rolls over and the scale gains a
- * zero -- the nine steps in between are $1M, $2M, ... $9M, and a mark on each of them is a row
- * of dots too fine to aim at. Zero gets one of its own, since it sits below the scale.
- */
-function marketingMarks(maxTick: number): { value: number; label?: string }[] {
-  const marks: { value: number; label?: string }[] = [
-    { value: -1, label: "$0" },
-  ];
-  for (let tick = 0; tick <= maxTick; tick += 9) {
-    marks.push({
-      value: tick,
-      label: formatMoneyConcise(getValueFromTick(tick)),
-    });
-  }
-  return marks;
-}
-
 // The rate slider runs $0 to $0.30/kWh, so its ticks are a fixed nickel apart
 const RATE_MARKS = [0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3].map((rate: number) => ({
   value: rate,
@@ -491,22 +449,23 @@ const RATE_MARKS = [0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3].map((rate: number) => ({
 }));
 
 /**
- * The useful part of the marketing forecast is its change, not its resulting total. At large
+ * The useful part of the customer forecast is its change, not its resulting total. At large
  * customer counts, formatting both totals compactly can turn `1m -> 1m` and hide the effect.
  */
-export function formatMarketingCustomerGrowth(
-  marketingSpend: number,
+export function formatCustomerChange(
+  change: number,
   customers: number,
 ): string {
-  const gained = customersFromMarketingSpend(marketingSpend);
-  const formattedGain = numbro(gained).format({
+  const formattedChange = numbro(Math.abs(change)).format({
     average: true,
     mantissa: 1,
     trimMantissa: true,
   });
   const percent =
-    customers > 0 ? ` (+${((gained / customers) * 100).toFixed(1)}%)` : "";
-  return `+${formattedGain}${percent}`;
+    customers > 0
+      ? ` (${change >= 0 ? "+" : "-"}${((Math.abs(change) / customers) * 100).toFixed(1)}%)`
+      : "";
+  return `${change >= 0 ? "+" : "-"}${formattedChange}${percent}`;
 }
 
 export default class Finances extends React.Component<Props, State> {
@@ -561,8 +520,8 @@ export default class Finances extends React.Component<Props, State> {
       }
     | undefined;
 
-  // Rebuilding a twenty-year projection costs ~120ms, and the marketing and rate sliders change
-  // one of its inputs on every pointer move. Drawing from the previous projection while the
+  // Rebuilding a twenty-year projection costs ~120ms, and the rate slider changes one of its
+  // inputs on every pointer move. Drawing from the previous projection while the
   // player is still dragging keeps the slider smooth, and the trailing timer below makes sure
   // the chart catches up with wherever they let go.
   private static readonly PROJECTION_THROTTLE_MS = 250;
@@ -646,7 +605,6 @@ export default class Finances extends React.Component<Props, State> {
       this.state.range,
       date.monthsEllapsed,
       game.monthlyHistory.length,
-      game.monthlyMarketingSpend,
       game.dollarsPerkWh,
       game.facilities.map((f) => `${f.id}${f.paused ? "p" : ""}`).join(","),
     ].join("|");
@@ -804,6 +762,43 @@ export default class Finances extends React.Component<Props, State> {
 
     const scenario =
       getScenario(game.scenarioId, game.customScenario) || SCENARIOS[0];
+    const marketRate = getMarketRate(
+      scenario.dollarsPerkWh,
+      date,
+      startingYear,
+      game.seed,
+    );
+    const customerChange = projectCustomerChange({
+      customers: now.customers,
+      customerRate: now.customerRate || game.customerRate || game.dollarsPerkWh,
+      currentRate: game.dollarsPerkWh,
+      marketRateAt: (tick: number) =>
+        getMarketRate(
+          scenario.dollarsPerkWh,
+          getDateFromMinute(date.minute + tick * TICK_MINUTES, startingYear),
+          startingYear,
+          game.seed,
+        ),
+      marketSizeAt: (tick: number) =>
+        customerMarketSizeAt(
+          game.customerMarketSize || now.customers * 2,
+          date.minute + tick * TICK_MINUTES,
+        ),
+      ownership: scenario.ownership,
+    });
+    const investorRateMax = Math.max(
+      0.05,
+      Math.ceil(marketRate * 200) / 100,
+      game.dollarsPerkWh,
+    );
+    const investorRateMarks = [
+      { value: 0, label: "$0" },
+      {
+        value: marketRate,
+        label: `${formatMoneyConcise(marketRate)} market`,
+      },
+      { value: investorRateMax, label: formatMoneyConcise(investorRateMax) },
+    ];
     // Six sparklines need width the phone layout does not have, and the dropdown they replace is
     // the right control at that size -- see MetricTiles
     const smallMultiples = isDesktopScreen();
@@ -925,114 +920,64 @@ export default class Finances extends React.Component<Props, State> {
           )}
           <br />
           <Toolbar>
-            {scenario.ownership === "Investor" && (
-              <Typography
-                className="flex-newline"
-                variant="body2"
-                color="textSecondary"
-              >
-                Marketing:&nbsp;
-                <Typography color="primary" component="strong">
-                  {formatMoneyConcise(game.monthlyMarketingSpend)}
-                </Typography>
-                /mo&nbsp;&mdash;&nbsp;
-                {numbro(now.customers).format({ average: true })} customers
-                {game.monthlyMarketingSpend > 0 && (
-                  <>
-                    &nbsp;&rarr;&nbsp;
-                    <Typography color="primary" component="strong">
-                      {formatMarketingCustomerGrowth(
-                        game.monthlyMarketingSpend,
-                        now.customers,
-                      )}
-                    </Typography>
-                    &nbsp;next month
-                  </>
-                )}
+            <Typography
+              className="flex-newline"
+              variant="body2"
+              color="textSecondary"
+            >
+              Electricity Rate
+              <ManualLink
+                entry={MANUAL_ENTRY.RATES}
+                label="electricity rates"
+              />
+              :&nbsp;
+              <Typography color="primary" component="strong">
+                {formatMoneyConcise(game.dollarsPerkWh)}
               </Typography>
-            )}
-            {scenario.ownership === "Investor" && (
-              <div className="budgetSlider flex-newline">
-                <Slider
-                  id="marketingSlider"
-                  disabled={!!game.replayPlayback}
-                  value={getTickFromValue(game.monthlyMarketingSpend)}
-                  aria-label="Monthly marketing budget"
-                  /* On the thumb, so the budget being chosen is legible during the drag that
-                     chooses it rather than only in the line above it */
-                  valueLabelDisplay="auto"
-                  valueLabelFormat={(tick: number) =>
-                    formatMoneyConcise(getValueFromTick(tick))
-                  }
-                  getAriaValueText={(tick: number) =>
-                    `${formatMoneyConcise(getValueFromTick(tick))} per month`
-                  }
-                  marks={marketingMarks(
-                    getTickFromValue(
-                      Math.max(now.cash / 12, game.monthlyMarketingSpend),
-                    ),
-                  )}
-                  min={-1}
-                  step={1}
-                  max={getTickFromValue(
-                    Math.max(now.cash / 12, game.monthlyMarketingSpend),
-                  )}
-                  onChange={(_e: Event, newTick: number | number[]) =>
-                    onDelta({
-                      monthlyMarketingSpend: getValueFromTick(
-                        Array.isArray(newTick) ? newTick[0] : newTick,
-                      ),
-                    })
-                  }
-                />
-              </div>
-            )}
-            {scenario.ownership === "Public" && (
-              <Typography
-                className="flex-newline"
-                variant="body2"
-                color="textSecondary"
-              >
-                Electricity Rate
-                <ManualLink
-                  entry={MANUAL_ENTRY.RATES}
-                  label="electricity rates"
-                />
-                :&nbsp;
-                <Typography color="primary" component="strong">
-                  {formatMoneyConcise(game.dollarsPerkWh)}
-                </Typography>
-                /kWh
-              </Typography>
-            )}
-            {scenario.ownership === "Public" && (
-              <div className="budgetSlider flex-newline">
-                <Slider
-                  id="rateSlider"
-                  disabled={!!game.replayPlayback}
-                  value={game.dollarsPerkWh}
-                  aria-label="The rate you charge for electricity generation"
-                  valueLabelDisplay="auto"
-                  valueLabelFormat={(rate: number) =>
-                    `${formatMoneyConcise(rate)}/kWh`
-                  }
-                  getAriaValueText={(rate: number) =>
-                    `${formatMoneyConcise(rate)} per kilowatt hour`
-                  }
-                  marks={RATE_MARKS}
-                  min={0}
-                  step={0.01}
-                  max={0.3}
-                  onChange={(_e: Event, newTick: number | number[]) =>
-                    onDelta({
-                      dollarsPerkWh: Array.isArray(newTick)
-                        ? newTick[0]
-                        : newTick,
-                    })
-                  }
-                />
-              </div>
-            )}
+              /kWh
+              {scenario.ownership === "Investor" && (
+                <>
+                  &nbsp;&mdash;&nbsp;market {formatMoneyConcise(marketRate)}/kWh
+                  &nbsp;&mdash;&nbsp;
+                  {numbro(now.customers).format({ average: true })} customers,
+                  projected&nbsp;
+                  <Typography color="primary" component="strong">
+                    {formatCustomerChange(customerChange, now.customers)}
+                  </Typography>
+                  &nbsp;next month
+                </>
+              )}
+            </Typography>
+            <div className="budgetSlider flex-newline">
+              <Slider
+                id="rateSlider"
+                disabled={!!game.replayPlayback}
+                value={game.dollarsPerkWh}
+                aria-label="The rate you charge for electricity generation"
+                valueLabelDisplay="auto"
+                valueLabelFormat={(rate: number) =>
+                  `${formatMoneyConcise(rate)}/kWh`
+                }
+                getAriaValueText={(rate: number) =>
+                  `${formatMoneyConcise(rate)} per kilowatt hour`
+                }
+                marks={
+                  scenario.ownership === "Investor"
+                    ? investorRateMarks
+                    : RATE_MARKS
+                }
+                min={0}
+                step={scenario.ownership === "Investor" ? 0.001 : 0.01}
+                max={scenario.ownership === "Investor" ? investorRateMax : 0.3}
+                onChange={(_e: Event, newTick: number | number[]) =>
+                  onDelta({
+                    dollarsPerkWh: Array.isArray(newTick)
+                      ? newTick[0]
+                      : newTick,
+                  })
+                }
+              />
+            </div>
             {/* On a wide screen this whole row goes away: the range moved up into the pane
                 header above, and the tiles below are the metric picker, so there is nothing
                 left here that isn't said somewhere else */}

--- a/src/components/views/FinancesSmallMultiples.test.tsx
+++ b/src/components/views/FinancesSmallMultiples.test.tsx
@@ -27,6 +27,10 @@ jest.mock("../base/GameCard", () => ({
     <div>{children}</div>
   ),
 }));
+jest.mock("../base/ManualLink", () => ({
+  __esModule: true,
+  default: () => null,
+}));
 
 const user = userEvent.setup({ delay: null });
 

--- a/src/components/views/Forecasts.tsx
+++ b/src/components/views/Forecasts.tsx
@@ -88,14 +88,12 @@ export default class Forecasts extends React.Component<Props, State> {
     // Because forecasts are computationally intense and long term, only update when the
     // month or state changes -- plus when the player selects a facility, which is a direct
     // request to re-highlight the stack and would otherwise wait for a month rollover, or moves
-    // a slider that feeds the forecast (marketing spend drives customer growth, the rate drives
-    // revenue), which would otherwise sit frozen until the next month rolled over
+    // the rate slider, which drives both customer growth and revenue and would otherwise sit
+    // frozen until the next month rolled over
     return (
       this.props.game.date.monthNumber !== nextProps.game.date.monthNumber ||
       this.props.selectedFacilityId !== nextProps.selectedFacilityId ||
       this.state.years !== nextState.years ||
-      this.props.game.monthlyMarketingSpend !==
-        nextProps.game.monthlyMarketingSpend ||
       this.props.game.dollarsPerkWh !== nextProps.game.dollarsPerkWh
     );
   }

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -51,7 +51,7 @@ export const MANUAL_ENTRY = {
   BTU: "BTU and MMBTU",
   CAPACITY_FACTOR: "Capacity Factor",
   CARBON_FEE: "Carbon Fee",
-  CUSTOMERS: "Customers, Demand & Marketing",
+  CUSTOMERS: "Customers, Demand & Pricing",
   EMISSIONS: "Emissions and CO2e",
   FORECASTS: "Forecasts",
   HYDROPOWER: "Hydropower & Reservoirs",
@@ -158,8 +158,8 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
         </p>
         <p>
           <strong>Finances</strong> shows where the money went, and is where you
-          set marketing spend (which buys customers) and, in public-ownership
-          scenarios, the rate you charge.
+          set the rate you charge. In investor-owned scenarios that rate also
+          determines whether customers choose you or a competitor.
         </p>
         <p>
           <strong>Forecasts</strong> projects all of that forward so you can see
@@ -179,7 +179,7 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     title: MANUAL_ENTRY.SYMBOLS,
     group: "Gameplay",
     keywords:
-      "icons glyphs legend key money supply demand blackout customers generator storage build buy reorder pause play time construction finances forecast marketing fuel weather danger goal",
+      "icons glyphs legend key money supply demand blackout customers generator storage build buy reorder pause play time construction finances forecast rate pricing fuel weather danger goal",
     entry: (
       <div>
         <p>
@@ -369,11 +369,12 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           sourceUrl="https://www.eia.gov/todayinenergy/detail.php?id=10211"
         />
         <p>
-          Like in real life, you as a company can spend money on marketing to
-          acquire more customers (you exist as one of many electricity
-          generation companies customers can select from). Your customer base
-          also naturally grows or shrinks depending on if you provide them good
-          service (i.e. few blackouts).
+          In investor-owned scenarios, you compete with other electricity
+          companies for a finite market. Charge less than the market rate and
+          customers gradually switch to you; charge more and they gradually
+          leave. They react to several months of bills rather than a single rate
+          change. Your customer base also naturally grows or shrinks depending
+          on whether you provide good service, including avoiding blackouts.
         </p>
         <p>
           Load changes continuously as people turn stuff on and off, as
@@ -611,9 +612,12 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           per kWh depending on the state.
         </p>
         <p>
-          In <strong>investor-owned</strong> scenarios the rate is fixed by the
-          regulator and you can't change it, so the only lever you have on
-          revenue is supplying more energy to more customers.
+          In <strong>investor-owned</strong> scenarios you compete for
+          customers. The market rate begins at the scenario's advertised rate
+          and rises with inflation. Charge below it to gain market share or
+          above it to earn more from each customer while accepting that some
+          will leave. Switching takes several months, and the available market
+          is finite.
         </p>
         <p>
           In <strong>public-owned</strong> scenarios you set the rate yourself

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -310,7 +310,7 @@ export const SCENARIOS = [
   },
   {
     id: 3, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
-    name: "Mission 5: Marketing",
+    name: "Mission 5: Pricing",
     icon: "wind",
     summary: "Grow your customers",
     locationId: "SF",
@@ -333,29 +333,29 @@ export const SCENARIOS = [
         target: "#financesNav",
         content: (
           <TutorialPrompt
-            concepts={["marketing", "customers"]}
-            text="Marketing lives in the Finances tab."
+            concepts={["rate", "customers"]}
+            text="Your electricity rate lives in the Finances tab."
           />
         ),
         desktop: {
           target: "#financesPane",
           content: (
             <TutorialPrompt
-              concepts={["marketing", "customers"]}
-              text="Marketing lives in the Finances pane."
+              concepts={["rate", "customers"]}
+              text="Your electricity rate lives in the Finances pane."
             />
           ),
         },
       },
       {
         card: "FINANCES",
-        target: "#marketingSlider",
-        advanceOn: (s: AppStateType) => s.game.monthlyMarketingSpend > 0,
+        target: "#rateSlider",
+        advanceOn: (s: AppStateType) => s.game.dollarsPerkWh < 0.07,
         content: (
           <TutorialPrompt
-            concepts={["marketing", "customers"]}
-            text="Raise the marketing budget."
-            action={["marketing"]}
+            concepts={["rate", "customers"]}
+            text="Lower the rate below market to win customers."
+            action={["rate"]}
           />
         ),
       },

--- a/src/helpers/Customers.test.tsx
+++ b/src/helpers/Customers.test.tsx
@@ -1,0 +1,110 @@
+import {
+  CUSTOMER_RATE_MEMORY_MONTHS,
+  customerMarketSizeAt,
+  customerSwitchingRate,
+  nextCustomerCount,
+  projectCustomerChange,
+  updateCustomerRate,
+} from "./Customers";
+import { TICKS_PER_MONTH } from "../Constants";
+
+describe("customer price competition", () => {
+  it("gains customers below market, holds share at market, and loses above it", () => {
+    const base = {
+      customers: 1_000_000,
+      marketSize: 2_000_000,
+      marketRate: 0.1,
+      ownership: "Investor" as const,
+      organicGrowthRate: 0,
+    };
+    expect(nextCustomerCount({ ...base, customerRate: 0.09 })).toBeGreaterThan(
+      base.customers,
+    );
+    expect(nextCustomerCount({ ...base, customerRate: 0.1 })).toBe(
+      base.customers,
+    );
+    expect(nextCustomerCount({ ...base, customerRate: 0.11 })).toBeLessThan(
+      base.customers,
+    );
+  });
+
+  it("does not let an investor exceed the addressable market", () => {
+    expect(
+      nextCustomerCount({
+        customers: 1_999_999,
+        customerRate: 0,
+        marketRate: 0.1,
+        marketSize: 2_000_000,
+        ownership: "Investor",
+      }),
+    ).toBeLessThanOrEqual(2_000_000);
+  });
+
+  it("keeps public customers insensitive to the electricity rate", () => {
+    const cheap = nextCustomerCount({
+      customers: 1_000_000,
+      customerRate: 0,
+      marketRate: 0.1,
+      marketSize: 2_000_000,
+      ownership: "Public",
+      organicGrowthRate: 0,
+    });
+    const expensive = nextCustomerCount({
+      customers: 1_000_000,
+      customerRate: 1,
+      marketRate: 0.1,
+      marketSize: 2_000_000,
+      ownership: "Public",
+      organicGrowthRate: 0,
+    });
+    expect(cheap).toBe(1_000_000);
+    expect(expensive).toBe(cheap);
+  });
+
+  it("caps extreme price responses and never returns a negative count", () => {
+    expect(customerSwitchingRate(0, 0.1)).toBe(0.3);
+    expect(customerSwitchingRate(1, 0.1)).toBe(-0.3);
+    expect(
+      nextCustomerCount({
+        customers: 1,
+        customerRate: 1,
+        marketRate: 0.1,
+        marketSize: 2,
+        ownership: "Investor",
+        organicGrowthRate: -2000,
+      }),
+    ).toBe(0);
+  });
+
+  it("smooths a new bill over roughly three months", () => {
+    let perceived = 0.1;
+    for (let i = 0; i < CUSTOMER_RATE_MEMORY_MONTHS * TICKS_PER_MONTH; i++) {
+      perceived = updateCustomerRate(perceived, 0.05);
+    }
+    expect(perceived).toBeGreaterThan(0.05);
+    expect(perceived).toBeCloseTo(0.0683, 3);
+  });
+
+  it("projects the same gradual response used by the tick model", () => {
+    const common = {
+      customers: 1_000_000,
+      customerRate: 0.1,
+      marketRateAt: () => 0.1,
+      marketSizeAt: () => 2_000_000,
+      ownership: "Investor" as const,
+    };
+    expect(
+      projectCustomerChange({ ...common, currentRate: 0.08 }),
+    ).toBeGreaterThan(0);
+    expect(
+      projectCustomerChange({ ...common, currentRate: 0.12 }),
+    ).toBeLessThan(0);
+  });
+
+  it("grows the serviceable market with the population", () => {
+    expect(customerMarketSizeAt(2_000_000, 0)).toBe(2_000_000);
+    expect(
+      customerMarketSizeAt(2_000_000, 12 * TICKS_PER_MONTH * 15),
+    ).toBeGreaterThan(2_000_000);
+  });
+});

--- a/src/helpers/Customers.tsx
+++ b/src/helpers/Customers.tsx
@@ -1,0 +1,142 @@
+import {
+  ORGANIC_GROWTH_MAX_ANNUAL,
+  TICK_MINUTES,
+  TICKS_PER_MONTH,
+  TICKS_PER_YEAR,
+} from "../Constants";
+import { getInflationIndex } from "../data/Economy";
+import { DateType } from "../Types";
+
+/** A new investor starts with half of the customers it could eventually serve. */
+export const CUSTOMER_MARKET_MULTIPLIER = 2;
+
+/**
+ * Customers remember roughly a quarter's worth of bills instead of reacting to the last slider
+ * movement. An exponential average makes a changed rate about 63% visible after this many months.
+ */
+export const CUSTOMER_RATE_MEMORY_MONTHS = 3;
+
+// A ten-percent price advantage moves fifteen percent of the available market in a year. The cap
+// keeps extreme rates from making a mature utility disappear or double in a single season.
+export const CUSTOMER_PRICE_ELASTICITY = 1.5;
+export const CUSTOMER_SWITCHING_MAX_ANNUAL = 0.3;
+
+/** The competitor benchmark follows the same cumulative inflation as the utility's costs. */
+export function getMarketRate(
+  startingRate: number,
+  date: Pick<DateType, "year" | "monthNumber">,
+  startingYear: number,
+  seed: number,
+): number {
+  return startingRate * getInflationIndex(date, startingYear, seed);
+}
+
+export interface CustomerTickInputType {
+  customers: number;
+  customerRate: number;
+  marketRate: number;
+  marketSize: number;
+  ownership: "Investor" | "Public";
+  organicGrowthRate?: number;
+}
+
+export function updateCustomerRate(
+  previousRate: number,
+  currentRate: number,
+): number {
+  const ticksOfMemory = CUSTOMER_RATE_MEMORY_MONTHS * TICKS_PER_MONTH;
+  return previousRate + (currentRate - previousRate) / ticksOfMemory;
+}
+
+/** Annual fraction of the relevant customer pool that switches to or from the company. */
+export function customerSwitchingRate(
+  customerRate: number,
+  marketRate: number,
+): number {
+  if (marketRate <= 0) {
+    return 0;
+  }
+  const priceAdvantage = (marketRate - customerRate) / marketRate;
+  return Math.max(
+    -CUSTOMER_SWITCHING_MAX_ANNUAL,
+    Math.min(
+      CUSTOMER_SWITCHING_MAX_ANNUAL,
+      priceAdvantage * CUSTOMER_PRICE_ELASTICITY,
+    ),
+  );
+}
+
+/**
+ * Advances the customer count by one game tick. Investor gains come out of the unserved market,
+ * while losses come out of the company's own base; public utilities have captive territories and
+ * therefore skip price switching. Organic growth and blackout attrition share the existing annual
+ * growth-rate input.
+ */
+export function nextCustomerCount({
+  customers,
+  customerRate,
+  marketRate,
+  marketSize,
+  ownership,
+  organicGrowthRate = ORGANIC_GROWTH_MAX_ANNUAL,
+}: CustomerTickInputType): number {
+  let change = (customers * organicGrowthRate) / TICKS_PER_YEAR;
+  if (ownership === "Investor") {
+    const switchingRate = customerSwitchingRate(customerRate, marketRate);
+    const switchingBase =
+      switchingRate >= 0
+        ? Math.max(0, marketSize - customers)
+        : Math.max(0, customers);
+    change += (switchingBase * switchingRate) / TICKS_PER_YEAR;
+  }
+  const next = Math.max(0, Math.round(customers + change));
+  return ownership === "Investor"
+    ? Math.min(Math.round(marketSize), next)
+    : next;
+}
+
+/** The addressable market grows with the same underlying population trend as neutral customers. */
+export function customerMarketSizeAt(
+  startingMarketSize: number,
+  minute: number,
+): number {
+  const elapsedYears = minute / TICK_MINUTES / TICKS_PER_YEAR;
+  return (
+    startingMarketSize * Math.pow(1 + ORGANIC_GROWTH_MAX_ANNUAL, elapsedYears)
+  );
+}
+
+export interface CustomerProjectionInputType {
+  customers: number;
+  customerRate: number;
+  currentRate: number;
+  marketRateAt: (tick: number) => number;
+  marketSizeAt: (tick: number) => number;
+  ownership: "Investor" | "Public";
+  ticks?: number;
+}
+
+/** Uses the exact tick rules to preview a rate change without running the electricity simulation. */
+export function projectCustomerChange({
+  customers,
+  customerRate,
+  currentRate,
+  marketRateAt,
+  marketSizeAt,
+  ownership,
+  ticks = TICKS_PER_MONTH,
+}: CustomerProjectionInputType): number {
+  const startingCustomers = customers;
+  let perceivedRate = customerRate;
+  for (let tick = 0; tick < ticks; tick++) {
+    perceivedRate = updateCustomerRate(perceivedRate, currentRate);
+    customers = nextCustomerCount({
+      customers,
+      customerRate: perceivedRate,
+      marketRate: marketRateAt(tick),
+      marketSize: marketSizeAt(tick),
+      ownership,
+    });
+  }
+  return customers - startingCustomers;
+}

--- a/src/helpers/DateTime.test.tsx
+++ b/src/helpers/DateTime.test.tsx
@@ -163,7 +163,6 @@ describe("summarizeTimeline", () => {
           expensesOM: 0,
           expensesCarbonFee: 0,
           expensesInterest: 0,
-          expensesMarketing: 0,
           kgco2e: 0,
           interestRate: 0.04 + i / 1000,
           inflationRate: 0.02,

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -31,7 +31,6 @@ export const EMPTY_HISTORY = {
   expensesOM: 0,
   expensesCarbonFee: 0,
   expensesInterest: 0,
-  expensesMarketing: 0,
   netWorth: 0,
   interestRate: 0,
   inflationRate: 0,
@@ -48,7 +47,6 @@ export function reduceHistories(
   acc.revenue += t.revenue;
   acc.expensesFuel += t.expensesFuel;
   acc.expensesOM += t.expensesOM;
-  acc.expensesMarketing += t.expensesMarketing;
   acc.expensesCarbonFee += t.expensesCarbonFee;
   acc.expensesInterest += t.expensesInterest;
   acc.cash = t.cash;
@@ -67,11 +65,7 @@ export function deriveExpandedSummary(
   s: MonthlyHistoryType,
 ): DerivedHistoryType {
   const expenses =
-    s.expensesFuel +
-    s.expensesOM +
-    s.expensesMarketing +
-    s.expensesCarbonFee +
-    s.expensesInterest;
+    s.expensesFuel + s.expensesOM + s.expensesCarbonFee + s.expensesInterest;
   const supplykWh = (s.supplyWh || 1) / 1000;
   return {
     ...s,
@@ -103,7 +97,6 @@ function accumulateTick(
   summary.revenue += t.revenue;
   summary.expensesFuel += t.expensesFuel;
   summary.expensesOM += t.expensesOM;
-  summary.expensesMarketing += t.expensesMarketing;
   summary.expensesCarbonFee += t.expensesCarbonFee;
   summary.expensesInterest += t.expensesInterest;
   summary.cash = t.cash;

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -1,5 +1,4 @@
 import {
-  customersFromMarketingSpend,
   CreditInputsType,
   facilityCashBack,
   facilityLifetime,
@@ -139,29 +138,6 @@ describe("facilityCashBack", () => {
         facilityCashBack(aFacility({ yearsToBuildLeft })),
       ).toBeLessThanOrEqual(1000000);
     });
-  });
-});
-
-describe("customersFromMarketingSpend", () => {
-  it("signs up nobody for nothing", () => {
-    expect(customersFromMarketingSpend(0)).toBe(0);
-  });
-
-  it("returns a whole number of customers", () => {
-    expect(Number.isInteger(customersFromMarketingSpend(1234567))).toBe(true);
-  });
-
-  it("wins more customers the more is spent", () => {
-    expect(customersFromMarketingSpend(1000000)).toBeGreaterThan(
-      customersFromMarketingSpend(100000),
-    );
-  });
-
-  it("costs more per customer as spend grows", () => {
-    // The acquisition cost rises with spend, so the last dollar buys less than the first
-    const costPer = (spend: number) =>
-      spend / customersFromMarketingSpend(spend);
-    expect(costPer(10000000)).toBeGreaterThan(costPer(100000));
   });
 });
 
@@ -320,7 +296,6 @@ describe("getCreditInputs", () => {
       expensesOM: 0,
       expensesCarbonFee: 0,
       expensesInterest: 0,
-      expensesMarketing: 0,
       supplyWh: 1000,
     }) as never;
 

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -239,8 +239,3 @@ export function facilityCashBack(
   // down payment/equity because the outstanding loan is settled at the same time.
   return g.buildCost - g.loanAmountLeft;
 }
-
-// CAC $100->150, increasing as you spend more - https://woodlawnassociates.com/electrical-potential-solar-and-competitive-electricity/
-export function customersFromMarketingSpend(spend: number) {
-  return Math.floor(spend / (100 + spend / 1000000));
-}

--- a/src/helpers/Scoring.test.tsx
+++ b/src/helpers/Scoring.test.tsx
@@ -19,7 +19,6 @@ it("gives a public utility that supplied no electricity a finite score", () => {
     expensesOM: 0,
     expensesCarbonFee: 0,
     expensesInterest: 0,
-    expensesMarketing: 0,
     kgco2e: 0,
     interestRate: 0.05,
     inflationRate: 0.02,

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -12,7 +12,6 @@ import {
   getSunriseSunset,
 } from "../helpers/DateTime";
 import {
-  customersFromMarketingSpend,
   facilityCashBack,
   getCreditInputs,
   getCreditPremium,
@@ -20,6 +19,13 @@ import {
   getPaymentInterest,
 } from "../helpers/Financials";
 import { getInflationRate, getPrimeRate } from "../data/Economy";
+import {
+  CUSTOMER_MARKET_MULTIPLIER,
+  customerMarketSizeAt,
+  getMarketRate,
+  nextCustomerCount,
+  updateCustomerRate,
+} from "../helpers/Customers";
 import {
   formatMoneyConcise,
   formatWatts,
@@ -438,7 +444,8 @@ const initialGame: GameType = {
   inGame: false,
   feePerKgCO2e: 0, // Start on easy mode
   dollarsPerkWh: 0.07,
-  monthlyMarketingSpend: 0,
+  customerMarketSize: 0,
+  customerRate: 0.07,
   // Placeholders until initGame prices the company against the year it actually starts in. The
   // new game screens read these before any economic data has been loaded.
   interestRate: INTEREST_RATE_YEARLY,
@@ -545,6 +552,8 @@ export const gameSlice = createSlice({
       // The rate the scenario advertises on the new game screen, and the rate Public scenarios are
       // scored against, so the game has to actually start there rather than at the slice default
       state.dollarsPerkWh = scenario.dollarsPerkWh;
+      state.customerRate = scenario.dollarsPerkWh;
+      state.customerMarketSize = a.customers * CUSTOMER_MARKET_MULTIPLIER;
       state.location = a.location;
       state.timeline = generateNewTimeline(state, a.cash, a.customers);
 
@@ -606,8 +615,8 @@ export const gameSlice = createSlice({
       // Establish the comparison before time moves. A fleet that was already dearer on day one
       // has not crossed anything; the first monthly ordering change is the event.
       state.fuelCostSnapshot = currentFuelCosts(state);
-      // Anything the player did before the clock first moved -- setting a rate or a marketing
-      // budget on the way in. tickState picks up everything after this
+      // Anything the player did before the clock first moved -- setting a rate on the way in.
+      // tickState picks up everything after this
       applyPendingReplayActions(state);
     },
     buildFacility: (state, action: PayloadAction<BuildFacilityAction>) => {
@@ -1020,6 +1029,7 @@ export function tickState(state: GameType) {
       previousMonth = state.date.month;
       const history = state.monthlyHistory;
       const { cash, customers } = now;
+      state.customerRate = now.customerRate;
 
       // Record final history for the month, then generate the new timeline
       history.unshift(summarizeTimeline(state.timeline, state.startingYear));
@@ -1254,19 +1264,32 @@ export function hasChronicBlackouts(history: MonthlyHistoryType[]): boolean {
   );
 }
 
-// Simplified customer forecast, assumes no blackouts since supply calculation depends on demand (circular depedency)
+// Simplified customer forecast, assumes no blackouts since supply calculation depends on demand
+// (circular dependency). The supply pass repeats the calculation with reliability attrition.
 function getDemandW(
   date: DateType,
   game: GameType,
   prev: TickPresentFutureType,
   now: TickPresentFutureType,
 ) {
-  const marketingGrowth =
-    customersFromMarketingSpend(game.monthlyMarketingSpend) / TICKS_PER_MONTH;
-  now.customers = Math.round(
-    prev.customers * (1 + ORGANIC_GROWTH_MAX_ANNUAL / TICKS_PER_YEAR) +
-      marketingGrowth,
+  const scenario =
+    getScenario(game.scenarioId, game.customScenario) || SCENARIOS[0];
+  now.customerRate = updateCustomerRate(
+    prev.customerRate || game.customerRate,
+    game.dollarsPerkWh,
   );
+  now.customers = nextCustomerCount({
+    customers: prev.customers,
+    customerRate: now.customerRate,
+    marketRate: getMarketRate(
+      scenario.dollarsPerkWh,
+      date,
+      game.startingYear,
+      game.seed,
+    ),
+    marketSize: customerMarketSizeAt(game.customerMarketSize, now.minute),
+    ownership: scenario.ownership,
+  });
   const sun = getSunriseSunset(date, game.location);
 
   // https://www.eia.gov/todayinenergy/detail.php?id=830
@@ -1747,7 +1770,6 @@ function updateSupplyFacilitiesFinances(
     }
   });
   const expensesCarbonFee = state.feePerKgCO2e * kgco2e;
-  const expensesMarketing = state.monthlyMarketingSpend / TICKS_PER_MONTH;
 
   // Customers
   // Demand is the customer count times a multiple, so a run that blacks out for long enough
@@ -1759,13 +1781,23 @@ function updateSupplyFacilitiesFinances(
   const organicGrowthRate =
     ORGANIC_GROWTH_MAX_ANNUAL -
     difficulty.blackoutPenalty * percentDemandUnfulfilled;
-  const marketingGrowth =
-    customersFromMarketingSpend(state.monthlyMarketingSpend) / TICKS_PER_MONTH;
+  const scenario =
+    getScenario(state.scenarioId, state.customScenario) || SCENARIOS[0];
 
   // Save new financial info
-  now.customers = Math.round(
-    prev.customers * (1 + organicGrowthRate / TICKS_PER_YEAR) + marketingGrowth,
-  );
+  now.customers = nextCustomerCount({
+    customers: prev.customers,
+    customerRate: now.customerRate,
+    marketRate: getMarketRate(
+      scenario.dollarsPerkWh,
+      tickDate,
+      state.startingYear,
+      state.seed,
+    ),
+    marketSize: customerMarketSizeAt(state.customerMarketSize, now.minute),
+    ownership: scenario.ownership,
+    organicGrowthRate,
+  });
   now.cash = Math.round(
     prev.cash +
       revenue -
@@ -1773,7 +1805,6 @@ function updateSupplyFacilitiesFinances(
       expensesFuel -
       expensesCarbonFee -
       expensesInterest -
-      expensesMarketing -
       principalRepayment,
   );
   now.netWorth = getNetWorth(facilities, now.cash, now.minute);
@@ -1782,7 +1813,6 @@ function updateSupplyFacilitiesFinances(
   now.expensesFuel = expensesFuel;
   now.expensesCarbonFee = expensesCarbonFee;
   now.expensesInterest = expensesInterest;
-  now.expensesMarketing = expensesMarketing;
   now.kgco2e = kgco2e;
   // Deliberately this tick's own month rather than `date`, which is the month the game is
   // actually in and is shared by every tick of a forecast. Reading it from the tick is what lets
@@ -1856,6 +1886,9 @@ export function generateNewTimeline(
   // Loop invariant: the fleet is fixed across the horizon and the cash is a parameter, so this
   // was the same number recomputed for every one of up to a year's worth of ticks
   const netWorth = getNetWorth(state.facilities, cash, state.date.minute);
+  const currentCustomerRate =
+    getTimeFromTimeline(readOnlyState.date.minute, readOnlyState.timeline)
+      ?.customerRate || readOnlyState.customerRate;
   for (let i = 0; i < ticks; i++) {
     state.timeline[i] = {
       minute: state.date.minute + i * TICK_MINUTES,
@@ -1866,13 +1899,13 @@ export function generateNewTimeline(
       temperatureC: 0,
       cash,
       customers,
+      customerRate: currentCustomerRate,
       netWorth,
       revenue: 0,
       expensesFuel: 0,
       expensesOM: 0,
       expensesCarbonFee: 0,
       expensesInterest: 0,
-      expensesMarketing: 0,
       kgco2e: 0,
       // Both overwritten by updateSupplyFacilitiesFinances, from each tick's own date
       interestRate: 0,

--- a/src/reducers/Replay.test.tsx
+++ b/src/reducers/Replay.test.tsx
@@ -54,10 +54,10 @@ function playAScriptedGame(): GameType {
   );
 
   runMonths(state, 2);
-  state = dispatch(state, delta({ monthlyMarketingSpend: 40000 }));
+  state = dispatch(state, delta({ dollarsPerkWh: 0.06 }));
   // Two deltas in the same minute: the sliders fire one of these per pixel dragged, and only the
   // last matters, so the recorder merges them
-  state = dispatch(state, delta({ monthlyMarketingSpend: 60000 }));
+  state = dispatch(state, delta({ dollarsPerkWh: 0.065 }));
 
   runMonths(state, 2);
   state = dispatch(state, togglePauseFacility(state.facilities[0].id));
@@ -105,7 +105,7 @@ describe("recording a run", () => {
   it("merges the deltas fired within one minute into the value that stuck", () => {
     const deltas = played.replayLog!.filter((a) => a.type === "delta");
     expect(deltas.length).toBe(1);
-    expect(deltas[0].payload).toEqual({ monthlyMarketingSpend: 60000 });
+    expect(deltas[0].payload).toEqual({ dollarsPerkWh: 0.065 });
   });
 
   it("stamps each action with a tick boundary inside the run", () => {

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -152,12 +152,12 @@ describe("ending a scenario from inside the reducer", () => {
   });
 
   it("goes bankrupt without reading the revoked draft", () => {
-    // No cash and a marketing budget far past what the fleet earns: it is under within a month
+    // No cash and free electricity: operating the fleet puts it under within a month
     const scenario = customScenario({ cash: 0, durationMonths: 12 * 20 });
     let state = createGame({
       scenarioId: CUSTOM_SCENARIO_ID,
       scenario,
-      monthlyMarketingSpend: 1000000000,
+      dollarsPerkWh: 0,
     });
     while (state.date.monthsEllapsed < 2) {
       state = tick(state);
@@ -172,9 +172,11 @@ describe("ending a scenario from inside the reducer", () => {
     const scenario = SCENARIOS.find(
       (s: ScenarioType) => s.id === 100,
     ) as ScenarioType;
-    const state = createGame({
-      scenarioId: scenario.id,
-      monthlyMarketingSpend: 1000000000,
+    const state = createGame({ scenarioId: scenario.id });
+    // Start the month already overdrawn so this test reaches the bankruptcy path without relying
+    // on the removed marketing expense as an artificial cash drain.
+    state.timeline.forEach((tick) => {
+      tick.cash = -1;
     });
 
     playOutOnTheStore(state, 1);
@@ -217,7 +219,6 @@ describe("ending a scenario from inside the reducer", () => {
       expensesOM: 0,
       expensesCarbonFee: 0,
       expensesInterest: 0,
-      expensesMarketing: 0,
       kgco2e: 0,
       interestRate: 0.05,
       inflationRate: 0.02,

--- a/src/reducers/Tutorial.test.tsx
+++ b/src/reducers/Tutorial.test.tsx
@@ -20,7 +20,7 @@ function informational(card: "FACILITIES" | "FINANCES" = "FACILITIES") {
 
 function initialState(
   steps: TutorialStepType[],
-  options: { marketingSpend?: number; tutorialStep?: number } = {},
+  options: { rate?: number; tutorialStep?: number } = {},
 ): AppStateType {
   const init = { type: "test/init" };
   return {
@@ -35,7 +35,7 @@ function initialState(
         ...DEFAULT_CUSTOM_SCENARIO,
         tutorialSteps: steps,
       },
-      monthlyMarketingSpend: options.marketingSpend || 0,
+      dollarsPerkWh: options.rate ?? 0.07,
       tutorialStep: options.tutorialStep || 0,
     },
     settings: settingsReducer(undefined, init),
@@ -51,7 +51,7 @@ function reducer(
   if (action.type === "test/satisfy-predicate") {
     return {
       ...state,
-      game: { ...state.game, monthlyMarketingSpend: 1 },
+      game: { ...state.game, dollarsPerkWh: 0.06 },
     };
   }
   if (action.type === "game/delta") {
@@ -91,7 +91,7 @@ function reducer(
 
 function tutorialStore(
   steps: TutorialStepType[],
-  options?: { marketingSpend?: number; tutorialStep?: number },
+  options?: { rate?: number; tutorialStep?: number },
 ) {
   return configureStore({
     reducer,
@@ -112,7 +112,7 @@ describe("tutorialGateMiddleware", () => {
     const steps: TutorialStepType[] = [
       {
         ...informational(),
-        advanceOn: (state) => state.game.monthlyMarketingSpend > 0,
+        advanceOn: (state) => state.game.dollarsPerkWh < 0.07,
       },
       informational("FINANCES"),
     ];
@@ -143,11 +143,11 @@ describe("tutorialGateMiddleware", () => {
       { ...informational(), advanceOnAction: "test/do-it" },
       {
         ...informational(),
-        advanceOn: (state) => state.game.monthlyMarketingSpend > 0,
+        advanceOn: (state) => state.game.dollarsPerkWh < 0.07,
       },
       informational(),
     ];
-    const store = tutorialStore(steps, { marketingSpend: 1 });
+    const store = tutorialStore(steps, { rate: 0.06 });
 
     store.dispatch({ type: "test/do-it" });
 

--- a/src/testing/Invariants.tsx
+++ b/src/testing/Invariants.tsx
@@ -44,13 +44,13 @@ const FINITE_TICK_FIELDS: TickFieldType[] = [
   "storageLossWh",
   "cash",
   "customers",
+  "customerRate",
   "netWorth",
   "revenue",
   "expensesFuel",
   "expensesOM",
   "expensesCarbonFee",
   "expensesInterest",
-  "expensesMarketing",
   "kgco2e",
   "interestRate",
   "inflationRate",
@@ -77,7 +77,6 @@ const NON_NEGATIVE_TICK_FIELDS: TickFieldType[] = [
   "expensesOM",
   "expensesCarbonFee",
   "expensesInterest",
-  "expensesMarketing",
   "kgco2e",
   // A lender can quote any rate it likes, but never a negative one
   "interestRate",
@@ -94,7 +93,6 @@ const FINITE_MONTH_FIELDS: MonthFieldType[] = [
   "expensesOM",
   "expensesCarbonFee",
   "expensesInterest",
-  "expensesMarketing",
   "kgco2e",
   "interestRate",
   "inflationRate",
@@ -202,8 +200,7 @@ export function checkTick(
       now.expensesFuel +
       now.expensesOM +
       now.expensesCarbonFee +
-      now.expensesInterest +
-      now.expensesMarketing;
+      now.expensesInterest;
     const maxPrincipal = state.facilities.reduce(
       (acc: number, f: FacilityOperatingType) =>
         acc +

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -59,7 +59,7 @@ code rather than a vibe.
 | Monthly totals      | Billed supply never exceeds demand, and every total is finite                                                                                                                                     |
 
 `Simulation.test.tsx` asserts all of this as part of `npm test`, across every scenario, both ends
-of the difficulty range, marketing spend, and a run that builds on credit. It also pins down
+of the difficulty range, customer price competition, and a run that builds on credit. It also pins down
 determinism and a few economic identities (revenue really is rate times kilowatt hours, the carbon
 fee really is proportional to emissions).
 

--- a/src/testing/Report.tsx
+++ b/src/testing/Report.tsx
@@ -184,8 +184,7 @@ export function formatReport(
   lines.push(
     `  Expenses         ${formatMoneyConcise(derived.expenses)}  ` +
       `[fuel ${formatMoneyConcise(summary.expensesFuel)} · O&M ${formatMoneyConcise(summary.expensesOM)} · ` +
-      `interest ${formatMoneyConcise(summary.expensesInterest)} · carbon ${formatMoneyConcise(summary.expensesCarbonFee)} · ` +
-      `marketing ${formatMoneyConcise(summary.expensesMarketing)}]`,
+      `interest ${formatMoneyConcise(summary.expensesInterest)} · carbon ${formatMoneyConcise(summary.expensesCarbonFee)}]`,
   );
   lines.push(`  Profit           ${formatMoneyConcise(derived.profit)}`);
   lines.push(

--- a/src/testing/SimCli.tsx
+++ b/src/testing/SimCli.tsx
@@ -59,7 +59,6 @@ function baseOptions(): Omit<SimOptionsType, "scenarioId"> {
     months: envNumber("SIM_MONTHS"),
     seed: envNumber("SIM_SEED"),
     dollarsPerkWh: envNumber("SIM_RATE"),
-    monthlyMarketingSpend: envNumber("SIM_MARKETING"),
     strategy: (process.env.SIM_STRATEGY as StrategyType) || undefined,
     initialBuild: initialBuildName
       ? {

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -81,13 +81,11 @@ describe("simulation invariants", () => {
     });
   });
 
-  it("holds while spending on marketing", () => {
-    expectNoViolations(
-      runSimulation({
-        scenarioId: 101,
-        months: MONTHS,
-        monthlyMarketingSpend: 5000000,
-      }),
+  it("holds while gaining and losing customers through price competition", () => {
+    [0.01, 0.2].forEach((dollarsPerkWh) =>
+      expectNoViolations(
+        runSimulation({ scenarioId: 101, months: MONTHS, dollarsPerkWh }),
+      ),
     );
   });
 
@@ -252,6 +250,7 @@ describe("simulation economics", () => {
     },
     101: { sellFacilityId: 1 },
     102: {
+      dollarsPerkWh: 0.034,
       initialBuild: {
         name: "Natural Gas",
         peakW: 200000000,
@@ -261,6 +260,7 @@ describe("simulation economics", () => {
       sellAtMonth: 39,
     },
     103: {
+      dollarsPerkWh: 0.039,
       initialBuild: {
         name: "Natural Gas",
         peakW: 400000000,
@@ -271,6 +271,7 @@ describe("simulation economics", () => {
     },
     104: { dollarsPerkWh: 0.08 },
     105: {
+      dollarsPerkWh: 0.08,
       initialBuild: {
         name: "Natural Gas",
         peakW: 300000000,
@@ -281,10 +282,10 @@ describe("simulation economics", () => {
   const CEO_ACTION_COUNTS = {
     100: 2,
     101: 1,
-    102: 2,
-    103: 2,
+    102: 3,
+    103: 3,
     104: 1,
-    105: 1,
+    105: 2,
   } as Record<number, number>;
 
   SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
@@ -300,9 +301,6 @@ describe("simulation economics", () => {
 
         const play =
           CEO_WINNING_PLAYS[scenario.id as keyof typeof CEO_WINNING_PLAYS];
-        expect(
-          !("dollarsPerkWh" in play) || scenario.ownership === "Public",
-        ).toBe(true);
         const active = runSimulation({
           scenarioId: scenario.id,
           difficulty: "CEO",
@@ -351,6 +349,23 @@ describe("simulation economics", () => {
     const revenue = (r: SimResultType) =>
       r.months.reduce((a, m) => a + m.revenue, 0);
     expect(revenue(pricey)).toBeGreaterThan(revenue(cheap));
+  });
+
+  it("moves investor customers toward a cheaper utility and away from a dearer one", () => {
+    const customersAt = (dollarsPerkWh: number) =>
+      runSimulation({ scenarioId: 101, months: 12, dollarsPerkWh }).months.at(
+        -1,
+      )!.customers;
+    expect(customersAt(0.05)).toBeGreaterThan(customersAt(0.07));
+    expect(customersAt(0.07)).toBeGreaterThan(customersAt(0.1));
+  });
+
+  it("keeps public customer growth independent of the rate", () => {
+    const customersAt = (dollarsPerkWh: number) =>
+      runSimulation({ scenarioId: 104, months: 12, dollarsPerkWh }).months.at(
+        -1,
+      )!.customers;
+    expect(customersAt(0.02)).toBe(customersAt(0.2));
   });
 
   /**

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -71,7 +71,6 @@ export interface SimOptionsType {
   months?: number; // Defaults to the scenario's own duration
   seed?: number;
   dollarsPerkWh?: number;
-  monthlyMarketingSpend?: number;
   strategy?: StrategyType;
   initialBuild?: InitialBuildType;
   sellFacilityId?: number;
@@ -84,7 +83,6 @@ export interface ResolvedSimOptionsType {
   months: number;
   seed: number;
   dollarsPerkWh: number | null; // null = left at the scenario's own rate
-  monthlyMarketingSpend: number;
   strategy: StrategyType;
   initialBuild: InitialBuildType | null;
   sellFacilityId: number | null;
@@ -155,7 +153,6 @@ function setUpGame(
     state,
     delta({
       difficulty: options.difficulty,
-      monthlyMarketingSpend: options.monthlyMarketingSpend,
       // A scenario that isn't in SCENARIOS can only be found again through the slice, which is
       // exactly what the custom game screen does before it starts a game
       customScenario: SCENARIOS.some((s: ScenarioType) => s.id === scenario.id)
@@ -301,7 +298,6 @@ function resolveOptions(
           : DEFAULT_SEED,
     dollarsPerkWh:
       options.dollarsPerkWh === undefined ? null : options.dollarsPerkWh,
-    monthlyMarketingSpend: options.monthlyMarketingSpend || 0,
     strategy: options.strategy || "none",
     initialBuild: options.initialBuild || null,
     sellFacilityId: options.sellFacilityId ?? null,


### PR DESCRIPTION
## Summary
- replace investor marketing spend with a rate slider that drives customer gains and losses
- model inflation-adjusted market pricing, finite market size, and three-month customer rate memory
- update forecasts, tutorials, documentation, save/replay schemas, and simulation tooling
- keep public-utility customers captive while preserving their existing rate control

## Validation
- npm run check (686 tests)
- npm run build
- responsive browser QA at desktop and 390x844 mobile viewports

## Compatibility
- bumps save format to v5 and replay format to v4 because older sessions use the removed marketing model