### PR TITLE
Fix mobile slider drag cancellation

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -234,7 +234,18 @@ button,
   -webkit-user-select: none;
   -moz-user-select: none;
   user-select: none;
+}
+
+button,
+[role="button"],
+.facilityRow {
   touch-action: manipulation;
+}
+
+// A slider owns horizontal drags. Allowing browser panning here cancels the pointer stream on
+// touch devices, often while the player is still moving the thumb.
+.MuiSlider-root {
+  touch-action: none;
 }
 
 :where(


### PR DESCRIPTION
## Summary
- keep MUI sliders in control of horizontal touch gestures with `touch-action: none`
- retain `touch-action: manipulation` for buttons and draggable facility rows
- prevent mobile browsers from cancelling an active slider drag mid-gesture

## Testing
- `tsc --noEmit`
- `eslint "src/**/*.{ts,tsx}" --max-warnings=0`
- `prettier --check "src/**/*.{ts,tsx,js,jsx,css,scss,json}"`
- `react-scripts test --watchAll=false --testMatch="**/*.test.tsx"` (703 tests)
- verified at a 390×844 browser viewport that slider roots compute to `touch-action: none` while buttons remain `manipulation`