### PR TITLE
Extend start tracking to thermal plants

### DIFF
--- a/docs/facilities-economics.md
+++ b/docs/facilities-economics.md
@@ -1,6 +1,6 @@
 # Facility economics refresh
 
-Last reviewed: 2026-08-28. The implemented latest observations are 2023 for EIA's engineering
+Last reviewed: 2026-08-29. The implemented latest observations are 2023 for EIA's engineering
 estimates and 2024 for IRENA's global deployment data.
 
 ## Method
@@ -177,11 +177,34 @@ so their introductory economics and controls remain predictable. Existing saves 
 commissioning timestamp still begin their age clock on the first real tick, and saves without a
 degradation field use the modern solar or wind default from the day they resume.
 
-The facility panel now reports equivalent operating hours for generators and equivalent starts for
-natural gas. The 900-start hot-gas-path and 1,800-start major-inspection intervals are shown as
-maintenance context, but do not trigger a second refurbishment bill: EIA's $23,100/start figure is
-already the levelized major-maintenance cost. Maintenance decisions and wear-driven outage risk
-remain separate future work.
+The facility panel now reports equivalent operating hours for generators. It also reports
+equivalent starts for Natural Gas, Coal, Nuclear, Biomass, Geothermal, and Enhanced Geothermal.
+A real zero-to-generating edge represents `365 / 12` starts because the visible day stands for the
+average day in its month; ramping while already above zero does not add another start. Oil remains
+an internal-combustion-generator benchmark, and Hydro is not thermal, so neither is included.
+
+Start tracking and start charges are deliberately separate capabilities:
+
+| Facility | Tracks starts | Non-fuel start charge | Basis |
+| --- | --- | --- | --- |
+| Natural Gas | Yes | EIA's $23,100 per start at 419 MW, size-normalized | H-class simple-cycle reference |
+| Coal | Yes | $81.0185278/MW-start in 2023$, size-normalized | NREL supercritical hot-start cycling plus startup operations |
+| Nuclear | Yes | None | IAEA finds shutdown/startup cycling consequential but unit-specific |
+| Biomass | Yes | None | EIA documents diesel startup burners but no transferable quantity or wear cost |
+| Geothermal | Yes | None | Published lifetime FOM already annualizes overhaul and maintenance |
+| Enhanced Geothermal | Yes | None | Same FOM treatment, without commercial start-cost observations |
+
+Coal uses NREL's conservative hot-start values for 500-1,300 MW supercritical units: $54/MW-start
+of capitalized cycling and maintenance plus $5.81/MW-start of auxiliary operations, chemicals,
+water, and additives. Converting 2011 dollars with CPI-U (`304.702 / 224.939`) gives
+$81.0185278/MW-start in 2023 dollars, or $52,662.04 for the game's 650 MW reference plant before
+difficulty and game inflation. The resulting cost is fixed when the facility is created and is not
+repriced each month. Startup fuel, emissions, EFOR effects, and hot/warm/cold state are not modeled.
+
+Natural Gas alone shows the 900-start hot-gas-path and 1,800-start major-inspection context. Those
+intervals do not trigger a second refurbishment bill: EIA's per-start value is already the
+levelized major-maintenance cost. Maintenance decisions and wear-driven outage risk remain separate
+future work.
 
 ## Commercial technology review
 
@@ -217,4 +240,8 @@ No additional facility type is added in this pass:
 - [NREL 2024 ATB, utility-scale PV degradation assumptions](https://atb.nrel.gov/electricity/2024/utility-scale_pv)
 - [Lawrence Berkeley National Laboratory, U.S. wind-plant performance with age](https://emp.lbl.gov/publications/how-does-wind-project-performance)
 - [BLS, annual CPI-U indexes](https://www.bls.gov/regions/mid-atlantic/data/ConsumerPriceIndexAnnualandSemiAnnual_Table.htm)
+- [NREL, Power Plant Cycling Costs](https://docs.nrel.gov/docs/fy12osti/55433.pdf)
+- [IAEA, Non-baseload Operation in Nuclear Power Plants](https://www-pub.iaea.org/MTCD/Publications/PDF/P1756_web.pdf)
+- [NREL 2024 ATB, Geothermal](https://atb.nrel.gov/electricity/2024/geothermal)
+- [DOE, Geothermal Basics](https://www.energy.gov/hgeo/geothermal/geothermal-basics)
 - [DOE, Long-Duration Energy Storage portfolio](https://www.energy.gov/cmei/oced/long-duration-energy-storage)

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -29,6 +29,8 @@ import {
  */
 
 // Bump on any breaking schema change. Mismatched replays are ignored rather than migrated.
+// 7 extends equivalent-start tracking to thermal steam/geothermal plants and charges Coal; older
+// replays would have different Coal finances.
 // 6 adds start-based gas-turbine maintenance; older replays would have different finances.
 // 5 adds age-dependent renewable output and authored starting ages; older replays would dispatch
 // a different amount of solar and wind even if they contain exactly the same actions.
@@ -37,7 +39,7 @@ import {
 // 3 adds offshore wind weather and generation; an older replay would simulate a different grid.
 // 2 added `location`: a v1 replay names only a scenario, and a scenario no longer pins down
 // where it is played, so there is no safe way to migrate one.
-export const REPLAY_VERSION = 6;
+export const REPLAY_VERSION = 7;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -115,7 +115,15 @@ export function parseSave(raw: unknown): SaveGameType | null {
           value !== undefined &&
           (typeof value !== "number" || !Number.isFinite(value) || value < 0),
       );
-      return requiredNumbersInvalid || optionalNumbersInvalid;
+      const optionalBooleansInvalid = [
+        current.tracksStarts,
+        current.generatingLastRealTick,
+      ].some((value) => value !== undefined && typeof value !== "boolean");
+      return (
+        requiredNumbersInvalid ||
+        optionalNumbersInvalid ||
+        optionalBooleansInvalid
+      );
     }) ||
     !Array.isArray(game.timeline) ||
     !Array.isArray(game.monthlyHistory) ||

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -392,8 +392,11 @@ export interface GeneratorShoppingType extends SharedShoppingType {
   annualOutputDegradation?: number;
   spinMinutes: number; // 1 for renewables, to avoid eating up CPU on coersing to 1 in case it doesn't exist
   btuPerWh: number; // Heat Rate, but per W for less math per frame
-  // Non-fuel maintenance charged for one physical start. Only present when the technology's
-  // source case reports it separately from fixed and output-dependent O&M.
+  // Explicit because neither purchased fuel nor a start charge identifies every thermal plant:
+  // geothermal buys no fuel, while the Oil facility is an internal-combustion generator.
+  tracksStarts?: boolean;
+  // Non-fuel expense charged for one physical start. Only present when the technology's source
+  // case reports a transferable amount separately from fixed and output-dependent O&M.
   costPerStart?: number;
   // Conventional hydro only. whPerMm is calibrated against the loaded watershed record so that
   // long-run inflow lands on capacityFactor without flattening wet and dry years.

--- a/src/components/base/FacilityDetails.tsx
+++ b/src/components/base/FacilityDetails.tsx
@@ -200,13 +200,13 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
             value={Math.round(equivalentOperatingHours).toLocaleString()}
           />
         )}
-        {facility.costPerStart !== undefined && (
+        {facility.tracksStarts && (
           <Stat
             label="Equivalent starts"
             value={Math.round(facility.lifetimeStarts || 0).toLocaleString()}
           />
         )}
-        {facility.costPerStart !== undefined && (
+        {facility.tracksStarts && fuel === "Natural Gas" && (
           <Stat
             label="Service intervals"
             value="HGP 900 · major 1,800 starts"
@@ -214,11 +214,11 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
         )}
         {facility.costPerStart !== undefined && (
           <Stat
-            label="Start maintenance"
+            label="Non-fuel start cost"
             value={`${formatMoneyConcise(facility.costPerStart)}/start`}
           />
         )}
-        {facility.costPerStart !== undefined && (
+        {facility.tracksStarts && (
           <Stat
             label="Start accounting"
             value="Each simulated day represents its month"

--- a/src/components/views/BuildGenerators.test.tsx
+++ b/src/components/views/BuildGenerators.test.tsx
@@ -38,12 +38,44 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
   ).toBeInTheDocument();
   expect(
     screen.getByRole("row", {
-      name: /Startup maintenance.*Per equivalent start.*\$23\.1k\/start/,
+      name: /Non-fuel start cost.*Per equivalent start.*\$23\.1k\/start/,
     }),
   ).toBeInTheDocument();
   expect(
     screen.getByRole("row", {
       name: /Estimated O&M.*Base O&M plus one start\/day.*\$13\.4M\/yr/,
+    }),
+  ).toBeInTheDocument();
+});
+
+it("shows Coal's physical and representative-day start charges", () => {
+  const game = createGame({ scenarioId: 104, difficulty: "CEO" });
+  const generator = GENERATORS(game, 650000000, [], []).find(
+    (candidate) => candidate.name === "Coal",
+  );
+  expect(generator).toBeDefined();
+
+  render(
+    <GeneratorBuildItem
+      cash={1000000000}
+      date={game.date}
+      interestRate={game.interestRate}
+      generator={generator!}
+      location={game.location}
+      seed={game.seed}
+      onBuild={jest.fn()}
+    />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Show Coal details" }));
+
+  expect(
+    screen.getByRole("row", {
+      name: /Non-fuel start cost.*Per equivalent start.*\$52\.7k\/start/,
+    }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("row", {
+      name: /Representative-day charge.*365 \/ 12 equivalent starts.*\$1\.6M\/displayed start/,
     }),
   ).toBeInTheDocument();
 });

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -42,6 +42,7 @@ import { getFuelPricesPerMBTU } from "../../data/FuelPrices";
 import {
   DOWNPAYMENT_PERCENT,
   FUELS,
+  GAME_TO_REAL_YEARS,
   LOAN_MONTHS,
   TICKS_PER_YEAR,
 } from "../../Constants";
@@ -262,13 +263,29 @@ export function GeneratorBuildItem(
               {generator.costPerStart !== undefined && (
                 <TableRow>
                   <TableCell>
-                    Startup maintenance
+                    Non-fuel start cost
                     <Typography variant="body2" color="textSecondary">
                       Per equivalent start
                     </Typography>
                   </TableCell>
                   <TableCell align="right">
                     {formatMoneyConcise(generator.costPerStart)}/start
+                  </TableCell>
+                </TableRow>
+              )}
+              {generator.costPerStart !== undefined && (
+                <TableRow>
+                  <TableCell>
+                    Representative-day charge
+                    <Typography variant="body2" color="textSecondary">
+                      365 / 12 equivalent starts
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatMoneyConcise(
+                      generator.costPerStart * GAME_TO_REAL_YEARS,
+                    )}
+                    /displayed start
                   </TableCell>
                 </TableRow>
               )}

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -94,6 +94,27 @@ describe("the fleet list", () => {
     expect(screen.getByText("Earned")).toBeInTheDocument();
   });
 
+  it("shows Coal starts and cost without gas-turbine service intervals", () => {
+    const coal = game.facilities.find((facility) => facility.name === "Coal")!;
+    renderFacilities(game, coal.id);
+
+    expect(screen.getByText("Equivalent starts")).toBeInTheDocument();
+    expect(screen.getByText("Non-fuel start cost")).toBeInTheDocument();
+    expect(screen.queryByText("Service intervals")).toBeNull();
+  });
+
+  it("keeps gas-turbine service context on Natural Gas", () => {
+    const gas = game.facilities.find(
+      (facility) => facility.name === "Natural Gas",
+    )!;
+    renderFacilities(game, gas.id);
+
+    expect(screen.getByText("Service intervals")).toBeInTheDocument();
+    expect(
+      screen.getByText("HGP 900 · major 1,800 starts"),
+    ).toBeInTheDocument();
+  });
+
   it("leaves every row closed when nothing is selected", () => {
     renderFacilities(game, null);
     expect(screen.queryByText("Lifetime profit")).toBeNull();

--- a/src/data/Facilities.test.tsx
+++ b/src/data/Facilities.test.tsx
@@ -4,6 +4,7 @@ import {
   GENERATORS,
   STORAGE,
 } from "./Facilities";
+import { GAME_TO_REAL_YEARS } from "../Constants";
 import { getDateFromMinute } from "../helpers/DateTime";
 import { FacilityOperatingType, GameType, LocationType } from "../Types";
 
@@ -110,6 +111,44 @@ describe("current facility economics", () => {
     expect(
       generatorAt(2023, "Natural Gas", 100000000)?.costPerStart,
     ).toBeCloseTo((23100 * 100) / 419, 8);
+  });
+
+  it("scales Coal's CPI-normalized hot-start expense by nameplate MW", () => {
+    const referenceCost = generatorAt(2023, "Coal", 650000000)?.costPerStart;
+    expect(referenceCost).toBeCloseTo(52662.043056, 6);
+    expect((referenceCost || 0) * GAME_TO_REAL_YEARS).toBeCloseTo(
+      1601803.809623,
+      5,
+    );
+    const hundredMwCost = generatorAt(2023, "Coal", 100000000)?.costPerStart;
+    expect(hundredMwCost).toBeCloseTo(8101.852778, 6);
+    expect((hundredMwCost || 0) * GAME_TO_REAL_YEARS).toBeCloseTo(
+      246431.355328,
+      5,
+    );
+  });
+
+  it("tracks starts only for the audited thermal facilities", () => {
+    const generators = GENERATORS(stateAt(iceland, 2030), 50000000, [], []);
+    const byName = (name: string) =>
+      generators.find((generator) => generator.name === name);
+
+    for (const name of [
+      "Natural Gas",
+      "Coal",
+      "Nuclear",
+      "Biomass",
+      "Geothermal",
+      "Enhanced Geothermal",
+    ]) {
+      expect(byName(name)?.tracksStarts).toBe(true);
+    }
+    expect(byName("Oil")?.tracksStarts).toBeUndefined();
+    expect(byName("Hydro")?.tracksStarts).toBeUndefined();
+    expect(byName("Nuclear")?.costPerStart).toBeUndefined();
+    expect(byName("Biomass")?.costPerStart).toBeUndefined();
+    expect(byName("Geothermal")?.costPerStart).toBeUndefined();
+    expect(byName("Enhanced Geothermal")?.costPerStart).toBeUndefined();
   });
 
   it("uses the 2024 ATB midpoint for ten-hour pumped hydro", () => {

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -52,6 +52,20 @@ function offshoreEraMultiple(year: number): number {
 // annual-average CPI-U from BLS, not the game's inflation: that is applied separately below.
 const CPI_2019_TO_2023 = 304.702 / 255.657;
 const CPI_2020_TO_2024 = 313.689 / 258.811;
+// NREL's 500-1,300 MW supercritical-coal class reports $54/MW-start of capitalized
+// cycling/maintenance plus $5.81/MW-start of other startup operations, in 2011 dollars.
+const COAL_START_COST_PER_MW_2023 = (54 + 5.81) * (304.702 / 224.939);
+
+// Used only to upgrade current-version saves written before start tracking was added to these
+// technologies. New shopping and operating records carry the explicit tracksStarts field below.
+export const START_TRACKING_FACILITY_NAMES = new Set([
+  "Natural Gas",
+  "Coal",
+  "Nuclear",
+  "Biomass",
+  "Geothermal",
+  "Enhanced Geothermal",
+]);
 
 /** Exponential interpolation between two real-cost observations, held flat outside them. */
 function costBetween(
@@ -210,6 +224,10 @@ export function GENERATORS(
       // 6 hours - https://spectrum.ieee.org/green-tech/wind/taming-wind-power-with-better-forecasts
       // 4-8 hours - https://www.reuters.com/article/coal-power-generation/column-to-...wer-plants-must-become-more-flexible-kemp-idUSL5N0J42YG20131119
       annualOperatingCost: annualOperatingCost(peakW, 0.68, 61.6, 6.4),
+      tracksStarts: true,
+      // NREL's conservative hot-start case, normalized from 2011$ to 2023$ with annual-average
+      // CPI-U and scaled by nameplate MW. Fuel input and EFOR effects are deliberately excluded.
+      costPerStart: COAL_START_COST_PER_MW_2023 * (peakW / 1000000),
       yearsToBuild: 4 + magnitude / 3,
       // AEO2025 reference lead time is 60 months and operating life is 40 years.
       capacityFactor: 0.68,
@@ -235,6 +253,7 @@ export function GENERATORS(
       btuPerWh: 10.608,
       spinMinutes: 600,
       annualOperatingCost: annualOperatingCost(peakW, 0.93, 156.2, 2.52),
+      tracksStarts: true,
       yearsToBuild: 6 + magnitude / 3,
       // AEO2025 reference lead time is 84 months and operating life is 40 years.
       capacityFactor: 0.93,
@@ -260,6 +279,7 @@ export function GENERATORS(
       btuPerWh: 9.142,
       spinMinutes: 10,
       annualOperatingCost: annualOperatingCost(peakW, 0.45, 6.87, 1.24),
+      tracksStarts: true,
       // EIA AEO2025 Case 4 reports this separately from both fixed and variable O&M:
       // $23,100 per equivalent start for its 419 MW H-class simple-cycle reference plant.
       costPerStart: 23100 * (peakW / 419000000),
@@ -322,6 +342,7 @@ export function GENERATORS(
       // has one annual O&M field, so both are converted to 2018 dollars and variable O&M is
       // annualized at the observed 60.2% capacity factor.
       annualOperatingCost: 0.14471 * peakW,
+      tracksStarts: true,
       yearsToBuild: 5,
       // 2022 U.S. "other biomass" fleet average; wood was 57.9% in the same table.
       // https://www.eia.gov/electricity/annual/table.php?t=epa_04_08_b.html
@@ -512,6 +533,7 @@ export function GENERATORS(
       // ~800MW, except for one outlier - https://en.wikipedia.org/wiki/List_of_largest_power_stations#Geothermal
       btuPerWh: 0,
       annualOperatingCost: annualOperatingCost(peakW, 0.88, 150.6, 0),
+      tracksStarts: true,
       yearsToBuild: 3,
       // EIA AEO2025 reference lead time is 36 months and operating life is 40 years.
       spinMinutes: 1,
@@ -531,6 +553,7 @@ export function GENERATORS(
       maxPeakW: 500000000,
       btuPerWh: 0,
       annualOperatingCost: 0.16 * peakW,
+      tracksStarts: true,
       yearsToBuild: 3 + magnitude / 4,
       spinMinutes: 1,
       capacityFactor: 0.83,

--- a/src/reducers/FacilityLifetime.test.tsx
+++ b/src/reducers/FacilityLifetime.test.tsx
@@ -102,18 +102,29 @@ describe("per-facility lifetime totals", () => {
 
   it("does not count a forecast as time the fleet lived through", () => {
     const state = play(createGame({ scenarioId: 103 }), 8);
+    const coal = state.facilities[0];
+    coal.currentW = 0;
+    coal.generatingLastRealTick = false;
+    coal.annualOperatingCost = 0;
+    coal.btuPerWh = 0;
     const before = state.facilities.map(totals);
 
     const now = getTimeFromTimeline(state.date.minute, state.timeline);
     // A year of simulation, which the Forecasts pane asks for on every month rollover
-    generateNewTimeline(
+    const forecast = generateNewTimeline(
       state,
       now?.cash || 0,
       now?.customers || 0,
       TICKS_PER_DAY * 12,
     );
 
+    expect(forecast[0].expensesOM).toBeCloseTo(
+      (coal.costPerStart || 0) * GAME_TO_REAL_YEARS,
+      6,
+    );
     expect(state.facilities.map(totals)).toEqual(before);
+    expect(coal.currentW).toBe(0);
+    expect(coal.generatingLastRealTick).toBe(false);
   });
 
   it("does not count the reforecast a player action triggers", () => {
@@ -128,36 +139,71 @@ describe("per-facility lifetime totals", () => {
     expect(after.facilities.map(totals)).toEqual(before);
   });
 
-  it("charges gas maintenance once on a real off-to-on edge", () => {
-    const state = createGame({ scenarioId: 104, difficulty: "CEO" });
-    const gas = state.facilities.find(
-      (facility: FacilityOperatingType) => facility.fuel === "Natural Gas",
+  it("charges a start once to both Coal lifetime and company O&M", () => {
+    const state = createGame({ scenarioId: 103, difficulty: "CEO" });
+    // Let the opening tick build the month's forecast before forcing the real start under test.
+    tickState(state);
+    const coal = state.facilities.find(
+      (facility: FacilityOperatingType) => facility.fuel === "Coal",
     ) as FacilityOperatingType;
     state.facilities.forEach((facility: FacilityOperatingType) => {
       facility.annualOperatingCost = 0;
       facility.btuPerWh = 0;
       facility.currentW = 0;
-      facility.paused = facility.id !== gas.id;
+      facility.paused = facility.id !== coal.id;
     });
-    gas.generatingLastRealTick = false;
-    gas.lifetimeStarts = 0;
-    const openingExpenses = gas.lifetimeExpenses;
-    const expectedStartCost = (gas.costPerStart || 0) * GAME_TO_REAL_YEARS;
+    coal.generatingLastRealTick = false;
+    coal.lifetimeStarts = 0;
+    const openingExpenses = coal.lifetimeExpenses;
+    const expectedStartCost = (coal.costPerStart || 0) * GAME_TO_REAL_YEARS;
 
     tickState(state);
 
-    expect(gas.currentW).toBeGreaterThan(0);
-    expect(gas.lifetimeStarts).toBeCloseTo(GAME_TO_REAL_YEARS, 10);
-    expect(gas.lifetimeExpenses - openingExpenses).toBeCloseTo(
+    expect(coal.currentW).toBeGreaterThan(0);
+    expect(coal.lifetimeStarts).toBeCloseTo(GAME_TO_REAL_YEARS, 10);
+    expect(
+      getTimeFromTimeline(state.date.minute, state.timeline)?.expensesOM,
+    ).toBeCloseTo(expectedStartCost, 6);
+    expect(coal.lifetimeExpenses - openingExpenses).toBeCloseTo(
       expectedStartCost,
       6,
     );
 
-    const afterStart = totals(gas);
+    const afterStart = totals(coal);
     tickState(state);
-    expect(totals(gas)).toMatchObject({
+    expect(totals(coal)).toMatchObject({
       expenses: afterStart.expenses,
       starts: afterStart.starts,
     });
   });
+
+  it.each(["Nuclear", "Biomass", "Geothermal", "Enhanced Geothermal"])(
+    "tracks a zero-cost %s start without adding an expense",
+    (name) => {
+      const state = createGame({ scenarioId: 103 });
+      tickState(state);
+      const coal = state.facilities[0];
+      state.facilities.forEach((facility: FacilityOperatingType) => {
+        facility.annualOperatingCost = 0;
+        facility.btuPerWh = 0;
+        facility.currentW = 0;
+        facility.paused = facility.id !== coal.id;
+      });
+      coal.name = name;
+      coal.tracksStarts = true;
+      coal.costPerStart = undefined;
+      coal.generatingLastRealTick = false;
+      coal.lifetimeStarts = 0;
+      const openingExpenses = coal.lifetimeExpenses;
+
+      tickState(state);
+
+      expect(coal.currentW).toBeGreaterThan(0);
+      expect(coal.lifetimeStarts).toBeCloseTo(GAME_TO_REAL_YEARS, 10);
+      expect(coal.lifetimeExpenses).toBe(openingExpenses);
+      expect(
+        getTimeFromTimeline(state.date.minute, state.timeline)?.expensesOM,
+      ).toBe(0);
+    },
+  );
 });

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -86,6 +86,7 @@ import {
 } from "../Constants";
 import {
   GENERATORS,
+  START_TRACKING_FACILITY_NAMES,
   STORAGE,
   windAnnualOutputDegradation,
 } from "../data/Facilities";
@@ -674,6 +675,19 @@ export const gameSlice = createSlice({
     });
     builder.addCase(resume, (_state, action) => {
       const restored = cloneDeep(action.payload);
+      restored.facilities.forEach((facility) => {
+        // Save v6 predates the explicit capability for these technologies. Upgrade the facility
+        // snapshot once on resume, starting from its actual generating state so loading an online
+        // plant does not invent an opening start. Historical starts and charges remain unknown.
+        if (
+          facility.tracksStarts === undefined &&
+          START_TRACKING_FACILITY_NAMES.has(facility.name)
+        ) {
+          facility.tracksStarts = true;
+          facility.lifetimeStarts = facility.lifetimeStarts || 0;
+          facility.generatingLastRealTick = facility.currentW > 0;
+        }
+      });
       // The tick loop's module-level locals have to line up with the state being restored.
       // Unlike initGame, this one keeps the month: clearing it would make the first tick record a
       // second history entry for a month that's already in the log.
@@ -1616,7 +1630,7 @@ function updateSupplyFacilitiesFinances(
         hydroReservoirWh += g.reservoirWh || 0;
         hydroReservoirCapacityWh += g.reservoirCapacityWh || 0;
       }
-      if (!simulated && g.costPerStart !== undefined) {
+      if (!simulated && g.tracksStarts) {
         g.generatingLastRealTick = g.currentW > 0;
       }
       return;
@@ -1687,14 +1701,14 @@ function updateSupplyFacilitiesFinances(
           hydroMandatedReleaseW += Math.min(g.currentW, mandatedW);
         }
         if (
-          g.costPerStart !== undefined &&
+          g.tracksStarts &&
           !preRoll &&
           !previouslyGenerating &&
           g.currentW > 0
         ) {
           startedFacilityIds.add(g.id);
         }
-        if (!simulated && g.costPerStart !== undefined) {
+        if (!simulated && g.tracksStarts) {
           g.generatingLastRealTick = g.currentW > 0;
         }
       }
@@ -2097,7 +2111,7 @@ function buildFacilityHelper(
         ) + 1,
       currentW: newGame && g.peakWh === undefined ? g.peakW : 0,
       generatingLastRealTick:
-        g.costPerStart !== undefined && newGame && g.peakWh === undefined,
+        g.tracksStarts && newGame && g.peakWh === undefined,
       yearsToBuildLeft: newGame ? 0 : g.yearsToBuild,
       minuteCreated: state.date.minute,
       minuteOperational: newGame

--- a/src/reducers/Resume.test.tsx
+++ b/src/reducers/Resume.test.tsx
@@ -51,6 +51,26 @@ describe("resume", () => {
     expect(gameReducer(restored, loaded()).inGame).toBe(true);
   });
 
+  it("upgrades old thermal facilities without inventing an opening start", () => {
+    const oldSave = serialized(createGame({ scenarioId: 103, seed: 8675309 }));
+    const coal = oldSave.facilities.find(
+      (facility) => facility.name === "Coal",
+    )!;
+    coal.tracksStarts = undefined;
+    coal.costPerStart = undefined;
+    coal.lifetimeStarts = undefined;
+    coal.generatingLastRealTick = undefined;
+
+    const restored = restore(oldSave);
+    const restoredCoal = restored.facilities.find(
+      (facility) => facility.name === "Coal",
+    )!;
+    expect(restoredCoal.tracksStarts).toBe(true);
+    expect(restoredCoal.costPerStart).toBeUndefined();
+    expect(restoredCoal.lifetimeStarts).toBe(0);
+    expect(restoredCoal.generatingLastRealTick).toBe(restoredCoal.currentW > 0);
+  });
+
   /**
    * The regression the restored previousMonth guards: the tick loop's month tracker lives outside
    * Redux, so a resume that cleared it (the way initGame does) would roll the month over on the


### PR DESCRIPTION
## Summary
- add explicit equivalent-start tracking for Coal, Nuclear, Biomass, Geothermal, and Enhanced Geothermal while preserving Natural Gas behavior
- charge Coal the CPI-normalized NREL hot-start non-fuel cost and include it in quotes, forecasts, company O&M, and facility lifetime expenses
- migrate existing saves safely, gate gas-only service context, bump replay compatibility, and document the technology audit

## Validation
- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false --runInBand (74 suites, 755 tests)
- npm run build

Closes #243