### PR TITLE
Prefetch scenario data from detail screens

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -10,14 +10,62 @@ const APP_SHELL = [
   WEATHER_INDEX,
   ...MARKET_DATA,
 ];
+const LOCATION_ID = /^[A-Za-z0-9_-]{1,32}$/;
+const inFlightFetches = new Map();
+
+function absoluteUrl(request) {
+  return new URL(
+    typeof request === "string" ? request : request.url,
+    self.location.origin,
+  ).href;
+}
 
 async function fetchAndCache(cache, url) {
-  const response = await fetch(url, { cache: "no-cache" });
-  if (!response.ok) {
-    throw new Error(`${response.status} fetching ${url}`);
+  const key = absoluteUrl(url);
+  let pending = inFlightFetches.get(key);
+  if (!pending) {
+    pending = fetch(url, { cache: "no-cache" }).then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`${response.status} fetching ${key}`);
+      }
+      try {
+        await cache.put(url, response.clone());
+      } catch {
+        // A full or unavailable cache must not turn a successful network response into a failed
+        // game load. Prefetching is best-effort; the caller can still use the downloaded response.
+      }
+      return response;
+    });
+    inFlightFetches.set(key, pending);
   }
-  await cache.put(url, response.clone());
-  return response;
+
+  try {
+    return (await pending).clone();
+  } finally {
+    if (inFlightFetches.get(key) === pending) {
+      inFlightFetches.delete(key);
+    }
+  }
+}
+
+/** Fill any holes for one scenario without refreshing data that is already available offline. */
+async function cacheScenarioData(locationIds) {
+  const weatherUrls = Array.isArray(locationIds)
+    ? [...new Set(locationIds)]
+        .filter((id) => typeof id === "string" && LOCATION_ID.test(id))
+        .map((id) => `/data/weather/${id}.bin`)
+    : [];
+  const urls = [...MARKET_DATA, ...weatherUrls];
+  const cache = await caches.open(CACHE_VERSION);
+  const missing = (
+    await Promise.all(
+      urls.map(async (url) => ({ url, cached: await cache.match(url) })),
+    )
+  )
+    .filter(({ cached }) => !cached)
+    .map(({ url }) => url);
+
+  await Promise.allSettled(missing.map((url) => fetchAndCache(cache, url)));
 }
 
 /**
@@ -72,6 +120,8 @@ self.addEventListener("activate", (event) => {
 self.addEventListener("message", (event) => {
   if (event.data?.type === "SYNC_OFFLINE_DATA") {
     event.waitUntil(syncOfflineData());
+  } else if (event.data?.type === "CACHE_SCENARIO_DATA") {
+    event.waitUntil(cacheScenarioData(event.data.locationIds));
   }
 });
 
@@ -100,17 +150,13 @@ self.addEventListener("fetch", (event) => {
 
   if (/\/data\/weather\/.*\.bin$/.test(url.pathname)) {
     event.respondWith(
-      caches.match(request).then(
-        (cached) =>
-          cached ||
-          fetch(request).then((response) => {
-            const copy = response.clone();
-            caches
-              .open(CACHE_VERSION)
-              .then((cache) => cache.put(request, copy));
-            return response;
-          }),
-      ),
+      caches.match(request).then(async (cached) => {
+        if (cached) {
+          return cached;
+        }
+        const cache = await caches.open(CACHE_VERSION);
+        return fetchAndCache(cache, request);
+      }),
     );
     return;
   }

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -36,6 +36,7 @@ import { getViableLocationCount } from "../../data/FacilitySites";
 import { WEATHER_STARTING_YEAR } from "../../data/Weather";
 import { getFuelEscalation } from "../../data/FuelPrices";
 import { getStartingCustomers } from "../../data/LocationProfiles";
+import { prefetchScenarioData } from "../../helpers/OfflineData";
 import { getDateFromMinute } from "../../helpers/DateTime";
 import { getScenarioLocation } from "../../helpers/Locations";
 import { formatWattHours, formatWatts } from "../../helpers/Format";
@@ -228,6 +229,11 @@ export default function CustomGame(props: Props): React.JSX.Element {
   // one of its options renders blank and drops the choice on the next edit. Listed last, under
   // its own heading, so it doesn't shuffle the rest of the list around.
   const current = getScenarioLocation(scenario);
+  React.useEffect(() => {
+    if (current) {
+      void prefetchScenarioData(current);
+    }
+  }, [current]);
   const selectableLocations = React.useMemo(
     () =>
       current && !cities.some((c: CityType) => c.id === current.id)

--- a/src/components/views/NewGameDetails.test.tsx
+++ b/src/components/views/NewGameDetails.test.tsx
@@ -4,6 +4,7 @@ import { GameType } from "../../Types";
 import NewGameDetails, { Props } from "./NewGameDetails";
 
 const mockGetDocs = jest.fn();
+const mockPrefetchScenarioData = jest.fn();
 const mockWhere = jest.fn((field: string, op: string, value: unknown) => ({
   field,
   op,
@@ -27,6 +28,11 @@ jest.mock("../../Globals", () => ({
   login: jest.fn(),
 }));
 
+jest.mock("../../helpers/OfflineData", () => ({
+  prefetchScenarioData: (...args: unknown[]) =>
+    mockPrefetchScenarioData(...args),
+}));
+
 function game(difficulty: GameType["difficulty"]): GameType {
   return { scenarioId: 100, difficulty } as GameType;
 }
@@ -46,7 +52,17 @@ function props(overrides: Partial<Props> = {}): Props {
 describe("NewGameDetails leaderboard", () => {
   beforeEach(() => {
     mockGetDocs.mockResolvedValue({ docs: [] });
+    mockPrefetchScenarioData.mockClear();
     mockWhere.mockClear();
+  });
+
+  it("prefetches the scenario data while the player reads its details", async () => {
+    render(<NewGameDetails {...props()} />);
+
+    expect(mockPrefetchScenarioData).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "SF" }),
+    );
+    await screen.findByText("Play the scenario to set a high score");
   });
 
   it("is always visible and follows the selected difficulty", async () => {

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -38,6 +38,7 @@ import { DIFFICULTIES } from "../../Constants";
 import { getDb, login } from "../../Globals";
 import { getScenario } from "../../data/Scenarios";
 import { getScenarioLocation } from "../../helpers/Locations";
+import { prefetchScenarioData } from "../../helpers/OfflineData";
 import { decodeReplay } from "../../Replay";
 import {
   DifficultyType,
@@ -225,6 +226,9 @@ export default class NewGameDetails extends React.Component<Props, State> {
   }
 
   public componentDidMount() {
+    if (this.state.location) {
+      void prefetchScenarioData(this.state.location);
+    }
     // Unconditional: the board is public, so it no longer waits on a login that may never come.
     // It used to be kicked off from shouldComponentUpdate, which is a purity hook and not a place
     // to start network requests from

--- a/src/helpers/OfflineData.test.ts
+++ b/src/helpers/OfflineData.test.ts
@@ -1,0 +1,49 @@
+import { LocationType } from "../Types";
+import { prefetchScenarioData } from "./OfflineData";
+
+describe("prefetchScenarioData", () => {
+  const originalServiceWorker = navigator.serviceWorker;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: originalServiceWorker,
+    });
+  });
+
+  it("asks the active worker to cache the location and its watershed", async () => {
+    const postMessage = jest.fn();
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        ready: Promise.resolve({ active: { postMessage } }),
+      },
+    });
+    const location = {
+      id: "PIT",
+      watershedId: "AlleghenyUpper",
+    } as LocationType;
+
+    await prefetchScenarioData(location);
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: "CACHE_SCENARIO_DATA",
+      locationIds: ["PIT", "AlleghenyUpper"],
+    });
+  });
+
+  it("does nothing when no worker controls the app", async () => {
+    const postMessage = jest.fn();
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        ready: Promise.resolve({ active: null, postMessage }),
+      },
+    });
+
+    await expect(
+      prefetchScenarioData({ id: "SF" } as LocationType),
+    ).resolves.toBeUndefined();
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/helpers/OfflineData.ts
+++ b/src/helpers/OfflineData.ts
@@ -1,0 +1,25 @@
+import { LocationType } from "../Types";
+
+/**
+ * Asks the active service worker to cache everything needed to start a game at this location.
+ * This is deliberately only a download: initializing the weather and market modules here would
+ * replace the in-memory data for a game that may still be running.
+ */
+export async function prefetchScenarioData(
+  location: LocationType,
+): Promise<void> {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+    return;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    registration.active?.postMessage({
+      type: "CACHE_SCENARIO_DATA",
+      locationIds: [location.id, location.watershedId].filter(Boolean),
+    });
+  } catch {
+    // Prefetching is only an optimization. The loading screen owns errors and retries when the
+    // player actually asks to start the game.
+  }
+}


### PR DESCRIPTION
## Summary

- start caching a scenario's weather, watershed, economy, and fuel-price data when its details page opens
- prefetch the currently selected custom-game location as it changes
- share in-flight weather downloads between prefetch and Play while keeping cache failures non-blocking
- validate location IDs received by the service worker and cover the app-side message path

## Verification

- TypeScript typecheck
- ESLint
- Prettier check
- production build and built service-worker syntax check
- targeted OfflineData and NewGameDetails tests
- full suite: 720/721 passed; unrelated Insights timeout passed on isolated rerun