### PR TITLE
Fix blank cash and profit charts in Insights

### DIFF
--- a/src/components/base/ChartFinances.test.tsx
+++ b/src/components/base/ChartFinances.test.tsx
@@ -1,0 +1,30 @@
+import { MINUTES_PER_MONTH } from "../../helpers/DateTime";
+import { financeXTicks, financeXValue } from "./ChartFinances";
+
+describe("finance chart x values", () => {
+  it("converts its absolute month index to Insights' game-minute scale", () => {
+    expect(financeXValue({ month: 2020 * 12 + 3 }, 2020)).toBe(
+      2 * MINUTES_PER_MONTH,
+    );
+    expect(financeXValue({ month: 2025 * 12 + 3 }, 2020)).toBe(
+      62 * MINUTES_PER_MONTH,
+    );
+  });
+
+  it("keeps the absolute month index outside Insights", () => {
+    expect(financeXValue({ month: 2020 * 12 + 3 })).toBe(2020 * 12 + 3);
+  });
+});
+
+describe("finance chart x ticks", () => {
+  it("uses month-sized units when Insights plots on the game-minute scale", () => {
+    const ticks = financeXTicks([0, 20 * 12 * MINUTES_PER_MONTH], true);
+
+    expect(ticks.length).toBeLessThanOrEqual(6);
+    expect(ticks.every((tick) => tick % MINUTES_PER_MONTH === 0)).toBe(true);
+  });
+
+  it("keeps month-indexed finance charts on their original scale", () => {
+    expect(financeXTicks([12, 23], false)).toEqual([12, 14, 16, 18, 20, 22]);
+  });
+});

--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -42,6 +42,27 @@ interface State {
   startingYear?: number;
 }
 
+/**
+ * Finances normally plots one x unit per month. Insights converts those points to game minutes
+ * so its cursor can line up with the forecast charts, and must convert the tick unit with them.
+ */
+export function financeXTicks(
+  range: [number, number],
+  minuteScale: boolean,
+): number[] {
+  return stepTicks(range[0], range[1], minuteScale ? MINUTES_PER_MONTH : 1);
+}
+
+/** Convert the finance series' absolute month index to the minute scale used by Insights. */
+export function financeXValue(
+  point: Pick<ChartData, "month">,
+  startingYear?: number,
+): number {
+  return startingYear === undefined
+    ? point.month
+    : (point.month - startingYear * 12 - 1) * MINUTES_PER_MONTH;
+}
+
 function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
   return {
     width: 0, // set by UPlotChart
@@ -63,8 +84,8 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
     axes: [
       xAxis(scale, {
         splits: () => {
-          const [min, max] = getState().range;
-          return stepTicks(min, max, 1);
+          const state = getState();
+          return financeXTicks(state.range, state.startingYear !== undefined);
         },
         values: (_u, splits) => {
           const s = getState();
@@ -111,10 +132,7 @@ const ChartFinances = (props: Props): React.JSX.Element => {
   let domainMin = 0;
   let domainMax = 0;
   const minuteScale = props.startingYear !== undefined;
-  const xValue = (d: ChartData) =>
-    minuteScale
-      ? ((d.year - props.startingYear!) * 12 + d.month - 1) * MINUTES_PER_MONTH
-      : d.month;
+  const xValue = (d: ChartData) => financeXValue(d, props.startingYear);
   const firstX = xValue(props.timeline[0]);
   const lastX = xValue(props.timeline[props.timeline.length - 1]);
   const defaultSpan = minuteScale ? 11 * MINUTES_PER_MONTH : 11;

--- a/src/components/base/UPlotHelpers.ts
+++ b/src/components/base/UPlotHelpers.ts
@@ -442,8 +442,8 @@ export function padRange(
 
 /**
  * Evenly spaced ticks across a domain, snapped to whole steps of `unit`, spaced so at most
- * `maxTicks` land in the span. The month axes use it with a month's worth of minutes; the
- * finance charts use it with 1, because their x is already a month index.
+ * `maxTicks` land in the span. Minute-based month axes use it with a month's worth of minutes;
+ * charts whose x is already a month index use it with 1.
  */
 export function stepTicks(
   min: number,


### PR DESCRIPTION
## Summary
- convert absolute finance month indices correctly onto the Insights minute scale
- snap finance-axis ticks to game months when synchronized with forecast charts
- add regression coverage for March 2020 and multi-year ranges

## Verification
- npm test -- --watchAll=false --runInBand src/components/base/ChartFinances.test.tsx src/components/views/Insights.test.tsx src/components/views/Finances.test.tsx
- npm run typecheck
- npm run lint -- --no-cache
- Prettier and git diff checks