### PR TITLE
Improve Insights presets and demand chart ordering

### DIFF
--- a/src/components/base/ChartForecastDemandByType.test.tsx
+++ b/src/components/base/ChartForecastDemandByType.test.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import { DemandByTypeType, TickPresentFutureType } from "../../Types";
-import ChartForecastDemandByType from "./ChartForecastDemandByType";
+import ChartForecastDemandByType, {
+  demandTypesBySizeAtStart,
+  formatDemandTypeTooltip,
+} from "./ChartForecastDemandByType";
 
 function tick(
   minute: number,
@@ -43,4 +46,41 @@ it("makes every demand category readable without the canvas", () => {
   expect(chart).toHaveAccessibleName(/Industrial:/);
   expect(chart).toHaveAccessibleName(/Transportation:/);
   expect(chart).toHaveAccessibleName(/Data centers:/);
+});
+
+it("orders the legend and tooltip by demand at the start of the plotted range", () => {
+  const beforeRange = {
+    Residential: 900,
+    Commercial: 40,
+    Industrial: 30,
+    Transportation: 20,
+    "Data centers": 10,
+  };
+  const atStart = {
+    Residential: 200,
+    Commercial: 500,
+    Industrial: 300,
+    Transportation: 100,
+    "Data centers": 400,
+  };
+  const timeline = [
+    tick(-1440, beforeRange),
+    tick(0, atStart),
+    tick(1440, { ...atStart, Residential: 800 }),
+  ];
+
+  const ordered = demandTypesBySizeAtStart(timeline, 0);
+  expect(ordered).toEqual([
+    "Commercial",
+    "Data centers",
+    "Industrial",
+    "Residential",
+    "Transportation",
+  ]);
+  expect(
+    formatDemandTypeTooltip(0, atStart, 2020, ordered)
+      .split("\n")
+      .slice(1)
+      .map((line) => line.split(":")[0]),
+  ).toEqual(ordered);
 });

--- a/src/components/base/ChartForecastDemandByType.tsx
+++ b/src/components/base/ChartForecastDemandByType.tsx
@@ -26,6 +26,8 @@ export interface Props {
   height?: number;
   timeline: TickPresentFutureType[];
   domain: { x: [number, number] };
+  /** Shared with the DOM legend so both surfaces always present the same ranking. */
+  displayTypes?: readonly DemandTypeNameType[];
   startingYear: number;
   multiyear: boolean;
   showXLabels?: boolean;
@@ -34,6 +36,7 @@ export interface Props {
 
 interface State {
   byType: DemandByTypeType[];
+  displayTypes: readonly DemandTypeNameType[];
   minutes: number[];
   domain: Props["domain"];
   maxY: number;
@@ -96,15 +99,6 @@ function buildOptions(showXLabels: boolean) {
   });
 }
 
-function tooltip(idx: number, state: State): string {
-  return [
-    formatMinuteAsTooltipHeader(state.minutes[idx], state.startingYear),
-    ...DEMAND_TYPES.map(
-      (type) => `${type}: ${formatWatts(state.byType[idx][type])}`,
-    ).reverse(),
-  ].join("\n");
-}
-
 const EMPTY_BREAKDOWN: DemandByTypeType = {
   Residential: 0,
   Commercial: 0,
@@ -113,6 +107,46 @@ const EMPTY_BREAKDOWN: DemandByTypeType = {
   "Data centers": 0,
 };
 
+/**
+ * A stable ranking for the whole visible range. Reordering under the pointer would make the
+ * legend and stacked chart hard to follow, so the first plotted instant owns the ordering.
+ */
+export function demandTypesBySizeAtStart(
+  timeline: TickPresentFutureType[],
+  startMinute: number,
+): DemandTypeNameType[] {
+  const firstVisible =
+    timeline.find((tick) => tick.minute >= startMinute) ||
+    timeline[timeline.length - 1];
+  const breakdown = firstVisible?.demandByType || EMPTY_BREAKDOWN;
+  return [...DEMAND_TYPES].sort(
+    (a, b) =>
+      breakdown[b] - breakdown[a] ||
+      DEMAND_TYPES.indexOf(a) - DEMAND_TYPES.indexOf(b),
+  );
+}
+
+export function formatDemandTypeTooltip(
+  minute: number,
+  breakdown: DemandByTypeType,
+  startingYear: number,
+  displayTypes: readonly DemandTypeNameType[],
+): string {
+  return [
+    formatMinuteAsTooltipHeader(minute, startingYear),
+    ...displayTypes.map((type) => `${type}: ${formatWatts(breakdown[type])}`),
+  ].join("\n");
+}
+
+function tooltip(idx: number, state: State): string {
+  return formatDemandTypeTooltip(
+    state.minutes[idx],
+    state.byType[idx],
+    state.startingYear,
+    state.displayTypes,
+  );
+}
+
 export default class ChartForecastDemandByType extends React.PureComponent<
   Props,
   {}
@@ -120,6 +154,7 @@ export default class ChartForecastDemandByType extends React.PureComponent<
   public render() {
     const {
       domain,
+      displayTypes,
       height,
       timeline,
       startingYear,
@@ -152,6 +187,8 @@ export default class ChartForecastDemandByType extends React.PureComponent<
     const maxY = Math.max(...running, 0);
     const state: State = {
       byType,
+      displayTypes:
+        displayTypes || demandTypesBySizeAtStart(timeline, domain.x[0]),
       minutes,
       domain,
       maxY,

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -37,6 +37,13 @@ jest.mock("../base/ChartForecastFuelPrices", () => ({
 }));
 jest.mock("../base/ChartForecastDemandByType", () => ({
   __esModule: true,
+  demandTypesBySizeAtStart: () => [
+    "Residential",
+    "Commercial",
+    "Industrial",
+    "Transportation",
+    "Data centers",
+  ],
   default: ({ syncKey }: ChartMockProps) => (
     <div role="img" data-chart="demand-by-type" data-sync-key={syncKey} />
   ),
@@ -103,14 +110,68 @@ async function choosePreset(label: string) {
 describe("Insights layers", () => {
   beforeEach(() => localStorage.clear());
 
-  it("defines unique layers and useful presets", () => {
+  it("defines five distinct, purpose-ordered presets", () => {
     expect(new Set(INSIGHT_LAYERS.map((layer) => layer.id)).size).toBe(
       INSIGHT_LAYERS.length,
     );
-    expect(INSIGHT_PRESETS.reliability.layers).toContain("supplyDemand");
-    expect(INSIGHT_PRESETS.reliability.layers).toContain("demandByType");
-    expect(INSIGHT_PRESETS.profitability.layers).toContain("profit");
+    expect(Object.keys(INSIGHT_PRESETS)).toHaveLength(5);
+    expect(INSIGHT_PRESETS.overview.layers).toEqual([
+      "supplyDemand",
+      "cash",
+      "profit",
+      "customers",
+      "emissions",
+    ]);
+    expect(INSIGHT_PRESETS.reliability.layers).toEqual([
+      "supplyDemand",
+      "supplyByFuel",
+      "storage",
+      "weather",
+      "water",
+    ]);
+    expect(INSIGHT_PRESETS.profitability.layers).toEqual([
+      "profit",
+      "cash",
+      "revenue",
+      "expenses",
+      "fuelPrices",
+    ]);
+    expect(INSIGHT_PRESETS.growth.layers).toEqual([
+      "customers",
+      "demandByType",
+      "supplyDemand",
+      "revenue",
+      "profit",
+    ]);
+    expect(INSIGHT_PRESETS.decarbonization.layers).toEqual([
+      "emissions",
+      "supplyByFuel",
+      "supplyDemand",
+      "fuelPrices",
+      "profit",
+    ]);
     expect(presetForLayers(INSIGHT_PRESETS.growth.layers)).toBe("growth");
+  });
+
+  it("starts new players on the five-chart overview in priority order", () => {
+    renderInsights();
+
+    expect(
+      screen.getByRole("combobox", { name: "Insight preset" }),
+    ).toHaveTextContent("Overview");
+    const headings = screen.getAllByRole("heading", { level: 6 });
+    const expected = [
+      "Insights",
+      "Supply & Demand",
+      "Cash",
+      "Profit",
+      "Customers",
+      "CO2e Emitted",
+    ];
+    expect(headings).toHaveLength(expected.length);
+    expected.forEach((label, index) =>
+      expect(headings[index]).toHaveTextContent(label),
+    );
   });
 
   it("keeps tutorial targets visible without duplicating stored layers", () => {
@@ -140,15 +201,15 @@ describe("Insights layers", () => {
   it("persists custom visibility and ordering across a remount", async () => {
     const view = renderInsights();
     await user.click(screen.getByRole("button", { name: /Layers/ }));
-    await user.click(screen.getByRole("checkbox", { name: "Profit" }));
-    await user.click(screen.getByRole("button", { name: "Move Profit up" }));
+    await user.click(screen.getByRole("checkbox", { name: "Revenue" }));
+    await user.click(screen.getByRole("button", { name: "Move Revenue up" }));
 
     const stored = JSON.parse(localStorage.getItem("insightsLayers") || "[]");
-    expect(stored).toContain("profit");
+    expect(stored).toContain("revenue");
     view.unmount();
 
     renderInsights();
-    expect(screen.getByText("Profit", { selector: "h6" })).toBeVisible();
+    expect(screen.getByText("Revenue", { selector: "h6" })).toBeVisible();
     expect(
       screen.getByRole("combobox", { name: "Insight preset" }),
     ).toHaveTextContent("Custom");

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -64,14 +64,15 @@ import {
 } from "../../LocalStorage";
 import { generateNewTimeline } from "../../reducers/Game";
 import { getScenario, SCENARIOS } from "../../data/Scenarios";
-import { DEMAND_TYPES } from "../../data/DemandProfiles";
 import {
   chartPalette,
   demandTypeColors,
   fuelColors,
   fuelDashArrays,
 } from "../../Theme";
-import ChartForecastDemandByType from "../base/ChartForecastDemandByType";
+import ChartForecastDemandByType, {
+  demandTypesBySizeAtStart,
+} from "../base/ChartForecastDemandByType";
 import ChartFinances from "../base/ChartFinances";
 import ChartForecastFuelPrices, {
   PRICED_FUELS,
@@ -145,9 +146,9 @@ export const INSIGHT_LAYERS: readonly InsightLayerDefinition[] = [
 ] as const;
 
 export type InsightPresetId =
+  | "overview"
   | "reliability"
   | "profitability"
-  | "hydro"
   | "growth"
   | "decarbonization"
   | "custom";
@@ -156,31 +157,34 @@ export const INSIGHT_PRESETS: Record<
   Exclude<InsightPresetId, "custom">,
   { label: string; layers: InsightLayerId[] }
 > = {
+  // Each preset reads from the outcome a player is trying to protect into the causes they can
+  // act on. Overview is deliberately the five universal health signals: optional technologies
+  // belong in the diagnostic presets, not in the first view a new player sees.
+  overview: {
+    label: "Overview",
+    layers: ["supplyDemand", "cash", "profit", "customers", "emissions"],
+  },
   reliability: {
     label: "Reliability",
-    layers: [
-      "supplyDemand",
-      "demandByType",
-      "supplyByFuel",
-      "storage",
-      "weather",
-    ],
+    layers: ["supplyDemand", "supplyByFuel", "storage", "weather", "water"],
   },
   profitability: {
     label: "Profitability",
-    layers: ["profit", "revenue", "expenses", "fuelPrices", "financeDetails"],
-  },
-  hydro: {
-    label: "Hydro operations",
-    layers: ["supplyDemand", "water", "weather", "profit"],
+    layers: ["profit", "cash", "revenue", "expenses", "fuelPrices"],
   },
   growth: {
-    label: "Growth",
+    label: "Growth & pricing",
     layers: ["customers", "demandByType", "supplyDemand", "revenue", "profit"],
   },
   decarbonization: {
     label: "Decarbonization",
-    layers: ["supplyByFuel", "emissions", "fuelPrices", "profit"],
+    layers: [
+      "emissions",
+      "supplyByFuel",
+      "supplyDemand",
+      "fuelPrices",
+      "profit",
+    ],
   },
 };
 
@@ -245,7 +249,7 @@ function storedLayers(): InsightLayerId[] {
     (id, index): id is InsightLayerId =>
       ALL_LAYER_IDS.has(id as InsightLayerId) && value.indexOf(id) === index,
   );
-  return valid.length ? valid : [...INSIGHT_PRESETS.reliability.layers];
+  return valid.length ? valid : [...INSIGHT_PRESETS.overview.layers];
 }
 
 export function presetForLayers(layers: InsightLayerId[]): InsightPresetId {
@@ -784,11 +788,15 @@ export default class Insights extends React.Component<Props, State> {
             </>
           );
           break;
-        case "demandByType":
+        case "demandByType": {
+          const demandTypes = demandTypesBySizeAtStart(
+            projection.sampled,
+            projection.domain.x[0],
+          );
           body = (
             <>
               <ChartLegend
-                items={DEMAND_TYPES.map((type) => ({
+                items={demandTypes.map((type) => ({
                   name: type,
                   color: demandTypeColors()[type],
                 }))}
@@ -797,6 +805,7 @@ export default class Insights extends React.Component<Props, State> {
                 height={140}
                 timeline={projection.sampled}
                 domain={{ x: projection.domain.x }}
+                displayTypes={demandTypes}
                 startingYear={game.startingYear}
                 multiyear={multiyear}
                 syncKey={SYNC_KEY}
@@ -804,6 +813,7 @@ export default class Insights extends React.Component<Props, State> {
             </>
           );
           break;
+        }
         case "supplyByFuel":
           body = (
             <>

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -163,10 +163,12 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           together. This is also where you set the electricity rate.
         </p>
         <p>
-          A good first move is to open Insights, choose the Reliability preset,
-          find the first blackout, and work out whether it needs something cheap
-          that runs constantly or something expensive that starts quickly. The
-          rest of this manual explains the terms you'll meet along the way.
+          A good first move is to open Insights and scan the Overview: first for
+          blackouts or falling cash, then for the profit, customer and emissions
+          trends behind them. If supply falls short, choose Reliability to work
+          out whether the gap needs something cheap that runs constantly or
+          something expensive that starts quickly. The rest of this manual
+          explains the terms you'll meet along the way.
         </p>
       </div>
     ),


### PR DESCRIPTION
## Summary
- add a five-chart Overview as the default Insights view and refocus the other four presets around reliability, profitability, growth and pricing, and decarbonization
- fold hydro diagnostics into Reliability while keeping Demand by Load Type in the Growth and pricing workflow
- order the demand-source legend and tooltip from largest to smallest using demand at the start of the plotted range, with stable tie ordering
- update player guidance and lock the preset and demand ordering down with focused tests

## Validation
- npm test -- --watchAll=false --runInBand (720 tests)
- npm run typecheck
- npm run lint
- npm run format:check
- npm run build