### PR TITLE
Model Oil engine fixed and variable O&M

### DIFF
--- a/docs/facilities-economics.md
+++ b/docs/facilities-economics.md
@@ -45,10 +45,10 @@ detailed design is used for duration, life, construction time, and augmentation 
 
 ## Operating and performance logic
 
-The simulation has one annual non-fuel O&M field, while EIA reports fixed O&M in $/kW-year and
-variable O&M in $/MWh. For generators, variable O&M is converted to an annual amount at the
-facility's modeled capacity factor and added to fixed O&M. Actual fuel and carbon expenses remain
-separate.
+Most generator records retain one annual non-fuel O&M field: where a source separates fixed O&M
+in $/kW-year and variable O&M in $/MWh, the variable amount remains annualized at the modeled
+capacity factor for those technologies. Oil is the explicit exception described below. Actual fuel
+and carbon expenses remain separate for every generator.
 
 The EIA AEO2025 reference designs also update:
 
@@ -61,6 +61,14 @@ The EIA AEO2025 reference designs also update:
   The build quote adds one start per day ($8.432 million/year for the reference plant) to make the
   tradeoff legible, while live play charges only on actual off-to-on edges. Because one simulated
   day represents a month, each visible edge represents 365/12 equivalent starts.
+- Oil: the matched EIA commercial Oil reciprocating-engine case reports $24/kW-year fixed O&M and
+  $20/MWh variable O&M in 2015 dollars. Annual-average CPI-U (`304.702 / 237.017`) converts these
+  to $30.8536856/kW-year and $25.7114047/MWh in 2023 dollars. Fixed O&M scales with nameplate and
+  variable O&M is charged against actual representative-month generation. A 100 MW build at the
+  modeled 20% capacity factor therefore quotes $3.085 million/year fixed plus $4.505 million/year
+  variable, or $7.590 million/year before difficulty and later game inflation. Those multipliers
+  are persisted at construction. Legacy facilities recover the same multiplier from their former
+  `$0.05 × peakW` annual cost before adopting the split; prior expense history is unchanged.
 - Onshore wind: $33.06/kW-year fixed O&M, 21-month reference lead time, and 25-year life.
 - Offshore wind, added on `master` while this refresh was in progress, already uses the same EIA
   AEO2025 study: $3,689/kW and $154/kW-year for its 900 MW fixed-bottom reference plant.
@@ -168,8 +176,9 @@ The simulation now distinguishes three aging effects that were previously easy t
 
 At 0.5% annual degradation, solar retains `0.995^20 = 90.5%` of its original output after 20
 years—about a 9.5% loss, not 20%. Weather and curtailment still vary actual production around that
-aged maximum. The build screen's lifetime cost integrates the same compounding output curve, while
-annual O&M remains flat; fuel and carbon costs continue to scale only with energy actually produced.
+aged maximum. The build screen's lifetime cost integrates the same compounding output curve. Fixed
+annual O&M remains flat; Oil variable O&M, fuel, and carbon costs scale only with energy actually
+produced.
 
 Scenario starting ages are deliberately authored rather than inferred from technology or scenario
 year. The narrative scenarios now begin with mixed-age inherited fleets; tutorials keep new assets
@@ -181,18 +190,20 @@ The facility panel now reports equivalent operating hours for generators. It als
 equivalent starts for Natural Gas, Coal, Nuclear, Biomass, Geothermal, and Enhanced Geothermal.
 A real zero-to-generating edge represents `365 / 12` starts because the visible day stands for the
 average day in its month; ramping while already above zero does not add another start. Oil remains
-an internal-combustion-generator benchmark, and Hydro is not thermal, so neither is included.
+an internal-combustion-generator benchmark whose use-driven maintenance follows generated MWh, and
+Hydro is not thermal, so neither is included.
 
 Start tracking and start charges are deliberately separate capabilities:
 
-| Facility | Tracks starts | Non-fuel start charge | Basis |
-| --- | --- | --- | --- |
-| Natural Gas | Yes | EIA's $23,100 per start at 419 MW, size-normalized | H-class simple-cycle reference |
-| Coal | Yes | $81.0185278/MW-start in 2023$, size-normalized | NREL supercritical hot-start cycling plus startup operations |
-| Nuclear | Yes | None | IAEA finds shutdown/startup cycling consequential but unit-specific |
-| Biomass | Yes | None | EIA documents diesel startup burners but no transferable quantity or wear cost |
-| Geothermal | Yes | None | Published lifetime FOM already annualizes overhaul and maintenance |
-| Enhanced Geothermal | Yes | None | Same FOM treatment, without commercial start-cost observations |
+| Facility            | Tracks starts | Non-fuel start charge                              | Basis                                                                                   |
+| ------------------- | ------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Natural Gas         | Yes           | EIA's $23,100 per start at 419 MW, size-normalized | H-class simple-cycle reference                                                          |
+| Coal                | Yes           | $81.0185278/MW-start in 2023$, size-normalized     | NREL supercritical hot-start cycling plus startup operations                            |
+| Nuclear             | Yes           | None                                               | IAEA finds shutdown/startup cycling consequential but unit-specific                     |
+| Biomass             | Yes           | None                                               | EIA documents diesel startup burners but no transferable quantity or wear cost          |
+| Geothermal          | Yes           | None                                               | Published lifetime FOM already annualizes overhaul and maintenance                      |
+| Enhanced Geothermal | Yes           | None                                               | Same FOM treatment, without commercial start-cost observations                          |
+| Oil                 | No            | None                                               | Reciprocating-engine service follows use; starts do not change its maintenance schedule |
 
 Coal uses NREL's conservative hot-start values for 500-1,300 MW supercritical units: $54/MW-start
 of capitalized cycling and maintenance plus $5.81/MW-start of auxiliary operations, chemicals,
@@ -226,6 +237,8 @@ No additional facility type is added in this pass:
 - [EIA, Capital Cost and Performance Characteristics for Utility-Scale Electric Power Generating Technologies, AEO2025](https://www.eia.gov/analysis/studies/powerplants/capitalcost/pdf/capital_cost_AEO2025.pdf)
 - [EIA, 2020 edition of the same standardized study](https://www.eia.gov/analysis/studies/powerplants/capitalcost/archive/2020/pdf/capital_cost_AEO2020.pdf)
 - [EIA, construction costs for generators installed in 2023](https://www.eia.gov/electricity/generatorcosts/)
+- [EIA, Distributed Generation and Combined Heat & Power System Characteristics and Costs in the Buildings Sector](https://www.eia.gov/analysis/studies/buildings/distrigen/pdf/dg_chp.pdf)
+- [Wärtsilä, Combustion Engine Power Plants](https://www.wartsila.com/docs/default-source/power-plants-documents/downloads/white-papers/general/wartsila-bwp-combustion-engine-power-plants.pdf)
 - [IRENA, Renewable Power Generation Costs in 2024](https://www.irena.org/Publications/2025/Jun/Renewable-Power-Generation-Costs-in-2024)
 - [IRENA, Renewable Power Generation Costs in 2020](https://www.irena.org/Publications/2021/Jun/Renewable-Power-Costs-in-2020)
 - [NREL, Cost Projections for Utility-Scale Battery Storage: 2021 Update](https://docs.nrel.gov/docs/fy21osti/79236.pdf)

--- a/src/Replay.test.tsx
+++ b/src/Replay.test.tsx
@@ -104,6 +104,30 @@ describe("recordReplayAction", () => {
     ).toEqual(replay);
   });
 
+  it("round-trips an Oil build's variable O&M", () => {
+    const replay = aReplay({
+      actions: [
+        {
+          minute: 0,
+          type: "buildFacility",
+          payload: {
+            facility: {
+              name: "Oil",
+              fuel: "Oil",
+              peakW: 100000000,
+              annualOperatingCost: 3085368.560061,
+              variableOperatingCostPerMWh: 25.711404667176,
+            },
+            financed: false,
+          },
+        },
+      ],
+    });
+    expect(
+      decodeReplay(JSON.parse(JSON.stringify(encodeReplay(replay)))),
+    ).toEqual(replay);
+  });
+
   it("merges deltas fired within one minute", () => {
     const game = aGame(60, []);
     recordReplayAction(game, "delta", { dollarsPerkWh: 0.1 });

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -29,6 +29,8 @@ import {
  */
 
 // Bump on any breaking schema change. Mismatched replays are ignored rather than migrated.
+// 8 splits Oil's non-fuel O&M into fixed and output-dependent expenses; older replays would have
+// different Oil dispatch finances.
 // 7 extends equivalent-start tracking to thermal steam/geothermal plants and charges Coal; older
 // replays would have different Coal finances.
 // 6 adds start-based gas-turbine maintenance; older replays would have different finances.
@@ -39,7 +41,7 @@ import {
 // 3 adds offshore wind weather and generation; an older replay would simulate a different grid.
 // 2 added `location`: a v1 replay names only a scenario, and a scenario no longer pins down
 // where it is played, so there is no safe way to migrate one.
-export const REPLAY_VERSION = 7;
+export const REPLAY_VERSION = 8;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -45,6 +45,13 @@ describe("SaveGame", () => {
     expect(save!.game.facilities).toEqual(game.facilities);
     expect(save!.game.monthlyHistory).toEqual(game.monthlyHistory);
     expect(cash(save!.game)).toBe(cash(game));
+    expect(
+      save!.game.facilities.find((facility) => facility.name === "Oil")
+        ?.variableOperatingCostPerMWh,
+    ).toBe(
+      game.facilities.find((facility) => facility.name === "Oil")
+        ?.variableOperatingCostPerMWh,
+    );
   });
 
   // The memo must never alias the live game slice, or a Continue button would describe a game
@@ -101,6 +108,20 @@ describe("SaveGame", () => {
       GameType["facilities"][number]
     >;
     delete facility.lifetimeRevenue;
+    expect(
+      parseSave({
+        ...save,
+        game: { ...save.game, facilities: [facility] },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects a non-finite variable operating cost", () => {
+    const save = serializeSave(game);
+    const facility = {
+      ...save.game.facilities[0],
+      variableOperatingCostPerMWh: Number.POSITIVE_INFINITY,
+    };
     expect(
       parseSave({
         ...save,

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -101,15 +101,18 @@ export function parseSave(raw: unknown): SaveGameType | null {
       }
       const current = facility as Record<string, unknown>;
       const requiredNumbersInvalid = [
+        current.annualOperatingCost,
         current.lifespanYears,
         current.lifetimeWh,
         current.lifetimePotentialWh,
         current.lifetimeRevenue,
         current.lifetimeExpenses,
+        current.peakW,
       ].some((value) => typeof value !== "number" || !Number.isFinite(value));
       const optionalNumbersInvalid = [
         current.costPerStart,
         current.lifetimeStarts,
+        current.variableOperatingCostPerMWh,
       ].some(
         (value) =>
           value !== undefined &&

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -398,6 +398,9 @@ export interface GeneratorShoppingType extends SharedShoppingType {
   // Non-fuel expense charged for one physical start. Only present when the technology's source
   // case reports a transferable amount separately from fixed and output-dependent O&M.
   costPerStart?: number;
+  // Non-fuel O&M charged against actual generation. Optional because most legacy technology
+  // records already annualize every non-fuel operating expense into annualOperatingCost.
+  variableOperatingCostPerMWh?: number;
   // Conventional hydro only. whPerMm is calibrated against the loaded watershed record so that
   // long-run inflow lands on capacityFactor without flattening wet and dry years.
   reservoirCapacityWh?: number;

--- a/src/components/base/FacilityDetails.tsx
+++ b/src/components/base/FacilityDetails.tsx
@@ -116,6 +116,9 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
   const { facility, date, seed, location } = props;
   const lifetime = facilityLifetime(facility);
   const fuel = (facility as Partial<GeneratorOperatingType>).fuel;
+  const variableOperatingCostPerMWh = (
+    facility as Partial<GeneratorOperatingType>
+  ).variableOperatingCostPerMWh;
   const isStorage = facility.peakWh > 0;
   const accentColor = facilityColor(fuel);
   const underConstruction = facility.yearsToBuildLeft > 0;
@@ -198,6 +201,18 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
           <Stat
             label="Equivalent operating hours"
             value={Math.round(equivalentOperatingHours).toLocaleString()}
+          />
+        )}
+        {variableOperatingCostPerMWh !== undefined && (
+          <Stat
+            label="Fixed O&M"
+            value={`${formatMoneyConcise(facility.annualOperatingCost)}/yr`}
+          />
+        )}
+        {variableOperatingCostPerMWh !== undefined && (
+          <Stat
+            label="Variable O&M"
+            value={`$${variableOperatingCostPerMWh.toFixed(2)}/MWh generated`}
           />
         )}
         {facility.tracksStarts && (

--- a/src/components/views/BuildGenerators.test.tsx
+++ b/src/components/views/BuildGenerators.test.tsx
@@ -79,3 +79,46 @@ it("shows Coal's physical and representative-day start charges", () => {
     }),
   ).toBeInTheDocument();
 });
+
+it("shows Oil's fixed, variable, and expected-output O&M", () => {
+  const game = createGame({ scenarioId: 104, difficulty: "CEO" });
+  const generator = GENERATORS(game, 100000000, [], []).find(
+    (candidate) => candidate.name === "Oil",
+  );
+  expect(generator).toBeDefined();
+
+  render(
+    <GeneratorBuildItem
+      cash={1000000000}
+      date={game.date}
+      interestRate={game.interestRate}
+      generator={generator!}
+      location={game.location}
+      seed={game.seed}
+      onBuild={jest.fn()}
+    />,
+  );
+
+  expect(
+    screen.getByText("Estimated O&M (20% expected output)"),
+  ).toBeInTheDocument();
+  expect(screen.getByText("$7.59M/yr")).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "Show Oil details" }));
+
+  expect(
+    screen.getByRole("row", {
+      name: /Fixed O&M.*Standing annual expense.*\$3\.09M\/yr/,
+    }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("row", {
+      name: /Variable O&M.*Per generated MWh.*\$25\.71\/MWh generated/,
+    }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("row", {
+      name: /Estimated O&M.*20% expected output.*\$7\.59M\/yr/,
+    }),
+  ).toBeInTheDocument();
+  expect(screen.queryByText("Non-fuel start cost")).toBeNull();
+});

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -31,6 +31,7 @@ import SortIcon from "@mui/icons-material/Sort";
 import { getTimeFromTimeline } from "../../helpers/DateTime";
 import {
   estimatedAnnualOperatingCost,
+  estimatedAnnualVariableOperatingCost,
   getMonthlyPayment,
 } from "../../helpers/Financials";
 import {
@@ -104,6 +105,8 @@ export function GeneratorBuildItem(
     generator.viableLocationsRemaining,
   );
   const financingGap = Math.max(0, downpayment - cash);
+  const hasVariableOM = generator.variableOperatingCostPerMWh !== undefined;
+  const estimatedVariableOM = estimatedAnnualVariableOperatingCost(generator);
   // kg of CO2 equivalent released per MWh generated - 0 for carbon-free sources,
   // whose fuel either isn't in FUELS at all (sun, wind) or is emission-free (uranium)
   const kgCO2ePerMWh = Math.round(
@@ -169,9 +172,11 @@ export function GeneratorBuildItem(
         />
         <GeneratorMetric
           label={
-            generator.costPerStart !== undefined
-              ? "Est. O&M (1 start/day)"
-              : "Operating cost"
+            hasVariableOM
+              ? `Estimated O&M (${Math.round(generator.capacityFactor * 100)}% expected output)`
+              : generator.costPerStart !== undefined
+                ? "Est. O&M (1 start/day)"
+                : "Operating cost"
           }
           value={`${formatMoneyConcise(estimatedAnnualOperatingCost(generator))}/yr`}
         />
@@ -250,16 +255,31 @@ export function GeneratorBuildItem(
               </TableRow>
               <TableRow>
                 <TableCell>
-                  Base O&M
+                  {hasVariableOM ? "Fixed O&M" : "Base O&M"}
                   <Typography variant="body2" color="textSecondary">
-                    At {Math.round(generator.capacityFactor * 100)}% expected
-                    output
+                    {hasVariableOM
+                      ? "Standing annual expense"
+                      : `At ${Math.round(generator.capacityFactor * 100)}% expected output`}
                   </Typography>
                 </TableCell>
                 <TableCell align="right">
                   {formatMoneyConcise(generator.annualOperatingCost)}/yr
                 </TableCell>
               </TableRow>
+              {hasVariableOM && (
+                <TableRow>
+                  <TableCell>
+                    Variable O&M
+                    <Typography variant="body2" color="textSecondary">
+                      Per generated MWh
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    ${(generator.variableOperatingCostPerMWh || 0).toFixed(2)}
+                    /MWh generated
+                  </TableCell>
+                </TableRow>
+              )}
               {generator.costPerStart !== undefined && (
                 <TableRow>
                   <TableCell>
@@ -289,12 +309,14 @@ export function GeneratorBuildItem(
                   </TableCell>
                 </TableRow>
               )}
-              {generator.costPerStart !== undefined && (
+              {(hasVariableOM || generator.costPerStart !== undefined) && (
                 <TableRow>
                   <TableCell>
                     Estimated O&M
                     <Typography variant="body2" color="textSecondary">
-                      Base O&M plus one start/day
+                      {hasVariableOM
+                        ? `Fixed plus ${formatMoneyConcise(estimatedVariableOM)}/yr variable at ${Math.round(generator.capacityFactor * 100)}% expected output`
+                        : "Base O&M plus one start/day"}
                     </Typography>
                   </TableCell>
                   <TableCell align="right">

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -115,6 +115,21 @@ describe("the fleet list", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows Oil fixed and variable O&M without turbine start details", () => {
+    const oilGame = createGame({ scenarioId: 101, difficulty: "CEO" });
+    const oil = oilGame.facilities.find((facility) => facility.name === "Oil")!;
+    renderFacilities(oilGame, oil.id);
+
+    expect(screen.getByText("Equivalent operating hours")).toBeInTheDocument();
+    expect(screen.getByText("Fixed O&M")).toBeInTheDocument();
+    expect(screen.getByText("$3.09M/yr")).toBeInTheDocument();
+    expect(screen.getByText("Variable O&M")).toBeInTheDocument();
+    expect(screen.getByText("$25.71/MWh generated")).toBeInTheDocument();
+    expect(screen.queryByText("Equivalent starts")).toBeNull();
+    expect(screen.queryByText("Non-fuel start cost")).toBeNull();
+    expect(screen.queryByText("Service intervals")).toBeNull();
+  });
+
   it("leaves every row closed when nothing is selected", () => {
     renderFacilities(game, null);
     expect(screen.queryByText("Lifetime profit")).toBeNull();

--- a/src/components/views/Manual.test.tsx
+++ b/src/components/views/Manual.test.tsx
@@ -49,6 +49,7 @@ describe("Manual", () => {
     ["dispatch order", MANUAL_ENTRY.FORECASTS],
     ["peak shortage", MANUAL_ENTRY.FORECASTS],
     ["board of directors", MANUAL_ENTRY.BLACKOUTS],
+    ["variable O&M", MANUAL_ENTRY.TOTAL_COST_OF_ENERGY],
   ])("finds %s inside mixed markup", async (term: string, title: string) => {
     renderManual();
     await search(term);

--- a/src/data/Facilities.test.tsx
+++ b/src/data/Facilities.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "./Facilities";
 import { GAME_TO_REAL_YEARS } from "../Constants";
 import { getDateFromMinute } from "../helpers/DateTime";
+import { estimatedAnnualOperatingCost } from "../helpers/Financials";
 import { FacilityOperatingType, GameType, LocationType } from "../Types";
 
 function stateAt(
@@ -111,6 +112,16 @@ describe("current facility economics", () => {
     expect(
       generatorAt(2023, "Natural Gas", 100000000)?.costPerStart,
     ).toBeCloseTo((23100 * 100) / 419, 8);
+  });
+
+  it("splits Oil O&M into fixed capacity and variable generation costs", () => {
+    const oil = generatorAt(2023, "Oil", 100000000);
+
+    expect(oil?.annualOperatingCost).toBeCloseTo(3085368.560061, 6);
+    expect(oil?.variableOperatingCostPerMWh).toBeCloseTo(25.711404667176, 10);
+    expect(estimatedAnnualOperatingCost(oil!)).toBeCloseTo(7590006.65775, 5);
+    expect(oil?.tracksStarts).toBeUndefined();
+    expect(oil?.costPerStart).toBeUndefined();
   });
 
   it("scales Coal's CPI-normalized hot-start expense by nameplate MW", () => {

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -52,9 +52,16 @@ function offshoreEraMultiple(year: number): number {
 // annual-average CPI-U from BLS, not the game's inflation: that is applied separately below.
 const CPI_2019_TO_2023 = 304.702 / 255.657;
 const CPI_2020_TO_2024 = 313.689 / 258.811;
+const CPI_2015_TO_2023 = 304.702 / 237.017;
 // NREL's 500-1,300 MW supercritical-coal class reports $54/MW-start of capitalized
 // cycling/maintenance plus $5.81/MW-start of other startup operations, in 2011 dollars.
 const COAL_START_COST_PER_MW_2023 = (54 + 5.81) * (304.702 / 224.939);
+
+// EIA's directly matched 340 kW commercial Oil reciprocating-engine case, normalized from
+// 2015$ to 2023$ with annual-average CPI-U. These stay separate because fixed service is paid for
+// standing capacity while use-driven service and consumables follow the MWh actually generated.
+export const OIL_FIXED_OPERATING_COST_PER_KW_YEAR = 24 * CPI_2015_TO_2023;
+export const OIL_VARIABLE_OPERATING_COST_PER_MWH = 20 * CPI_2015_TO_2023;
 
 // Used only to upgrade current-version saves written before start tracking was added to these
 // technologies. New shopping and operating records carry the explicit tracksStarts field below.
@@ -309,9 +316,13 @@ export function GENERATORS(
       btuPerWh: 11,
       // https://www.eia.gov/electricity/annual/html/epa_08_01.html
       spinMinutes: 10,
-      annualOperatingCost: 0.05 * peakW,
-      // ~$0.006 -> .005/kwh 2008->18, -2%/yr - https://www.eia.gov/electricity/annual/html/epa_08_04.html
-      // ~$0.01/wy in 2016 - https://www.eia.gov/analysis/studies/powerplants/capitalcost/xls/table1.xls
+      // EIA, Distributed Generation and Combined Heat & Power System Characteristics and Costs
+      // in the Buildings Sector, Tables 4-38 through 4-41. The 2015-dollar source values are
+      // $24/kW-year fixed and $20/MWh variable before the CPI normalization above.
+      // https://www.eia.gov/analysis/studies/buildings/distrigen/pdf/dg_chp.pdf
+      annualOperatingCost:
+        (peakW / 1000) * OIL_FIXED_OPERATING_COST_PER_KW_YEAR,
+      variableOperatingCostPerMWh: OIL_VARIABLE_OPERATING_COST_PER_MWH,
       yearsToBuild: 1 + magnitude / 3,
       // https://www.eia.gov/outlooks/aeo/assumptions/pdf/table_8.2.pdf
       capacityFactor: 0.2,
@@ -567,6 +578,9 @@ export function GENERATORS(
   generators = generators.filter((g: GeneratorShoppingType) => {
     g.buildCost *= difficulty.buildCost * inflation;
     g.annualOperatingCost *= difficulty.expensesOM * inflation;
+    if (g.variableOperatingCostPerMWh !== undefined) {
+      g.variableOperatingCostPerMWh *= difficulty.expensesOM * inflation;
+    }
     if (g.costPerStart !== undefined) {
       g.costPerStart *= difficulty.expensesOM * inflation;
     }

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -729,13 +729,22 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
   {
     title: MANUAL_ENTRY.TOTAL_COST_OF_ENERGY,
     group: "Money",
-    keywords: "lcoe levelized cost of energy cost per mwh total energy cost",
+    keywords:
+      "lcoe levelized cost of energy cost per mwh total energy cost oil fixed variable operating maintenance om",
     entry: (
-      <p>
-        Also known as "Levelized Cost of Energy", it's the expected cost of all
-        energy produced by the plant during its lifetime, including
-        construction, maintenance and fuel.
-      </p>
+      <div>
+        <p>
+          Also known as "Levelized Cost of Energy", it's the expected cost of
+          all energy produced by the plant during its lifetime, including
+          construction, maintenance and fuel.
+        </p>
+        <p>
+          Operating and maintenance (O&amp;M) costs can be fixed or depend on
+          output. Oil plants pay fixed O&amp;M while available, plus variable
+          O&amp;M for each MWh they actually generate; pausing halves the fixed
+          charge and stops the variable charge.
+        </p>
+      </div>
     ),
   },
 ];

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -7,6 +7,7 @@ import {
   TUTORIALS,
 } from "./Scenarios";
 import { ScenarioType } from "../Types";
+import { render, screen } from "@testing-library/react";
 
 describe("getScenario", () => {
   it("finds an authored scenario by id", () => {
@@ -68,5 +69,16 @@ describe("tutorial mission metadata", () => {
       expect(tutorial.icon).toBeTruthy();
       expect(tutorial.summary).toBeTruthy();
     });
+  });
+
+  it("introduces Oil's fixed and output-dependent O&M", () => {
+    const generatorsMission = TUTORIALS.find(
+      (tutorial) => tutorial.name === "Mission 2: Generators",
+    )!;
+    render(generatorsMission.tutorialSteps![1].content);
+
+    expect(
+      screen.getByText(/Oil pays fixed O&M even when idle/),
+    ).toHaveTextContent("variable O&M whenever it generates");
   });
 });

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -114,7 +114,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["money", "time", "fuel"]}
-            text="Compare cost, build time and fuel."
+            text="Compare build cost, time, fuel and O&M. Oil pays fixed O&M even when idle, plus variable O&M whenever it generates."
           />
         ),
       },

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -211,6 +211,23 @@ describe("LCWH", () => {
     );
   });
 
+  it("quotes variable O&M at expected annual output", () => {
+    const oil = {
+      ...generator,
+      annualOperatingCost: 3085368.560061,
+      capacityFactor: 0.2,
+      variableOperatingCostPerMWh: 25.711404667176,
+    };
+    expect(estimatedAnnualOperatingCost(oil)).toBeCloseTo(7590006.65775, 5);
+
+    const totalWh =
+      oil.peakW * oil.lifespanYears * HOURS_PER_YEAR_REAL * oil.capacityFactor;
+    expect(LCWH(oil, date, 0, SEED)).toBeCloseTo(
+      (oil.buildCost + 7590006.65775 * oil.lifespanYears) / totalWh,
+      12,
+    );
+  });
+
   it("charges a carbon fee against a fuel's emissions", () => {
     const gas = {
       ...generator,

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -176,13 +176,35 @@ export function estimatedAnnualStartCost(
   return (generator.costPerStart || 0) * ASSUMED_STARTS_PER_YEAR;
 }
 
+export function estimatedAnnualVariableOperatingCost(
+  generator: Pick<
+    GeneratorShoppingType,
+    "capacityFactor" | "peakW" | "variableOperatingCostPerMWh"
+  >,
+): number {
+  return (
+    (generator.variableOperatingCostPerMWh || 0) *
+    (generator.peakW / 1000000) *
+    HOURS_PER_YEAR_REAL *
+    generator.capacityFactor
+  );
+}
+
 export function estimatedAnnualOperatingCost(
   generator: Pick<
     GeneratorShoppingType,
-    "annualOperatingCost" | "costPerStart"
+    | "annualOperatingCost"
+    | "capacityFactor"
+    | "costPerStart"
+    | "peakW"
+    | "variableOperatingCostPerMWh"
   >,
 ): number {
-  return generator.annualOperatingCost + estimatedAnnualStartCost(generator);
+  return (
+    generator.annualOperatingCost +
+    estimatedAnnualVariableOperatingCost(generator) +
+    estimatedAnnualStartCost(generator)
+  );
 }
 
 /**

--- a/src/reducers/FacilityLifetime.test.tsx
+++ b/src/reducers/FacilityLifetime.test.tsx
@@ -7,7 +7,9 @@ import gameReducer, {
 import {
   GAME_TO_REAL_YEARS,
   TICKS_PER_DAY,
+  TICKS_PER_HOUR,
   TICKS_PER_MONTH,
+  TICKS_PER_YEAR,
 } from "../Constants";
 import { facilityLifetime } from "../helpers/Financials";
 import { getTimeFromTimeline } from "../helpers/DateTime";
@@ -175,6 +177,149 @@ describe("per-facility lifetime totals", () => {
       expenses: afterStart.expenses,
       starts: afterStart.starts,
     });
+  });
+
+  it("charges Oil fixed and actual-output O&M once to both sets of books", () => {
+    const state = createGame({ scenarioId: 101, difficulty: "CEO" });
+    tickState(state);
+    const oil = state.facilities.find(
+      (facility: FacilityOperatingType) => facility.name === "Oil",
+    )!;
+    state.facilities.forEach((facility: FacilityOperatingType) => {
+      facility.annualOperatingCost = 0;
+      facility.variableOperatingCostPerMWh = undefined;
+      facility.btuPerWh = 0;
+      facility.currentW = 0;
+      facility.paused = facility.id !== oil.id;
+    });
+    oil.annualOperatingCost = 3085368.560061;
+    oil.variableOperatingCostPerMWh = 25.711404667176;
+    const openingWh = oil.lifetimeWh;
+    const openingExpenses = oil.lifetimeExpenses;
+
+    tickState(state);
+
+    const generatedWh = oil.lifetimeWh - openingWh;
+    const expectedOM =
+      oil.annualOperatingCost / TICKS_PER_YEAR +
+      (generatedWh / 1000000) * oil.variableOperatingCostPerMWh;
+    expect(generatedWh).toBeGreaterThan(0);
+    expect(
+      getTimeFromTimeline(state.date.minute, state.timeline)?.expensesOM,
+    ).toBeCloseTo(expectedOM, 6);
+    expect(oil.lifetimeExpenses - openingExpenses).toBeCloseTo(expectedOM, 6);
+    expect(oil.lifetimeStarts).toBe(0);
+  });
+
+  it("charges an idle Oil plant fixed O&M but no variable O&M", () => {
+    const state = createGame({ scenarioId: 101, difficulty: "CEO" });
+    tickState(state);
+    const oil = state.facilities.find(
+      (facility: FacilityOperatingType) => facility.name === "Oil",
+    )!;
+    state.facilities.forEach((facility: FacilityOperatingType) => {
+      facility.annualOperatingCost = 0;
+      facility.variableOperatingCostPerMWh = undefined;
+      facility.btuPerWh = 0;
+      facility.currentW = 0;
+      facility.paused = facility.id !== oil.id;
+    });
+    oil.annualOperatingCost = 3085368.560061;
+    oil.variableOperatingCostPerMWh = 25.711404667176;
+    oil.spinMinutes = Number.POSITIVE_INFINITY;
+    const openingWh = oil.lifetimeWh;
+    const openingExpenses = oil.lifetimeExpenses;
+
+    tickState(state);
+
+    const expectedFixedOM = oil.annualOperatingCost / TICKS_PER_YEAR;
+    expect(oil.lifetimeWh).toBe(openingWh);
+    expect(
+      getTimeFromTimeline(state.date.minute, state.timeline)?.expensesOM,
+    ).toBeCloseTo(expectedFixedOM, 6);
+    expect(oil.lifetimeExpenses - openingExpenses).toBeCloseTo(
+      expectedFixedOM,
+      6,
+    );
+  });
+
+  it("keeps paused Oil at half fixed O&M with no variable charge", () => {
+    const state = createGame({ scenarioId: 101, difficulty: "CEO" });
+    tickState(state);
+    const oil = state.facilities.find(
+      (facility: FacilityOperatingType) => facility.name === "Oil",
+    )!;
+    state.facilities.forEach((facility: FacilityOperatingType) => {
+      facility.annualOperatingCost = 0;
+      facility.variableOperatingCostPerMWh = undefined;
+      facility.btuPerWh = 0;
+      facility.paused = true;
+    });
+    oil.annualOperatingCost = 3085368.560061;
+    oil.variableOperatingCostPerMWh = 25.711404667176;
+    oil.currentW = oil.peakW;
+    const openingWh = oil.lifetimeWh;
+    const openingExpenses = oil.lifetimeExpenses;
+
+    tickState(state);
+
+    const expectedFixedOM = oil.annualOperatingCost / TICKS_PER_YEAR / 2;
+    expect(oil.lifetimeWh).toBe(openingWh);
+    expect(
+      getTimeFromTimeline(state.date.minute, state.timeline)?.expensesOM,
+    ).toBeCloseTo(expectedFixedOM, 6);
+    expect(oil.lifetimeExpenses - openingExpenses).toBeCloseTo(
+      expectedFixedOM,
+      6,
+    );
+  });
+
+  it("forecasts Oil variable O&M without mutating the live facility", () => {
+    const state = play(createGame({ scenarioId: 101, difficulty: "CEO" }), 8);
+    const oil = state.facilities.find(
+      (facility: FacilityOperatingType) => facility.name === "Oil",
+    )!;
+    state.facilities.forEach((facility: FacilityOperatingType) => {
+      facility.annualOperatingCost = 0;
+      facility.variableOperatingCostPerMWh = undefined;
+      facility.btuPerWh = 0;
+    });
+    oil.variableOperatingCostPerMWh = 25.711404667176;
+    const before = cloneDeep(state.facilities);
+    const now = getTimeFromTimeline(state.date.minute, state.timeline)!;
+    const forecast = generateNewTimeline(
+      state,
+      now.cash,
+      now.customers,
+      TICKS_PER_DAY,
+    );
+    const withoutVariable = cloneDeep(state);
+    withoutVariable.facilities.find(
+      (facility) => facility.id === oil.id,
+    )!.variableOperatingCostPerMWh = undefined;
+    const baseline = generateNewTimeline(
+      withoutVariable,
+      now.cash,
+      now.customers,
+      TICKS_PER_DAY,
+    );
+    const projectedVariableOM = forecast.reduce(
+      (sum, tick, index) => sum + tick.expensesOM - baseline[index].expensesOM,
+      0,
+    );
+    const expectedVariableOM = forecast.reduce(
+      (sum, tick) =>
+        sum +
+        (((tick.supplyByFuel.Oil || 0) / TICKS_PER_HOUR) *
+          GAME_TO_REAL_YEARS *
+          oil.variableOperatingCostPerMWh!) /
+          1000000,
+      0,
+    );
+
+    expect(projectedVariableOM).toBeGreaterThan(0);
+    expect(projectedVariableOM).toBeCloseTo(expectedVariableOM, 5);
+    expect(state.facilities).toEqual(before);
   });
 
   it.each(["Nuclear", "Biomass", "Geothermal", "Enhanced Geothermal"])(

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -86,6 +86,8 @@ import {
 } from "../Constants";
 import {
   GENERATORS,
+  OIL_FIXED_OPERATING_COST_PER_KW_YEAR,
+  OIL_VARIABLE_OPERATING_COST_PER_MWH,
   START_TRACKING_FACILITY_NAMES,
   STORAGE,
   windAnnualOutputDegradation,
@@ -676,6 +678,29 @@ export const gameSlice = createSlice({
     builder.addCase(resume, (_state, action) => {
       const restored = cloneDeep(action.payload);
       restored.facilities.forEach((facility) => {
+        // The former Oil model stored one annual expense equal to $0.05/W-year. Recover the
+        // facility's already-applied difficulty and build-date inflation multiplier, then use it
+        // for both halves of the sourced fixed/variable split. Historical books are untouched.
+        if (
+          facility.name === "Oil" &&
+          facility.variableOperatingCostPerMWh === undefined
+        ) {
+          const legacyBaseAnnualCost = 0.05 * facility.peakW;
+          const recoveredMultiplier =
+            legacyBaseAnnualCost > 0
+              ? facility.annualOperatingCost / legacyBaseAnnualCost
+              : 1;
+          const multiplier =
+            Number.isFinite(recoveredMultiplier) && recoveredMultiplier >= 0
+              ? recoveredMultiplier
+              : 1;
+          facility.annualOperatingCost =
+            (facility.peakW / 1000) *
+            OIL_FIXED_OPERATING_COST_PER_KW_YEAR *
+            multiplier;
+          facility.variableOperatingCostPerMWh =
+            OIL_VARIABLE_OPERATING_COST_PER_MWH * multiplier;
+        }
         // Save v6 predates the explicit capability for these technologies. Upgrade the facility
         // snapshot once on resume, starting from its actual generating state so loading an online
         // plant does not invent an opening start. Historical starts and charges remain unknown.
@@ -1778,19 +1803,28 @@ function updateSupplyFacilitiesFinances(
     // facility as well as into the company's own totals below
     let facilityExpenses = 0;
     if (g.yearsToBuildLeft === 0) {
+      // Output-dependent costs use the same representative-month scaling as fuel and lifetime
+      // generation. A paused plant may still be ramping down internally, but it produces and
+      // incurs no variable O&M while it is disconnected from dispatch.
+      const deliveredW = g.paused ? 0 : Math.max(0, g.currentW);
+      const generatedWh = (deliveredW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+      let facilityOM = 0;
       if (g.paused) {
         // paused facilities only pay half of their operating costs
-        facilityExpenses += g.annualOperatingCost / TICKS_PER_YEAR / 2;
+        facilityOM += g.annualOperatingCost / TICKS_PER_YEAR / 2;
       } else {
-        facilityExpenses += g.annualOperatingCost / TICKS_PER_YEAR;
+        facilityOM += g.annualOperatingCost / TICKS_PER_YEAR;
       }
+      facilityOM +=
+        (generatedWh / 1000000) * (g.variableOperatingCostPerMWh || 0);
       const started = startedFacilityIds.has(g.id);
       if (started) {
         // One simulated day stands for the average month. The visible off-to-on edge therefore
         // represents the same daily start repeated throughout that month.
-        facilityExpenses += (g.costPerStart || 0) * GAME_TO_REAL_YEARS;
+        facilityOM += (g.costPerStart || 0) * GAME_TO_REAL_YEARS;
       }
-      expensesOM += facilityExpenses;
+      facilityExpenses += facilityOM;
+      expensesOM += facilityOM;
       if (g.fuel && FUELS[g.fuel]) {
         const fuelBtu =
           ((g.currentW * (g.btuPerWh || 0)) / TICKS_PER_HOUR) *
@@ -1837,8 +1871,7 @@ function updateSupplyFacilitiesFinances(
         // down, and those watts are deliberately left out of the company's supply, so
         // crediting them here would book revenue nobody was paid for. Its potential keeps
         // accruing though -- being switched off is exactly what a capacity factor is for
-        const deliveredW = g.paused ? 0 : Math.max(0, g.currentW);
-        g.lifetimeWh += (deliveredW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+        g.lifetimeWh += generatedWh;
         g.lifetimePotentialWh +=
           (g.peakW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
         g.lifetimeRevenue += deliveredW * revenuePerSuppliedW;

--- a/src/reducers/Resume.test.tsx
+++ b/src/reducers/Resume.test.tsx
@@ -3,6 +3,10 @@ import gameReducer, { loaded, resume, start, tickState } from "./Game";
 import { parseSave, serializeSave } from "../SaveGame";
 import { createGame } from "../testing/Simulator";
 import { GameType } from "../Types";
+import {
+  OIL_FIXED_OPERATING_COST_PER_KW_YEAR,
+  OIL_VARIABLE_OPERATING_COST_PER_MWH,
+} from "../data/Facilities";
 
 jest.setTimeout(60000);
 
@@ -69,6 +73,32 @@ describe("resume", () => {
     expect(restoredCoal.costPerStart).toBeUndefined();
     expect(restoredCoal.lifetimeStarts).toBe(0);
     expect(restoredCoal.generatingLastRealTick).toBe(restoredCoal.currentW > 0);
+  });
+
+  it("migrates legacy Oil O&M with its saved difficulty and vintage multiplier", () => {
+    const oldSave = serialized(createGame({ scenarioId: 101, seed: 8675309 }));
+    const oil = oldSave.facilities.find((facility) => facility.name === "Oil")!;
+    const multiplier = 1.37;
+    const historicalExpenses = oil.lifetimeExpenses;
+    oil.annualOperatingCost = 0.05 * oil.peakW * multiplier;
+    oil.variableOperatingCostPerMWh = undefined;
+
+    const restoredOil = restore(oldSave).facilities.find(
+      (facility) => facility.name === "Oil",
+    )!;
+    expect(restoredOil.annualOperatingCost).toBeCloseTo(
+      (restoredOil.peakW / 1000) *
+        OIL_FIXED_OPERATING_COST_PER_KW_YEAR *
+        multiplier,
+      6,
+    );
+    expect(restoredOil.variableOperatingCostPerMWh).toBeCloseTo(
+      OIL_VARIABLE_OPERATING_COST_PER_MWH * multiplier,
+      10,
+    );
+    expect(restoredOil.lifetimeExpenses).toBe(historicalExpenses);
+    expect(Number.isFinite(restoredOil.annualOperatingCost)).toBe(true);
+    expect(Number.isFinite(restoredOil.variableOperatingCostPerMWh)).toBe(true);
   });
 
   /**

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -323,7 +323,8 @@ describe("simulation economics", () => {
     },
     104: { dollarsPerkWh: 0.08 },
     105: {
-      dollarsPerkWh: 0.08,
+      // Oil's output-dependent O&M makes the old $0.08/kWh play run out of cash in 2007.
+      dollarsPerkWh: 0.085,
       initialBuild: {
         name: "Natural Gas",
         peakW: 300000000,


### PR DESCRIPTION
## Summary

- split Oil non-fuel O&M into persisted fixed and per-MWh costs using the CPI-normalized EIA reciprocating-engine values
- charge variable O&M from actual representative-month generation in live accounting and forecast clones, with legacy save migration and replay version 8
- update build/facility details, levelized-cost estimates, documentation, and scenario regression coverage while keeping Oil start-neutral
- explain fixed versus variable Oil O&M in the Total Cost of Energy manual entry and Mission 2 generator tutorial

## Verification

- npm run check
- 75 test suites and 782 tests passed

Closes #246