### PR TITLE
Model renewable output degradation and plant age

### DIFF
--- a/docs/facilities-economics.md
+++ b/docs/facilities-economics.md
@@ -143,6 +143,40 @@ not distinguish. Actual plants can outlive these economic lives after refurbishm
 the game needs one reference life for predictable resale rather than trying to price future major
 overhauls.
 
+## Operating age and performance degradation
+
+The simulation now distinguishes three aging effects that were previously easy to conflate:
+
+1. **Asset age and value.** Every operating facility has a commissioning minute and an economic
+   design life. Age already reduced resale value linearly; scenario authors can now set
+   `initialAgeYears` for inherited fleets, and the facility detail panel shows age against design
+   life. Reaching design life does not automatically close a plant.
+2. **Renewable output.** Solar output compounds down by 0.5% per operating year. Onshore wind uses
+   0.5% for pre-2008 vintages and 0.2% for newer vintages, rounded from the 0.53% and 0.17% annual
+   performance declines measured across 917 U.S. plants. Offshore wind remains unchanged because
+   the evidence is less settled and its model already applies an explicit availability/loss factor.
+3. **Battery use.** Battery capacity remains constant. Its existing $10/kWh-year O&M assumption
+   includes augmentation for roughly 1.5% annual capacity loss, so reducing usable capacity as well
+   would charge for degradation twice. The facility panel instead reports equivalent full cycles
+   as cumulative discharged energy divided by original energy capacity, against the existing
+   7,300-cycle design-life assumption.
+
+At 0.5% annual degradation, solar retains `0.995^20 = 90.5%` of its original output after 20
+years—about a 9.5% loss, not 20%. Weather and curtailment still vary actual production around that
+aged maximum. The build screen's lifetime cost integrates the same compounding output curve, while
+annual O&M remains flat; fuel and carbon costs continue to scale only with energy actually produced.
+
+Scenario starting ages are deliberately authored rather than inferred from technology or scenario
+year. The narrative scenarios now begin with mixed-age inherited fleets; tutorials keep new assets
+so their introductory economics and controls remain predictable. Existing saves without a
+commissioning timestamp still begin their age clock on the first real tick, and saves without a
+degradation field use the modern solar or wind default from the day they resume.
+
+The next fidelity step is intentionally separate: starts and equivalent operating hours for thermal
+plants, start costs for natural gas, maintenance/refurbishment decisions, and wear-driven outage
+risk. Adding an arbitrary fossil output penalty now would duplicate mechanisms that should instead
+depend on duty cycle, starts, and maintenance history.
+
 ## Commercial technology review
 
 No additional facility type is added in this pass:
@@ -174,5 +208,7 @@ No additional facility type is added in this pass:
 - [NREL, Update to Enhanced Geothermal System Resource Potential Estimate](https://docs.nrel.gov/docs/fy17osti/66428.pdf)
 - [DOE, Hydropower Basics](https://www.energy.gov/cmei/water/hydropower-basics)
 - [EIA, age and license extensions of U.S. nuclear plants](https://www.eia.gov/tools/faqs/faq.php?id=228&t=1)
+- [NREL 2024 ATB, utility-scale PV degradation assumptions](https://atb.nrel.gov/electricity/2024/utility-scale_pv)
+- [Lawrence Berkeley National Laboratory, U.S. wind-plant performance with age](https://emp.lbl.gov/publications/how-does-wind-project-performance)
 - [BLS, annual CPI-U indexes](https://www.bls.gov/regions/mid-atlantic/data/ConsumerPriceIndexAnnualandSemiAnnual_Table.htm)
 - [DOE, Long-Duration Energy Storage portfolio](https://www.energy.gov/cmei/oced/long-duration-energy-storage)

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -29,12 +29,14 @@ import {
  */
 
 // Bump on any breaking schema change. Mismatched replays are ignored rather than migrated.
+// 5 adds age-dependent renewable output and authored starting ages; older replays would dispatch
+// a different amount of solar and wind even if they contain exactly the same actions.
 // 4 replaces investor marketing with price-driven customer switching; older replays would grow a
 // different customer base even if they contain no explicit marketing action.
 // 3 adds offshore wind weather and generation; an older replay would simulate a different grid.
 // 2 added `location`: a v1 replay names only a scenario, and a scenario no longer pins down
 // where it is played, so there is no safe way to migrate one.
-export const REPLAY_VERSION = 4;
+export const REPLAY_VERSION = 5;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -371,6 +371,10 @@ export interface GeneratorShoppingType extends SharedShoppingType {
   fuel: FuelNameType;
   maxPeakW: number; // Maximum size the technology is currently buildable
   capacityFactor: number; // 0 - 1, percent of theoretical output actually produced across a year
+  // Fraction of nameplate output permanently lost each operating year. Optional because most
+  // generator types do not have a well-supported secular output decline, and because older saves
+  // predate the field.
+  annualOutputDegradation?: number;
   spinMinutes: number; // 1 for renewables, to avoid eating up CPU on coersing to 1 in case it doesn't exist
   btuPerWh: number; // Heat Rate, but per W for less math per frame
   // Conventional hydro only. whPerMm is calibrated against the loaded watershed record so that
@@ -473,8 +477,13 @@ export interface ScenarioType {
   endTitle?: string;
   endMessage?: string;
   feePerKgCO2e: number;
-  facilities: Array<Partial<FacilityShoppingType>>;
+  facilities: ScenarioFacilityType[];
 }
+
+/** An authored starting asset may already have spent years in service when a scenario opens. */
+export type ScenarioFacilityType = Partial<FacilityShoppingType> & {
+  initialAgeYears?: number;
+};
 
 /**
  * What kind of thing happened, which is all the event log's icons and colours are keyed off.

--- a/src/components/base/FacilityDetails.tsx
+++ b/src/components/base/FacilityDetails.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
 import { Typography } from "@mui/material";
 import { getFuelPricesPerMBTU } from "../../data/FuelPrices";
-import { facilityLifetime } from "../../helpers/Financials";
+import {
+  facilityAgeYears,
+  facilityEquivalentCycles,
+  facilityLifetime,
+  facilityOutputFactor,
+} from "../../helpers/Financials";
 import {
   formatMoneyConcise,
   formatWattHours,
@@ -114,6 +119,9 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
   const accentColor = facilityColor(fuel);
   const underConstruction = facility.yearsToBuildLeft > 0;
   const isHydro = fuel === "Hydro" && !!facility.reservoirCapacityWh;
+  const ageYears = facilityAgeYears(facility, date.minute);
+  const outputFactor = facilityOutputFactor(facility, date.minute);
+  const equivalentCycles = facilityEquivalentCycles(facility);
 
   const trend = fuel ? fuelPriceTrend(fuel, date, seed, location) : [];
   const trendChange =
@@ -130,16 +138,22 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
             value={`${Math.ceil(facility.yearsToBuildLeft * 12)} months`}
           />
         ) : (
-          <Stat
-            // Capacity factor is the generator's word for it; a battery isn't producing
-            // anything, it's being used or it isn't
-            label={isStorage ? "Utilization" : "Capacity factor"}
-            value={
-              lifetime.capacityFactor === undefined
-                ? "—"
-                : percent(lifetime.capacityFactor)
-            }
-          />
+          <>
+            <Stat
+              label="Age / design life"
+              value={`${ageYears.toFixed(1)} / ${facility.lifespanYears} yr${ageYears >= facility.lifespanYears ? " · beyond" : ""}`}
+            />
+            <Stat
+              // Capacity factor is the generator's word for it; a battery isn't producing
+              // anything, it's being used or it isn't
+              label={isStorage ? "Utilization" : "Capacity factor"}
+              value={
+                lifetime.capacityFactor === undefined
+                  ? "—"
+                  : percent(lifetime.capacityFactor)
+              }
+            />
+          </>
         )}
         <Stat
           label="Cost"
@@ -170,6 +184,12 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
               facility.currentWh,
               (facility as StorageOperatingType).peakWh,
             )}
+          />
+        )}
+        {facility.name === "Battery" && equivalentCycles !== undefined && (
+          <Stat
+            label="Equivalent cycles"
+            value={`${Math.round(equivalentCycles).toLocaleString()} / 7,300`}
           />
         )}
         {isHydro && (
@@ -203,6 +223,12 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
         )}
         {!isStorage && (
           <Stat label="Nameplate" value={formatWatts(facility.peakW)} />
+        )}
+        {!isStorage && outputFactor < 1 && (
+          <Stat
+            label="Effective max"
+            value={`${formatWatts(facility.peakW * outputFactor)} · ${percent(outputFactor)} health`}
+          />
         )}
         {facility.loanAmountLeft > 0 && (
           <Stat

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -345,6 +345,9 @@ export function GENERATORS(
       // EIA AEO2025 reference lead time is 21 months for a 200MW plant.
       spinMinutes: 1,
       capacityFactor: windCapacityFactor,
+      // Older fleets lose output faster than modern projects. Rounded from the 0.53% and 0.17%
+      // annual declines measured across 917 U.S. wind plants.
+      annualOutputDegradation: windAnnualOutputDegradation(year),
       // 37% = Max value from https://en.wikipedia.org/wiki/Capacity_factor#United_States
       // ~25% duty cycle - https://sunmetrix.com/what-is-capacity-factor-and-how-does-solar-energy-compare/
       lifespanYears: 25,
@@ -400,6 +403,9 @@ export function GENERATORS(
       // EIA AEO2025 reference lead time is 36 months for a 150MW plant.
       spinMinutes: 1,
       capacityFactor: solarCapacityFactor,
+      // A rounded central case: NREL's 2024 ATB spans 0.7%/yr baseline to 0.5%/yr moderate
+      // improvement (and 0.2%/yr advanced).
+      annualOutputDegradation: 0.005,
       // 26% = Max value from https://en.wikipedia.org/wiki/Capacity_factor#United_States
       // ~10-25% duty cycle - https://sunmetrix.com/what-is-capacity-factor-and-how-does-solar-energy-compare/
       lifespanYears: 35,
@@ -509,6 +515,11 @@ export function GENERATORS(
   });
 
   return generators;
+}
+
+/** Rounded vintage cohorts from LBNL's U.S. wind-plant performance study. */
+export function windAnnualOutputDegradation(commissioningYear: number): number {
+  return commissioningYear < 2008 ? 0.005 : 0.002;
 }
 
 export function STORAGE(state: GameType, peakWh: number) {

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -515,8 +515,8 @@ export const SCENARIOS = [
     dollarsPerkWh: 0.05,
     durationMonths: 12 * 12,
     facilities: [
-      { fuel: "Coal", peakW: 300000000 },
-      { fuel: "Natural Gas", peakW: 200000000 },
+      { fuel: "Coal", peakW: 300000000, initialAgeYears: 30 },
+      { fuel: "Natural Gas", peakW: 200000000, initialAgeYears: 10 },
     ],
   },
   {
@@ -531,7 +531,7 @@ export const SCENARIOS = [
     feePerKgCO2e: 0,
     dollarsPerkWh: 0.03,
     durationMonths: 12 * 20,
-    facilities: [{ fuel: "Coal", peakW: 500000000 }],
+    facilities: [{ fuel: "Coal", peakW: 500000000, initialAgeYears: 25 }],
   },
   {
     id: 105, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
@@ -546,9 +546,9 @@ export const SCENARIOS = [
     dollarsPerkWh: 0.07,
     durationMonths: 12 * 12,
     facilities: [
-      { fuel: "Oil", peakW: 450000000 },
-      { fuel: "Wind", peakW: 150000000 },
-      { fuel: "Sun", peakW: 50000000 },
+      { fuel: "Oil", peakW: 450000000, initialAgeYears: 20 },
+      { fuel: "Wind", peakW: 150000000, initialAgeYears: 8 },
+      { fuel: "Sun", peakW: 50000000, initialAgeYears: 5 },
     ],
   },
   {
@@ -564,8 +564,8 @@ export const SCENARIOS = [
     dollarsPerkWh: 0.02,
     durationMonths: 12 * 12,
     facilities: [
-      { fuel: "Oil", peakW: 100000000 },
-      { fuel: "Uranium", peakW: 400000000 },
+      { fuel: "Oil", peakW: 100000000, initialAgeYears: 20 },
+      { fuel: "Uranium", peakW: 400000000, initialAgeYears: 15 },
     ],
   },
   {
@@ -581,9 +581,9 @@ export const SCENARIOS = [
     dollarsPerkWh: 0.05,
     durationMonths: 12 * 20,
     facilities: [
-      { fuel: "Oil", peakW: 220000000 },
-      { fuel: "Natural Gas", peakW: 200000000 },
-      { fuel: "Coal", peakW: 100000000 },
+      { fuel: "Oil", peakW: 220000000, initialAgeYears: 25 },
+      { fuel: "Natural Gas", peakW: 200000000, initialAgeYears: 10 },
+      { fuel: "Coal", peakW: 100000000, initialAgeYears: 30 },
     ],
   },
   {
@@ -599,8 +599,8 @@ export const SCENARIOS = [
     dollarsPerkWh: 0.025,
     durationMonths: 12 * 20,
     facilities: [
-      { fuel: "Coal", peakW: 200000000 },
-      { fuel: "Coal", peakW: 300000000 },
+      { fuel: "Coal", peakW: 200000000, initialAgeYears: 25 },
+      { fuel: "Coal", peakW: 300000000, initialAgeYears: 10 },
     ],
   },
   // TODO more public-ownership scenarios, such as in LA or Nebraska

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -1,7 +1,10 @@
 import {
   CreditInputsType,
+  degradedLifetimeYears,
   facilityCashBack,
+  facilityEquivalentCycles,
   facilityLifetime,
+  facilityOutputFactor,
   getCompanyInterestRate,
   getCreditInputs,
   getCreditPremium,
@@ -170,6 +173,24 @@ describe("LCWH", () => {
     expect(LCWH(generator, date, 0, SEED)).toBeCloseTo(
       (200000000 + 4000000 * 25) / totalWh,
       12,
+    );
+  });
+
+  it("includes compounding output degradation in a lifetime quote", () => {
+    const degrading = { ...generator, annualOutputDegradation: 0.005 };
+    const productiveYears = degradedLifetimeYears(25, 0.005);
+    const totalWh =
+      generator.peakW *
+      productiveYears *
+      HOURS_PER_YEAR_REAL *
+      generator.capacityFactor;
+
+    expect(LCWH(degrading, date, 0, SEED)).toBeCloseTo(
+      (generator.buildCost + generator.annualOperatingCost * 25) / totalWh,
+      12,
+    );
+    expect(LCWH(degrading, date, 0, SEED)).toBeGreaterThan(
+      LCWH(generator, date, 0, SEED),
     );
   });
 
@@ -370,5 +391,40 @@ describe("facilityLifetime", () => {
     expect(lifetime.capacityFactor).toBe(0);
     expect(lifetime.costPerMWh).toBeUndefined();
     expect(lifetime.profit).toBeCloseTo(-4500, 10);
+  });
+});
+
+describe("facility aging", () => {
+  const minute = (years: number) => years * DAYS_PER_YEAR * 24 * 60;
+
+  it("compounds solar output loss to about ten percent after twenty years", () => {
+    const solar = aFacility({ annualOutputDegradation: 0.005 });
+    expect(facilityOutputFactor(solar, minute(20))).toBeCloseTo(
+      Math.pow(0.995, 20),
+      10,
+    );
+    expect(facilityOutputFactor(solar, minute(20))).toBeCloseTo(0.905, 3);
+  });
+
+  it("leaves technologies without an evidence-backed decline at nameplate", () => {
+    expect(facilityOutputFactor(aFacility(), minute(60))).toBe(1);
+  });
+
+  it("gives legacy solar saves a degradation default", () => {
+    const legacySolar = aFacility({ fuel: "Sun" });
+    expect(legacySolar.annualOutputDegradation).toBeUndefined();
+    expect(facilityOutputFactor(legacySolar, minute(20))).toBeCloseTo(
+      Math.pow(0.995, 20),
+      10,
+    );
+  });
+
+  it("derives battery equivalent full cycles from discharged energy", () => {
+    const battery = aFacility({
+      peakWh: 4000000,
+      lifetimeWh: 10000000,
+    });
+    expect(facilityEquivalentCycles(battery)).toBeCloseTo(2.5, 10);
+    expect(facilityEquivalentCycles(aFacility())).toBeUndefined();
   });
 });

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -151,14 +151,37 @@ export function LCWH(
   // a window with no sun or no wind in it. The cost per Wh of a plant expected to produce nothing
   // is genuinely unbounded, so this returns Infinity rather than inventing a number; the money
   // formatters render that as a dash.
+  const productiveYears = degradedLifetimeYears(
+    g.lifespanYears,
+    g.annualOutputDegradation || 0,
+  );
   const totalWh =
-    g.peakW * g.lifespanYears * HOURS_PER_YEAR_REAL * g.capacityFactor;
+    g.peakW * productiveYears * HOURS_PER_YEAR_REAL * g.capacityFactor;
   const costPerWh =
     (g.buildCost +
       g.annualOperatingCost * g.lifespanYears +
       (fuelCostPerWh + carbonCostPerWh) * totalWh) /
     totalWh;
   return costPerWh;
+}
+
+/**
+ * Nameplate-equivalent years delivered across a design life with compounding annual decline.
+ * Runtime degradation is continuous in operating age, so the lifetime quote integrates the same
+ * curve instead of approximating it with beginning- or end-of-year steps.
+ */
+export function degradedLifetimeYears(
+  lifespanYears: number,
+  annualOutputDegradation: number,
+): number {
+  if (annualOutputDegradation <= 0) {
+    return lifespanYears;
+  }
+  if (annualOutputDegradation >= 1) {
+    return 0;
+  }
+  const retention = 1 - annualOutputDegradation;
+  return (Math.pow(retention, lifespanYears) - 1) / Math.log(retention);
 }
 
 /**
@@ -212,6 +235,36 @@ export function facilityAgeYears(
         0,
         (currentMinute - g.minuteOperational) / MINUTES_PER_GAME_YEAR,
       );
+}
+
+/** Current output capability after permanent age-related degradation. */
+export function facilityOutputFactor(
+  g: FacilityOperatingType,
+  currentMinute: number,
+): number {
+  // Current facilities carry their researched rate. Legacy saves do not, so apply the modern
+  // defaults rather than making old solar and wind immune to aging from the day they resume.
+  const annualDegradation =
+    g.annualOutputDegradation ??
+    (g.fuel === "Sun" ? 0.005 : g.fuel === "Wind" ? 0.002 : 0);
+  if (annualDegradation <= 0) {
+    return 1;
+  }
+  return Math.pow(
+    Math.max(0, 1 - annualDegradation),
+    facilityAgeYears(g, currentMinute),
+  );
+}
+
+/**
+ * Storage lifetimeWh already counts discharge only, which is the industry convention for an
+ * equivalent full cycle. Deriving the counter keeps old saves compatible and avoids a second
+ * running total that could drift out of sync.
+ */
+export function facilityEquivalentCycles(
+  g: FacilityOperatingType,
+): number | undefined {
+  return g.peakWh > 0 ? (g.lifetimeWh || 0) / g.peakWh : undefined;
 }
 
 // Returns how much cash the user receives if they sell / cancel the facility. Construction

--- a/src/reducers/CustomGame.test.tsx
+++ b/src/reducers/CustomGame.test.tsx
@@ -1,6 +1,7 @@
 import { LOCATIONS } from "../Constants";
 import { CUSTOM_SCENARIO_ID, DEFAULT_CUSTOM_SCENARIO } from "../data/Scenarios";
 import { getTimeFromTimeline } from "../helpers/DateTime";
+import { facilityAgeYears, facilityOutputFactor } from "../helpers/Financials";
 import { getPlayedScenarioIds } from "../LocalStorage";
 import { createGame, runSimulation } from "../testing/Simulator";
 import {
@@ -78,6 +79,25 @@ describe("a custom game", () => {
       expect(f.yearsToBuildLeft).toBe(0);
       expect(f.loanAmountLeft).toBe(0);
     });
+  });
+
+  it("commissions an authored starting facility at its supplied age", () => {
+    const state = createGame({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: {
+        ...CUSTOM,
+        startingYear: 2020,
+        facilities: [{ fuel: "Sun", peakW: 100000000, initialAgeYears: 20 }],
+      },
+    });
+    const solar = state.facilities[0];
+
+    expect(facilityAgeYears(solar, state.date.minute)).toBeCloseTo(20, 10);
+    expect(facilityOutputFactor(solar, state.date.minute)).toBeCloseTo(
+      Math.pow(0.995, 20),
+      10,
+    );
+    expect(solar.currentW).toBeLessThan(solar.peakW);
   });
 
   it("dispatches an offshore wind starting facility from offshore weather", () => {

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -17,6 +17,7 @@ import {
   getCreditPremium,
   getMonthlyPayment,
   getPaymentInterest,
+  facilityOutputFactor,
 } from "../helpers/Financials";
 import { getInflationRate, getPrimeRate } from "../data/Economy";
 import {
@@ -60,6 +61,7 @@ import {
 } from "./UI";
 import { navigate, navigateBack } from "./Card";
 import {
+  DAYS_PER_YEAR,
   DIFFICULTIES,
   DOWNPAYMENT_PERCENT,
   FUELS,
@@ -78,7 +80,11 @@ import {
   OUTSKIRTS_WIND_MULTIPLIER,
   LOCATIONS,
 } from "../Constants";
-import { GENERATORS, STORAGE } from "../data/Facilities";
+import {
+  GENERATORS,
+  STORAGE,
+  windAnnualOutputDegradation,
+} from "../data/Facilities";
 import { getViableLocationsRemaining } from "../data/FacilitySites";
 import { logEvent } from "../Globals";
 import { getPlayedScenarioIds, recordScenarioPlayed } from "../LocalStorage";
@@ -106,6 +112,7 @@ import {
   GameType,
   GeneratorOperatingType,
   MonthlyHistoryType,
+  ScenarioFacilityType,
   ScenarioType,
   ScoreBreakdownType,
   SpeedType,
@@ -128,7 +135,7 @@ interface ReprioritizeFacilityAction {
 }
 
 interface NewGameAction {
-  facilities: Array<Partial<FacilityShoppingType>>;
+  facilities: ScenarioFacilityType[];
   cash: number;
   customers: number;
   location: LocationType;
@@ -558,33 +565,42 @@ export const gameSlice = createSlice({
       state.location = a.location;
       state.timeline = generateNewTimeline(state, a.cash, a.customers);
 
-      a.facilities.forEach((search: Partial<FacilityShoppingType>) => {
+      a.facilities.forEach((search: ScenarioFacilityType) => {
+        // Age is scenario metadata rather than a catalog property, so exclude it from the exact
+        // technology match and pass it to the completed operating asset separately.
+        const { initialAgeYears = 0, ...facilitySearch } = search;
         const generator = GENERATORS(
           state,
-          search.peakW || 1000000,
+          facilitySearch.peakW || 1000000,
           [],
           [],
         ).find((g: FacilityShoppingType) => {
           if (g.viableLocationsRemaining === 0) {
             return false;
           }
-          for (const property in search) {
-            if (g[property] !== search[property]) {
+          for (const property in facilitySearch) {
+            if (g[property] !== facilitySearch[property]) {
               return false;
             }
           }
           return true;
         });
         if (generator) {
-          state = buildFacilityHelper(state, generator, false, true);
+          state = buildFacilityHelper(
+            state,
+            generator,
+            false,
+            true,
+            initialAgeYears,
+          );
         } else {
-          const storage = STORAGE(state, search.peakWh || 1000000).find(
+          const storage = STORAGE(state, facilitySearch.peakWh || 1000000).find(
             (g: FacilityShoppingType) => {
               if (g.viableLocationsRemaining === 0) {
                 return false;
               }
-              for (const property in search) {
-                if (g[property] !== search[property]) {
+              for (const property in facilitySearch) {
+                if (g[property] !== facilitySearch[property]) {
                   return false;
                 }
               }
@@ -592,7 +608,13 @@ export const gameSlice = createSlice({
             },
           );
           if (storage) {
-            state = buildFacilityHelper(state, storage, false, true);
+            state = buildFacilityHelper(
+              state,
+              storage,
+              false,
+              true,
+              initialAgeYears,
+            );
           } else {
             // A spec that matches nothing used to vanish without a trace, which is a rough way to
             // find out that the technology you picked wasn't invented yet in the year you started
@@ -1515,6 +1537,7 @@ function updateSupplyFacilitiesFinances(
   let hydroMandatedReleaseW = 0;
   facilities.forEach((g: FacilityOperatingType, i: number) => {
     let dispatchPeakW = g.peakW;
+    const outputFactor = facilityOutputFactor(g, now.minute);
     let mandatedW = 0;
     const hydro = g.fuel === "Hydro" && !!g.reservoirCapacityWh;
     const storage = !!g.peakWh && g.yearsToBuildLeft === 0;
@@ -1592,10 +1615,10 @@ function updateSupplyFacilitiesFinances(
         const requiredTargetW = Math.max(targetW, mandatedW);
         switch (g.fuel) {
           case "Sun":
-            g.currentW = g.peakW * solarOutputFactor;
+            g.currentW = g.peakW * outputFactor * solarOutputFactor;
             break;
           case "Wind":
-            g.currentW = g.peakW * windOutputFactor;
+            g.currentW = g.peakW * outputFactor * windOutputFactor;
             break;
           case "Offshore Wind":
             g.currentW = g.peakW * offshoreWindOutputFactor;
@@ -1970,6 +1993,7 @@ function buildFacilityHelper(
   g: FacilityShoppingType,
   financed: boolean,
   newGame = false,
+  initialAgeYears = 0,
 ): GameType {
   const now = getTimeFromTimeline(state.date.minute, state.timeline);
 
@@ -2002,6 +2026,15 @@ function buildFacilityHelper(
     }
     const facility = {
       ...g,
+      // A scenario's catalog is priced in its starting year, but an inherited wind farm belongs
+      // to its commissioning vintage and should use that cohort's observed degradation rate.
+      ...(newGame && g.fuel === "Wind"
+        ? {
+            annualOutputDegradation: windAnnualOutputDegradation(
+              state.date.year - initialAgeYears,
+            ),
+          }
+        : {}),
       ...financing,
       id:
         state.facilities.reduce(
@@ -2011,7 +2044,9 @@ function buildFacilityHelper(
       currentW: newGame && g.peakWh === undefined ? g.peakW : 0,
       yearsToBuildLeft: newGame ? 0 : g.yearsToBuild,
       minuteCreated: state.date.minute,
-      minuteOperational: newGame ? state.date.minute : undefined,
+      minuteOperational: newGame
+        ? state.date.minute - initialAgeYears * DAYS_PER_YEAR * 24 * 60
+        : undefined,
     } as FacilityOperatingType;
     if (g.fuel === "Hydro" && g.reservoirCapacityWh) {
       // A completed dam starts at a neutral mid-pool. New construction carries this initial


### PR DESCRIPTION
## Summary

- apply compounding output degradation to solar and onshore wind, including vintage-specific wind rates
- let authored scenarios provide commissioning age for inherited facilities and show age/design-life plus effective output in facility details
- derive battery equivalent full cycles from discharged lifetime energy while preserving augmentation-funded usable capacity
- integrate degraded lifetime output into build-screen levelized cost and bump the replay version for deterministic compatibility
- document what aging is modeled, what was already captured, and why thermal wear remains separate

## Modeling choices

- Solar declines 0.5% per operating year, retaining about 90.5% after 20 years.
- Onshore wind uses 0.5% for pre-2008 commissioning vintages and 0.2% for newer vintages, rounded from LBNL's measured 0.53% and 0.17% rates.
- Offshore wind and conventional generators receive no unsupported blanket output penalty.
- Battery capacity stays constant because existing O&M includes augmentation; equivalent cycles are reported against the existing 7,300-cycle life.
- Existing saves without a degradation field receive modern solar/wind defaults; missing commissioning timestamps retain the existing start-on-resume behavior.

## Validation

- npm run check
- 63 test suites passed
- 696 tests passed

## Follow-up

Thermal starts, equivalent operating hours, start costs, refurbishment, and wear-driven outages are scoped in #227.