### PR TITLE
Fix responsive QA issues and chart summaries

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -348,6 +348,15 @@ button,
   cursor: auto !important;
 }
 
+// react-floater sizes the tutorial wrapper to the full viewport, then offsets it 10px from the
+// left edge. On phones that makes the document 10px wider even though the tooltip itself fits.
+@media screen and (max-width: ($abswidthmax - 1px)) {
+  .react-joyride__floater {
+    width: calc(100vw - 20px) !important;
+    max-width: calc(100vw - 20px) !important;
+  }
+}
+
 .MuiSelect-select {
   padding-top: 2px !important;
   padding-left: 6px !important;
@@ -837,6 +846,7 @@ $pane_header_height: 40px;
 .chartDataSummary {
   margin: 4px 8px 10px;
   font-size: 0.75rem;
+  overflow-x: auto;
 
   summary {
     width: fit-content;
@@ -847,6 +857,7 @@ $pane_header_height: 40px;
 
   table {
     width: 100%;
+    min-width: max-content;
     margin-top: 6px;
   }
 }

--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -174,6 +174,7 @@ const ChartFinances = (props: Props): React.JSX.Element => {
   return (
     <UPlotChart<State>
       ariaLabel={`Chart of ${props.title} over time`}
+      formatSummaryValue={(value) => String(state.format(value))}
       id={props.id || "chartFinances"}
       height={props.height}
       state={state}

--- a/src/components/base/ChartForecastDemandByType.tsx
+++ b/src/components/base/ChartForecastDemandByType.tsx
@@ -163,6 +163,7 @@ export default class ChartForecastDemandByType extends React.PureComponent<
       <div id="chartForecastDemandByType">
         <UPlotChart<State>
           ariaLabel="Chart of forecasted electricity demand by load type"
+          formatSummaryValue={formatWatts}
           height={height}
           state={state}
           data={[minutes, ...stacked]}

--- a/src/components/base/ChartForecastFuelPrices.tsx
+++ b/src/components/base/ChartForecastFuelPrices.tsx
@@ -148,6 +148,7 @@ export default class ChartForecastFuelPrices extends React.PureComponent<
       <div id="chartForecastFuelPrices">
         <UPlotChart<State>
           ariaLabel="Chart of forecasted fuel prices"
+          formatSummaryValue={formatMoneyStable}
           height={height}
           state={{ prices, minutes, domain, startingYear, multiyear }}
           data={[minutes, ...prices]}

--- a/src/components/base/ChartForecastStorage.tsx
+++ b/src/components/base/ChartForecastStorage.tsx
@@ -115,6 +115,7 @@ export default class chartForecastStorage extends React.PureComponent<
       <UPlotChart<State>
         id="chartForecastStorage"
         ariaLabel="Chart of forecasted stored power"
+        formatSummaryValue={formatWattHours}
         height={height}
         state={{ timeline, domain, startingYear, multiyear }}
         data={[minutes, stored]}

--- a/src/components/base/ChartForecastSupplyByFuel.tsx
+++ b/src/components/base/ChartForecastSupplyByFuel.tsx
@@ -228,6 +228,7 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
       <div id="chartForecastSupplyByFuel">
         <UPlotChart<State>
           ariaLabel="Chart of forecasted electricity supply by fuel type"
+          formatSummaryValue={formatWatts}
           height={height}
           state={state}
           data={[minutes, ...stacked, demand]}

--- a/src/components/base/ChartForecastSupplyDemand.tsx
+++ b/src/components/base/ChartForecastSupplyDemand.tsx
@@ -143,6 +143,7 @@ export default class chartForecastSupplyDemand extends React.PureComponent<
       <UPlotChart<State>
         id="chartForecastSupplyDemand"
         ariaLabel="Chart of forecasted electricity supply and demand"
+        formatSummaryValue={formatWatts}
         height={height}
         state={state}
         data={[minutes, supply, demand]}

--- a/src/components/base/ChartForecastWater.tsx
+++ b/src/components/base/ChartForecastWater.tsx
@@ -146,6 +146,9 @@ export default class ChartForecastWater extends React.PureComponent<Props, {}> {
       <UPlotChart<State>
         id="chartForecastWater"
         ariaLabel="Chart of watershed precipitation, snowpack, and hydro reservoir level"
+        formatSummaryValue={(value, seriesIndex) =>
+          seriesIndex < 2 ? `${Math.round(value)} mm` : formatWattHours(value)
+        }
         height={height}
         state={{ timeline, domain, startingYear, multiyear }}
         data={[minutes, precipitation, snowpack, reservoir]}

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -287,6 +287,7 @@ const ChartSupplyDemand = (props: Props): React.JSX.Element => {
   return (
     <UPlotChart<State>
       ariaLabel="Chart of electricity supply and demand over the day"
+      formatSummaryValue={formatWatts}
       id="chartSupplyDemand"
       height={height}
       state={state}

--- a/src/components/base/UPlotChart.tsx
+++ b/src/components/base/UPlotChart.tsx
@@ -50,6 +50,8 @@ export interface UPlotChartProps<S> {
   syncKey?: string;
   /** Human names for each y-series, used by the keyboard/screen-reader summary below. */
   seriesLabels?: string[];
+  /** Formats summary values with the same compact units the visible chart uses. */
+  formatSummaryValue?: (value: number, seriesIndex: number) => string;
 }
 
 const TOOLTIP_OFFSET = 8;
@@ -118,6 +120,8 @@ export default function UPlotChart<S>(
     () => new Intl.NumberFormat(undefined, { maximumSignificantDigits: 4 }),
     [],
   );
+  const formatSummaryValue =
+    props.formatSummaryValue || ((value: number) => number.format(value));
   const seriesSummary = (props.summaryData || data)
     .slice(1)
     .map((series, index) => {
@@ -129,16 +133,22 @@ export default function UPlotChart<S>(
       const latest = values[values.length - 1] || 0;
       return {
         label: props.seriesLabels?.[index] || `Series ${index + 1}`,
-        latest,
-        minimum: values.length ? Math.min(...values) : 0,
-        maximum: values.length ? Math.max(...values) : 0,
+        latest: formatSummaryValue(latest, index),
+        minimum: formatSummaryValue(
+          values.length ? Math.min(...values) : 0,
+          index,
+        ),
+        maximum: formatSummaryValue(
+          values.length ? Math.max(...values) : 0,
+          index,
+        ),
         trend: latest > first ? "up" : latest < first ? "down" : "flat",
       };
     });
   const accessibleLabel = `${ariaLabel}. ${seriesSummary
     .map(
       (series) =>
-        `${series.label}: latest ${number.format(series.latest)}, range ${number.format(series.minimum)} to ${number.format(series.maximum)}, trend ${series.trend}`,
+        `${series.label}: latest ${series.latest}, range ${series.minimum} to ${series.maximum}, trend ${series.trend}`,
     )
     .join(". ")}`;
 
@@ -258,9 +268,9 @@ export default function UPlotChart<S>(
             {seriesSummary.map((series) => (
               <tr key={series.label}>
                 <th>{series.label}</th>
-                <td>{number.format(series.latest)}</td>
-                <td>{number.format(series.minimum)}</td>
-                <td>{number.format(series.maximum)}</td>
+                <td>{series.latest}</td>
+                <td>{series.minimum}</td>
+                <td>{series.maximum}</td>
                 <td>{series.trend}</td>
               </tr>
             ))}

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -563,7 +563,6 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
           <IconButton
             onClick={() => props.onSpeedChange("PAUSED")}
             aria-label="pause"
-            edge="end"
             color="primary"
             size="large"
           >
@@ -572,7 +571,6 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
         )}
         <IconButton
           id="close-button"
-          edge="end"
           color="primary"
           onClick={onBack}
           aria-label="close"
@@ -610,7 +608,6 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
         />
         <IconButton
           id="sort"
-          edge="end"
           color="primary"
           onClick={onSortOpen}
           aria-label="sort"

--- a/src/components/views/BuildStorage.test.tsx
+++ b/src/components/views/BuildStorage.test.tsx
@@ -41,3 +41,21 @@ it("shows remaining pumped-hydro locations in the expanded build view", () => {
   expect(row).toHaveTextContent("648");
   expect(row).toHaveTextContent("Each project uses one suitable site");
 });
+
+it("keeps toolbar actions inside compact viewport gutters", () => {
+  render(
+    <BuildStorage
+      game={game()}
+      onBuildStorage={jest.fn()}
+      onBack={jest.fn()}
+      onSpeedChange={jest.fn()}
+    />,
+  );
+
+  expect(screen.getByRole("button", { name: "close" })).not.toHaveClass(
+    "MuiIconButton-edgeEnd",
+  );
+  expect(screen.getByRole("button", { name: "sort" })).not.toHaveClass(
+    "MuiIconButton-edgeEnd",
+  );
+});

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -373,7 +373,6 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
           <IconButton
             onClick={() => props.onSpeedChange("PAUSED")}
             aria-label="pause"
-            edge="end"
             color="primary"
             size="large"
           >
@@ -382,7 +381,6 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
         )}
         <IconButton
           id="close-button"
-          edge="end"
           color="primary"
           onClick={onBack}
           aria-label="close"
@@ -419,7 +417,6 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
           onChange={handleSliderChange}
         />
         <IconButton
-          edge="end"
           color="primary"
           onClick={onSortOpen}
           aria-label="sort"

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -99,6 +99,25 @@ describe("the fleet list", () => {
     expect(screen.queryByText("Lifetime profit")).toBeNull();
   });
 
+  it("uses singular construction copy for one month remaining", () => {
+    const underConstruction = createGame({ scenarioId: 100 });
+    underConstruction.facilities[0].yearsToBuildLeft = 1 / 12;
+    renderFacilities(underConstruction, null);
+
+    expect(screen.getByText(/1 month left/)).toBeInTheDocument();
+    expect(screen.queryByText(/1 months left/)).toBeNull();
+  });
+
+  it("uses compact watt units in the accessible chart summary", () => {
+    renderFacilities(game, null);
+
+    expect(
+      screen.getByRole("img", {
+        name: /electricity supply and demand over the day/i,
+      }),
+    ).toHaveAccessibleName(/MW/);
+  });
+
   /**
    * onReprioritize was declared and passed for years without the row ever calling it: dispatch
    * order could only be changed by dragging, which is undiscoverable with a mouse and unusable

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -157,12 +157,13 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
     facility.peakW > 0 ? Math.min(1, facility.currentW / facility.peakW) : 0;
   let secondaryText = "";
   if (underConstruction) {
+    const monthsLeft = Math.ceil(props.facility.yearsToBuildLeft * 12);
     const percentBuilt = Math.round(
       ((facility.yearsToBuild - facility.yearsToBuildLeft) /
         facility.yearsToBuild) *
         100,
     );
-    secondaryText = `Building: ${percentBuilt}%, ${Math.ceil(props.facility.yearsToBuildLeft * 12)} months left`;
+    secondaryText = `Building: ${percentBuilt}%, ${monthsLeft} ${monthsLeft === 1 ? "month" : "months"} left`;
   } else if (facility.peakWh) {
     secondaryText = `${formatWattHoursOfPeak(facility.currentWh, facility.peakWh)}, ${formatWatts(facility.peakW)}`;
   } else if (fuel === "Hydro" && facility.reservoirCapacityWh) {


### PR DESCRIPTION
## Summary

- keep generator and storage toolbar actions inside 320px viewports
- constrain the mobile tutorial floater so it cannot widen the document
- make chart summaries horizontally reachable in narrow tablet panes and format values with visible units
- use singular construction copy when one month remains

## QA coverage

Two QA sub-agents exercised mobile, tablet, desktop, and large-screen gameplay, including onboarding, builders, Facilities, Insights, Events, settings, save/continue, and resize transitions.

Manual rechecks confirmed:

- 320px builder document width stays at 320px; close/sort buttons end at 316px
- 320px tutorial document width stays at 320px; floater ends near 310px
- 768x1024 chart summaries expose horizontal scrolling and compact values such as 351MW

## Validation

- 70 test suites / 721 tests pass
- TypeScript, ESLint, and Prettier checks pass
- production build succeeds