### PR TITLE
Simplify Insights range and audio settings

### DIFF
--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -230,6 +230,20 @@ describe("Insights layers", () => {
     );
   });
 
+  it("offers one rolling 12-month range instead of separate calendar years", async () => {
+    localStorage.setItem("insightsRange", "current");
+    renderInsights();
+
+    const range = screen.getByRole("combobox", { name: "Insight range" });
+    expect(range).toHaveTextContent("Next 12 months");
+    await user.click(range);
+
+    const options = within(await screen.findByRole("listbox"));
+    expect(options.getByText("Next 12 months")).toBeVisible();
+    expect(options.queryByText("Current year")).toBeNull();
+    expect(options.queryByText("Next year")).toBeNull();
+  });
+
   it("keeps tutorial targets visible without duplicating stored layers", () => {
     expect(withRequiredLayers(["profit"], 4)).toEqual([
       "profit",

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -95,13 +95,7 @@ import { UnitsContext } from "../base/UnitsContext";
 import { formatCustomerChange } from "./Finances";
 
 export type InsightRange =
-  | "all"
-  | "current"
-  | "next1"
-  | "next5"
-  | "next10"
-  | "next20"
-  | `year:${number}`;
+  "all" | "next1" | "next5" | "next10" | "next20" | `year:${number}`;
 
 export type InsightLayerId =
   | "supplyDemand"
@@ -202,7 +196,6 @@ export const INSIGHT_PRESETS: Record<
 const RANGE_KEY = "insightsRange";
 const LAYERS_KEY = "insightsLayers";
 const FORECAST_RANGE_OPTIONS: readonly InsightRange[] = [
-  "current",
   "next1",
   "next5",
   "next10",
@@ -635,10 +628,6 @@ export default class Insights extends React.Component<Props, State> {
       timeline,
       game.startingYear,
     ).slice(1, 1 + monthsAhead);
-    const financePast =
-      this.state.range === "current"
-        ? game.monthlyHistory.filter((month) => month.year === game.date.year)
-        : [];
     const projection: ProjectionView = {
       historical: false,
       timeline,
@@ -649,7 +638,7 @@ export default class Insights extends React.Component<Props, State> {
       largestBlackout,
       hasStorage: timeline.some((tick) => tick.storedWh > 0),
       hasHydro: game.facilities.some((facility) => facility.fuel === "Hydro"),
-      financePast,
+      financePast: [],
       financeProjected: [currentMonth, ...projectedMonths],
     };
     this.projectionCache = { key, projection };
@@ -1135,8 +1124,7 @@ export default class Insights extends React.Component<Props, State> {
               className="headerControl"
               aria-label="Insight range"
             >
-              <MenuItem value="current">Current year</MenuItem>
-              <MenuItem value="next1">Next year</MenuItem>
+              <MenuItem value="next1">Next 12 months</MenuItem>
               <MenuItem value="next5">Next 5 years</MenuItem>
               <MenuItem value="next10">Next 10 years</MenuItem>
               <MenuItem value="next20">Next 20 years</MenuItem>

--- a/src/components/views/Settings.test.tsx
+++ b/src/components/views/Settings.test.tsx
@@ -34,7 +34,7 @@ function renderSettings(overrides: Partial<Props> = {}) {
     onBack: () => undefined,
     ...overrides,
   };
-  render(<Settings {...props} />);
+  return render(<Settings {...props} />);
 }
 
 function exportButton(): HTMLButtonElement {
@@ -89,6 +89,31 @@ describe("Settings", () => {
     );
     expect(onMusicVolumeChange).toHaveBeenCalledWith(0.35);
     expect(onSoundEffectsVolumeChange).toHaveBeenCalledWith(0.8);
+  });
+
+  it("only shows volume controls while audio is enabled", () => {
+    const view = renderSettings();
+
+    expect(screen.queryByRole("slider", { name: /music volume/i })).toBeNull();
+    expect(
+      screen.queryByRole("slider", { name: /sound effects volume/i }),
+    ).toBeNull();
+
+    view.unmount();
+    renderSettings({
+      settings: {
+        audioEnabled: true,
+        musicVolume: 1,
+        soundEffectsVolume: 1,
+        units: "metric",
+        theme: "system",
+      },
+    });
+
+    expect(screen.getByRole("slider", { name: /music volume/i })).toBeVisible();
+    expect(
+      screen.getByRole("slider", { name: /sound effects volume/i }),
+    ).toBeVisible();
   });
 
   it("names the saved game that Export would download", async () => {

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -175,31 +175,31 @@ export default function Settings(props: Props): React.JSX.Element {
                   : "Music and sound effects disabled"
               }
             />
-            <Box sx={{ width: "100%", maxWidth: 360, px: 1 }}>
-              <Typography id="music-volume-label" variant="body2">
-                Music volume: {Math.round(props.settings.musicVolume * 100)}%
-              </Typography>
-              <Slider
-                aria-labelledby="music-volume-label"
-                value={Math.round(props.settings.musicVolume * 100)}
-                disabled={!props.settings.audioEnabled}
-                onChange={(_e: Event, value: number | number[]) =>
-                  props.onMusicVolumeChange((value as number) / 100)
-                }
-              />
-              <Typography id="effects-volume-label" variant="body2">
-                Sound effects volume:{" "}
-                {Math.round(props.settings.soundEffectsVolume * 100)}%
-              </Typography>
-              <Slider
-                aria-labelledby="effects-volume-label"
-                value={Math.round(props.settings.soundEffectsVolume * 100)}
-                disabled={!props.settings.audioEnabled}
-                onChange={(_e: Event, value: number | number[]) =>
-                  props.onSoundEffectsVolumeChange((value as number) / 100)
-                }
-              />
-            </Box>
+            {!!props.settings.audioEnabled && (
+              <Box sx={{ width: "100%", maxWidth: 360, px: 1 }}>
+                <Typography id="music-volume-label" variant="body2">
+                  Music volume: {Math.round(props.settings.musicVolume * 100)}%
+                </Typography>
+                <Slider
+                  aria-labelledby="music-volume-label"
+                  value={Math.round(props.settings.musicVolume * 100)}
+                  onChange={(_e: Event, value: number | number[]) =>
+                    props.onMusicVolumeChange((value as number) / 100)
+                  }
+                />
+                <Typography id="effects-volume-label" variant="body2">
+                  Sound effects volume:{" "}
+                  {Math.round(props.settings.soundEffectsVolume * 100)}%
+                </Typography>
+                <Slider
+                  aria-labelledby="effects-volume-label"
+                  value={Math.round(props.settings.soundEffectsVolume * 100)}
+                  onChange={(_e: Event, value: number | number[]) =>
+                    props.onSoundEffectsVolumeChange((value as number) / 100)
+                  }
+                />
+              </Box>
+            )}
           </SettingsSection>
 
           <SettingsSection id="account-settings" title="Account">


### PR DESCRIPTION
## Summary
- replace separate Current year and Next year Insights options with a rolling Next 12 months range
- fall back from the removed stored Current year choice to Next 12 months
- hide music and sound-effect volume sliders while audio is disabled
- add regression coverage for both behaviors

## Testing
- npm test -- --watchAll=false (73 suites, 741 tests)
- npm run typecheck
- ESLint and Prettier checks for changed files