### PR TITLE
Reduce finite facility site duplication

### DIFF
--- a/src/components/base/BuildAvailability.tsx
+++ b/src/components/base/BuildAvailability.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { TableCell, TableRow, Typography } from "@mui/material";
+
+interface BuildAvailability {
+  buildable: boolean;
+  secondaryText: React.ReactNode;
+}
+
+/** Shared availability copy and state for generator and storage purchase cards. */
+export function getBuildAvailability(
+  description: string,
+  sizeBuildable: boolean,
+  maxSizeLabel: React.ReactNode,
+  viableLocationsRemaining?: number,
+): BuildAvailability {
+  const siteBuildable = viableLocationsRemaining !== 0;
+  if (!siteBuildable) {
+    return {
+      buildable: false,
+      secondaryText: "No viable locations remaining.",
+    };
+  }
+  if (!sizeBuildable) {
+    return {
+      buildable: false,
+      secondaryText: (
+        <div>
+          Too large for current tech.
+          <br />
+          Max size: <strong>{maxSizeLabel}</strong>
+        </div>
+      ),
+    };
+  }
+  return { buildable: true, secondaryText: description };
+}
+
+/** A detail row shared by every technology with a finite site inventory. */
+export function ViableLocationsRow(props: {
+  remaining?: number;
+}): React.JSX.Element | null {
+  if (props.remaining === undefined) {
+    return null;
+  }
+  return (
+    <TableRow>
+      <TableCell>
+        Number of viable locations remaining
+        <Typography variant="body2" color="textSecondary">
+          Each project uses one suitable site
+        </Typography>
+      </TableCell>
+      <TableCell align="right">{props.remaining}</TableCell>
+    </TableRow>
+  );
+}

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -56,6 +56,10 @@ import { formatMass } from "../../helpers/Units";
 import ManualLink from "../base/ManualLink";
 import { useUnits } from "../base/UnitsContext";
 import ConceptIcon from "../base/ConceptIcon";
+import {
+  getBuildAvailability,
+  ViableLocationsRow,
+} from "../base/BuildAvailability";
 
 interface GeneratorBuildItemProps {
   cash: number;
@@ -87,26 +91,18 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
     LOAN_MONTHS,
   );
   const sizeBuildable = props.generator.peakW <= props.generator.maxPeakW;
-  const siteBuildable = props.generator.viableLocationsRemaining !== 0;
-  const buildable = sizeBuildable && siteBuildable;
+  const { buildable, secondaryText } = getBuildAvailability(
+    generator.description,
+    sizeBuildable,
+    formatWatts(generator.maxPeakW),
+    generator.viableLocationsRemaining,
+  );
   const financingGap = Math.max(0, downpayment - cash);
   // kg of CO2 equivalent released per MWh generated - 0 for carbon-free sources,
   // whose fuel either isn't in FUELS at all (sun, wind) or is emission-free (uranium)
   const kgCO2ePerMWh = Math.round(
     1000000 * generator.btuPerWh * (fuel.kgCO2ePerBtu || 0),
   );
-  const secondaryText = !siteBuildable ? (
-    "No viable locations remaining."
-  ) : sizeBuildable ? (
-    generator.description
-  ) : (
-    <div>
-      Too large for current tech.
-      <br />
-      Max size: <strong>{formatWatts(props.generator.maxPeakW)}</strong>
-    </div>
-  );
-
   const toggleExpand = () => {
     setExpanded(!expanded);
   };
@@ -291,19 +287,9 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
                   {generator.lifespanYears} years
                 </TableCell>
               </TableRow>
-              {generator.viableLocationsRemaining !== undefined && (
-                <TableRow>
-                  <TableCell>
-                    Number of viable locations remaining
-                    <Typography variant="body2" color="textSecondary">
-                      Each project uses one suitable site
-                    </Typography>
-                  </TableCell>
-                  <TableCell align="right">
-                    {generator.viableLocationsRemaining}
-                  </TableCell>
-                </TableRow>
-              )}
+              <ViableLocationsRow
+                remaining={generator.viableLocationsRemaining}
+              />
               {props.secondaryMetric !== "yearsToBuild" && (
                 <TableRow>
                   <TableCell>Time to build</TableCell>

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -39,6 +39,10 @@ import { STORAGE } from "../../data/Facilities";
 import { MANUAL_ENTRY } from "../../data/Manual";
 import ManualLink from "../base/ManualLink";
 import ConceptIcon from "../base/ConceptIcon";
+import {
+  getBuildAvailability,
+  ViableLocationsRow,
+} from "../base/BuildAvailability";
 import { GameType, SpeedType, StorageShoppingType } from "../../Types";
 
 interface StorageBuildItemProps {
@@ -60,18 +64,11 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
     LOAN_MONTHS,
   );
   const sizeBuildable = props.storage.peakWh <= props.storage.maxPeakWh;
-  const siteBuildable = props.storage.viableLocationsRemaining !== 0;
-  const buildable = sizeBuildable && siteBuildable;
-  const secondaryText = !siteBuildable ? (
-    "No viable locations remaining."
-  ) : sizeBuildable ? (
-    storage.description
-  ) : (
-    <div>
-      Too large for current tech.
-      <br />
-      Max size: <strong>{formatWatts(props.storage.maxPeakWh)}h</strong>
-    </div>
+  const { buildable, secondaryText } = getBuildAvailability(
+    storage.description,
+    sizeBuildable,
+    `${formatWatts(storage.maxPeakWh)}h`,
+    storage.viableLocationsRemaining,
   );
 
   const toggleExpand = () => {
@@ -170,19 +167,9 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
                 </TableCell>
                 <TableCell align="right">{storage.spinMinutes} min</TableCell>
               </TableRow>
-              {storage.viableLocationsRemaining !== undefined && (
-                <TableRow>
-                  <TableCell>
-                    Number of viable locations remaining
-                    <Typography variant="body2" color="textSecondary">
-                      Each project uses one suitable site
-                    </Typography>
-                  </TableCell>
-                  <TableCell align="right">
-                    {storage.viableLocationsRemaining}
-                  </TableCell>
-                </TableRow>
-              )}
+              <ViableLocationsRow
+                remaining={storage.viableLocationsRemaining}
+              />
             </TableBody>
           </Table>
         </TableContainer>

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -32,7 +32,7 @@ import VictoryConditions from "../base/VictoryConditions";
 import { DIFFICULTIES } from "../../Constants";
 import { CityType, getCities, initCities } from "../../data/Cities";
 import { GENERATORS, STORAGE } from "../../data/Facilities";
-import { getViableLocationCount } from "../../data/FacilitySites";
+import { getViableLocationsRemaining } from "../../data/FacilitySites";
 import { WEATHER_STARTING_YEAR } from "../../data/Weather";
 import { getFuelEscalation } from "../../data/FuelPrices";
 import { getStartingCustomers } from "../../data/LocationProfiles";
@@ -241,17 +241,20 @@ export default function CustomGame(props: Props): React.JSX.Element {
 
   // Rolling the year back past a technology's invention would otherwise leave a facility in the
   // list that quietly disappears once the game loads
-  const usedSites = new Map<string, number>();
+  const claimedSites: Array<{ name: string }> = [];
   const unavailable = scenario.facilities.filter(
     (f: Partial<FacilityShoppingType>) => {
       const name = facilityName(f);
       if (!technologies.some((t) => t.name === name)) {
         return true;
       }
-      const used = (usedSites.get(name) || 0) + 1;
-      usedSites.set(name, used);
-      const sites = getViableLocationCount(location, name);
-      return sites !== undefined && used > sites;
+      const sitesRemaining = getViableLocationsRemaining(
+        location,
+        claimedSites,
+        name,
+      );
+      claimedSites.push({ name });
+      return sitesRemaining === 0;
     },
   );
 

--- a/src/data/FacilitySites.test.tsx
+++ b/src/data/FacilitySites.test.tsx
@@ -1,4 +1,6 @@
-import { FacilityOperatingType, LocationType } from "../Types";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { LocationType } from "../Types";
 import {
   getViableLocationCount,
   getViableLocationsRemaining,
@@ -10,7 +12,15 @@ const location = (id: string, resources?: LocationType["resources"]) =>
 
 describe("finite facility sites", () => {
   it("has a researched pumped-hydro count for every currently playable location", () => {
-    expect(Object.keys(PUMPED_HYDRO_SITES_BY_LOCATION)).toHaveLength(41);
+    const weatherIndex = JSON.parse(
+      readFileSync(
+        join(process.cwd(), "public/data/weather/index.json"),
+        "utf8",
+      ),
+    ) as { cities: Record<string, unknown> };
+    expect(Object.keys(PUMPED_HYDRO_SITES_BY_LOCATION).sort()).toEqual(
+      Object.keys(weatherIndex.cities).sort(),
+    );
     expect(getViableLocationCount(location("Memphis"), "Pumped Hydro")).toBe(1);
     expect(getViableLocationCount(location("Chicago"), "Pumped Hydro")).toBe(0);
     expect(getViableLocationCount(location("Reykjavik"), "Pumped Hydro")).toBe(
@@ -37,7 +47,7 @@ describe("finite facility sites", () => {
       { name: "Geothermal" },
       { name: "Enhanced Geothermal" },
       { name: "Geothermal", yearsToBuildLeft: 2 },
-    ] as FacilityOperatingType[];
+    ];
 
     expect(
       getViableLocationsRemaining(

--- a/src/data/FacilitySites.tsx
+++ b/src/data/FacilitySites.tsx
@@ -1,7 +1,12 @@
-import type { FacilityOperatingType, LocationType } from "../Types";
+import type { LocationType } from "../Types";
 import { hasGeothermalResource, hasHydroResource } from "./LocationProfiles";
 
 export type SiteLimitedFacilityName = "Hydro" | "Geothermal" | "Pumped Hydro";
+
+/** The only facility state needed to determine whether a project has claimed a site. */
+export interface FacilitySiteClaim {
+  name: string;
+}
 
 // Conventional hydro and geothermal used to express scarcity only through a linear price
 // multiplier. Until those resources get the same site-level GIS treatment as pumped hydro, keep
@@ -83,7 +88,7 @@ export function getViableLocationCount(
 /** Counts projects already owned or under construction because either one has claimed its site. */
 export function getViableLocationsRemaining(
   location: LocationType | undefined,
-  facilities: readonly FacilityOperatingType[],
+  facilities: readonly FacilitySiteClaim[],
   facilityName: string,
 ): number | undefined {
   const total = getViableLocationCount(location, facilityName);

--- a/src/reducers/BuildFacility.test.tsx
+++ b/src/reducers/BuildFacility.test.tsx
@@ -100,6 +100,9 @@ describe("buildFacility", () => {
     expect(
       state.facilities.filter((facility) => facility.name === "Hydro"),
     ).toHaveLength(3);
+    state.facilities.forEach((facility) => {
+      expect(facility).not.toHaveProperty("viableLocationsRemaining");
+    });
   });
 
   it("keeps a long cash forecast finite when hydro finishes construction", () => {

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -573,17 +573,9 @@ export const gameSlice = createSlice({
           facilitySearch.peakW || 1000000,
           [],
           [],
-        ).find((g: FacilityShoppingType) => {
-          if (g.viableLocationsRemaining === 0) {
-            return false;
-          }
-          for (const property in facilitySearch) {
-            if (g[property] !== facilitySearch[property]) {
-              return false;
-            }
-          }
-          return true;
-        });
+        ).find((g: FacilityShoppingType) =>
+          matchesFacilitySearch(g, facilitySearch),
+        );
         if (generator) {
           state = buildFacilityHelper(
             state,
@@ -594,17 +586,8 @@ export const gameSlice = createSlice({
           );
         } else {
           const storage = STORAGE(state, facilitySearch.peakWh || 1000000).find(
-            (g: FacilityShoppingType) => {
-              if (g.viableLocationsRemaining === 0) {
-                return false;
-              }
-              for (const property in facilitySearch) {
-                if (g[property] !== facilitySearch[property]) {
-                  return false;
-                }
-              }
-              return true;
-            },
+            (g: FacilityShoppingType) =>
+              matchesFacilitySearch(g, facilitySearch),
           );
           if (storage) {
             state = buildFacilityHelper(
@@ -796,6 +779,18 @@ export default gameSlice.reducer;
  * reproduce the original run rather than an approximation of it: there is one implementation of
  * "the player built a plant", not two that have to be kept in step.
  */
+function matchesFacilitySearch(
+  candidate: FacilityShoppingType,
+  search: Partial<FacilityShoppingType>,
+): boolean {
+  if (candidate.viableLocationsRemaining === 0) {
+    return false;
+  }
+  return Object.keys(search).every(
+    (property: string) => candidate[property] === search[property],
+  );
+}
+
 function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
   const built = payload.facility;
   const viableLocationsRemaining = getViableLocationsRemaining(
@@ -2028,8 +2023,14 @@ function buildFacilityHelper(
       // purchased in cash
       now.cash -= g.buildCost;
     }
+    // Site availability belongs to the current fleet quote, not the facility bought from it. A
+    // saved operating asset must not retain a permanently stale "remaining" count.
+    const {
+      viableLocationsRemaining: _viableLocationsRemaining,
+      ...facilitySnapshot
+    } = g;
     const facility = {
-      ...g,
+      ...facilitySnapshot,
       // A scenario's catalog is priced in its starting year, but an inherited wind farm belongs
       // to its commissioning vintage and should use that cohort's observed degradation rate.
       ...(newGame && g.fuel === "Wind"


### PR DESCRIPTION
Consolidates finite-site counting across custom-game setup and gameplay, extracts shared build-card availability UI and facility matching, prevents stale remaining-site counts from being persisted on operating facilities, and verifies pumped-hydro coverage against the playable-city catalog. Validation: typecheck, lint, formatting, focused tests, and the complete 718-test suite all pass.