### PR TITLE
Fix watershed reservoir axis spacing

### DIFF
--- a/src/components/base/ChartForecastWater.test.tsx
+++ b/src/components/base/ChartForecastWater.test.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import { TickPresentFutureType } from "../../Types";
-import ChartForecastWater from "./ChartForecastWater";
+import ChartForecastWater, {
+  formatReservoirAxisValue,
+} from "./ChartForecastWater";
 
 function tick(minute: number, scale: number): TickPresentFutureType {
   return {
@@ -28,4 +30,10 @@ it("makes precipitation, snowpack, and reservoir level readable without the canv
   expect(chart).toHaveAccessibleName(/Precipitation:/);
   expect(chart).toHaveAccessibleName(/Snowpack:/);
   expect(chart).toHaveAccessibleName(/Reservoir:/);
+});
+
+it("formats reservoir ticks as gigawatt-hour values without repeating the unit", () => {
+  expect(
+    [0, 20e9, 100e9, 1e12].map((value) => formatReservoirAxisValue(value)),
+  ).toEqual(["0", "20", "100", "1,000"]);
 });

--- a/src/components/base/ChartForecastWater.tsx
+++ b/src/components/base/ChartForecastWater.tsx
@@ -17,7 +17,7 @@ import {
   formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
 } from "../../helpers/DateTime";
-import { formatWattHours, formatWattHoursAxis } from "../../helpers/Format";
+import { formatWattHours, formatWattsInUnit } from "../../helpers/Format";
 import { chartPalette } from "../../Theme";
 
 export interface Props {
@@ -38,6 +38,11 @@ interface State {
 }
 
 const RESERVOIR_SCALE = "reservoir";
+const GIGAWATT = { suffix: "G", divisor: 1e9 };
+
+export function formatReservoirAxisValue(value: number): string {
+  return formatWattsInUnit(value, GIGAWATT).replace(/GW$/, "");
+}
 
 function buildOptions(showXLabels: boolean) {
   return ({ getState, scale }: BuildContext<State>): uPlot.Options => ({
@@ -81,11 +86,10 @@ function buildOptions(showXLabels: boolean) {
       yAxis(scale, {
         scale: RESERVOIR_SCALE,
         side: 1,
-        label: "Reservoir",
+        label: "Reservoir (GWh)",
         stroke: chartPalette().reservoir,
         size: FORECAST_AXIS_RIGHT - AXIS_LABEL_SIZE,
-        values: (_u, splits) =>
-          splits.map((v) => formatWattHoursAxis(v, splits)),
+        values: (_u, splits) => splits.map((v) => formatReservoirAxisValue(v)),
       }),
     ],
     series: [


### PR DESCRIPTION
## Summary
- move the reservoir unit into the rotated axis title
- render right-axis ticks as compact GWh values without repeated suffixes
- cover representative reservoir tick formatting with a regression test

## Verification
- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false --testMatch **/*.{spec,test}.{js,jsx,ts,tsx} (687 tests)
- visually verified at a 710px viewport