### PR TITLE
Add solar capacity factor insight chart

### DIFF
--- a/src/components/base/ChartForecastSolarCapacityFactor.test.tsx
+++ b/src/components/base/ChartForecastSolarCapacityFactor.test.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { TickPresentFutureType } from "../../Types";
+import { MINUTES_PER_MONTH } from "../../helpers/DateTime";
+import ChartForecastSolarCapacityFactor, {
+  monthlySolarCapacityFactors,
+} from "./ChartForecastSolarCapacityFactor";
+
+function tick(
+  minute: number,
+  solarIrradianceWM2: number,
+): TickPresentFutureType {
+  return { minute, solarIrradianceWM2 } as TickPresentFutureType;
+}
+
+describe("ChartForecastSolarCapacityFactor", () => {
+  const timeline = [
+    tick(0, 0),
+    tick(10, 1_000),
+    tick(MINUTES_PER_MONTH, 500),
+    tick(MINUTES_PER_MONTH + 10, 500),
+  ];
+
+  it("averages the solar estimate into monthly capacity factors", () => {
+    expect(monthlySolarCapacityFactors(timeline)).toEqual([
+      { minute: 5, capacityFactor: 0.45 },
+      { minute: MINUTES_PER_MONTH + 5, capacityFactor: 0.45 },
+    ]);
+  });
+
+  it("exposes the chart values to assistive technology as percentages", () => {
+    render(
+      <ChartForecastSolarCapacityFactor
+        timeline={timeline}
+        domain={{ x: [0, MINUTES_PER_MONTH + 10] }}
+        startingYear={2020}
+        multiyear={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", {
+        name: /Solar capacity factor \(%\): latest 45, range 45 to 45/,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/base/ChartForecastSolarCapacityFactor.tsx
+++ b/src/components/base/ChartForecastSolarCapacityFactor.tsx
@@ -1,0 +1,174 @@
+import * as React from "react";
+import uPlot from "uplot";
+import UPlotChart, { BuildContext } from "./UPlotChart";
+import {
+  FORECAST_AXIS_LEFT,
+  FORECAST_AXIS_RIGHT,
+  stepTicks,
+  xAxis,
+  yAxis,
+} from "./UPlotHelpers";
+import { TickPresentFutureType } from "../../Types";
+import {
+  formatMinuteAsMonthAxis,
+  formatMinuteAsTooltipHeader,
+  MINUTES_PER_MONTH,
+} from "../../helpers/DateTime";
+import { getSolarCapacityFactor } from "../../helpers/Energy";
+import { fuelColors } from "../../Theme";
+
+export interface Props {
+  height?: number;
+  timeline: TickPresentFutureType[];
+  domain: { x: [number, number] };
+  startingYear: number;
+  multiyear: boolean;
+  /** Shares a cursor with the other charts drawn against the same months */
+  syncKey?: string;
+}
+
+export interface SolarCapacityFactorPoint {
+  minute: number;
+  capacityFactor: number;
+}
+
+interface State {
+  data: SolarCapacityFactorPoint[];
+  domain: Props["domain"];
+  capacityFactorMax: number;
+  startingYear: number;
+  multiyear: boolean;
+}
+
+/** Average the game's irradiance-based solar output estimate into readable monthly values. */
+export function monthlySolarCapacityFactors(
+  timeline: TickPresentFutureType[],
+): SolarCapacityFactorPoint[] {
+  const points: SolarCapacityFactorPoint[] = [];
+  let month = -1;
+  let firstMinute = 0;
+  let lastMinute = 0;
+  let irradiances: number[] = [];
+
+  const addPoint = () => {
+    if (irradiances.length > 0) {
+      points.push({
+        minute: Math.round((firstMinute + lastMinute) / 2),
+        capacityFactor: getSolarCapacityFactor(irradiances),
+      });
+    }
+  };
+
+  timeline.forEach((tick) => {
+    const tickMonth = Math.floor(tick.minute / MINUTES_PER_MONTH);
+    if (tickMonth !== month) {
+      addPoint();
+      month = tickMonth;
+      firstMinute = tick.minute;
+      irradiances = [];
+    }
+    lastMinute = tick.minute;
+    irradiances.push(tick.solarIrradianceWM2);
+  });
+  addPoint();
+
+  return points;
+}
+
+function percent(fraction: number): string {
+  return `${Math.round(fraction * 100)}%`;
+}
+
+function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
+  return {
+    width: 0,
+    height: 0,
+    padding: [5 * scale, FORECAST_AXIS_RIGHT * scale, 0, 0],
+    cursor: {
+      x: true,
+      y: false,
+      points: { show: false },
+      drag: { x: false, y: false, setScale: false },
+    },
+    legend: { show: false },
+    scales: {
+      x: { time: false, range: () => getState().domain.x },
+      y: {
+        range: () => [0, Math.min(1, getState().capacityFactorMax * 1.1)],
+      },
+    },
+    axes: [
+      xAxis(scale, {
+        splits: () => {
+          const [min, max] = getState().domain.x;
+          return stepTicks(min, max, MINUTES_PER_MONTH);
+        },
+        values: (_u, splits) => {
+          const state = getState();
+          return splits.map((minute) =>
+            formatMinuteAsMonthAxis(
+              minute,
+              state.startingYear,
+              state.multiyear,
+            ),
+          );
+        },
+      }),
+      yAxis(scale, {
+        grid: true,
+        size: FORECAST_AXIS_LEFT,
+        values: (_u, splits) => splits.map(percent),
+      }),
+    ],
+    series: [
+      {},
+      {
+        stroke: fuelColors().Sun,
+        width: 2,
+        points: { show: true, size: 4 * scale },
+      },
+    ],
+  };
+}
+
+function tooltip(idx: number, state: State): string {
+  const point = state.data[idx];
+  const header = formatMinuteAsTooltipHeader(point.minute, state.startingYear);
+  return `${header}\nSolar capacity factor: ${percent(point.capacityFactor)}`;
+}
+
+export default class ChartForecastSolarCapacityFactor extends React.PureComponent<
+  Props,
+  {}
+> {
+  public render() {
+    const { domain, height, timeline, startingYear, multiyear, syncKey } =
+      this.props;
+    const data = monthlySolarCapacityFactors(timeline);
+    const minutes = data.map((point) => point.minute);
+    const capacityFactors = data.map((point) => point.capacityFactor);
+    const percentages = capacityFactors.map((factor) => factor * 100);
+    const capacityFactorMax = Math.max(0.25, ...capacityFactors);
+
+    return (
+      <UPlotChart<State>
+        id="chartForecastSolarCapacityFactor"
+        ariaLabel="Chart of forecasted monthly solar capacity factor"
+        height={height}
+        state={{
+          data,
+          domain,
+          capacityFactorMax,
+          startingYear,
+          multiyear,
+        }}
+        data={[minutes, capacityFactors]}
+        summaryData={[minutes, percentages]}
+        seriesLabels={["Solar capacity factor (%)"]}
+        buildOptions={buildOptions}
+        syncKey={syncKey}
+        tooltip={tooltip}
+      />
+    );
+  }
+}

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -60,6 +60,16 @@ jest.mock("../base/ChartForecastStorage", () => ({
     <div role="img" data-chart="storage" data-sync-key={syncKey} />
   ),
 }));
+jest.mock("../base/ChartForecastSolarCapacityFactor", () => ({
+  __esModule: true,
+  default: ({ syncKey }: ChartMockProps) => (
+    <div
+      role="img"
+      data-testid="solar-capacity-factor-chart"
+      data-sync-key={syncKey}
+    />
+  ),
+}));
 jest.mock("../base/ChartForecastWater", () => ({
   __esModule: true,
   default: ({ syncKey }: ChartMockProps) => (
@@ -142,5 +152,21 @@ describe("Insights layers", () => {
     expect(
       screen.getByRole("combobox", { name: "Insight preset" }),
     ).toHaveTextContent("Custom");
+  });
+
+  it("offers a solar capacity factor chart as an insight layer", async () => {
+    renderInsights();
+    await user.click(screen.getByRole("button", { name: /Layers/ }));
+    await user.click(
+      screen.getByRole("checkbox", { name: "Solar Capacity Factor" }),
+    );
+
+    expect(
+      screen.getByText("Solar Capacity Factor", { selector: "h6" }),
+    ).toBeVisible();
+    expect(screen.getByTestId("solar-capacity-factor-chart")).toHaveAttribute(
+      "data-sync-key",
+      "insights",
+    );
   });
 });

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -76,6 +76,7 @@ import ChartFinances from "../base/ChartFinances";
 import ChartForecastFuelPrices, {
   PRICED_FUELS,
 } from "../base/ChartForecastFuelPrices";
+import ChartForecastSolarCapacityFactor from "../base/ChartForecastSolarCapacityFactor";
 import ChartForecastStorage from "../base/ChartForecastStorage";
 import ChartForecastSupplyByFuel, {
   forecastFuels,
@@ -96,6 +97,7 @@ export type InsightLayerId =
   | "supplyByFuel"
   | "storage"
   | "fuelPrices"
+  | "solarCapacityFactor"
   | "water"
   | "weather"
   | "profit"
@@ -133,6 +135,11 @@ export const INSIGHT_LAYERS: readonly InsightLayerDefinition[] = [
   { id: "financeDetails", label: "Financial Details", group: "Economics" },
   { id: "fuelPrices", label: "Fuel Prices", group: "Economics" },
   { id: "emissions", label: "CO2e Emitted", group: "Environment" },
+  {
+    id: "solarCapacityFactor",
+    label: "Solar Capacity Factor",
+    group: "Environment",
+  },
   { id: "weather", label: "Weather", group: "Environment" },
   { id: "water", label: "Water", group: "Environment", availability: "hydro" },
 ] as const;
@@ -854,6 +861,18 @@ export default class Insights extends React.Component<Props, State> {
                 syncKey={SYNC_KEY}
               />
             </>
+          );
+          break;
+        case "solarCapacityFactor":
+          body = (
+            <ChartForecastSolarCapacityFactor
+              height={140}
+              timeline={projection.timeline}
+              domain={{ x: projection.domain.x }}
+              startingYear={game.startingYear}
+              multiyear={multiyear}
+              syncKey={SYNC_KEY}
+            />
           );
           break;
         case "water":


### PR DESCRIPTION
## Summary
- add Solar Capacity Factor as a selectable Environment layer in Insights
- chart monthly averages from the game's irradiance-based solar capacity factor model, with percentage axes, tooltips, shared cursor support, and accessible summaries
- test monthly aggregation and Insights layer selection

## Testing
- npm run check (718 tests passed)