### PR TITLE
Add natural gas start maintenance costs

### DIFF
--- a/docs/facilities-economics.md
+++ b/docs/facilities-economics.md
@@ -55,7 +55,12 @@ The EIA AEO2025 reference designs also update:
 - Coal: 8,638 Btu/kWh, 60-month reference lead time, and 40-year operating life.
 - Nuclear: 10,608 Btu/kWh, 84-month reference lead time, and 40-year economic life.
 - Natural gas: the H-class simple-cycle design matches the facility's fast-start role: 9,142
-  Btu/kWh, a 40-month lead time, and a 40-year life.
+  Btu/kWh, a 40-month lead time, and a 40-year life. Its $6.87/kW-year fixed O&M and $1.24/MWh
+  consumables remain the base O&M; EIA reports start maintenance separately at $23,100 per
+  equivalent start for the 419 MW reference plant, scaled linearly for the player's chosen size.
+  The build quote adds one start per day ($8.432 million/year for the reference plant) to make the
+  tradeoff legible, while live play charges only on actual off-to-on edges. Because one simulated
+  day represents a month, each visible edge represents 365/12 equivalent starts.
 - Onshore wind: $33.06/kW-year fixed O&M, 21-month reference lead time, and 25-year life.
 - Offshore wind, added on `master` while this refresh was in progress, already uses the same EIA
   AEO2025 study: $3,689/kW and $154/kW-year for its 900 MW fixed-bottom reference plant.
@@ -172,10 +177,11 @@ so their introductory economics and controls remain predictable. Existing saves 
 commissioning timestamp still begin their age clock on the first real tick, and saves without a
 degradation field use the modern solar or wind default from the day they resume.
 
-The next fidelity step is intentionally separate: starts and equivalent operating hours for thermal
-plants, start costs for natural gas, maintenance/refurbishment decisions, and wear-driven outage
-risk. Adding an arbitrary fossil output penalty now would duplicate mechanisms that should instead
-depend on duty cycle, starts, and maintenance history.
+The facility panel now reports equivalent operating hours for generators and equivalent starts for
+natural gas. The 900-start hot-gas-path and 1,800-start major-inspection intervals are shown as
+maintenance context, but do not trigger a second refurbishment bill: EIA's $23,100/start figure is
+already the levelized major-maintenance cost. Maintenance decisions and wear-driven outage risk
+remain separate future work.
 
 ## Commercial technology review
 

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -29,6 +29,7 @@ import {
  */
 
 // Bump on any breaking schema change. Mismatched replays are ignored rather than migrated.
+// 6 adds start-based gas-turbine maintenance; older replays would have different finances.
 // 5 adds age-dependent renewable output and authored starting ages; older replays would dispatch
 // a different amount of solar and wind even if they contain exactly the same actions.
 // 4 replaces investor marketing with price-driven customer switching; older replays would grow a
@@ -36,7 +37,7 @@ import {
 // 3 adds offshore wind weather and generation; an older replay would simulate a different grid.
 // 2 added `location`: a v1 replay names only a scenario, and a scenario no longer pins down
 // where it is played, so there is no safe way to migrate one.
-export const REPLAY_VERSION = 5;
+export const REPLAY_VERSION = 6;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -100,13 +100,22 @@ export function parseSave(raw: unknown): SaveGameType | null {
         return true;
       }
       const current = facility as Record<string, unknown>;
-      return [
+      const requiredNumbersInvalid = [
         current.lifespanYears,
         current.lifetimeWh,
         current.lifetimePotentialWh,
         current.lifetimeRevenue,
         current.lifetimeExpenses,
       ].some((value) => typeof value !== "number" || !Number.isFinite(value));
+      const optionalNumbersInvalid = [
+        current.costPerStart,
+        current.lifetimeStarts,
+      ].some(
+        (value) =>
+          value !== undefined &&
+          (typeof value !== "number" || !Number.isFinite(value) || value < 0),
+      );
+      return requiredNumbersInvalid || optionalNumbersInvalid;
     }) ||
     !Array.isArray(game.timeline) ||
     !Array.isArray(game.monthlyHistory) ||

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -320,6 +320,9 @@ export interface GeneratorOperatingType
   // Set when construction completes; absent while the facility is still being built.
   minuteOperational?: number;
   paused: boolean;
+  // Last real-tick state for start edge detection. Forecast/pre-roll dispatch mutates currentW,
+  // so currentW alone cannot distinguish a player-visible start from a synthetic one.
+  generatingLastRealTick?: boolean;
   reservoirWh?: number;
   hydroLastInflowWh?: number;
   hydroLastSpillWh?: number;
@@ -350,6 +353,9 @@ export interface LifetimeTotals {
   lifetimePotentialWh: number;
   lifetimeRevenue: number; // Its pro-rata share of what the company sold
   lifetimeExpenses: number; // Its own fuel, O&M, carbon fees and loan interest
+  // Representative starts: one on/off edge in the sampled day stands for every day in its month.
+  // Optional so launch saves made before start-based maintenance remain readable.
+  lifetimeStarts?: number;
 }
 
 interface LoanInfo {
@@ -381,6 +387,9 @@ export interface GeneratorShoppingType extends SharedShoppingType {
   annualOutputDegradation?: number;
   spinMinutes: number; // 1 for renewables, to avoid eating up CPU on coersing to 1 in case it doesn't exist
   btuPerWh: number; // Heat Rate, but per W for less math per frame
+  // Non-fuel maintenance charged for one physical start. Only present when the technology's
+  // source case reports it separately from fixed and output-dependent O&M.
+  costPerStart?: number;
   // Conventional hydro only. whPerMm is calibrated against the loaded watershed record so that
   // long-run inflow lands on capacityFactor without flattening wet and dry years.
   reservoirCapacityWh?: number;

--- a/src/components/base/FacilityDetails.tsx
+++ b/src/components/base/FacilityDetails.tsx
@@ -4,6 +4,7 @@ import { getFuelPricesPerMBTU } from "../../data/FuelPrices";
 import {
   facilityAgeYears,
   facilityEquivalentCycles,
+  facilityEquivalentOperatingHours,
   facilityLifetime,
   facilityOutputFactor,
 } from "../../helpers/Financials";
@@ -122,6 +123,7 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
   const ageYears = facilityAgeYears(facility, date.minute);
   const outputFactor = facilityOutputFactor(facility, date.minute);
   const equivalentCycles = facilityEquivalentCycles(facility);
+  const equivalentOperatingHours = facilityEquivalentOperatingHours(facility);
 
   const trend = fuel ? fuelPriceTrend(fuel, date, seed, location) : [];
   const trendChange =
@@ -190,6 +192,36 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
           <Stat
             label="Equivalent cycles"
             value={`${Math.round(equivalentCycles).toLocaleString()} / 7,300`}
+          />
+        )}
+        {!isStorage && equivalentOperatingHours !== undefined && (
+          <Stat
+            label="Equivalent operating hours"
+            value={Math.round(equivalentOperatingHours).toLocaleString()}
+          />
+        )}
+        {facility.costPerStart !== undefined && (
+          <Stat
+            label="Equivalent starts"
+            value={Math.round(facility.lifetimeStarts || 0).toLocaleString()}
+          />
+        )}
+        {facility.costPerStart !== undefined && (
+          <Stat
+            label="Service intervals"
+            value="HGP 900 · major 1,800 starts"
+          />
+        )}
+        {facility.costPerStart !== undefined && (
+          <Stat
+            label="Start maintenance"
+            value={`${formatMoneyConcise(facility.costPerStart)}/start`}
+          />
+        )}
+        {facility.costPerStart !== undefined && (
+          <Stat
+            label="Start accounting"
+            value="Each simulated day represents its month"
           />
         )}
         {isHydro && (

--- a/src/components/views/BuildGenerators.test.tsx
+++ b/src/components/views/BuildGenerators.test.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { GENERATORS } from "../../data/Facilities";
+import { createGame } from "../../testing/Simulator";
+import { GeneratorBuildItem } from "./BuildGenerators";
+
+jest.mock("../base/ManualLink", () => () => null);
+
+it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
+  const game = createGame({ scenarioId: 104, difficulty: "CEO" });
+  const generator = GENERATORS(game, 419000000, [], []).find(
+    (candidate) => candidate.name === "Natural Gas",
+  );
+  expect(generator).toBeDefined();
+
+  render(
+    <GeneratorBuildItem
+      cash={1000000000}
+      date={game.date}
+      interestRate={game.interestRate}
+      generator={generator!}
+      location={game.location}
+      seed={game.seed}
+      onBuild={jest.fn()}
+    />,
+  );
+
+  expect(screen.getByText("Est. O&M (1 start/day)")).toBeInTheDocument();
+  expect(screen.getByText("$13.4M/yr")).toBeInTheDocument();
+  fireEvent.click(
+    screen.getByRole("button", { name: "Show Natural Gas details" }),
+  );
+
+  expect(
+    screen.getByRole("row", {
+      name: /Base O&M.*45% expected output.*\$4\.93M/,
+    }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("row", {
+      name: /Startup maintenance.*Per equivalent start.*\$23\.1k\/start/,
+    }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("row", {
+      name: /Estimated O&M.*Base O&M plus one start\/day.*\$13\.4M\/yr/,
+    }),
+  ).toBeInTheDocument();
+});

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -29,7 +29,10 @@ import CloseIcon from "@mui/icons-material/Close";
 import PauseIcon from "@mui/icons-material/Pause";
 import SortIcon from "@mui/icons-material/Sort";
 import { getTimeFromTimeline } from "../../helpers/DateTime";
-import { getMonthlyPayment } from "../../helpers/Financials";
+import {
+  estimatedAnnualOperatingCost,
+  getMonthlyPayment,
+} from "../../helpers/Financials";
 import {
   formatMoneyConcise,
   formatMoneyStable,
@@ -72,7 +75,9 @@ interface GeneratorBuildItemProps {
   onBuild: (financed: boolean) => void;
 }
 
-function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
+export function GeneratorBuildItem(
+  props: GeneratorBuildItemProps,
+): React.JSX.Element {
   const { generator, cash } = props;
   const units = useUnits();
   const fuel = FUELS[generator.fuel] || {};
@@ -162,8 +167,12 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
           value={`${Math.round(generator.yearsToBuild * 12)} mo`}
         />
         <GeneratorMetric
-          label="Operating cost"
-          value={`${formatMoneyConcise(generator.annualOperatingCost)}/yr`}
+          label={
+            generator.costPerStart !== undefined
+              ? "Est. O&M (1 start/day)"
+              : "Operating cost"
+          }
+          value={`${formatMoneyConcise(estimatedAnnualOperatingCost(generator))}/yr`}
         />
         <GeneratorMetric
           label="Energy cost"
@@ -213,6 +222,9 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
                     <Typography variant="body2" color="textSecondary">
                       Across life, based on{" "}
                       {Math.round(generator.capacityFactor * 100)}% uptime
+                      {generator.costPerStart !== undefined
+                        ? " and one start/day"
+                        : ""}
                     </Typography>
                   </TableCell>
                   <TableCell align="right">
@@ -237,15 +249,45 @@ function GeneratorBuildItem(props: GeneratorBuildItemProps): React.JSX.Element {
               </TableRow>
               <TableRow>
                 <TableCell>
-                  Operating costs
+                  Base O&M
                   <Typography variant="body2" color="textSecondary">
-                    Regardless of output
+                    At {Math.round(generator.capacityFactor * 100)}% expected
+                    output
                   </Typography>
                 </TableCell>
                 <TableCell align="right">
                   {formatMoneyConcise(generator.annualOperatingCost)}/yr
                 </TableCell>
               </TableRow>
+              {generator.costPerStart !== undefined && (
+                <TableRow>
+                  <TableCell>
+                    Startup maintenance
+                    <Typography variant="body2" color="textSecondary">
+                      Per equivalent start
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatMoneyConcise(generator.costPerStart)}/start
+                  </TableCell>
+                </TableRow>
+              )}
+              {generator.costPerStart !== undefined && (
+                <TableRow>
+                  <TableCell>
+                    Estimated O&M
+                    <Typography variant="body2" color="textSecondary">
+                      Base O&M plus one start/day
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatMoneyConcise(
+                      estimatedAnnualOperatingCost(generator),
+                    )}
+                    /yr
+                  </TableCell>
+                </TableRow>
+              )}
               {fuelPrices[generator.fuel] && (
                 <TableRow>
                   <TableCell>

--- a/src/data/Facilities.test.tsx
+++ b/src/data/Facilities.test.tsx
@@ -98,6 +98,15 @@ describe("current facility economics", () => {
     expect(battery?.yearsToBuild).toBeCloseTo(1.5, 2);
   });
 
+  it("scales natural-gas start maintenance from EIA's 419 MW reference", () => {
+    expect(generatorAt(2023, "Natural Gas", 419000000)?.costPerStart).toBe(
+      23100,
+    );
+    expect(
+      generatorAt(2023, "Natural Gas", 100000000)?.costPerStart,
+    ).toBeCloseTo((23100 * 100) / 419, 8);
+  });
+
   it("uses the 2024 ATB midpoint for ten-hour pumped hydro", () => {
     const pumpedHydro = STORAGE(stateAt(iceland, 2024), 1000000000).find(
       (facility) => facility.name === "Pumped Hydro",

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -243,6 +243,9 @@ export function GENERATORS(
       btuPerWh: 9.142,
       spinMinutes: 10,
       annualOperatingCost: annualOperatingCost(peakW, 0.45, 6.87, 1.24),
+      // EIA AEO2025 Case 4 reports this separately from both fixed and variable O&M:
+      // $23,100 per equivalent start for its 419 MW H-class simple-cycle reference plant.
+      costPerStart: 23100 * (peakW / 419000000),
       yearsToBuild: 2.46 + magnitude / 3,
       capacityFactor: 0.45,
       // ~38% duty cycle - https://sunmetrix.com/what-is-capacity-factor-and-how-does-solar-energy-compare/
@@ -504,6 +507,9 @@ export function GENERATORS(
   generators = generators.filter((g: GeneratorShoppingType) => {
     g.buildCost *= difficulty.buildCost * inflation;
     g.annualOperatingCost *= difficulty.expensesOM * inflation;
+    if (g.costPerStart !== undefined) {
+      g.costPerStart *= difficulty.expensesOM * inflation;
+    }
     g.yearsToBuild *= difficulty.buildTime;
     // The custom game screen asks what can be built in a year before any game has loaded the
     // price data a levelized cost needs. Nothing there reads lcWh, and a cost per Wh with no

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -5,6 +5,7 @@ import {
   facilityEquivalentCycles,
   facilityLifetime,
   facilityOutputFactor,
+  estimatedAnnualOperatingCost,
   getCompanyInterestRate,
   getCreditInputs,
   getCreditPremium,
@@ -188,6 +189,25 @@ describe("LCWH", () => {
     );
     expect(LCWH(degrading, date, 0, SEED)).toBeGreaterThan(
       LCWH(generator, date, 0, SEED),
+    );
+  });
+
+  it("quotes start maintenance at one start per day", () => {
+    const peaker = {
+      ...generator,
+      annualOperatingCost: 4926635.52,
+      costPerStart: 23100,
+    };
+    expect(estimatedAnnualOperatingCost(peaker)).toBeCloseTo(13358135.52, 2);
+
+    const totalWh =
+      peaker.peakW *
+      peaker.lifespanYears *
+      HOURS_PER_YEAR_REAL *
+      peaker.capacityFactor;
+    expect(LCWH(peaker, date, 0, SEED)).toBeCloseTo(
+      (peaker.buildCost + 13358135.52 * peaker.lifespanYears) / totalWh,
+      12,
     );
   });
 

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -159,10 +159,30 @@ export function LCWH(
     g.peakW * productiveYears * HOURS_PER_YEAR_REAL * g.capacityFactor;
   const costPerWh =
     (g.buildCost +
-      g.annualOperatingCost * g.lifespanYears +
+      estimatedAnnualOperatingCost(g) * g.lifespanYears +
       (fuelCostPerWh + carbonCostPerWh) * totalWh) /
     totalWh;
   return costPerWh;
+}
+
+// The build quote needs one legible operating pattern. A daily start matches a peaking turbine
+// that shuts down overnight, and turns EIA's per-start maintenance value into an annual estimate;
+// live play still charges only when the facility actually crosses from off to generating.
+export const ASSUMED_STARTS_PER_YEAR = 365;
+
+export function estimatedAnnualStartCost(
+  generator: Pick<GeneratorShoppingType, "costPerStart">,
+): number {
+  return (generator.costPerStart || 0) * ASSUMED_STARTS_PER_YEAR;
+}
+
+export function estimatedAnnualOperatingCost(
+  generator: Pick<
+    GeneratorShoppingType,
+    "annualOperatingCost" | "costPerStart"
+  >,
+): number {
+  return generator.annualOperatingCost + estimatedAnnualStartCost(generator);
 }
 
 /**
@@ -261,6 +281,13 @@ export function facilityEquivalentCycles(
   g: FacilityOperatingType,
 ): number | undefined {
   return g.peakWh > 0 ? g.lifetimeWh / g.peakWh : undefined;
+}
+
+/** Nameplate-equivalent hours generated, using the already calendar-scaled lifetime energy. */
+export function facilityEquivalentOperatingHours(
+  g: FacilityOperatingType,
+): number | undefined {
+  return !g.peakWh && g.peakW > 0 ? g.lifetimeWh / g.peakW : undefined;
 }
 
 // Returns how much cash the user receives if they sell / cancel the facility. Construction

--- a/src/reducers/FacilityLifetime.test.tsx
+++ b/src/reducers/FacilityLifetime.test.tsx
@@ -4,7 +4,11 @@ import gameReducer, {
   tickState,
   togglePauseFacility,
 } from "./Game";
-import { TICKS_PER_DAY, TICKS_PER_MONTH } from "../Constants";
+import {
+  GAME_TO_REAL_YEARS,
+  TICKS_PER_DAY,
+  TICKS_PER_MONTH,
+} from "../Constants";
 import { facilityLifetime } from "../helpers/Financials";
 import { getTimeFromTimeline } from "../helpers/DateTime";
 import { createGame } from "../testing/Simulator";
@@ -32,6 +36,7 @@ function totals(f: FacilityOperatingType) {
     potentialWh: f.lifetimePotentialWh,
     revenue: f.lifetimeRevenue,
     expenses: f.lifetimeExpenses,
+    starts: f.lifetimeStarts,
   };
 }
 
@@ -121,5 +126,38 @@ describe("per-facility lifetime totals", () => {
     );
 
     expect(after.facilities.map(totals)).toEqual(before);
+  });
+
+  it("charges gas maintenance once on a real off-to-on edge", () => {
+    const state = createGame({ scenarioId: 104, difficulty: "CEO" });
+    const gas = state.facilities.find(
+      (facility: FacilityOperatingType) => facility.fuel === "Natural Gas",
+    ) as FacilityOperatingType;
+    state.facilities.forEach((facility: FacilityOperatingType) => {
+      facility.annualOperatingCost = 0;
+      facility.btuPerWh = 0;
+      facility.currentW = 0;
+      facility.paused = facility.id !== gas.id;
+    });
+    gas.generatingLastRealTick = false;
+    gas.lifetimeStarts = 0;
+    const openingExpenses = gas.lifetimeExpenses;
+    const expectedStartCost = (gas.costPerStart || 0) * GAME_TO_REAL_YEARS;
+
+    tickState(state);
+
+    expect(gas.currentW).toBeGreaterThan(0);
+    expect(gas.lifetimeStarts).toBeCloseTo(GAME_TO_REAL_YEARS, 10);
+    expect(gas.lifetimeExpenses - openingExpenses).toBeCloseTo(
+      expectedStartCost,
+      6,
+    );
+
+    const afterStart = totals(gas);
+    tickState(state);
+    expect(totals(gas)).toMatchObject({
+      expenses: afterStart.expenses,
+      starts: afterStart.starts,
+    });
   });
 });

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -18,6 +18,7 @@ import {
   getMonthlyPayment,
   getPaymentInterest,
   facilityOutputFactor,
+  estimatedAnnualOperatingCost,
 } from "../helpers/Financials";
 import { getInflationRate, getPrimeRate } from "../data/Economy";
 import {
@@ -300,7 +301,9 @@ function generatorCostPerMWh(
     WH_PER_MWH *
     (FUELS[generator.fuel]?.kgCO2ePerBtu || 0) *
     feePerKgCO2e;
-  return generator.annualOperatingCost / annualMWh + fuelCost + carbonCost;
+  return (
+    estimatedAnnualOperatingCost(generator) / annualMWh + fuelCost + carbonCost
+  );
 }
 
 function currentFuelCosts(
@@ -619,6 +622,7 @@ export const gameSlice = createSlice({
           state,
           state.timeline[0],
           state.timeline[0],
+          true,
           true,
         );
       }
@@ -1080,6 +1084,7 @@ export function tickState(state: GameType) {
           state.timeline[0],
           state.timeline[0],
           true,
+          true,
         );
       }
 
@@ -1473,6 +1478,7 @@ function updateSupplyFacilitiesFinances(
   prev: TickPresentFutureType,
   now: TickPresentFutureType,
   simulated?: boolean,
+  preRoll?: boolean,
 ) {
   const { facilities, date } = state;
   const tickDate = getDateFromMinute(now.minute, state.startingYear);
@@ -1531,7 +1537,12 @@ function updateSupplyFacilitiesFinances(
   let hydroReservoirCapacityWh = 0;
   let hydroSpillWh = 0;
   let hydroMandatedReleaseW = 0;
+  const startedFacilityIds = new Set<number>();
   facilities.forEach((g: FacilityOperatingType, i: number) => {
+    const previousW = g.currentW;
+    const previouslyGenerating = simulated
+      ? previousW > 0
+      : (g.generatingLastRealTick ?? previousW > 0);
     let dispatchPeakW = g.peakW;
     const outputFactor = facilityOutputFactor(g, now.minute);
     let mandatedW = 0;
@@ -1599,6 +1610,9 @@ function updateSupplyFacilitiesFinances(
         hydroReservoirWh += g.reservoirWh || 0;
         hydroReservoirCapacityWh += g.reservoirCapacityWh || 0;
       }
+      if (!simulated && g.costPerStart !== undefined) {
+        g.generatingLastRealTick = g.currentW > 0;
+      }
       return;
     }
     if (g.yearsToBuildLeft === 0) {
@@ -1663,6 +1677,17 @@ function updateSupplyFacilitiesFinances(
           g.reservoirWh = Math.max(0, (g.reservoirWh || 0) - generatedWh);
           hydroMandatedReleaseW += Math.min(g.currentW, mandatedW);
         }
+        if (
+          g.costPerStart !== undefined &&
+          !preRoll &&
+          !previouslyGenerating &&
+          g.currentW > 0
+        ) {
+          startedFacilityIds.add(g.id);
+        }
+        if (!simulated && g.costPerStart !== undefined) {
+          g.generatingLastRealTick = g.currentW > 0;
+        }
       }
       if (g.peakWh) {
         // Capable of storing electricity
@@ -1725,7 +1750,7 @@ function updateSupplyFacilitiesFinances(
   // whether it has paid for itself. Curtailed output earns nothing, which pro-rating against the
   // served total is exactly what expresses
   const revenuePerSuppliedW = supply > 0 ? revenue / supply : 0;
-  facilities.forEach((g: FacilityShoppingType) => {
+  facilities.forEach((g: FacilityOperatingType) => {
     // Everything this facility costs the company this tick, so it can be booked against the
     // facility as well as into the company's own totals below
     let facilityExpenses = 0;
@@ -1735,6 +1760,12 @@ function updateSupplyFacilitiesFinances(
         facilityExpenses += g.annualOperatingCost / TICKS_PER_YEAR / 2;
       } else {
         facilityExpenses += g.annualOperatingCost / TICKS_PER_YEAR;
+      }
+      const started = startedFacilityIds.has(g.id);
+      if (started) {
+        // One simulated day stands for the average month. The visible off-to-on edge therefore
+        // represents the same daily start repeated throughout that month.
+        facilityExpenses += (g.costPerStart || 0) * GAME_TO_REAL_YEARS;
       }
       expensesOM += facilityExpenses;
       if (g.fuel && FUELS[g.fuel]) {
@@ -1789,6 +1820,9 @@ function updateSupplyFacilitiesFinances(
           (g.peakW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
         g.lifetimeRevenue += deliveredW * revenuePerSuppliedW;
         g.lifetimeExpenses += facilityExpenses;
+        if (started) {
+          g.lifetimeStarts = (g.lifetimeStarts || 0) + GAME_TO_REAL_YEARS;
+        }
       }
     } else {
       facilityExpenses =
@@ -2045,12 +2079,15 @@ function buildFacilityHelper(
       lifetimePotentialWh: 0,
       lifetimeRevenue: 0,
       lifetimeExpenses: 0,
+      lifetimeStarts: 0,
       id:
         state.facilities.reduce(
           (max: number, f: FacilityOperatingType) => (max > f.id ? max : f.id),
           0,
         ) + 1,
       currentW: newGame && g.peakWh === undefined ? g.peakW : 0,
+      generatingLastRealTick:
+        g.costPerStart !== undefined && newGame && g.peakWh === undefined,
       yearsToBuildLeft: newGame ? 0 : g.yearsToBuild,
       minuteCreated: state.date.minute,
       minuteOperational: newGame


### PR DESCRIPTION
## Summary

- price Natural Gas starts from the EIA AEO2025 419 MW H-class simple-cycle reference: $23,100 per equivalent start, scaled linearly by nameplate and with the normal O&M difficulty/inflation multipliers
- charge real off-to-on dispatch edges as 365/12 represented starts, while excluding initialization and synthetic pre-roll edges and preserving forecast-only counters
- keep the existing $6.87/kW-year plus $1.24/MWh base O&M, and show the build quote as base O&M plus an explicit one-start/day estimate
- add equivalent operating hours, equivalent starts, service-interval context, start-cost context, persistence validation, and replay versioning

For the 419 MW reference, the build card now shows $4.93M/year base O&M, $23.1K/equivalent start, and about $13.4M/year estimated O&M assuming one start/day.

## Verification

- `npm run check`
- 74 test suites, 743 tests passed
- focused build-card and real start-edge regression tests

Closes #227