### PR TITLE
Remove pre-release save compatibility

### DIFF
--- a/src/LocalStorage.tsx
+++ b/src/LocalStorage.tsx
@@ -114,10 +114,7 @@ const CUSTOM_GAME_KEY = "customGame";
 // rather than back at the defaults. Unlike a save, this is only the setup, never a game in
 // progress - see SaveGame for the latter
 export function getCustomScenario(fallback: ScenarioType): ScenarioType {
-  const stored = getStorageJson<Partial<ScenarioType>>(CUSTOM_GAME_KEY, {});
-  // A config written by an older version can be missing fields the screen now expects, and
-  // spreading over the defaults is cheaper than versioning something this small
-  return { ...fallback, ...stored };
+  return getStorageJson<ScenarioType>(CUSTOM_GAME_KEY, fallback);
 }
 
 export function recordCustomScenario(scenario: ScenarioType) {

--- a/src/SaveFile.test.tsx
+++ b/src/SaveFile.test.tsx
@@ -25,6 +25,10 @@ function fakeGame(overrides: Partial<GameType> = {}): GameType {
     facilities: [],
     timeline: [],
     monthlyHistory: [],
+    eventLog: [],
+    reportedEventKeys: [],
+    eventLogReadThroughId: 0,
+    worldEvents: { active: [], checkedKeys: [] },
     ...overrides,
   } as unknown as GameType;
 }

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -81,6 +81,34 @@ describe("SaveGame", () => {
     expect(parseSave({ ...save, game: withoutMarket })).toBeNull();
   });
 
+  it("rejects a current-version save without current runtime state", () => {
+    const save = serializeSave(game);
+    for (const field of [
+      "eventLog",
+      "reportedEventKeys",
+      "eventLogReadThroughId",
+      "worldEvents",
+    ] as const) {
+      const incomplete = { ...save.game } as Partial<GameType>;
+      delete incomplete[field];
+      expect(parseSave({ ...save, game: incomplete })).toBeNull();
+    }
+  });
+
+  it("rejects a current-version save with incomplete facility totals", () => {
+    const save = serializeSave(game);
+    const facility = { ...save.game.facilities[0] } as Partial<
+      GameType["facilities"][number]
+    >;
+    delete facility.lifetimeRevenue;
+    expect(
+      parseSave({
+        ...save,
+        game: { ...save.game, facilities: [facility] },
+      }),
+    ).toBeNull();
+  });
+
   it("ignores corrupt JSON", () => {
     window.localStorage.setItem(SAVE_KEY, "{not json");
     expect(readSave()).toBeNull();

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -25,12 +25,8 @@ import type { AppStore } from "./Store";
 
 export const SAVE_KEY = "savedGame";
 // Bump on any breaking schema change. Mismatched saves are ignored rather than migrated.
-// 5: investor customers respond to rate history and a finite market instead of marketing spend.
-// 4: conventional hydro carries a reservoir water balance and storage applies hourly losses.
-// 3: timeline rows may carry offshore wind, which changes the output of an offshore fleet.
-// 2: facilities carry the rate their loan was signed at, and the game carries the rate a new one
-// would cost. A version 1 save has neither, and a loan with no rate cannot be repaid.
-export const SAVE_VERSION = 5;
+// Version 6 is the launch schema; earlier values identify unsupported pre-release saves.
+export const SAVE_VERSION = 6;
 
 export interface SaveGameType {
   version: number;
@@ -95,10 +91,38 @@ export function parseSave(raw: unknown): SaveGameType | null {
   ) {
     return null;
   }
+  if (!Array.isArray(game.facilities)) {
+    return null;
+  }
   if (
-    !Array.isArray(game.facilities) ||
+    game.facilities.some((facility) => {
+      if (typeof facility !== "object" || facility === null) {
+        return true;
+      }
+      const current = facility as Record<string, unknown>;
+      return [
+        current.lifespanYears,
+        current.lifetimeWh,
+        current.lifetimePotentialWh,
+        current.lifetimeRevenue,
+        current.lifetimeExpenses,
+      ].some((value) => typeof value !== "number" || !Number.isFinite(value));
+    }) ||
     !Array.isArray(game.timeline) ||
-    !Array.isArray(game.monthlyHistory)
+    !Array.isArray(game.monthlyHistory) ||
+    !Array.isArray(game.eventLog) ||
+    !Array.isArray(game.reportedEventKeys) ||
+    typeof game.eventLogReadThroughId !== "number"
+  ) {
+    return null;
+  }
+  const worldEvents = game.worldEvents as
+    Partial<GameType["worldEvents"]> | undefined;
+  if (
+    typeof worldEvents !== "object" ||
+    worldEvents === null ||
+    !Array.isArray(worldEvents.active) ||
+    !Array.isArray(worldEvents.checkedKeys)
   ) {
     return null;
   }

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -100,9 +100,6 @@ export type CardNameType =
   | "BUILD_STORAGE"
   | "FACILITIES"
   | "INSIGHTS"
-  // Kept as navigation aliases for old saved/tutorial state; new UI routes both to Insights.
-  | "FINANCES"
-  | "FORECASTS"
   | "EVENTS"
   | "LOADING"
   | "MAIN_MENU"
@@ -307,8 +304,7 @@ export interface GeneratorOperatingType
   currentW: number;
   yearsToBuildLeft: number;
   minuteCreated: number; // That the user clicked buy, not construction complete
-  // Set when construction completes. Optional so saves made before depreciation existed still
-  // load; the first real tick establishes their remaining lifetime from that point onward.
+  // Set when construction completes; absent while the facility is still being built.
   minuteOperational?: number;
   paused: boolean;
   reservoirWh?: number;
@@ -332,19 +328,15 @@ export interface StorageOperatingType
  * earning its keep rather than only what it cost to build. Accumulated per tick by
  * updateSupplyFacilitiesFinances, and only while the game is really ticking -- a forecast runs
  * against a deep clone of the fleet and throws the clone away, so its ticks never land here.
- *
- * Every field is optional because a save written before these existed has none of them, and a
- * fleet resumed from one should keep playing rather than start reporting NaN. Read them through
- * helpers/Financials' facilityLifetime, which is where the zero defaults live.
  */
 export interface LifetimeTotals {
-  lifetimeWh?: number; // Delivered to the grid. Storage counts discharge only, not charging
+  lifetimeWh: number; // Delivered to the grid. Storage counts discharge only, not charging
   // What it could have delivered running flat out over the same span, ie the denominator of its
   // capacity factor. Accrues from the moment construction finishes, so pauses and idle hours
   // count against it the way they do for a real plant
-  lifetimePotentialWh?: number;
-  lifetimeRevenue?: number; // Its pro-rata share of what the company sold
-  lifetimeExpenses?: number; // Its own fuel, O&M, carbon fees and loan interest
+  lifetimePotentialWh: number;
+  lifetimeRevenue: number; // Its pro-rata share of what the company sold
+  lifetimeExpenses: number; // Its own fuel, O&M, carbon fees and loan interest
 }
 
 interface LoanInfo {
@@ -372,8 +364,7 @@ export interface GeneratorShoppingType extends SharedShoppingType {
   maxPeakW: number; // Maximum size the technology is currently buildable
   capacityFactor: number; // 0 - 1, percent of theoretical output actually produced across a year
   // Fraction of nameplate output permanently lost each operating year. Optional because most
-  // generator types do not have a well-supported secular output decline, and because older saves
-  // predate the field.
+  // generator types do not have a well-supported secular output decline.
   annualOutputDegradation?: number;
   spinMinutes: number; // 1 for renewables, to avoid eating up CPU on coersing to 1 in case it doesn't exist
   btuPerWh: number; // Heat Rate, but per W for less math per frame
@@ -469,8 +460,7 @@ export interface ScenarioType {
   seed?: number;
   startingYear: number;
   cash: number;
-  // Optional for backwards compatibility with authored and locally stored scenarios. When absent,
-  // the location profile supplies the starting grid size.
+  // When absent, the location profile supplies the starting grid size.
   startingCustomers?: number;
   dollarsPerkWh: number;
   durationMonths: number;
@@ -573,21 +563,20 @@ export interface GameType {
   startingYear: number;
   timeline: TickPresentFutureType[]; // anything before currentMinute is history, anything after is a forecast
   monthlyHistory: MonthlyHistoryType[]; // live updated; for calculation simplicity, 0 = most recent (prepend new entries)
-  // Newest first, capped at MAX_EVENTS. Optional because a save written before the log existed
-  // has none, and an empty log and a missing one mean the same thing to everything that reads it
-  eventLog?: GameEventType[];
+  // Newest first, capped at MAX_EVENTS.
+  eventLog: GameEventType[];
   // Keys outlive the capped event log: a once-per-run lesson must not repeat just because its
   // original row was the 101st one and fell off the visible history.
-  reportedEventKeys?: string[];
-  eventLogReadThroughId?: number;
+  reportedEventKeys: string[];
+  eventLogReadThroughId: number;
   // All-in $/MWh by fuel at the last monthly rollover, used to edge-detect cost-order changes.
   fuelCostSnapshot?: Partial<Record<FuelNameType, number>>;
-  worldEvents?: WorldEventStateType;
+  worldEvents: WorldEventStateType;
   facilities: Array<StorageOperatingType | GeneratorOperatingType>;
   // Every simulation-affecting thing the player has done this run, for the replay attached to a
   // high score. Undefined means the run isn't being recorded: before a game starts, while one is
-  // being watched, after resuming a save from before replays existed, or once a run has grown
-  // past MAX_REPLAY_ACTIONS. Persisted with the rest of the slice, so a replay survives a reload
+  // being watched, or once a run has grown past MAX_REPLAY_ACTIONS. Persisted with the rest of the
+  // slice, so a replay survives a reload.
   replayLog?: ReplayActionType[];
   // Set only while watching a replay. Doubles as the "this is a replay" flag: player controls are
   // hidden, nothing is autosaved, and no score is submitted while it's here

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -547,8 +547,6 @@ export default class Compositor extends React.Component<Props, {}> {
       case "BUILD_STORAGE":
         return <BuildStorageContainer />;
       case "INSIGHTS":
-      case "FINANCES":
-      case "FORECASTS":
         return <InsightsContainer />;
       case "EVENTS":
         return <EventLogContainer />;

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -155,7 +155,7 @@ describe("onTutorialStep", () => {
         content: <span />,
         onNext: () => sideEffect,
       },
-      { card: "FINANCES", target: "#second", content: <span /> },
+      { card: "INSIGHTS", target: "#second", content: <span /> },
     ];
 
     it("fires onNext when leaving a step forwards", () => {
@@ -166,7 +166,7 @@ describe("onTutorialStep", () => {
 
     it("doesn't replay onNext when stepping backwards", () => {
       expect(
-        step({ steps, fromStep: 1, toStep: 0, currentCard: "FINANCES" }),
+        step({ steps, fromStep: 1, toStep: 0, currentCard: "INSIGHTS" }),
       ).not.toContainEqual(sideEffect);
     });
   });

--- a/src/components/base/Navigation.tsx
+++ b/src/components/base/Navigation.tsx
@@ -19,17 +19,12 @@ export default function Navigation() {
   const cardName = useAppSelector(selectCardName);
   const paneLayout = isPaneLayout();
   // Facilities is always the left pane at this width. If a resize lands here while that was
-  // the active phone tab, Insights is the second pane actually being shown. The two old values
-  // are aliases for saved sessions from before the screens were consolidated.
+  // the active phone tab, Insights is the second pane actually being shown.
   const selectedCard =
-    cardName === "FINANCES" || cardName === "FORECASTS"
-      ? "INSIGHTS"
-      : paneLayout && cardName === "FACILITIES"
-        ? "INSIGHTS"
-        : cardName;
+    paneLayout && cardName === "FACILITIES" ? "INSIGHTS" : cardName;
   const unreadEvents = useAppSelector((state) => {
-    const latest = state.game.eventLog?.[0]?.id || 0;
-    return latest > (state.game.eventLogReadThroughId || 0);
+    const latest = state.game.eventLog[0]?.id || 0;
+    return latest > state.game.eventLogReadThroughId;
   });
   return (
     <BottomNavigation

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -102,7 +102,7 @@ function inEraMoney(base: number, startingYear: number): number {
 }
 
 // The option nearest a value, used to keep the player's position in a list when the era under it
-// moves, and to migrate a custom game stored before these became era-aware.
+// moves.
 function nearestIndex(options: number[], value: number): number {
   let best = 0;
   options.forEach((option: number, i: number) => {
@@ -113,35 +113,6 @@ function nearestIndex(options: number[], value: number): number {
   return best;
 }
 
-/**
- * A stored custom game with its cash, rate and fee snapped onto the options this screen
- * offers - the rate and fee against its own starting year.
- *
- * Only ever changes a game saved before those became era-aware. Doing it on the way in rather
- * than on the way out is what keeps the screen honest: showing the nearest option while the
- * scenario still held the old number would start a game at a rate the player was never shown.
- * There is no recovering what they originally meant -- fifty dollars a ton is a rounding error in
- * 2090 money -- so the nearest option is the best that can be done, once.
- */
-function inEraScenario(scenario: ScenarioType): ScenarioType {
-  const rates = RATES_PER_KWH.map((r: number) =>
-    inEraMoney(r, scenario.startingYear),
-  );
-  const fees = FEES_PER_TON.map((f: number) =>
-    inEraMoney(f, scenario.startingYear),
-  );
-  return {
-    ...scenario,
-    // Cash is quoted the same in every era, so this only catches a game stored against an
-    // amount the picker no longer offers - which would otherwise render the field blank
-    cash: STARTING_CASH[nearestIndex(STARTING_CASH, scenario.cash)],
-    startingCustomers:
-      scenario.startingCustomers ||
-      getStartingCustomers(getScenarioLocation(scenario)),
-    dollarsPerkWh: rates[nearestIndex(rates, scenario.dollarsPerkWh)],
-    feePerKgCO2e: fees[nearestIndex(fees, scenario.feePerKgCO2e * 1000)] / 1000,
-  };
-}
 const STARTING_CASH = [100000000, 200000000, 500000000, 1000000000];
 const RATES_PER_KWH = [0.05, 0.07, 0.1, 0.15];
 const FEES_PER_TON = [0, 20, 50, 100];
@@ -209,9 +180,7 @@ function facilitySize(facility: Partial<FacilityShoppingType>): string {
 export default function CustomGame(props: Props): React.JSX.Element {
   const { game, onBack, onDelta, onStart } = props;
   const units = useUnits();
-  const [scenario, setScenario] = React.useState<ScenarioType>(() =>
-    inEraScenario(props.scenario),
-  );
+  const [scenario, setScenario] = React.useState<ScenarioType>(props.scenario);
   const [victoryDialogOpen, setVictoryDialogOpen] = React.useState(false);
   const [feeDialogOpen, setFeeDialogOpen] = React.useState(false);
   const [addName, setAddName] = React.useState("");

--- a/src/components/views/EventLogContainer.tsx
+++ b/src/components/views/EventLogContainer.tsx
@@ -5,13 +5,9 @@ import type { AppDispatch } from "../../Store";
 import { markEventsRead } from "../../reducers/Game";
 import { navigate } from "../../reducers/Card";
 
-// One shared array for a run with nothing in its log yet - and for a save written before the log
-// existed. A fresh [] per call would be a new prop every tick, which is a re-render every tick
-const NO_EVENTS: GameEventType[] = [];
-
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
-    events: state.game.eventLog || NO_EVENTS,
+    events: state.game.eventLog,
   };
 };
 

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -848,7 +848,7 @@ export default class Finances extends React.Component<Props, State> {
     const selectedLifetime =
       selectedFacility && facilityLifetime(selectedFacility);
     const fleetWh = game.facilities.reduce(
-      (sum: number, f: FacilityOperatingType) => sum + (f.lifetimeWh || 0),
+      (sum: number, f: FacilityOperatingType) => sum + f.lifetimeWh,
       0,
     );
 

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -427,7 +427,7 @@ export const SCENARIOS = [
         card: "FACILITIES",
         target: "#speedChangeButtons",
         advanceOn: (s: AppStateType) =>
-          (s.game.eventLog || []).some((event) => event.kind === "BLACKOUT"),
+          s.game.eventLog.some((event) => event.kind === "BLACKOUT"),
         content: (
           <TutorialPrompt
             concepts={["play", "blackout"]}

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -32,6 +32,10 @@ function aFacility(
     lifespanYears: 40,
     minuteCreated: 0,
     minuteOperational: 0,
+    lifetimeWh: 0,
+    lifetimePotentialWh: 0,
+    lifetimeRevenue: 0,
+    lifetimeExpenses: 0,
     ...overrides,
   } as FacilityOperatingType;
 }
@@ -112,13 +116,6 @@ describe("facilityCashBack", () => {
     expect(facilityCashBack(aFacility(), minute(20))).toBeCloseTo(500000, 6);
     expect(facilityCashBack(aFacility(), minute(40))).toBe(0);
     expect(facilityCashBack(aFacility(), minute(60))).toBe(0);
-  });
-
-  it("uses a conservative life for a legacy save with no lifespan", () => {
-    const currentMinute = 15 * DAYS_PER_YEAR * 24 * 60;
-    expect(
-      facilityCashBack(aFacility({ lifespanYears: undefined }), currentMinute),
-    ).toBeCloseTo(500000, 6);
   });
 
   it("refunds the same committed equity throughout construction", () => {
@@ -408,15 +405,6 @@ describe("facility aging", () => {
 
   it("leaves technologies without an evidence-backed decline at nameplate", () => {
     expect(facilityOutputFactor(aFacility(), minute(60))).toBe(1);
-  });
-
-  it("gives legacy solar saves a degradation default", () => {
-    const legacySolar = aFacility({ fuel: "Sun" });
-    expect(legacySolar.annualOutputDegradation).toBeUndefined();
-    expect(facilityOutputFactor(legacySolar, minute(20))).toBeCloseTo(
-      Math.pow(0.995, 20),
-      10,
-    );
   });
 
   it("derives battery equivalent full cycles from discharged energy", () => {

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -206,10 +206,10 @@ export interface FacilityLifetimeType {
 export function facilityLifetime(
   f: FacilityOperatingType,
 ): FacilityLifetimeType {
-  const wh = f.lifetimeWh || 0;
-  const revenue = f.lifetimeRevenue || 0;
-  const expenses = f.lifetimeExpenses || 0;
-  const potentialWh = f.lifetimePotentialWh || 0;
+  const wh = f.lifetimeWh;
+  const revenue = f.lifetimeRevenue;
+  const expenses = f.lifetimeExpenses;
+  const potentialWh = f.lifetimePotentialWh;
   const mwh = wh / 1000000;
   return {
     wh,
@@ -242,11 +242,7 @@ export function facilityOutputFactor(
   g: FacilityOperatingType,
   currentMinute: number,
 ): number {
-  // Current facilities carry their researched rate. Legacy saves do not, so apply the modern
-  // defaults rather than making old solar and wind immune to aging from the day they resume.
-  const annualDegradation =
-    g.annualOutputDegradation ??
-    (g.fuel === "Sun" ? 0.005 : g.fuel === "Wind" ? 0.002 : 0);
+  const annualDegradation = g.annualOutputDegradation || 0;
   if (annualDegradation <= 0) {
     return 1;
   }
@@ -258,13 +254,13 @@ export function facilityOutputFactor(
 
 /**
  * Storage lifetimeWh already counts discharge only, which is the industry convention for an
- * equivalent full cycle. Deriving the counter keeps old saves compatible and avoids a second
- * running total that could drift out of sync.
+ * equivalent full cycle. Deriving the counter avoids a second running total that could drift out
+ * of sync.
  */
 export function facilityEquivalentCycles(
   g: FacilityOperatingType,
 ): number | undefined {
-  return g.peakWh > 0 ? (g.lifetimeWh || 0) / g.peakWh : undefined;
+  return g.peakWh > 0 ? g.lifetimeWh / g.peakWh : undefined;
 }
 
 // Returns how much cash the user receives if they sell / cancel the facility. Construction
@@ -275,16 +271,9 @@ export function facilityCashBack(
   currentMinute = g.minuteOperational ?? g.minuteCreated,
 ): number {
   if (g.yearsToBuildLeft === 0) {
-    // Saves from before technology-specific lives were added do not have this field. Thirty years
-    // is the conservative common economic-life assumption; the facility's researched value wins
-    // for every new game and save written by current code.
-    const lifespanYears =
-      Number.isFinite(g.lifespanYears) && g.lifespanYears > 0
-        ? g.lifespanYears
-        : 30;
     const remainingLife = Math.max(
       0,
-      1 - facilityAgeYears(g, currentMinute) / lifespanYears,
+      1 - facilityAgeYears(g, currentMinute) / g.lifespanYears,
     );
     return g.buildCost * remainingLife - g.loanAmountLeft;
   }

--- a/src/reducers/EventLog.test.tsx
+++ b/src/reducers/EventLog.test.tsx
@@ -33,11 +33,11 @@ function ticked(state: GameType, ticks: number): GameType {
 }
 
 function messages(state: GameType): string[] {
-  return (state.eventLog || []).map((e: GameEventType) => e.message);
+  return state.eventLog.map((e: GameEventType) => e.message);
 }
 
 function kinds(state: GameType): string[] {
-  return (state.eventLog || []).map((e: GameEventType) => e.kind);
+  return state.eventLog.map((e: GameEventType) => e.kind);
 }
 
 // A fleet that has been switched off entirely, which is the shortest road to a blackout
@@ -67,7 +67,7 @@ describe("the event log", () => {
       f.paused = false;
     });
     const lit = ticked(recovered, 60);
-    const over = (lit.eventLog || []).find(
+    const over = lit.eventLog.find(
       (e: GameEventType) => e.kind === "BLACKOUT_OVER",
     );
     expect(over).toBeDefined();
@@ -78,7 +78,7 @@ describe("the event log", () => {
 
   it("stamps each entry with the month it happened in, newest first", () => {
     const dark = ticked(pauseEverything(createGame({ scenarioId: 100 })), 200);
-    const log = dark.eventLog || [];
+    const log = dark.eventLog;
     expect(log.length).toBeGreaterThan(0);
     expect(log[0].label).toMatch(/^[A-Z][a-z]{2} \d{4}$/);
     // Ids are handed out in order, so newest first means descending
@@ -127,7 +127,7 @@ describe("the event log", () => {
    */
   it("keeps only the most recent hundred entries", () => {
     const dark = ticked(pauseEverything(createGame({ scenarioId: 100 })), 400);
-    const log = dark.eventLog || [];
+    const log = dark.eventLog;
     expect(log.length).toBeLessThanOrEqual(100);
   });
 
@@ -162,8 +162,8 @@ describe("the event log", () => {
     logFuelCrossovers(game);
     expect(kinds(game)).toContain("FUEL_CROSSOVER");
     expect(messages(game)[0]).toContain(`${dearer} is now more expensive`);
-    expect(game.eventLog?.[0].importance).toEqual("NOTABLE");
-    expect(game.eventLog?.[0].actionTarget).toEqual("FACILITIES");
+    expect(game.eventLog[0].importance).toEqual("NOTABLE");
+    expect(game.eventLog[0].actionTarget).toEqual("FACILITIES");
     expect(game.speed).toEqual("PAUSED");
 
     // Even after recreating the same edge, the persistent per-fuel key suppresses it.

--- a/src/reducers/FacilityLifetime.test.tsx
+++ b/src/reducers/FacilityLifetime.test.tsx
@@ -70,8 +70,7 @@ describe("per-facility lifetime totals", () => {
   it("never books more than one company's revenue across the fleet", () => {
     const booked = (state: GameType) =>
       state.facilities.reduce(
-        (sum: number, f: FacilityOperatingType) =>
-          sum + (f.lifetimeRevenue || 0),
+        (sum: number, f: FacilityOperatingType) => sum + f.lifetimeRevenue,
         0,
       );
 

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -205,12 +205,9 @@ function logGameEvent(
 ): boolean {
   if (
     options.reportedKey &&
-    (state.reportedEventKeys || []).includes(options.reportedKey)
+    state.reportedEventKeys.includes(options.reportedKey)
   ) {
     return false;
-  }
-  if (!state.eventLog) {
-    state.eventLog = [];
   }
   const log = state.eventLog;
   log.unshift({
@@ -222,7 +219,6 @@ function logGameEvent(
     actionTarget: options.actionTarget,
   });
   if (options.reportedKey) {
-    state.reportedEventKeys = state.reportedEventKeys || [];
     state.reportedEventKeys.push(options.reportedKey);
   }
   if (log.length > MAX_EVENTS) {
@@ -385,7 +381,6 @@ const MAX_WORLD_EVENT_CHECKS = 2400;
 
 /** Starts/ends authored events before this month's forecast is built. */
 function updateWorldEvents(state: GameType) {
-  state.worldEvents = state.worldEvents || { active: [], checkedKeys: [] };
   state.worldEvents.active = state.worldEvents.active.filter(
     (event) => event.endsMinute > state.date.minute,
   );
@@ -395,12 +390,12 @@ function updateWorldEvents(state: GameType) {
       date: state.date,
       location: state.location,
     });
-    if (state.worldEvents!.checkedKeys.includes(resolved.checkedKey)) {
+    if (state.worldEvents.checkedKeys.includes(resolved.checkedKey)) {
       return;
     }
-    state.worldEvents!.checkedKeys.push(resolved.checkedKey);
+    state.worldEvents.checkedKeys.push(resolved.checkedKey);
     if (resolved.occurrence) {
-      state.worldEvents!.active.push(resolved.occurrence);
+      state.worldEvents.active.push(resolved.occurrence);
       logGameEvent(
         state,
         resolved.occurrence.kind,
@@ -428,7 +423,7 @@ function getEffectiveFuelPrices(
 ): FuelPricesType {
   const prices = getFuelPricesPerMBTU(date, state.seed, state.location);
   const multipliers = activeWorldEventEffects(
-    state.worldEvents?.active,
+    state.worldEvents.active,
     date.minute,
   ).fuelPriceMultipliers;
   if (!multipliers) {
@@ -465,6 +460,9 @@ const initialGame: GameType = {
   timeline: [] as TickPresentFutureType[],
   monthlyHistory: [] as MonthlyHistoryType[],
   eventLog: [] as GameEventType[],
+  reportedEventKeys: [],
+  eventLogReadThroughId: 0,
+  worldEvents: { active: [], checkedKeys: [] },
 };
 
 // Restarts the self-rescheduling tick() loop when leaving PAUSED, unless it's already running.
@@ -672,7 +670,7 @@ export const gameSlice = createSlice({
       ensureTicking(state);
     },
     markEventsRead: (state) => {
-      state.eventLogReadThroughId = state.eventLog?.[0]?.id || 0;
+      state.eventLogReadThroughId = state.eventLog[0]?.id || 0;
     },
   },
   // start, loaded and quit are declared in GameActions so that Card and UI can react to them
@@ -699,12 +697,6 @@ export const gameSlice = createSlice({
       // Never resume mid-tick; loaded() flips inGame once the CSVs are back
       restored.speed = "PAUSED";
       restored.inGame = false;
-      // Saves written before replays existed have no log, and a run recorded from halfway
-      // through would play back as a different game. Undefined is how the recorder is told to
-      // stay off for the rest of this run, so the score it eventually sets carries no replay
-      if (!Array.isArray(restored.replayLog)) {
-        restored.replayLog = undefined;
-      }
       // Nothing ever autosaves a replay, so anything here came out of a hand-edited save
       restored.replayPlayback = undefined;
       // tickLoopRunning is deliberately left alone: any loop still alive clears the flag and stops
@@ -1360,10 +1352,7 @@ function getDemandW(
     40 * minutesFrom9amLogistics +
     30 * minutesFromDarkLogistics -
     65 * minutesFrom5pmLogistics;
-  const effects = activeWorldEventEffects(
-    game.worldEvents?.active,
-    date.minute,
-  );
+  const effects = activeWorldEventEffects(game.worldEvents.active, date.minute);
   return demandMultiple * now.customers * (effects.demandMultiplier || 1);
 }
 
@@ -1404,7 +1393,7 @@ function reforecastWeatherAndPrices(
       const weather = getWeather(date, state.seed, cumulativeMegatons);
       const fuelPrices = getEffectiveFuelPrices(date, state);
       const effects = activeWorldEventEffects(
-        state.worldEvents?.active,
+        state.worldEvents.active,
         date.minute,
       );
       const hydroKey = `${date.year}-${date.monthNumber}`;
@@ -1788,15 +1777,11 @@ function updateSupplyFacilitiesFinances(
         // crediting them here would book revenue nobody was paid for. Its potential keeps
         // accruing though -- being switched off is exactly what a capacity factor is for
         const deliveredW = g.paused ? 0 : Math.max(0, g.currentW);
-        g.lifetimeWh =
-          (g.lifetimeWh || 0) +
-          (deliveredW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
-        g.lifetimePotentialWh =
-          (g.lifetimePotentialWh || 0) +
+        g.lifetimeWh += (deliveredW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+        g.lifetimePotentialWh +=
           (g.peakW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
-        g.lifetimeRevenue =
-          (g.lifetimeRevenue || 0) + deliveredW * revenuePerSuppliedW;
-        g.lifetimeExpenses = (g.lifetimeExpenses || 0) + facilityExpenses;
+        g.lifetimeRevenue += deliveredW * revenuePerSuppliedW;
+        g.lifetimeExpenses += facilityExpenses;
       }
     } else {
       facilityExpenses =
@@ -1805,7 +1790,7 @@ function updateSupplyFacilitiesFinances(
       // A half-built plant is already costing interest, and a row that only started counting on
       // the day it switched on would hide the cheapest place to notice that
       if (!simulated) {
-        g.lifetimeExpenses = (g.lifetimeExpenses || 0) + facilityExpenses;
+        g.lifetimeExpenses += facilityExpenses;
       }
     }
   });
@@ -2036,6 +2021,10 @@ function buildFacilityHelper(
           }
         : {}),
       ...financing,
+      lifetimeWh: 0,
+      lifetimePotentialWh: 0,
+      lifetimeRevenue: 0,
+      lifetimeExpenses: 0,
       id:
         state.facilities.reduce(
           (max: number, f: FacilityOperatingType) => (max > f.id ? max : f.id),

--- a/src/reducers/Replay.test.tsx
+++ b/src/reducers/Replay.test.tsx
@@ -209,24 +209,3 @@ describe("watching a replay", () => {
     );
   });
 });
-
-describe("resuming a recorded run", () => {
-  /**
-   * A save from before replays existed carries no log, and a run recorded from halfway through
-   * would play back as a different game. Recording stays off rather than starting mid-run.
-   */
-  it("gives up on the replay rather than recording half of one", () => {
-    const played = createGame(OPTIONS);
-    runMonths(played, 2);
-
-    const { replayLog: _dropped, ...withoutLog } = played;
-    let resumed = cloneDeep(withoutLog) as GameType;
-    resumed = dispatch(
-      resumed,
-      buildFacility({ facility: aGeneratorToBuild(resumed), financed: true }),
-    );
-
-    expect(resumed.replayLog).toBeUndefined();
-    expect(serializeReplay(resumed)).toBeUndefined();
-  });
-});

--- a/src/reducers/Tutorial.test.tsx
+++ b/src/reducers/Tutorial.test.tsx
@@ -10,7 +10,7 @@ import { tutorialGateMiddleware } from "./Tutorial";
 import uiReducer from "./UI";
 import userReducer from "./User";
 
-function informational(card: "FACILITIES" | "FINANCES" = "FACILITIES") {
+function informational(card: "FACILITIES" | "INSIGHTS" = "FACILITIES") {
   return {
     card,
     target: "#information",
@@ -114,14 +114,14 @@ describe("tutorialGateMiddleware", () => {
         ...informational(),
         advanceOn: (state) => state.game.dollarsPerkWh < 0.07,
       },
-      informational("FINANCES"),
+      informational("INSIGHTS"),
     ];
     const store = tutorialStore(steps);
 
     store.dispatch({ type: "test/satisfy-predicate" });
 
     expect(store.getState().game.tutorialStep).toBe(1);
-    expect(store.getState().card.name).toBe("FINANCES");
+    expect(store.getState().card.name).toBe("INSIGHTS");
   });
 
   it("advances an action gate only for a declared action type", () => {


### PR DESCRIPTION
Removes pre-release save migrations and fallbacks, makes current runtime state explicit, and rejects saves that do not match the launch schema. Also removes stale navigation aliases and legacy-only tests. Verification: npm run check (66 suites, 705 tests).