### PR TITLE
Add finite facility site inventories

### DIFF
--- a/docs/facilities-economics.md
+++ b/docs/facilities-economics.md
@@ -75,6 +75,40 @@ midpoint of NREL's $2,205-$4,434/kW closed-loop site range), equivalent to $332/
 Fixed O&M becomes $19/kW-year. NREL projects no cost or efficiency improvement for this mature
 technology.
 
+## Finite project locations
+
+Conventional hydro, conventional geothermal, and pumped hydro now expose and enforce a count of
+viable locations. A project claims its location as soon as construction begins; cancelling or
+selling removes the project from the fleet and makes the location available again. Enhanced
+geothermal is deliberately not limited because its purpose in the model is to open resources that
+conventional hydrothermal geography cannot.
+
+Pumped hydro has its own location inventory rather than inheriting conventional hydro's river
+profile. The facility is modeled as closed-loop storage, so elevation separation and room for two
+reservoirs matter more than river flow:
+
+- For U.S. cities, counts are the optimized, non-overlapping 10-hour systems in NREL's 2022
+  national closed-loop resource assessment whose reservoir-pair midpoint is within 250 km of the
+  city. The assessment starts with 30-meter terrain data, removes protected land, critical habitat,
+  urban areas, wetlands, existing waterways and water bodies, then pairs reservoirs and selects a
+  least-cost non-overlapping set. It reports 14,846 technical-potential systems nationwide.
+- For London, Paris, Berlin, and Reykjavik, counts are the site points in ANU's unprotected global
+  greenfield 2 GWh / 6 hour layer within the same 250 km radius. That is the atlas class closest to
+  the game's utility-scale project. ANU requires at least 100 m of head, a slope of at least 1:20,
+  a reservoir volume of at least 1 GL, and a water-to-rock ratio of at least 3.
+- The radius is a game boundary: each city represents a regional utility, not a municipal service
+  polygon. The source studies describe technical potential, not construction-ready projects. Both
+  explicitly warn that individual sites still need geological, environmental, ownership,
+  transmission, and commercial review.
+
+Conventional hydro and geothermal do not yet have equivalent site-by-site global data in the game.
+Their former scarcity curves implied a three-site hydro and four-site geothermal scale; those are
+now explicit gameplay caps. The old linear price increases have been removed. A hard count already
+models scarcity, while a generic multiplier charged the same penalty regardless of plant size or
+actual site quality. If site-quality decline is added later, it should use source cost ranks or a
+regional supply curve—especially for pumped hydro, whose assessed site costs span widely—rather
+than restore the artificial per-project multiplier.
+
 ## Lifetimes and depreciation
 
 Facility resale value now follows straight-line physical depreciation from commercial operation:
@@ -133,6 +167,9 @@ No additional facility type is added in this pass:
 - [IRENA, Renewable Power Generation Costs in 2020](https://www.irena.org/Publications/2021/Jun/Renewable-Power-Costs-in-2020)
 - [NREL, Cost Projections for Utility-Scale Battery Storage: 2021 Update](https://docs.nrel.gov/docs/fy21osti/79236.pdf)
 - [NREL, 2024 Annual Technology Baseline: Pumped Storage Hydropower](https://atb.nrel.gov/electricity/2024b/pumped_storage_hydropower)
+- [NREL, Closed-Loop Pumped Storage Hydropower Resource Assessment for the United States](https://www.nrel.gov/docs/fy22osti/81277.pdf)
+- [NREL/OEDI, U.S. closed-loop pumped-storage site dataset](https://data.openei.org/submissions/5711)
+- [ANU, Global Greenfield Pumped Hydro Energy Storage Atlas](https://re100.eng.anu.edu.au/global/)
 - [NREL, Cost and Performance Data for Power Generation Technologies](https://docs.nrel.gov/docs/fy11osti/48595.pdf)
 - [NREL, Update to Enhanced Geothermal System Resource Potential Estimate](https://docs.nrel.gov/docs/fy17osti/66428.pdf)
 - [DOE, Hydropower Basics](https://www.energy.gov/cmei/water/hydropower-basics)

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -393,6 +393,9 @@ interface SharedShoppingType {
   annualOperatingCost: number;
   // all costs should be in that year's $ / not account for inflation when possible
   peakW: number;
+  // Present only for technologies whose geography imposes a finite number of project sites.
+  // Includes projects under construction because choosing to build has already claimed the site.
+  viableLocationsRemaining?: number;
   lifespanYears: number;
   yearsToBuild: number;
 }

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -86,14 +86,18 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
     props.interestRate,
     LOAN_MONTHS,
   );
-  const buildable = props.generator.peakW <= props.generator.maxPeakW;
+  const sizeBuildable = props.generator.peakW <= props.generator.maxPeakW;
+  const siteBuildable = props.generator.viableLocationsRemaining !== 0;
+  const buildable = sizeBuildable && siteBuildable;
   const financingGap = Math.max(0, downpayment - cash);
   // kg of CO2 equivalent released per MWh generated - 0 for carbon-free sources,
   // whose fuel either isn't in FUELS at all (sun, wind) or is emission-free (uranium)
   const kgCO2ePerMWh = Math.round(
     1000000 * generator.btuPerWh * (fuel.kgCO2ePerBtu || 0),
   );
-  const secondaryText = buildable ? (
+  const secondaryText = !siteBuildable ? (
+    "No viable locations remaining."
+  ) : sizeBuildable ? (
     generator.description
   ) : (
     <div>
@@ -287,6 +291,19 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
                   {generator.lifespanYears} years
                 </TableCell>
               </TableRow>
+              {generator.viableLocationsRemaining !== undefined && (
+                <TableRow>
+                  <TableCell>
+                    Number of viable locations remaining
+                    <Typography variant="body2" color="textSecondary">
+                      Each project uses one suitable site
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    {generator.viableLocationsRemaining}
+                  </TableCell>
+                </TableRow>
+              )}
               {props.secondaryMetric !== "yearsToBuild" && (
                 <TableRow>
                   <TableCell>Time to build</TableCell>

--- a/src/components/views/BuildStorage.test.tsx
+++ b/src/components/views/BuildStorage.test.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createGame } from "../../testing/Simulator";
+import { GameType } from "../../Types";
+import BuildStorage from "./BuildStorage";
+
+jest.mock("../base/ManualLink", () => () => null);
+
+function game(): GameType {
+  const state = createGame({ scenarioId: 103 });
+  return {
+    ...state,
+    location: {
+      id: "Reykjavik",
+      name: "Reykjavik, Iceland",
+      lat: 64.1466,
+      long: -21.9426,
+      country: "Iceland",
+      region: "Europe",
+    },
+  };
+}
+
+it("shows remaining pumped-hydro locations in the expanded build view", () => {
+  render(
+    <BuildStorage
+      game={game()}
+      onBuildStorage={jest.fn()}
+      onBack={jest.fn()}
+      onSpeedChange={jest.fn()}
+    />,
+  );
+
+  fireEvent.click(
+    screen.getByRole("button", { name: "Show Pumped Hydro details" }),
+  );
+
+  const row = screen.getByRole("row", {
+    name: /Number of viable locations remaining.*648/,
+  });
+  expect(row).toHaveTextContent("648");
+  expect(row).toHaveTextContent("Each project uses one suitable site");
+});

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -59,8 +59,12 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
     props.interestRate,
     LOAN_MONTHS,
   );
-  const buildable = props.storage.peakWh <= props.storage.maxPeakWh;
-  const secondaryText = buildable ? (
+  const sizeBuildable = props.storage.peakWh <= props.storage.maxPeakWh;
+  const siteBuildable = props.storage.viableLocationsRemaining !== 0;
+  const buildable = sizeBuildable && siteBuildable;
+  const secondaryText = !siteBuildable ? (
+    "No viable locations remaining."
+  ) : sizeBuildable ? (
     storage.description
   ) : (
     <div>
@@ -166,6 +170,19 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
                 </TableCell>
                 <TableCell align="right">{storage.spinMinutes} min</TableCell>
               </TableRow>
+              {storage.viableLocationsRemaining !== undefined && (
+                <TableRow>
+                  <TableCell>
+                    Number of viable locations remaining
+                    <Typography variant="body2" color="textSecondary">
+                      Each project uses one suitable site
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    {storage.viableLocationsRemaining}
+                  </TableCell>
+                </TableRow>
+              )}
             </TableBody>
           </Table>
         </TableContainer>

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -32,6 +32,7 @@ import VictoryConditions from "../base/VictoryConditions";
 import { DIFFICULTIES } from "../../Constants";
 import { CityType, getCities, initCities } from "../../data/Cities";
 import { GENERATORS, STORAGE } from "../../data/Facilities";
+import { getViableLocationCount } from "../../data/FacilitySites";
 import { WEATHER_STARTING_YEAR } from "../../data/Weather";
 import { getFuelEscalation } from "../../data/FuelPrices";
 import { getStartingCustomers } from "../../data/LocationProfiles";
@@ -271,9 +272,18 @@ export default function CustomGame(props: Props): React.JSX.Element {
 
   // Rolling the year back past a technology's invention would otherwise leave a facility in the
   // list that quietly disappears once the game loads
+  const usedSites = new Map<string, number>();
   const unavailable = scenario.facilities.filter(
-    (f: Partial<FacilityShoppingType>) =>
-      !technologies.some((t) => t.name === facilityName(f)),
+    (f: Partial<FacilityShoppingType>) => {
+      const name = facilityName(f);
+      if (!technologies.some((t) => t.name === name)) {
+        return true;
+      }
+      const used = (usedSites.get(name) || 0) + 1;
+      usedSites.set(name, used);
+      const sites = getViableLocationCount(location, name);
+      return sites !== undefined && used > sites;
+    },
   );
 
   const change = (delta: Partial<ScenarioType>) => {
@@ -606,9 +616,9 @@ export default function CustomGame(props: Props): React.JSX.Element {
         </Typography>
         {unavailable.length > 0 && (
           <Typography variant="body2" color="error" sx={{ paddingLeft: 1 }}>
-            {unavailable.map(facilityName).join(", ")} can't be built in{" "}
-            {scenario.startingYear} - remove{" "}
-            {unavailable.length === 1 ? "it" : "them"} or pick a later year.
+            {unavailable.map(facilityName).join(", ")} can't be built with this
+            location and year, or exceeds the number of viable sites. Remove{" "}
+            {unavailable.length === 1 ? "it" : "them"} or change the setup.
           </Typography>
         )}
 

--- a/src/data/Facilities.test.tsx
+++ b/src/data/Facilities.test.tsx
@@ -107,6 +107,7 @@ describe("current facility economics", () => {
       peakW: 100000000,
       annualOperatingCost: 1900000,
       roundTripEfficiency: 0.8,
+      viableLocationsRemaining: 648,
     });
     expect(pumpedHydro?.buildCost).toBeCloseTo(333900000, -2);
   });
@@ -170,7 +171,7 @@ describe("location-aware facilities", () => {
     expect(storage).not.toContain("Pumped Hydro");
   });
 
-  it("makes each additional conventional hydro site more expensive", () => {
+  it("uses an explicit conventional hydro site limit without changing its benchmark cost", () => {
     const baseline = GENERATORS(stateAt(iceland, 2024), 100000000, [], []).find(
       (generator) => generator.name === "Hydro",
     );
@@ -183,8 +184,10 @@ describe("location-aware facilities", () => {
       [],
     ).find((generator) => generator.name === "Hydro");
 
+    expect(baseline?.viableLocationsRemaining).toBe(3);
+    expect(withExisting?.viableLocationsRemaining).toBe(2);
     expect(withExisting?.buildCost).toBeCloseTo(
-      (baseline?.buildCost as number) * (4 / 3),
+      baseline?.buildCost as number,
       -2,
     );
   });
@@ -231,7 +234,7 @@ describe("enhanced geothermal", () => {
     expect(withExistingEnhanced?.buildCost).toBe(baseline?.buildCost);
   });
 
-  it("only counts conventional plants for conventional geothermal scarcity", () => {
+  it("only counts conventional plants against conventional geothermal sites", () => {
     const baseline = generatorAt(iceland, 2030, "Geothermal");
     const withEnhanced = generatorAt(iceland, 2030, "Geothermal", [
       geothermalFacility("Enhanced Geothermal"),
@@ -241,9 +244,10 @@ describe("enhanced geothermal", () => {
     ]);
 
     expect(withEnhanced?.buildCost).toBe(baseline?.buildCost);
-    expect(withConventional?.buildCost).toBe(
-      (baseline?.buildCost as number) * 1.25,
-    );
+    expect(withConventional?.buildCost).toBe(baseline?.buildCost);
+    expect(baseline?.viableLocationsRemaining).toBe(4);
+    expect(withEnhanced?.viableLocationsRemaining).toBe(4);
+    expect(withConventional?.viableLocationsRemaining).toBe(3);
   });
 
   it("uses the 2030 cost and performance assumptions", () => {

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -8,9 +8,12 @@ import {
   getWindCapacityFactor,
   getSolarCapacityFactor,
 } from "../helpers/Energy";
-import { hasGeothermalResource, hasHydroResource } from "./LocationProfiles";
 import { hasOffshoreWind } from "./Weather";
 import { HYDRO_TARGET_CAPACITY_FACTOR, hydroSizing } from "../helpers/Hydro";
+import {
+  getViableLocationCount,
+  getViableLocationsRemaining,
+} from "./FacilitySites";
 
 /**
  * What a dollar in the tables below is worth by the time the game reaches this month. Every cost
@@ -138,13 +141,21 @@ export function GENERATORS(
   const magnitude = Math.log10(peakW) - 6; // 0 = 1MW, 4 = 10GW (+1 for each 10x)
   const year = state.date.year;
 
-  // only needed as a temporary hack for geothermal until https://github.com/toddmedema/electrify/issues/86 done
-  const conventionalGeothermalCount = state.facilities.filter(
-    (f) => f.name === "Geothermal",
-  ).length;
-  const conventionalHydroCount = state.facilities.filter(
-    (f) => f.name === "Hydro",
-  ).length;
+  const hydroLocations = getViableLocationCount(state.location, "Hydro");
+  const hydroLocationsRemaining = getViableLocationsRemaining(
+    state.location,
+    state.facilities,
+    "Hydro",
+  );
+  const geothermalLocations = getViableLocationCount(
+    state.location,
+    "Geothermal",
+  );
+  const geothermalLocationsRemaining = getViableLocationsRemaining(
+    state.location,
+    state.facilities,
+    "Geothermal",
+  );
   const enhancedGeothermalCostPerW = Math.max(
     3,
     5.5 * Math.pow(3 / 5.5, (year - 2028) / 7),
@@ -421,13 +432,12 @@ export function GENERATORS(
       name: "Hydro",
       fuel: "Hydro",
       description: "Clean and dispatchable, where rivers allow",
-      available: year > 1882 && hasHydroResource(state.location),
-      buildCost:
-        scaledBuildCost(hydroCostPerW(year), 100000000, peakW) *
-        (1 + conventionalHydroCount / 3),
+      available: year > 1882 && (hydroLocations || 0) > 0,
+      buildCost: scaledBuildCost(hydroCostPerW(year), 100000000, peakW),
       // IRENA's inflation-normalized global installed cost was effectively flat from 2020 to
-      // 2024 at $2,267/kW. Regional resource availability is handled above.
+      // 2024 at $2,267/kW. Site scarcity is now an explicit cap rather than a second price.
       peakW,
+      viableLocationsRemaining: hydroLocationsRemaining,
       maxPeakW: 10000000000,
       btuPerWh: 0,
       spinMinutes: 1,
@@ -446,16 +456,12 @@ export function GENERATORS(
       name: "Geothermal",
       fuel: "Geothermal",
       description: "Consistent, but few locations",
-      available: hasGeothermalResource(state.location),
-      buildCost:
-        scaledBuildCost(geothermalCostPerW(year), 50000000, peakW) *
-        (1 + conventionalGeothermalCount / 4),
-      // To compensate for limited locations, cost to build increases significantly with each construction
-      // Future ideas: new tech in ~2000 opened up more locations at a slightly higher cost
-      // Have multiplier be based on totalPeakWByFuel instead, so that you don't suffer as much from building many smaller plants
+      available: (geothermalLocations || 0) > 0,
+      buildCost: scaledBuildCost(geothermalCostPerW(year), 50000000, peakW),
       // IRENA global installed cost fell from inflation-normalized $5,415/kW in 2020 to
       // $4,015/kW in 2024, although its small project sample makes this series volatile.
       peakW,
+      viableLocationsRemaining: geothermalLocationsRemaining,
       maxPeakW: 800000000,
       // ~800MW, except for one outlier - https://en.wikipedia.org/wiki/List_of_largest_power_stations#Geothermal
       btuPerWh: 0,
@@ -509,6 +515,15 @@ export function STORAGE(state: GameType, peakWh: number) {
   // 0 = 1MW, 4 = 10GW (+1 for each 10x)
   const magnitude = Math.log10(peakWh) - 6;
   const year = state.date.year;
+  const pumpedHydroLocations = getViableLocationCount(
+    state.location,
+    "Pumped Hydro",
+  );
+  const pumpedHydroLocationsRemaining = getViableLocationsRemaining(
+    state.location,
+    state.facilities,
+    "Pumped Hydro",
+  );
 
   let storage = [
     {
@@ -545,11 +560,12 @@ export function STORAGE(state: GameType, peakWh: number) {
     {
       name: "Pumped Hydro",
       description: "Slow to build and charge / discharge",
-      available: year > 1930 && hasHydroResource(state.location), // New Milford plant, 33MW - https://blogs.scientificamerican.com/plugged-in/throwback-thursday-the-first-u-s-energy-storage-plant/
+      available: year > 1930 && (pumpedHydroLocations || 0) > 0, // New Milford plant, 33MW - https://blogs.scientificamerican.com/plugged-in/throwback-thursday-the-first-u-s-energy-storage-plant/
       buildCost: 2000000 + 0.3319 * peakWh,
       // NREL's 2024 ATB closed-loop sites span $2,205-$4,434/kW. At this facility's ten-hour
       // duration, the midpoint is $332/kWh; costs are held flat because the technology is mature.
       peakW: 0.1 * peakWh,
+      viableLocationsRemaining: pumpedHydroLocationsRemaining,
       // Around 1/5th to 1/20th for larger projects - https://en.wikipedia.org/wiki/List_of_pumped-storage_hydroelectric_power_stations
       peakWh,
       maxPeakWh: 20000000000,

--- a/src/data/FacilitySites.test.tsx
+++ b/src/data/FacilitySites.test.tsx
@@ -1,0 +1,59 @@
+import { FacilityOperatingType, LocationType } from "../Types";
+import {
+  getViableLocationCount,
+  getViableLocationsRemaining,
+  PUMPED_HYDRO_SITES_BY_LOCATION,
+} from "./FacilitySites";
+
+const location = (id: string, resources?: LocationType["resources"]) =>
+  ({ id, name: id, lat: 0, long: 0, resources }) as LocationType;
+
+describe("finite facility sites", () => {
+  it("has a researched pumped-hydro count for every currently playable location", () => {
+    expect(Object.keys(PUMPED_HYDRO_SITES_BY_LOCATION)).toHaveLength(41);
+    expect(getViableLocationCount(location("Memphis"), "Pumped Hydro")).toBe(1);
+    expect(getViableLocationCount(location("Chicago"), "Pumped Hydro")).toBe(0);
+    expect(getViableLocationCount(location("Reykjavik"), "Pumped Hydro")).toBe(
+      648,
+    );
+  });
+
+  it("keeps pumped hydro separate from conventional hydro geography", () => {
+    expect(getViableLocationCount(location("Berlin"), "Pumped Hydro")).toBe(2);
+    expect(getViableLocationCount(location("Berlin"), "Hydro")).toBe(0);
+    expect(
+      getViableLocationCount(location("Chicago", { hydro: true }), "Hydro"),
+    ).toBe(3);
+    expect(
+      getViableLocationCount(
+        location("Chicago", { hydro: true }),
+        "Pumped Hydro",
+      ),
+    ).toBe(0);
+  });
+
+  it("counts owned and under-construction projects as claimed sites", () => {
+    const facilities = [
+      { name: "Geothermal" },
+      { name: "Enhanced Geothermal" },
+      { name: "Geothermal", yearsToBuildLeft: 2 },
+    ] as FacilityOperatingType[];
+
+    expect(
+      getViableLocationsRemaining(
+        location("Local", { geothermal: true }),
+        facilities,
+        "Geothermal",
+      ),
+    ).toBe(2);
+  });
+
+  it("does not impose a site count on ordinary or enhanced technologies", () => {
+    expect(
+      getViableLocationCount(location("Paris"), "Battery"),
+    ).toBeUndefined();
+    expect(
+      getViableLocationCount(location("Paris"), "Enhanced Geothermal"),
+    ).toBeUndefined();
+  });
+});

--- a/src/data/FacilitySites.tsx
+++ b/src/data/FacilitySites.tsx
@@ -1,0 +1,97 @@
+import type { FacilityOperatingType, LocationType } from "../Types";
+import { hasGeothermalResource, hasHydroResource } from "./LocationProfiles";
+
+export type SiteLimitedFacilityName = "Hydro" | "Geothermal" | "Pumped Hydro";
+
+// Conventional hydro and geothermal used to express scarcity only through a linear price
+// multiplier. Until those resources get the same site-level GIS treatment as pumped hydro, keep
+// the old curve's three/four-site scale as an explicit, understandable gameplay limit instead.
+const CONVENTIONAL_HYDRO_SITES = 3;
+const CONVENTIONAL_GEOTHERMAL_SITES = 4;
+
+/**
+ * Modeled greenfield closed-loop pumped-hydro systems within 250 km of each playable city.
+ *
+ * U.S. counts come from NREL's optimized, non-overlapping 10-hour resource assessment. European
+ * counts use the point records in ANU's unprotected 2 GWh / 6 hour global greenfield layer. The
+ * radius treats a game location as a regional grid rather than the city boundary. These are
+ * technical-potential candidates, not project-level feasibility findings; see the methodology and
+ * source links in docs/facilities-economics.md.
+ */
+export const PUMPED_HYDRO_SITES_BY_LOCATION: Readonly<Record<string, number>> =
+  Object.freeze({
+    PIT: 179,
+    SF: 51,
+    LA: 218,
+    CAMountains: 885,
+    HNL: 104,
+    SJU: 7,
+    NewYork: 43,
+    Chicago: 0,
+    Houston: 0,
+    Phoenix: 466,
+    Philadelphia: 105,
+    SanAntonio: 0,
+    SanDiego: 90,
+    Dallas: 3,
+    Austin: 0,
+    Jacksonville: 0,
+    Columbus: 0,
+    Indianapolis: 0,
+    Charlotte: 176,
+    Seattle: 384,
+    Denver: 156,
+    Boston: 30,
+    Detroit: 0,
+    Nashville: 202,
+    Portland: 559,
+    LasVegas: 1201,
+    Memphis: 1,
+    Baltimore: 170,
+    Milwaukee: 0,
+    Albuquerque: 673,
+    Tucson: 256,
+    Fresno: 612,
+    Sacramento: 522,
+    KansasCity: 0,
+    Atlanta: 265,
+    Miami: 0,
+    Minneapolis: 0,
+    London: 2,
+    Paris: 0,
+    Berlin: 2,
+    Reykjavik: 648,
+  });
+
+/** Total sites for a finite-site technology, or undefined for an unconstrained technology. */
+export function getViableLocationCount(
+  location: LocationType | undefined,
+  facilityName: string,
+): number | undefined {
+  if (facilityName === "Hydro") {
+    return hasHydroResource(location) ? CONVENTIONAL_HYDRO_SITES : 0;
+  }
+  if (facilityName === "Geothermal") {
+    return hasGeothermalResource(location) ? CONVENTIONAL_GEOTHERMAL_SITES : 0;
+  }
+  if (facilityName === "Pumped Hydro") {
+    return location ? PUMPED_HYDRO_SITES_BY_LOCATION[location.id] || 0 : 0;
+  }
+  return undefined;
+}
+
+/** Counts projects already owned or under construction because either one has claimed its site. */
+export function getViableLocationsRemaining(
+  location: LocationType | undefined,
+  facilities: readonly FacilityOperatingType[],
+  facilityName: string,
+): number | undefined {
+  const total = getViableLocationCount(location, facilityName);
+  if (total === undefined) {
+    return undefined;
+  }
+  const used = facilities.filter(
+    (facility) => facility.name === facilityName,
+  ).length;
+  return Math.max(0, total - used);
+}

--- a/src/reducers/BuildFacility.test.tsx
+++ b/src/reducers/BuildFacility.test.tsx
@@ -83,6 +83,25 @@ describe("buildFacility", () => {
     ).toEqual(pastBefore);
   });
 
+  it("rejects a stale purchase after the last viable site has been claimed", () => {
+    let state = createGame({ scenarioId: 103 });
+    const hydro = GENERATORS(state, 50000000, [20], [500]).find(
+      (g: GeneratorShoppingType) => g.name === "Hydro",
+    );
+    expect(hydro?.viableLocationsRemaining).toBe(3);
+
+    for (let attempt = 0; attempt < 4; attempt++) {
+      state = gameReducer(
+        state,
+        buildFacility({ facility: hydro!, financed: true }),
+      );
+    }
+
+    expect(
+      state.facilities.filter((facility) => facility.name === "Hydro"),
+    ).toHaveLength(3);
+  });
+
   it("keeps a long cash forecast finite when hydro finishes construction", () => {
     const before = createGame({ scenarioId: 103 });
     const hydro = GENERATORS(before, 50000000, [20], [500]).find(

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -79,6 +79,7 @@ import {
   LOCATIONS,
 } from "../Constants";
 import { GENERATORS, STORAGE } from "../data/Facilities";
+import { getViableLocationsRemaining } from "../data/FacilitySites";
 import { logEvent } from "../Globals";
 import { getPlayedScenarioIds, recordScenarioPlayed } from "../LocalStorage";
 import {
@@ -564,6 +565,9 @@ export const gameSlice = createSlice({
           [],
           [],
         ).find((g: FacilityShoppingType) => {
+          if (g.viableLocationsRemaining === 0) {
+            return false;
+          }
           for (const property in search) {
             if (g[property] !== search[property]) {
               return false;
@@ -576,6 +580,9 @@ export const gameSlice = createSlice({
         } else {
           const storage = STORAGE(state, search.peakWh || 1000000).find(
             (g: FacilityShoppingType) => {
+              if (g.viableLocationsRemaining === 0) {
+                return false;
+              }
               for (const property in search) {
                 if (g[property] !== search[property]) {
                   return false;
@@ -776,6 +783,16 @@ export default gameSlice.reducer;
  */
 function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
   const built = payload.facility;
+  const viableLocationsRemaining = getViableLocationsRemaining(
+    state.location,
+    state.facilities,
+    built.name,
+  );
+  // Recheck current state instead of trusting the shopping-card snapshot in the action. It keeps
+  // a stale dialog or replay action from claiming one more site after the last one was used.
+  if (viableLocationsRemaining !== undefined && viableLocationsRemaining <= 0) {
+    return;
+  }
   logGameEvent(
     state,
     "BUILD",


### PR DESCRIPTION
## Summary

- show the number of viable locations remaining in expanded generator and storage build views
- add a separate pumped-hydro site inventory for every playable location
- enforce hydro, geothermal, and pumped-hydro site caps when building and configuring custom games
- replace the old conventional hydro/geothermal scarcity price multipliers with explicit site limits

## Research and modeling

- U.S. pumped-hydro counts use NREL's optimized, non-overlapping 10-hour closed-loop systems within 250 km of each city
- European counts use ANU's unprotected 2 GWh / 6 hour greenfield candidates within the same 250 km regional-utility radius
- the documentation calls out that these are technical-potential candidates, not construction-ready sites
- conventional hydro and geothermal use explicit three- and four-site gameplay caps derived from the scale of the former scarcity curves

The generic per-project price escalation stays removed. The hard caps already model scarcity; any future site-quality decline should use ranked site costs or a regional supply curve instead of a size-insensitive project-count multiplier.

## Verification

- 66 test suites / 699 tests passed in the complete workspace suite
- 5 focused suites / 46 tests passed again on the isolated PR branch
- TypeScript, ESLint, Prettier, and diff checks passed
