### PR TITLE
Streamline in-game navigation chrome

### DIFF
--- a/src/components/base/GameAppBar.test.tsx
+++ b/src/components/base/GameAppBar.test.tsx
@@ -7,17 +7,13 @@ import { FacilityOperatingType } from "../../Types";
 
 jest.mock("../../Globals", () => ({
   ...jest.requireActual("../../Globals"),
-  isBigScreen: () => false,
-  isSmallScreen: () => true,
+  isBigScreen: () => true,
 }));
 
 function renderAppBar(overrides: Partial<Props> = {}) {
   const game = createGame({ scenarioId: 101 });
   const props: Props = {
     game: { ...game, inGame: true },
-    audioEnabled: true,
-    onAudioChange: () => undefined,
-    onEvents: () => undefined,
     onManual: () => undefined,
     onNextTutorial: () => undefined,
     onQuit: () => undefined,
@@ -28,7 +24,7 @@ function renderAppBar(overrides: Partial<Props> = {}) {
   return render(<GameAppBar {...props} />);
 }
 
-describe("GameAppBar mobile speed controls", () => {
+describe("GameAppBar", () => {
   it("keeps all four speeds one tap away", () => {
     const onSpeedChange = jest.fn();
     renderAppBar({ onSpeedChange });
@@ -59,9 +55,18 @@ describe("GameAppBar mobile speed controls", () => {
     expect(screen.queryByText(/% reserve/)).not.toBeInTheDocument();
   });
 
-  it("omits the redundant money and time icons", () => {
+  it("omits the redundant money and time icons on desktop", () => {
     renderAppBar();
     expect(screen.queryByLabelText("Money")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Time")).not.toBeInTheDocument();
+  });
+
+  it("omits events and sound controls from the menu", () => {
+    renderAppBar();
+    fireEvent.click(screen.getByRole("button", { name: "menu" }));
+
+    expect(screen.queryByRole("menuitem", { name: /events/i })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: /turn sound/i })).toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Options" })).toBeVisible();
   });
 });

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -16,10 +16,9 @@ import { TICKS_PER_HOUR, TICK_MS } from "../../Constants";
 import { formatHour, getTimeFromTimeline } from "../../helpers/DateTime";
 import { formatMoneyStable, formatWatts } from "../../helpers/Format";
 import { navigate } from "../../reducers/Card";
-import { isBigScreen, isSmallScreen, openWindow } from "../../Globals";
+import { isBigScreen, openWindow } from "../../Globals";
 import { getNextTutorial, getScenario } from "../../data/Scenarios";
 import { quit, setSpeed, startTutorial } from "../../reducers/Game";
-import { change as changeSettings } from "../../reducers/Settings";
 import {
   AppStateType,
   FacilityOperatingType,
@@ -42,17 +41,14 @@ import ConceptIcon from "./ConceptIcon";
 
 export interface StateProps {
   game: GameType;
-  audioEnabled?: boolean;
 }
 
 export interface DispatchProps {
-  onEvents: () => void;
   onManual: () => void;
   onSettings: () => void;
   onSpeedChange: (speed: SpeedType) => void;
   onNextTutorial: (scenarioId: number) => void;
   onQuit: () => void;
-  onAudioChange: (enabled: boolean) => void;
 }
 
 export interface Props extends StateProps, DispatchProps {}
@@ -150,17 +146,8 @@ function buildSpeedOptions({
 }
 
 export function GameAppBar(props: Props) {
-  const {
-    game,
-    audioEnabled,
-    onAudioChange,
-    onEvents,
-    onManual,
-    onNextTutorial,
-    onQuit,
-    onSettings,
-    onSpeedChange,
-  } = props;
+  const { game, onManual, onNextTutorial, onQuit, onSettings, onSpeedChange } =
+    props;
   const date = game.date;
   const now = getTimeFromTimeline(date.minute, game.timeline);
   const [menuAnchorEl, setMenuAnchorEl] = React.useState<HTMLElement | null>(
@@ -168,7 +155,6 @@ export function GameAppBar(props: Props) {
   );
   const [scenarioDetailsOpen, setScenarioDetailsOpen] = React.useState(false);
 
-  const smallScreen = isSmallScreen();
   const bigScreen = isBigScreen();
   const speed = game.speed;
   // Watching somebody else's run rather than playing your own. The speed controls stay live --
@@ -182,9 +168,6 @@ export function GameAppBar(props: Props) {
   // gets the "Save & Quit" reminder that leaving keeps it around to come back to
   const isTutorial = !!getScenario(game.scenarioId, game.customScenario)
     ?.tutorialSteps;
-  const hasUnreadEvents =
-    (game.eventLog?.[0]?.id || 0) > (game.eventLogReadThroughId || 0);
-
   const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
     setMenuAnchorEl(event.currentTarget);
   const handleMenuClose = () => setMenuAnchorEl(null);
@@ -226,19 +209,8 @@ export function GameAppBar(props: Props) {
           open={Boolean(menuAnchorEl)}
           onClose={handleMenuClose}
         >
-          <MenuItem onClick={onEvents}>
-            Events{hasUnreadEvents ? " •" : ""}
-          </MenuItem>
           <MenuItem onClick={onManual}>Manual</MenuItem>
           <MenuItem onClick={onSettings}>Options</MenuItem>
-          <MenuItem
-            onClick={() => {
-              onAudioChange(!audioEnabled);
-              handleMenuClose();
-            }}
-          >
-            Turn sound {audioEnabled ? "off" : "on"}
-          </MenuItem>
           <MenuItem
             onClick={() => {
               setScenarioDetailsOpen(true);
@@ -266,14 +238,10 @@ export function GameAppBar(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       menuAnchorEl,
-      onEvents,
-      hasUnreadEvents,
       onManual,
       onSettings,
       onNextTutorial,
       onQuit,
-      onAudioChange,
-      audioEnabled,
       nextTutorial,
       isReplay,
       isTutorial,
@@ -298,11 +266,9 @@ export function GameAppBar(props: Props) {
           {menu}
           <Typography variant="h6" className="gameStatus">
             <span className="gameStatusValue">
-              {!smallScreen && <ConceptIcon concept="money" fontSize="small" />}
               {formatMoneyStable(now.cash)}
             </span>
             <span className="weak gameStatusValue">
-              {!smallScreen && <ConceptIcon concept="time" fontSize="small" />}
               {date.month} {date.year}
               {bigScreen ? `, ${formatHour(date)}` : ""}
             </span>
@@ -345,16 +311,12 @@ export function GameAppBar(props: Props) {
 
 const mapStateToProps = (state: AppStateType): StateProps => ({
   game: state.game,
-  audioEnabled: state.settings.audioEnabled,
 });
 
 const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onManual: () => {
       dispatch(navigate("MANUAL"));
-    },
-    onEvents: () => {
-      dispatch(navigate("EVENTS"));
     },
     onSettings: () => {
       dispatch(navigate("SETTINGS"));
@@ -367,9 +329,6 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     },
     onQuit: () => {
       dispatch(quit());
-    },
-    onAudioChange: (enabled: boolean) => {
-      dispatch(changeSettings({ audioEnabled: enabled }));
     },
   };
 };

--- a/src/components/base/Navigation.test.tsx
+++ b/src/components/base/Navigation.test.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { store } from "../../Store";
+import { isPaneLayout } from "../../Globals";
+import Navigation from "./Navigation";
+
+jest.mock("../../Globals", () => ({
+  ...jest.requireActual("../../Globals"),
+  isPaneLayout: jest.fn(),
+}));
+
+const mockIsPaneLayout = isPaneLayout as jest.MockedFunction<
+  typeof isPaneLayout
+>;
+
+function renderNavigation() {
+  return render(
+    <Provider store={store}>
+      <Navigation />
+    </Provider>,
+  );
+}
+
+describe("Navigation", () => {
+  it("shows Facilities in the single-panel layout", () => {
+    mockIsPaneLayout.mockReturnValue(false);
+    renderNavigation();
+
+    expect(screen.getByRole("button", { name: "Facilities" })).toBeVisible();
+  });
+
+  it("omits Facilities when it is pinned in the two-panel layout", () => {
+    mockIsPaneLayout.mockReturnValue(true);
+    renderNavigation();
+
+    expect(screen.queryByRole("button", { name: "Facilities" })).toBeNull();
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+  });
+});

--- a/src/components/base/Navigation.tsx
+++ b/src/components/base/Navigation.tsx
@@ -7,6 +7,7 @@ import InsertChartIcon from "@mui/icons-material/InsertChart";
 import { useAppSelector, useAppDispatch } from "../../Store";
 import { CardNameType, CardType } from "../../Types";
 import { navigate, selectCardName } from "../../reducers/Card";
+import { isPaneLayout } from "../../Globals";
 
 export interface StateProps {
   card: CardType;
@@ -17,6 +18,11 @@ export interface Props extends StateProps {}
 export default function Navigation() {
   const dispatch = useAppDispatch();
   const cardName = useAppSelector(selectCardName);
+  const paneLayout = isPaneLayout();
+  // Facilities is always the left pane at this width. If a resize lands here while that was
+  // the active phone tab, Finances is the second pane actually being shown.
+  const selectedCard =
+    paneLayout && cardName === "FACILITIES" ? "FINANCES" : cardName;
   const unreadEvents = useAppSelector((state) => {
     const latest = state.game.eventLog?.[0]?.id || 0;
     return latest > (state.game.eventLogReadThroughId || 0);
@@ -25,17 +31,19 @@ export default function Navigation() {
     <BottomNavigation
       id="navfooter"
       showLabels
-      value={cardName || "MAIN_MENU"}
+      value={selectedCard || "MAIN_MENU"}
       onChange={(_e: React.SyntheticEvent, name: CardNameType) =>
         dispatch(navigate(name))
       }
     >
-      <BottomNavigationAction
-        id="faciltiesNav"
-        label="Facilities"
-        value="FACILITIES"
-        icon={<FlashOnIcon />}
-      />
+      {!paneLayout && (
+        <BottomNavigationAction
+          id="faciltiesNav"
+          label="Facilities"
+          value="FACILITIES"
+          icon={<FlashOnIcon />}
+        />
+      )}
       <BottomNavigationAction
         id="financesNav"
         label="Finances"


### PR DESCRIPTION
## Summary

- remove the redundant money and time icons from the desktop game status bar
- remove Events and the sound toggle from the in-game menu
- hide Facilities from the two-panel bottom navigation because that pane is pinned
- preserve the correct selected navigation state when resizing from Facilities

## Testing

- npm run check
- responsive browser verification at 1000px and 1400px