### PR TITLE
Model and visualize demand by load type

### DIFF
--- a/docs/demand-model.md
+++ b/docs/demand-model.md
@@ -1,0 +1,41 @@
+# Demand by load type
+
+Electrify models demand using the four end-use sectors used by the U.S. Energy Information
+Administration—residential, commercial, industrial, and transportation—plus data centers as a
+fifth explicit category. Data centers are normally counted inside the commercial sector; they are
+separated here because their recent growth is large enough to be a distinct planning problem.
+
+Each forecast tick now carries a five-part demand breakdown. The components have different daily
+shapes: residential demand peaks in the morning and evening, commercial demand in the daytime,
+transportation demand leans toward overnight charging, and industrial and data-center demand are
+comparatively flat. At a scenario's opening instant the five components are normalized to the
+scenario's previous total demand, preserving authored starting balance. From there they follow
+regional and local structural trends and their sum becomes the load the player must serve.
+
+The broad regional sector mixes and growth rates are game-scale assumptions, not city forecasts.
+They let mature markets flatten, high-growth markets expand, and industrial demand decline in
+parts of the U.S. Midwest while growing in faster-growing states. Customer growth remains the
+common demographic baseline, so these rates represent changes in consumption per customer.
+
+## Data centers
+
+The U.S. data-center curve is interpolated between published historical and projected anchors:
+
+- 2000: 28.2 TWh, about 0.8% of U.S. electricity use
+- 2006: 61.4 TWh, about 1.5%
+- 2014: 58 TWh, about 1.5%
+- 2018: 1.9%
+- 2023: 176 TWh, 4.4%
+- 2028: 9.35%, the midpoint of Berkeley Lab's 6.7%–12.0% scenario range
+
+Before 2000 the category is zero. After 2028 the curve tapers and is capped, since extrapolating
+near-term AI buildout indefinitely would overwhelm century-long sandbox games. Berkeley Lab
+identifies Virginia as the largest U.S. data-center electricity load, followed by California and
+Texas; local multipliers reflect that ordering but are scenario parameters rather than measured
+state market shares. Other countries use conservative regional exposure factors.
+
+Sources:
+
+- [EIA international end-use sector definitions](https://www.eia.gov/tools/faqs/faq.php?id=447&t=1)
+- [DOE data-center energy usage profile](https://www1.eere.energy.gov/manufacturing/datacenters/pdfs/chp_data_centers.pdf)
+- [Berkeley Lab 2024 U.S. Data Center Energy Usage Report](https://eta-publications.lbl.gov/sites/default/files/2024-12/lbnl-2024-united-states-data-center-energy-usage-report_1.pdf)

--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -5,7 +5,12 @@
 
 import { blue, green, grey, red, amber } from "@mui/material/colors";
 import { createTheme, Theme } from "@mui/material/styles";
-import { FuelNameType, ThemeChoiceType, ThemeModeType } from "./Types";
+import {
+  DemandTypeNameType,
+  FuelNameType,
+  ThemeChoiceType,
+  ThemeModeType,
+} from "./Types";
 
 /**
  * The game's two palettes.
@@ -58,6 +63,31 @@ const FUEL_COLORS: { [mode in ThemeModeType]: { [fuel: string]: string } } = {
 /** The fuel colours for the palette in use. */
 export function fuelColors(): { [fuel: string]: string } {
   return FUEL_COLORS[currentMode];
+}
+
+const DEMAND_TYPE_COLORS: Record<
+  ThemeModeType,
+  Record<DemandTypeNameType, string>
+> = {
+  light: {
+    Residential: "#1565c0",
+    Commercial: "#6a1b9a",
+    Industrial: "#8d4b20",
+    Transportation: "#2e7d32",
+    "Data centers": "#c62828",
+  },
+  dark: {
+    Residential: "#64b5f6",
+    Commercial: "#ce93d8",
+    Industrial: "#d7a86e",
+    Transportation: "#81c784",
+    "Data centers": "#ef9a9a",
+  },
+};
+
+/** Colors shared by the demand-by-type chart and its DOM legend. */
+export function demandTypeColors(): Record<DemandTypeNameType, string> {
+  return DEMAND_TYPE_COLORS[currentMode];
 }
 
 /** One fuel's colour, or the storage colour for a facility that burns nothing. */

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -87,6 +87,16 @@ export interface FuelProductionType {
   Hydro?: number; // wh
 }
 
+/** The five high-level end-use groups used by the demand model and its stacked chart. */
+export type DemandTypeNameType =
+  | "Residential"
+  | "Commercial"
+  | "Industrial"
+  | "Transportation"
+  | "Data centers";
+
+export type DemandByTypeType = Record<DemandTypeNameType, number>;
+
 export interface DifficultyMultipliersType {
   buildCost: number;
   expensesOM: number;
@@ -237,6 +247,9 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     minute: number;
     supplyW: number; // Watts
     demandW: number; // Watts
+    // Components sum to demandW. Kept on forecast ticks so Insights can explain what is driving
+    // load without bloating the long-lived monthly history in saves.
+    demandByType: DemandByTypeType;
     solarIrradianceWM2: number;
     windKph: number;
     windOffshoreKph?: number;

--- a/src/components/base/ChartForecastDemandByType.test.tsx
+++ b/src/components/base/ChartForecastDemandByType.test.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { DemandByTypeType, TickPresentFutureType } from "../../Types";
+import ChartForecastDemandByType from "./ChartForecastDemandByType";
+
+function tick(
+  minute: number,
+  demandByType: DemandByTypeType,
+): TickPresentFutureType {
+  return { minute, demandByType } as TickPresentFutureType;
+}
+
+it("makes every demand category readable without the canvas", () => {
+  render(
+    <ChartForecastDemandByType
+      timeline={[
+        tick(0, {
+          Residential: 390,
+          Commercial: 340,
+          Industrial: 220,
+          Transportation: 10,
+          "Data centers": 40,
+        }),
+        tick(1440, {
+          Residential: 400,
+          Commercial: 345,
+          Industrial: 220,
+          Transportation: 12,
+          "Data centers": 55,
+        }),
+      ]}
+      domain={{ x: [0, 1440] }}
+      startingYear={2020}
+      multiyear={false}
+    />,
+  );
+
+  const chart = screen.getByRole("img", {
+    name: /electricity demand by load type/i,
+  });
+  expect(chart).toHaveAccessibleName(/Residential:/);
+  expect(chart).toHaveAccessibleName(/Commercial:/);
+  expect(chart).toHaveAccessibleName(/Industrial:/);
+  expect(chart).toHaveAccessibleName(/Transportation:/);
+  expect(chart).toHaveAccessibleName(/Data centers:/);
+});

--- a/src/components/base/ChartForecastDemandByType.tsx
+++ b/src/components/base/ChartForecastDemandByType.tsx
@@ -1,0 +1,179 @@
+import * as React from "react";
+import uPlot from "uplot";
+import { DEMAND_TYPES } from "../../data/DemandProfiles";
+import {
+  DemandByTypeType,
+  DemandTypeNameType,
+  TickPresentFutureType,
+} from "../../Types";
+import {
+  formatMinuteAsMonthAxis,
+  formatMinuteAsTooltipHeader,
+  MINUTES_PER_MONTH,
+} from "../../helpers/DateTime";
+import { formatWatts, formatWattsAxis } from "../../helpers/Format";
+import { chartPalette, demandTypeColors } from "../../Theme";
+import UPlotChart, { BuildContext } from "./UPlotChart";
+import {
+  FORECAST_AXIS_LEFT,
+  FORECAST_AXIS_RIGHT,
+  stepTicks,
+  xAxis,
+  yAxis,
+} from "./UPlotHelpers";
+
+export interface Props {
+  height?: number;
+  timeline: TickPresentFutureType[];
+  domain: { x: [number, number] };
+  startingYear: number;
+  multiyear: boolean;
+  showXLabels?: boolean;
+  syncKey?: string;
+}
+
+interface State {
+  byType: DemandByTypeType[];
+  minutes: number[];
+  domain: Props["domain"];
+  maxY: number;
+  startingYear: number;
+  multiyear: boolean;
+}
+
+function buildOptions(showXLabels: boolean) {
+  return ({ getState, scale }: BuildContext<State>): uPlot.Options => ({
+    width: 0,
+    height: 0,
+    padding: [5 * scale, FORECAST_AXIS_RIGHT * scale, 0, 0],
+    cursor: {
+      x: true,
+      y: false,
+      points: { show: false },
+      drag: { x: false, y: false, setScale: false },
+    },
+    legend: { show: false },
+    scales: {
+      x: { time: false, range: () => getState().domain.x },
+      y: { range: () => [0, getState().maxY] as [number, number] },
+    },
+    axes: [
+      xAxis(scale, {
+        showLabels: showXLabels,
+        splits: () => {
+          const [min, max] = getState().domain.x;
+          return stepTicks(min, max, MINUTES_PER_MONTH);
+        },
+        values: (_u, splits) => {
+          const state = getState();
+          return splits.map((minute) =>
+            formatMinuteAsMonthAxis(
+              minute,
+              state.startingYear,
+              state.multiyear,
+            ),
+          );
+        },
+      }),
+      yAxis(scale, {
+        size: FORECAST_AXIS_LEFT,
+        values: (_u, splits) =>
+          splits.map((value) => formatWattsAxis(value, splits)),
+      }),
+    ],
+    series: [
+      {},
+      ...DEMAND_TYPES.map((type) => ({
+        fill: demandTypeColors()[type],
+        stroke: chartPalette().background,
+        width: 0.5,
+        points: { show: false },
+      })),
+    ],
+    bands: DEMAND_TYPES.slice(1).map((_type, index) => ({
+      series: [index + 2, index + 1],
+    })),
+  });
+}
+
+function tooltip(idx: number, state: State): string {
+  return [
+    formatMinuteAsTooltipHeader(state.minutes[idx], state.startingYear),
+    ...DEMAND_TYPES.map(
+      (type) => `${type}: ${formatWatts(state.byType[idx][type])}`,
+    ).reverse(),
+  ].join("\n");
+}
+
+const EMPTY_BREAKDOWN: DemandByTypeType = {
+  Residential: 0,
+  Commercial: 0,
+  Industrial: 0,
+  Transportation: 0,
+  "Data centers": 0,
+};
+
+export default class ChartForecastDemandByType extends React.PureComponent<
+  Props,
+  {}
+> {
+  public render() {
+    const {
+      domain,
+      height,
+      timeline,
+      startingYear,
+      multiyear,
+      showXLabels,
+      syncKey,
+    } = this.props;
+    const minutes: number[] = [];
+    const byType: DemandByTypeType[] = [];
+    timeline.forEach((tick) => {
+      if (minutes.length && minutes[minutes.length - 1] === tick.minute) {
+        return;
+      }
+      minutes.push(tick.minute);
+      // Old saves can briefly render one pre-migration tick before the first reforecast.
+      byType.push(tick.demandByType || EMPTY_BREAKDOWN);
+    });
+
+    const stacked: number[][] = [];
+    const unstacked: number[][] = DEMAND_TYPES.map((type) =>
+      byType.map((breakdown) => breakdown[type]),
+    );
+    const running = new Array<number>(minutes.length).fill(0);
+    DEMAND_TYPES.forEach((_type: DemandTypeNameType, typeIndex) => {
+      for (let i = 0; i < minutes.length; i++) {
+        running[i] += unstacked[typeIndex][i];
+      }
+      stacked.push([...running]);
+    });
+    const maxY = Math.max(...running, 0);
+    const state: State = {
+      byType,
+      minutes,
+      domain,
+      maxY,
+      startingYear,
+      multiyear,
+    };
+
+    return (
+      <div id="chartForecastDemandByType">
+        <UPlotChart<State>
+          ariaLabel="Chart of forecasted electricity demand by load type"
+          height={height}
+          state={state}
+          data={[minutes, ...stacked]}
+          summaryData={[minutes, ...unstacked]}
+          seriesLabels={[...DEMAND_TYPES]}
+          buildOptions={buildOptions(showXLabels !== false)}
+          structureKey={String(showXLabels !== false)}
+          syncKey={syncKey}
+          tooltip={tooltip}
+        />
+      </div>
+    );
+  }
+}

--- a/src/components/base/UPlotChart.tsx
+++ b/src/components/base/UPlotChart.tsx
@@ -34,6 +34,8 @@ export interface UPlotChartProps<S> {
   /** Everything the option callbacks and plugins need, recomputed every render */
   state: S;
   data: uPlot.AlignedData;
+  /** Optional unstacked values for the accessible summary when the canvas needs cumulative data. */
+  summaryData?: uPlot.AlignedData;
   /** Called once per plot. Width and height are filled in by this component. */
   buildOptions: (ctx: BuildContext<S>) => uPlot.Options;
   /** Change to force a rebuild, eg when the number of series changes */
@@ -116,20 +118,23 @@ export default function UPlotChart<S>(
     () => new Intl.NumberFormat(undefined, { maximumSignificantDigits: 4 }),
     [],
   );
-  const seriesSummary = data.slice(1).map((series, index) => {
-    const values = Array.from(series).filter(
-      (value): value is number => typeof value === "number" && isFinite(value),
-    );
-    const first = values[0] || 0;
-    const latest = values[values.length - 1] || 0;
-    return {
-      label: props.seriesLabels?.[index] || `Series ${index + 1}`,
-      latest,
-      minimum: values.length ? Math.min(...values) : 0,
-      maximum: values.length ? Math.max(...values) : 0,
-      trend: latest > first ? "up" : latest < first ? "down" : "flat",
-    };
-  });
+  const seriesSummary = (props.summaryData || data)
+    .slice(1)
+    .map((series, index) => {
+      const values = Array.from(series).filter(
+        (value): value is number =>
+          typeof value === "number" && isFinite(value),
+      );
+      const first = values[0] || 0;
+      const latest = values[values.length - 1] || 0;
+      return {
+        label: props.seriesLabels?.[index] || `Series ${index + 1}`,
+        latest,
+        minimum: values.length ? Math.min(...values) : 0,
+        maximum: values.length ? Math.max(...values) : 0,
+        trend: latest > first ? "up" : latest < first ? "down" : "flat",
+      };
+    });
   const accessibleLabel = `${ariaLabel}. ${seriesSummary
     .map(
       (series) =>

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -35,6 +35,12 @@ jest.mock("../base/ChartForecastFuelPrices", () => ({
     <div role="img" data-chart="fuel-prices" data-sync-key={syncKey} />
   ),
 }));
+jest.mock("../base/ChartForecastDemandByType", () => ({
+  __esModule: true,
+  default: ({ syncKey }: ChartMockProps) => (
+    <div role="img" data-chart="demand-by-type" data-sync-key={syncKey} />
+  ),
+}));
 jest.mock("../base/ChartForecastSupplyByFuel", () => ({
   __esModule: true,
   forecastFuels: () => [],
@@ -92,6 +98,7 @@ describe("Insights layers", () => {
       INSIGHT_LAYERS.length,
     );
     expect(INSIGHT_PRESETS.reliability.layers).toContain("supplyDemand");
+    expect(INSIGHT_PRESETS.reliability.layers).toContain("demandByType");
     expect(INSIGHT_PRESETS.profitability.layers).toContain("profit");
     expect(presetForLayers(INSIGHT_PRESETS.growth.layers)).toBe("growth");
   });

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -64,7 +64,14 @@ import {
 } from "../../LocalStorage";
 import { generateNewTimeline } from "../../reducers/Game";
 import { getScenario, SCENARIOS } from "../../data/Scenarios";
-import { chartPalette, fuelColors, fuelDashArrays } from "../../Theme";
+import { DEMAND_TYPES } from "../../data/DemandProfiles";
+import {
+  chartPalette,
+  demandTypeColors,
+  fuelColors,
+  fuelDashArrays,
+} from "../../Theme";
+import ChartForecastDemandByType from "../base/ChartForecastDemandByType";
 import ChartFinances from "../base/ChartFinances";
 import ChartForecastFuelPrices, {
   PRICED_FUELS,
@@ -85,6 +92,7 @@ export type InsightRange = "current" | "next1" | "next5" | "next10" | "next20";
 
 export type InsightLayerId =
   | "supplyDemand"
+  | "demandByType"
   | "supplyByFuel"
   | "storage"
   | "fuelPrices"
@@ -109,6 +117,7 @@ export interface InsightLayerDefinition {
 
 export const INSIGHT_LAYERS: readonly InsightLayerDefinition[] = [
   { id: "supplyDemand", label: "Supply & Demand", group: "Grid" },
+  { id: "demandByType", label: "Demand by Load Type", group: "Grid" },
   { id: "supplyByFuel", label: "Supply by Fuel", group: "Grid" },
   {
     id: "storage",
@@ -142,7 +151,13 @@ export const INSIGHT_PRESETS: Record<
 > = {
   reliability: {
     label: "Reliability",
-    layers: ["supplyDemand", "supplyByFuel", "storage", "weather"],
+    layers: [
+      "supplyDemand",
+      "demandByType",
+      "supplyByFuel",
+      "storage",
+      "weather",
+    ],
   },
   profitability: {
     label: "Profitability",
@@ -154,7 +169,7 @@ export const INSIGHT_PRESETS: Record<
   },
   growth: {
     label: "Growth",
-    layers: ["customers", "supplyDemand", "revenue", "profit"],
+    layers: ["customers", "demandByType", "supplyDemand", "revenue", "profit"],
   },
   decarbonization: {
     label: "Decarbonization",
@@ -759,6 +774,26 @@ export default class Insights extends React.Component<Props, State> {
                   {formatWatts(projection.largestBlackout.peakW)}
                 </Typography>
               )}
+            </>
+          );
+          break;
+        case "demandByType":
+          body = (
+            <>
+              <ChartLegend
+                items={DEMAND_TYPES.map((type) => ({
+                  name: type,
+                  color: demandTypeColors()[type],
+                }))}
+              />
+              <ChartForecastDemandByType
+                height={140}
+                timeline={projection.sampled}
+                domain={{ x: projection.domain.x }}
+                startingYear={game.startingYear}
+                multiyear={multiyear}
+                syncKey={SYNC_KEY}
+              />
             </>
           );
           break;

--- a/src/data/DemandProfiles.test.tsx
+++ b/src/data/DemandProfiles.test.tsx
@@ -1,0 +1,87 @@
+import { getDateFromMinute, MINUTES_PER_MONTH } from "../helpers/DateTime";
+import { LocationType } from "../Types";
+import {
+  dataCenterLoadShare,
+  DEMAND_TYPES,
+  demandByTypeAt,
+} from "./DemandProfiles";
+
+const location = (
+  admin: string,
+  id = admin,
+): LocationType & { admin: string } => ({
+  id,
+  name: id,
+  lat: 0,
+  long: 0,
+  country: "United States",
+  region: "North America",
+  admin,
+});
+
+function total(values: ReturnType<typeof demandByTypeAt>) {
+  return DEMAND_TYPES.reduce((sum, type) => sum + values[type], 0);
+}
+
+describe("demand profiles", () => {
+  it("preserves an authored scenario's opening demand while exposing five components", () => {
+    const date = getDateFromMinute(0, 2019);
+    const breakdown = demandByTypeAt(1_000_000, date, 2019, location("CA"));
+
+    expect(Object.keys(breakdown)).toEqual(DEMAND_TYPES);
+    expect(total(breakdown)).toBeCloseTo(1_000_000);
+    DEMAND_TYPES.forEach((type) => expect(breakdown[type]).toBeGreaterThan(0));
+  });
+
+  it("introduces data centers around 2000 and accelerates them after 2025", () => {
+    const california = location("CA");
+    expect(dataCenterLoadShare(1999, california)).toBe(0);
+    expect(dataCenterLoadShare(2000, california)).toBeGreaterThan(0);
+    expect(
+      dataCenterLoadShare(2028, california) -
+        dataCenterLoadShare(2025, california),
+    ).toBeGreaterThan(
+      dataCenterLoadShare(2025, california) -
+        dataCenterLoadShare(2022, california),
+    );
+  });
+
+  it("makes the leading data-center states materially different", () => {
+    expect(dataCenterLoadShare(2028, location("VA"))).toBeGreaterThan(
+      dataCenterLoadShare(2028, location("CA")),
+    );
+    expect(dataCenterLoadShare(2028, location("CA"))).toBeGreaterThan(
+      dataCenterLoadShare(2028, location("PA")),
+    );
+  });
+
+  it("allows declining industrial load in the Midwest and growth in Texas", () => {
+    const date = getDateFromMinute(10 * 12 * MINUTES_PER_MONTH, 2020);
+    const ohio = demandByTypeAt(1_000_000, date, 2020, location("OH"));
+    const texas = demandByTypeAt(1_000_000, date, 2020, location("TX"));
+
+    expect(ohio.Industrial).toBeLessThan(
+      demandByTypeAt(
+        1_000_000,
+        getDateFromMinute(0, 2020),
+        2020,
+        location("OH"),
+      ).Industrial,
+    );
+    expect(texas.Industrial).toBeGreaterThan(ohio.Industrial);
+    expect(total(texas)).toBeGreaterThan(total(ohio));
+  });
+
+  it("shows residential evenings and commercial middays without changing the opening total", () => {
+    const midday = getDateFromMinute(12 * 60, 2020);
+    const evening = getDateFromMinute(19 * 60, 2020);
+    const city = location("PA");
+    const day = demandByTypeAt(1_000_000, midday, 2020, city);
+    const night = demandByTypeAt(1_000_000, evening, 2020, city);
+
+    expect(day.Commercial).toBeGreaterThan(night.Commercial);
+    expect(night.Residential).toBeGreaterThan(day.Residential);
+    expect(Math.abs(total(day) - 1_000_000) / 1_000_000).toBeLessThan(0.001);
+    expect(Math.abs(total(night) - 1_000_000) / 1_000_000).toBeLessThan(0.001);
+  });
+});

--- a/src/data/DemandProfiles.tsx
+++ b/src/data/DemandProfiles.tsx
@@ -1,0 +1,348 @@
+import {
+  DateType,
+  DemandByTypeType,
+  DemandTypeNameType,
+  LocationType,
+} from "../Types";
+import { DAYS_PER_YEAR } from "../Constants";
+
+export const DEMAND_TYPES: readonly DemandTypeNameType[] = [
+  "Residential",
+  "Commercial",
+  "Industrial",
+  "Transportation",
+  "Data centers",
+] as const;
+
+type NonDataCenterType = Exclude<DemandTypeNameType, "Data centers">;
+type SectorMix = Record<NonDataCenterType, number>;
+type GrowthProfile = Record<NonDataCenterType, number>;
+
+// EIA divides end-use demand into residential, commercial, industrial, and transportation.
+// These broad regional mixes preserve that standard while data centers are pulled out of the
+// commercial sector below. They are intentionally scenario-scale profiles rather than a claim
+// that every city in a region has an identical measured mix.
+// https://www.eia.gov/tools/faqs/faq.php?id=447&t=1
+const REGION_MIX: Record<string, SectorMix> = {
+  "North America": {
+    Residential: 0.39,
+    Commercial: 0.34,
+    Industrial: 0.265,
+    Transportation: 0.005,
+  },
+  "South America": {
+    Residential: 0.35,
+    Commercial: 0.24,
+    Industrial: 0.4,
+    Transportation: 0.01,
+  },
+  Europe: {
+    Residential: 0.33,
+    Commercial: 0.31,
+    Industrial: 0.34,
+    Transportation: 0.02,
+  },
+  Africa: {
+    Residential: 0.5,
+    Commercial: 0.2,
+    Industrial: 0.29,
+    Transportation: 0.01,
+  },
+  "Middle East": {
+    Residential: 0.38,
+    Commercial: 0.3,
+    Industrial: 0.31,
+    Transportation: 0.01,
+  },
+  "South Asia": {
+    Residential: 0.38,
+    Commercial: 0.21,
+    Industrial: 0.4,
+    Transportation: 0.01,
+  },
+  "East Asia": {
+    Residential: 0.22,
+    Commercial: 0.25,
+    Industrial: 0.52,
+    Transportation: 0.01,
+  },
+  "Southeast Asia": {
+    Residential: 0.32,
+    Commercial: 0.24,
+    Industrial: 0.43,
+    Transportation: 0.01,
+  },
+  Oceania: {
+    Residential: 0.37,
+    Commercial: 0.32,
+    Industrial: 0.29,
+    Transportation: 0.02,
+  },
+};
+
+// Annual change in load per customer. Customer growth remains the common demographic baseline;
+// these rates create the issue's location-sensitive structural change on top of it: mature
+// regions can flatten, industrial load can retreat, and electrified transport can grow.
+const REGION_GROWTH: Record<string, GrowthProfile> = {
+  "North America": {
+    Residential: 0,
+    Commercial: 0.002,
+    Industrial: -0.002,
+    Transportation: 0.025,
+  },
+  "South America": {
+    Residential: 0.004,
+    Commercial: 0.006,
+    Industrial: 0.005,
+    Transportation: 0.02,
+  },
+  Europe: {
+    Residential: -0.003,
+    Commercial: 0,
+    Industrial: -0.005,
+    Transportation: 0.025,
+  },
+  Africa: {
+    Residential: 0.012,
+    Commercial: 0.015,
+    Industrial: 0.014,
+    Transportation: 0.025,
+  },
+  "Middle East": {
+    Residential: 0.008,
+    Commercial: 0.01,
+    Industrial: 0.009,
+    Transportation: 0.025,
+  },
+  "South Asia": {
+    Residential: 0.012,
+    Commercial: 0.014,
+    Industrial: 0.015,
+    Transportation: 0.025,
+  },
+  "East Asia": {
+    Residential: -0.003,
+    Commercial: 0.004,
+    Industrial: 0.006,
+    Transportation: 0.025,
+  },
+  "Southeast Asia": {
+    Residential: 0.01,
+    Commercial: 0.013,
+    Industrial: 0.015,
+    Transportation: 0.025,
+  },
+  Oceania: {
+    Residential: 0.005,
+    Commercial: 0.006,
+    Industrial: 0.002,
+    Transportation: 0.03,
+  },
+};
+
+const DEFAULT_MIX = REGION_MIX["North America"];
+const DEFAULT_GROWTH = REGION_GROWTH["North America"];
+
+// These are historical/projected shares of total U.S. electricity, linearly interpolated between
+// published observations. 2000 (28.2 TWh) and 2006 (61.4 TWh) are from DOE's data-center energy
+// profile; 2014, 2018, 2023 and the 2028 midpoint are from Berkeley Lab's 2024 report. The 2028
+// midpoint represents its 6.7%-12.0% scenario range, not a false point forecast.
+// https://www1.eere.energy.gov/manufacturing/datacenters/pdfs/chp_data_centers.pdf
+// https://eta-publications.lbl.gov/sites/default/files/2024-12/lbnl-2024-united-states-data-center-energy-usage-report_1.pdf
+const US_DATA_CENTER_SHARES: readonly [number, number][] = [
+  [1999, 0],
+  [2000, 0.008],
+  [2006, 0.015],
+  [2014, 0.015],
+  [2018, 0.019],
+  [2023, 0.044],
+  [2028, 0.0935],
+  [2035, 0.14],
+];
+
+const REGION_DATA_CENTER_FACTOR: Record<string, number> = {
+  "North America": 0.9,
+  "South America": 0.35,
+  Europe: 0.75,
+  Africa: 0.2,
+  "Middle East": 0.45,
+  "South Asia": 0.45,
+  "East Asia": 0.9,
+  "Southeast Asia": 0.65,
+  Oceania: 0.7,
+};
+
+// Berkeley Lab identifies Virginia as the largest U.S. data-center load, followed by California
+// and Texas. Multipliers turn that ordinal real-world finding into game-scale local exposure;
+// they are deliberately capped below rather than presented as measured state shares.
+const US_DATA_CENTER_FACTOR: Record<string, number> = {
+  VA: 2.8,
+  CA: 1.35,
+  TX: 1.35,
+};
+
+const RUST_BELT = new Set(["MI", "OH", "PA", "WV"]);
+const HIGH_GROWTH_US = new Set(["AZ", "FL", "GA", "NC", "TX"]);
+
+function adminFor(location?: LocationType): string | undefined {
+  return (location as (LocationType & { admin?: string }) | undefined)?.admin;
+}
+
+function interpolate(
+  points: readonly [number, number][],
+  year: number,
+): number {
+  if (year < points[0][0]) {
+    return points[0][1];
+  }
+  for (let i = 1; i < points.length; i++) {
+    const [nextYear, nextValue] = points[i];
+    const [previousYear, previousValue] = points[i - 1];
+    if (year <= nextYear) {
+      const progress = (year - previousYear) / (nextYear - previousYear);
+      return previousValue + (nextValue - previousValue) * progress;
+    }
+  }
+  const [lastYear, lastValue] = points[points.length - 1];
+  // Long-range uncertainty is high. Taper the post-2035 curve and keep one category from taking
+  // over the whole grid even in century-long sandbox games.
+  return Math.min(0.2, lastValue * Math.pow(1.02, year - lastYear));
+}
+
+/** Fraction of local demand represented by data centers before the other sector trends apply. */
+export function dataCenterLoadShare(
+  year: number,
+  location?: LocationType,
+): number {
+  const national = interpolate(US_DATA_CENTER_SHARES, year);
+  if (location?.country === "United States") {
+    return Math.min(
+      0.25,
+      national * (US_DATA_CENTER_FACTOR[adminFor(location) || ""] || 1),
+    );
+  }
+  const regional = REGION_DATA_CENTER_FACTOR[location?.region || ""] || 0.5;
+  return Math.min(0.2, national * regional);
+}
+
+function growthFor(location?: LocationType): GrowthProfile {
+  const profile = {
+    ...(REGION_GROWTH[location?.region || ""] || DEFAULT_GROWTH),
+  };
+  if (location?.country !== "United States") {
+    return profile;
+  }
+  const admin = adminFor(location) || "";
+  if (RUST_BELT.has(admin)) {
+    return {
+      Residential: -0.005,
+      Commercial: -0.003,
+      Industrial: -0.015,
+      Transportation: profile.Transportation,
+    };
+  }
+  if (HIGH_GROWTH_US.has(admin)) {
+    return {
+      Residential: 0.01,
+      Commercial: 0.015,
+      Industrial: 0.01,
+      Transportation: profile.Transportation,
+    };
+  }
+  if (admin === "CA") {
+    return {
+      Residential: -0.002,
+      Commercial: 0.005,
+      Industrial: -0.006,
+      Transportation: 0.04,
+    };
+  }
+  return profile;
+}
+
+function hourShape(type: DemandTypeNameType, minuteOfDay: number): number {
+  const hour = minuteOfDay / 60;
+  const peak = (at: number, width: number) =>
+    Math.exp(-Math.pow(hour - at, 2) / (2 * width * width));
+  switch (type) {
+    case "Residential":
+      return 0.65 + 0.45 * peak(7, 1.8) + 0.75 * peak(19, 2.5);
+    case "Commercial":
+      return 0.35 + 0.9 * peak(13, 4.5);
+    case "Industrial":
+      return 1;
+    case "Transportation":
+      return 0.55 + 0.8 * peak(1, 3) + 0.55 * peak(21, 2.5);
+    case "Data centers":
+      return 1;
+  }
+}
+
+/**
+ * Splits baseline demand into five end uses and applies their local trajectories.
+ *
+ * The starting instant is normalised back to baselineDemandW, so authored scenarios retain their
+ * tuned opening balance. After that, the components can diverge and their sum becomes the actual
+ * demand used by dispatch, finance, blackout logic, and the Insights forecast.
+ */
+export function demandByTypeAt(
+  baselineDemandW: number,
+  date: DateType,
+  startingYear: number,
+  location?: LocationType,
+): DemandByTypeType {
+  const mix = REGION_MIX[location?.region || ""] || DEFAULT_MIX;
+  const growth = growthFor(location);
+  const startDataCenters = dataCenterLoadShare(startingYear, location);
+  // date.percentOfYear deliberately substitutes 0.00001 at midnight on New Year's Day for
+  // legacy chart math. Elapsed game minutes give this model a true zero at scenario start.
+  const currentYear = startingYear + date.minute / (DAYS_PER_YEAR * 24 * 60);
+  const years = Math.max(0, currentYear - startingYear);
+  const currentDataCenters = dataCenterLoadShare(currentYear, location);
+  const nonDataCenterScale = 1 - startDataCenters;
+
+  const startingWeights = {
+    Residential: nonDataCenterScale * mix.Residential,
+    Commercial: nonDataCenterScale * mix.Commercial,
+    Industrial: nonDataCenterScale * mix.Industrial,
+    Transportation: nonDataCenterScale * mix.Transportation,
+    "Data centers": startDataCenters,
+  } satisfies Record<DemandTypeNameType, number>;
+  const shapedStartingTotal = DEMAND_TYPES.reduce(
+    (sum, type) =>
+      sum + startingWeights[type] * hourShape(type, date.minuteOfDay),
+    0,
+  );
+
+  const result = {} as DemandByTypeType;
+  DEMAND_TYPES.forEach((type) => {
+    const shape = hourShape(type, date.minuteOfDay);
+    if (type === "Data centers") {
+      // When a game begins before 2000 there is no starting component to grow, so introduce the
+      // later load directly. Otherwise scale the opening component along the measured curve.
+      const weight =
+        startDataCenters > 0
+          ? startingWeights[type] * (currentDataCenters / startDataCenters)
+          : currentDataCenters;
+      result[type] = (baselineDemandW * weight * shape) / shapedStartingTotal;
+      return;
+    }
+    result[type] =
+      (baselineDemandW *
+        startingWeights[type] *
+        shape *
+        Math.pow(1 + growth[type], years)) /
+      shapedStartingTotal;
+  });
+  if (years === 0) {
+    const openingTotal = DEMAND_TYPES.reduce(
+      (sum, type) => sum + result[type],
+      0,
+    );
+    // Besides preserving authored balance conceptually, keep it bit-for-bit stable. A few UI
+    // calculations compare the change in reserve capacity after adding a plant, and a residual
+    // fraction of a watt from summing five floating-point components should not leak into that.
+    result["Data centers"] += baselineDemandW - openingTotal;
+  }
+  return result;
+}

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -41,6 +41,7 @@ import {
   getWindOutputFactor,
 } from "../helpers/Energy";
 import { getFuelPricesPerMBTU } from "../data/FuelPrices";
+import { DEMAND_TYPES, demandByTypeAt } from "../data/DemandProfiles";
 import {
   activeWorldEventEffects,
   resolveWorldEvent,
@@ -1353,7 +1354,18 @@ function getDemandW(
     30 * minutesFromDarkLogistics -
     65 * minutesFrom5pmLogistics;
   const effects = activeWorldEventEffects(game.worldEvents.active, date.minute);
-  return demandMultiple * now.customers * (effects.demandMultiplier || 1);
+  const baselineDemandW =
+    demandMultiple * now.customers * (effects.demandMultiplier || 1);
+  now.demandByType = demandByTypeAt(
+    baselineDemandW,
+    date,
+    game.startingYear,
+    game.location,
+  );
+  return DEMAND_TYPES.reduce(
+    (total, type) => total + now.demandByType[type],
+    0,
+  );
 }
 
 const KG_PER_MEGATON = 1000000000;
@@ -1919,6 +1931,13 @@ export function generateNewTimeline(
       minute: state.date.minute + i * TICK_MINUTES,
       supplyW: 0,
       demandW: 0,
+      demandByType: {
+        Residential: 0,
+        Commercial: 0,
+        Industrial: 0,
+        Transportation: 0,
+        "Data centers": 0,
+      },
       solarIrradianceWM2: 0,
       windKph: 0,
       temperatureC: 0,


### PR DESCRIPTION
## Summary

- model demand as residential, commercial, industrial, transportation, and data-center load with distinct daily shapes
- add region- and U.S. state-sensitive growth profiles, including declining Midwest industrial load and higher-growth states
- add a historical/projected data-center curve from 2000 onward, with stronger exposure in Virginia, California, and Texas
- add an accessible stacked Demand by Load Type chart to Insights and its Reliability and Growth presets
- document the data sources, projections, and game-scale assumptions

## Data sources

- EIA end-use sector definitions: https://www.eia.gov/tools/faqs/faq.php?id=447&t=1
- DOE data-center energy profile: https://www1.eere.energy.gov/manufacturing/datacenters/pdfs/chp_data_centers.pdf
- Berkeley Lab 2024 U.S. Data Center Energy Usage Report: https://eta-publications.lbl.gov/sites/default/files/2024-12/lbnl-2024-united-states-data-center-energy-usage-report_1.pdf

## Verification

- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false (69 suites, 715 tests)
- npm run build

Closes #183