### PR TITLE
Make scenarios and grid decisions feel consequential

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -476,6 +476,23 @@ export interface TutorialStepChangeType {
   currentCard: CardNameType;
 }
 
+export type ScenarioBriefingToneType =
+  "transition" | "boom" | "island" | "innovation" | "storm" | "legacy";
+
+/**
+ * The authored promise of a scenario, kept beside its simulation setup so the mission list and
+ * briefing screen tell the same story. The artwork is assembled from the existing fuel icons and
+ * a limited-palette tone rather than requiring a bespoke bitmap for every new scenario.
+ */
+export interface ScenarioBriefingType {
+  tone: ScenarioBriefingToneType;
+  fantasy: string;
+  objective: string;
+  constraint: string;
+  threat: string;
+  target: string;
+}
+
 export interface ScenarioType {
   id: number;
   name: string;
@@ -486,6 +503,7 @@ export interface ScenarioType {
   // wins over locationId; getScenarioLocation is the one place that resolves the two.
   location?: LocationType;
   summary?: string;
+  briefing?: ScenarioBriefingType;
   ownership: "Investor" | "Public";
   tutorialSteps?: TutorialStepType[];
   // Pins the run's RNG so it plays out identically every time. Every authored scenario leaves
@@ -683,6 +701,27 @@ export interface VictoryType {
   // A failed run still earns and submits a score, but the score screen must not celebrate it as a
   // completed mission or let the terminal game resume and submit the same run again
   outcome?: "completed" | "bankrupt" | "fired";
+  debrief?: VictoryDebriefType;
+}
+
+export interface VictoryFleetCapacityType {
+  fuel: FuelNameType;
+  watts: number;
+}
+
+/** A compact, serializable story of the run captured before the reducer's Immer draft expires. */
+export interface VictoryDebriefType {
+  startingFleet: VictoryFleetCapacityType[];
+  finalFleet: VictoryFleetCapacityType[];
+  startingCash: number;
+  finalCash: number;
+  finalCustomers: number;
+  reliability: number;
+  unservedWh: number;
+  kgco2e: number;
+  highlights: Array<
+    Pick<GameEventType, "kind" | "label" | "message" | "importance">
+  >;
 }
 
 export interface UIType {

--- a/src/app.scss
+++ b/src/app.scss
@@ -781,6 +781,87 @@ $pane_header_height: 40px;
   padding: 0 !important;
 }
 
+.decisionImpact {
+  padding: 12px 16px 14px;
+  border-bottom: 1px solid var(--border-selected);
+  background: var(--bg-selected);
+
+  & > .MuiTypography-overline {
+    font-weight: 800;
+    letter-spacing: 0.1em;
+  }
+}
+
+.decisionImpactFacts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.decisionImpactFact {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 8px;
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--border-tile);
+  border-radius: 7px;
+  background: var(--bg-primary);
+}
+
+.generatorDecisionLead {
+  display: grid;
+  gap: 4px;
+  padding: 0 16px 12px;
+}
+
+.generatorComparison {
+  padding: 8px 16px 10px;
+  border-bottom: 1px solid var(--border-selected);
+  background: var(--bg-selected);
+}
+
+.generatorComparisonHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.generatorComparisonChoices {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.generatorComparisonChoice {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  column-gap: 7px;
+  padding: 7px;
+  border: 1px solid var(--border-tile);
+  border-radius: 7px;
+  background: var(--bg-primary);
+
+  img {
+    grid-row: 1 / span 3;
+    width: 34px;
+    height: 34px;
+  }
+
+  .MuiTypography-root {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 620px) {
+  .decisionImpactFacts,
+  .generatorComparisonChoices {
+    grid-template-columns: 1fr;
+  }
+}
+
 // Facility rows paint an .outputProgressBar behind their contents, so both the text and the
 // action buttons have to be lifted over it - and they have to be lifted by the same amount, or
 // the full-width text block would cover the left edge of the buttons and eat their clicks.
@@ -982,9 +1063,224 @@ html[data-theme="dark"] .uplot {
   border-left: 4px solid var(--interactive-blue);
 }
 
+// Authored scenarios share one limited-palette art grammar. The real starting fleet supplies the
+// foreground drawings, so the postcard stays honest to the scenario without a bespoke bitmap.
+.scenarioArtwork {
+  --scene-a: #0d47a1;
+  --scene-b: #26a69a;
+  position: relative;
+  min-height: 220px;
+  overflow: hidden;
+  border-radius: 12px;
+  background:
+    linear-gradient(145deg, rgba(4, 12, 24, 0.05), rgba(4, 12, 24, 0.58)),
+    linear-gradient(135deg, var(--scene-a), var(--scene-b));
+  isolation: isolate;
+
+  &.tone-transition {
+    --scene-a: #0d47a1;
+    --scene-b: #f9a825;
+  }
+
+  &.tone-boom {
+    --scene-a: #4a148c;
+    --scene-b: #ef6c00;
+  }
+
+  &.tone-island {
+    --scene-a: #006064;
+    --scene-b: #29b6f6;
+  }
+
+  &.tone-innovation {
+    --scene-a: #283593;
+    --scene-b: #00acc1;
+  }
+
+  &.tone-storm {
+    --scene-a: #263238;
+    --scene-b: #546e7a;
+  }
+
+  &.tone-legacy {
+    --scene-a: #212121;
+    --scene-b: #8d4b20;
+  }
+}
+
+.scenarioArtworkSun {
+  position: absolute;
+  top: 18%;
+  right: 14%;
+  width: 64px;
+  height: 64px;
+  border: 2px solid rgba(255, 255, 255, 0.62);
+  border-radius: 50%;
+  box-shadow: 0 0 0 18px rgba(255, 255, 255, 0.07);
+}
+
+.scenarioArtworkGrid {
+  position: absolute;
+  inset: 52% -8% -15%;
+  opacity: 0.38;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.3) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.3) 1px, transparent 1px);
+  background-size: 30px 24px;
+  transform: perspective(160px) rotateX(46deg);
+}
+
+.scenarioArtworkMark {
+  position: absolute;
+  top: 18px;
+  left: 22px;
+  width: 116px;
+  height: 116px;
+  opacity: 0.3;
+  filter: grayscale(1) brightness(3);
+}
+
+.scenarioArtworkFleet {
+  position: absolute;
+  z-index: 1;
+  right: 22px;
+  bottom: 18px;
+  left: 22px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  gap: 10px;
+
+  img {
+    width: 66px;
+    height: 66px;
+    border-radius: 50%;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+  }
+}
+
+.scenarioArtwork.compact {
+  width: 112px;
+  min-height: 72px;
+  border-radius: 7px;
+
+  .scenarioArtworkSun {
+    top: 12px;
+    right: 14px;
+    width: 24px;
+    height: 24px;
+    box-shadow: 0 0 0 7px rgba(255, 255, 255, 0.07);
+  }
+
+  .scenarioArtworkMark {
+    top: 8px;
+    left: 8px;
+    width: 44px;
+    height: 44px;
+  }
+
+  .scenarioArtworkFleet {
+    right: 8px;
+    bottom: 7px;
+    left: 8px;
+    gap: 3px;
+
+    img {
+      width: 27px;
+      height: 27px;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+    }
+  }
+}
+
+.scenarioPostcardHeader {
+  align-items: stretch !important;
+
+  .MuiCardHeader-avatar {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.scenarioDossier {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.9fr) minmax(360px, 1.1fr);
+  gap: 24px;
+  max-width: 1040px;
+  margin: 24px auto;
+  padding: 0 20px;
+}
+
+.scenarioDossierCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.scenarioBriefingFacts {
+  display: grid;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.scenarioBriefingFact,
+.scenarioTarget {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: start;
+  gap: 10px;
+  padding: 9px 11px;
+  border: 1px solid var(--border-tile);
+  border-radius: 8px;
+  background: var(--bg-raised);
+
+  .MuiTypography-overline {
+    font-weight: 800;
+    line-height: 1.2;
+    letter-spacing: 0.08em;
+  }
+}
+
+.scenarioTarget {
+  border-color: var(--border-selected);
+  background: var(--bg-selected);
+}
+
+.scenarioStartControls {
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+
 .leaderboard {
   margin: 20px auto;
   max-width: 760px;
+}
+
+.leaderboardToggle {
+  text-align: center;
+  padding: 4px 0 12px;
+}
+
+@media (max-width: 760px) {
+  .scenarioDossier {
+    display: block;
+    padding: 0 12px;
+  }
+
+  .scenarioDossier > .scenarioArtwork {
+    min-height: 170px;
+    margin-bottom: 16px;
+  }
+
+  .scenarioPostcard .MuiCardHeader-root {
+    padding: 10px 8px;
+  }
+
+  .scenarioArtwork.compact {
+    width: 82px;
+    min-height: 62px;
+  }
 }
 
 // Units appended to numbers in tables, de-emphasized so the number still reads first
@@ -1100,6 +1396,122 @@ html[data-theme="dark"] .uplot {
     outline: 2px solid $interactive_blue;
     outline-offset: 2px;
     border-radius: 2px;
+  }
+}
+
+.victoryDebrief {
+  display: grid;
+  gap: 10px;
+  margin: 10px 0 14px;
+  padding: 12px;
+  border: 1px solid var(--border-tile);
+  border-radius: 10px;
+  background: var(--bg-raised);
+
+  & > h3 {
+    font-weight: 800;
+  }
+}
+
+.victoryFleetComparison {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.victoryFleetMix h4 {
+  font-weight: 800;
+  line-height: 1.3;
+}
+
+.victoryFleetBar {
+  display: flex;
+  height: 18px;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: 9px;
+  background: var(--bg-sunken);
+
+  span {
+    min-width: 3px;
+  }
+
+  .empty {
+    width: 100%;
+    background: repeating-linear-gradient(
+      135deg,
+      var(--border-tile),
+      var(--border-tile) 4px,
+      transparent 4px,
+      transparent 8px
+    );
+  }
+}
+
+.victoryFleetLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 8px;
+  margin-top: 4px;
+  color: $font_color_faded;
+  font-size: 0.72rem;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  i {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+  }
+}
+
+.victoryDebriefStats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+  gap: 7px;
+
+  & > div {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 2px 6px;
+    padding: 7px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 7px;
+    background: var(--bg-primary);
+  }
+
+  .conceptIcon {
+    grid-row: 1 / span 2;
+  }
+}
+
+.victoryHighlights {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: start;
+    gap: 7px;
+  }
+
+  li span span {
+    display: block;
+  }
+}
+
+@media (max-width: 520px) {
+  .victoryFleetComparison {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/components/base/DecisionImpactPreview.test.tsx
+++ b/src/components/base/DecisionImpactPreview.test.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import DecisionImpactPreview from "./DecisionImpactPreview";
+
+it("keeps an exact delta beside its explanation", () => {
+  render(
+    <DecisionImpactPreview
+      facts={[
+        {
+          concept: "money",
+          label: "Cash purchase",
+          value: "$330M → $179M",
+          detail: "A loan uses a smaller down payment.",
+        },
+      ]}
+    />,
+  );
+
+  expect(
+    screen.getByRole("region", { name: "Expected impact" }),
+  ).toHaveTextContent("$330M → $179M");
+  expect(screen.getByText(/smaller down payment/)).toBeInTheDocument();
+});

--- a/src/components/base/DecisionImpactPreview.tsx
+++ b/src/components/base/DecisionImpactPreview.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { Typography } from "@mui/material";
+import ConceptIcon, { ConceptNameType } from "./ConceptIcon";
+
+export interface DecisionImpactFactType {
+  concept: ConceptNameType;
+  label: string;
+  value: string;
+  detail?: string;
+}
+
+export interface DecisionImpactPreviewProps {
+  facts: DecisionImpactFactType[];
+}
+
+/** A common before-commit grammar: action first, exact delta second, explanation last. */
+export default function DecisionImpactPreview({
+  facts,
+}: DecisionImpactPreviewProps): React.JSX.Element {
+  return (
+    <section className="decisionImpact" aria-label="Expected impact">
+      <Typography variant="overline" component="h3">
+        What changes
+      </Typography>
+      <div className="decisionImpactFacts">
+        {facts.map((fact) => (
+          <div className="decisionImpactFact" key={fact.label}>
+            <ConceptIcon concept={fact.concept} fontSize="small" />
+            <div>
+              <Typography variant="caption" component="div">
+                {fact.label}
+              </Typography>
+              <Typography variant="body2" component="div">
+                <strong>{fact.value}</strong>
+              </Typography>
+              {fact.detail && (
+                <Typography variant="caption" color="textSecondary">
+                  {fact.detail}
+                </Typography>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/base/ScenarioArtwork.test.tsx
+++ b/src/components/base/ScenarioArtwork.test.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { SCENARIOS } from "../../data/Scenarios";
+import ScenarioArtwork from "./ScenarioArtwork";
+
+it("turns the authored starting fleet into an accessible postcard", () => {
+  const scenario = SCENARIOS.find((candidate) => candidate.id === 100)!;
+  render(<ScenarioArtwork scenario={scenario} />);
+
+  expect(
+    screen.getByRole("img", {
+      name: "Carbon Fee starting grid: Coal, Natural Gas",
+    }),
+  ).toHaveClass("tone-transition");
+});

--- a/src/components/base/ScenarioArtwork.tsx
+++ b/src/components/base/ScenarioArtwork.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { ScenarioFacilityType, ScenarioType } from "../../Types";
+
+export interface ScenarioArtworkProps {
+  scenario: ScenarioType;
+  compact?: boolean;
+}
+
+function facilityImageName(facility: ScenarioFacilityType): string | undefined {
+  return facility.fuel || facility.name;
+}
+
+/**
+ * A reusable, data-driven scenario postcard. It deliberately uses the shipped facility drawings
+ * rather than a one-off image so a new scenario only needs copy, a tone and its real starting
+ * fleet to gain a coherent piece of art.
+ */
+export default function ScenarioArtwork({
+  scenario,
+  compact = false,
+}: ScenarioArtworkProps): React.JSX.Element {
+  const fleet = Array.from(
+    new Set(
+      scenario.facilities
+        .map(facilityImageName)
+        .filter((name): name is string => Boolean(name)),
+    ),
+  ).slice(0, compact ? 3 : 5);
+  const tone = scenario.briefing?.tone || "transition";
+  const fleetLabel = fleet.length > 0 ? fleet.join(", ") : scenario.icon;
+
+  return (
+    <div
+      className={`scenarioArtwork tone-${tone}${compact ? " compact" : ""}`}
+      role="img"
+      aria-label={`${scenario.name} starting grid: ${fleetLabel}`}
+    >
+      <div className="scenarioArtworkSun" aria-hidden />
+      <div className="scenarioArtworkGrid" aria-hidden />
+      <img
+        className="scenarioArtworkMark"
+        src={`/images/${scenario.icon.toLowerCase()}.svg`}
+        alt=""
+        aria-hidden
+      />
+      <div className="scenarioArtworkFleet" aria-hidden>
+        {fleet.map((name) => (
+          <img key={name} src={`/images/${name.toLowerCase()}.svg`} alt="" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/base/VictoryDialog.test.tsx
+++ b/src/components/base/VictoryDialog.test.tsx
@@ -82,6 +82,48 @@ describe("VictoryDialog", () => {
     expect(screen.getAllByText(/Mission complete/i)).toHaveLength(1);
   });
 
+  it("shows how the fleet and company changed over the run", () => {
+    renderDialog({
+      victory: aVictory({
+        debrief: {
+          startingFleet: [
+            { fuel: "Coal", watts: 300000000 },
+            { fuel: "Natural Gas", watts: 200000000 },
+          ],
+          finalFleet: [
+            { fuel: "Sun", watts: 400000000 },
+            { fuel: "Natural Gas", watts: 200000000 },
+          ],
+          startingCash: 330000000,
+          finalCash: 510000000,
+          finalCustomers: 1200000,
+          reliability: 0.998,
+          unservedWh: 1000000000,
+          kgco2e: 2000000000,
+          highlights: [
+            {
+              kind: "CONSTRUCTION",
+              label: "Jan 2028",
+              message: "Construction complete: Solar",
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(screen.getByText("The story of your grid")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: /Coal 300MW, Natural Gas 200MW/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: /Sun 400MW, Natural Gas 200MW/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("99.8%")).toBeInTheDocument();
+    expect(
+      screen.getByText("Construction complete: Solar"),
+    ).toBeInTheDocument();
+  });
+
   it("fills in the global rank once it resolves", async () => {
     mockFetchGlobalRank.mockResolvedValue(4);
     renderDialog();

--- a/src/components/base/VictoryDialog.tsx
+++ b/src/components/base/VictoryDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
   Skeleton,
   Stack,
   Typography,
@@ -13,7 +14,12 @@ import ShareIcon from "@mui/icons-material/Share";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import numbro from "numbro";
-import { VictoryType } from "../../Types";
+import {
+  GameEventKindType,
+  VictoryDebriefType,
+  VictoryFleetCapacityType,
+  VictoryType,
+} from "../../Types";
 import { fetchGlobalRank } from "../../reducers/User";
 import {
   buildScoreShareContent,
@@ -22,6 +28,14 @@ import {
 } from "../../helpers/Share";
 import ConceptIcon, { ConceptNameType } from "./ConceptIcon";
 import InstallAppButton from "./InstallAppButton";
+import { fuelColors } from "../../Theme";
+import {
+  formatMoneyConcise,
+  formatWattHours,
+  formatWatts,
+} from "../../helpers/Format";
+import { formatLargeMass } from "../../helpers/Units";
+import { useUnits } from "./UnitsContext";
 
 // What each scored category is called on the score screen. The breakdown's keys differ by
 // ownership (see reducers/Game), so this is a lookup rather than a fixed list -- a scenario type
@@ -63,6 +77,151 @@ export interface Props extends StateProps, DispatchProps {}
 
 export function formatScore(score: number): string {
   return numbro(score).format({ thousandSeparated: true, mantissa: 0 });
+}
+
+const EVENT_CONCEPTS: Record<GameEventKindType, ConceptNameType> = {
+  BLACKOUT: "blackout",
+  BLACKOUT_OVER: "supply",
+  CONSTRUCTION: "construction",
+  BUILD: "build",
+  SELL: "money",
+  LOAN: "finances",
+  FUEL_PRICE: "fuel",
+  FUEL_CROSSOVER: "fuel",
+};
+
+function FleetMix(props: {
+  title: string;
+  fleet: VictoryFleetCapacityType[];
+}): React.JSX.Element {
+  const total = props.fleet.reduce((sum, item) => sum + item.watts, 0);
+  const label =
+    props.fleet.length > 0
+      ? props.fleet
+          .map((item) => `${item.fuel} ${formatWatts(item.watts)}`)
+          .join(", ")
+      : "No operational generation";
+  const colors = fuelColors();
+  return (
+    <div className="victoryFleetMix">
+      <Typography variant="overline" component="h4">
+        {props.title}
+      </Typography>
+      <div className="victoryFleetBar" role="img" aria-label={label}>
+        {props.fleet.map((item) => (
+          <span
+            key={item.fuel}
+            style={{
+              flexGrow: item.watts,
+              backgroundColor: colors[item.fuel],
+            }}
+          />
+        ))}
+        {total === 0 && <span className="empty" />}
+      </div>
+      <div className="victoryFleetLegend">
+        {props.fleet.map((item) => (
+          <span key={item.fuel}>
+            <i style={{ backgroundColor: colors[item.fuel] }} />
+            {item.fuel} {formatWatts(item.watts)}
+          </span>
+        ))}
+        {props.fleet.length === 0 && <span>No operational generation</span>}
+      </div>
+    </div>
+  );
+}
+
+function RunDebrief({
+  debrief,
+}: {
+  debrief: VictoryDebriefType;
+}): React.JSX.Element {
+  const units = useUnits();
+  const reliability = `${(debrief.reliability * 100).toFixed(
+    debrief.reliability >= 0.999 ? 2 : 1,
+  )}%`;
+  return (
+    <section className="victoryDebrief" aria-labelledby="debrief-title">
+      <Typography id="debrief-title" variant="h6" component="h3">
+        The story of your grid
+      </Typography>
+      <div className="victoryFleetComparison">
+        <FleetMix
+          title="Then · starting capacity"
+          fleet={debrief.startingFleet}
+        />
+        <FleetMix
+          title="Now · operational capacity"
+          fleet={debrief.finalFleet}
+        />
+      </div>
+      <div className="victoryDebriefStats">
+        <div>
+          <ConceptIcon concept="supply" fontSize="small" />
+          <Typography variant="caption">Demand served</Typography>
+          <strong>{reliability}</strong>
+        </div>
+        <div>
+          <ConceptIcon concept="money" fontSize="small" />
+          <Typography variant="caption">Cash</Typography>
+          <strong>
+            {formatMoneyConcise(debrief.startingCash)} →{" "}
+            {formatMoneyConcise(debrief.finalCash)}
+          </strong>
+        </div>
+        <div>
+          <ConceptIcon concept="customers" fontSize="small" />
+          <Typography variant="caption">Customers</Typography>
+          <strong>
+            {numbro(debrief.finalCustomers).format({ average: true })}
+          </strong>
+        </div>
+        <div>
+          <ConceptIcon concept="danger" fontSize="small" />
+          <Typography variant="caption">Emissions</Typography>
+          <strong>{formatLargeMass(debrief.kgco2e, units)}</strong>
+        </div>
+        {debrief.unservedWh > 0 && (
+          <div>
+            <ConceptIcon concept="blackout" fontSize="small" />
+            <Typography variant="caption">Energy unserved</Typography>
+            <strong>{formatWattHours(debrief.unservedWh)}</strong>
+          </div>
+        )}
+      </div>
+      {debrief.highlights.length > 0 && (
+        <>
+          <Divider />
+          <Typography variant="overline" component="h4">
+            Turning points
+          </Typography>
+          <ol className="victoryHighlights">
+            {debrief.highlights.map((event, index) => (
+              <li key={`${event.label}-${index}`}>
+                <ConceptIcon
+                  concept={EVENT_CONCEPTS[event.kind]}
+                  fontSize="small"
+                />
+                <span>
+                  <Typography variant="body2" component="span">
+                    {event.message}
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    color="textSecondary"
+                    component="span"
+                  >
+                    {event.label}
+                  </Typography>
+                </span>
+              </li>
+            ))}
+          </ol>
+        </>
+      )}
+    </section>
+  );
 }
 
 /**
@@ -202,6 +361,8 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
             {endMessage}
           </Typography>
         )}
+        {victory.debrief && <RunDebrief debrief={victory.debrief} />}
+        {victory.debrief && <Divider sx={{ my: 1.5 }} />}
         <Typography variant="body1" sx={{ fontWeight: 600 }}>
           Final score: <strong>{formatScore(victory.score)}</strong>
         </Typography>

--- a/src/components/views/BuildGenerators.test.tsx
+++ b/src/components/views/BuildGenerators.test.tsx
@@ -2,7 +2,10 @@ import * as React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { GENERATORS } from "../../data/Facilities";
 import { createGame } from "../../testing/Simulator";
-import { GeneratorBuildItem } from "./BuildGenerators";
+import BuildGenerators, {
+  GeneratorBuildItem,
+  generatorRole,
+} from "./BuildGenerators";
 
 jest.mock("../base/ManualLink", () => () => null);
 
@@ -27,6 +30,8 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
 
   expect(screen.getByText("Est. O&M (1 start/day)")).toBeInTheDocument();
   expect(screen.getByText("$13.4M/yr")).toBeInTheDocument();
+  expect(screen.getByText("Flexible power")).toBeInTheDocument();
+  expect(screen.getByText(/typical output/)).toBeInTheDocument();
   fireEvent.click(
     screen.getByRole("button", { name: "Show Natural Gas details" }),
   );
@@ -46,6 +51,15 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
       name: /Estimated O&M.*Base O&M plus one start\/day.*\$13\.4M\/yr/,
     }),
   ).toBeInTheDocument();
+
+  fireEvent.click(
+    screen.getByRole("button", { name: "Review purchase of Natural Gas" }),
+  );
+  const impact = screen.getByRole("region", { name: "Expected impact" });
+  expect(impact).toHaveTextContent("What changes");
+  expect(impact).toHaveTextContent("Cash purchase");
+  expect(impact).toHaveTextContent("Online in");
+  expect(impact).toHaveTextContent("Typical supply");
 });
 
 it("shows Coal's physical and representative-day start charges", () => {
@@ -121,4 +135,33 @@ it("shows Oil's fixed, variable, and expected-output O&M", () => {
     }),
   ).toBeInTheDocument();
   expect(screen.queryByText("Non-fuel start cost")).toBeNull();
+});
+
+it("describes clean variable generation as a strategic role", () => {
+  const game = createGame({ scenarioId: 100, difficulty: "Employee" });
+  const solar = GENERATORS(game, 200000000, [], []).find(
+    (candidate) => candidate.name === "Solar",
+  )!;
+  expect(generatorRole(solar)).toEqual(
+    expect.objectContaining({ label: "Clean, weather-led" }),
+  );
+});
+
+it("pins up to three current-grid choices into a comparison tray", () => {
+  const game = createGame({ scenarioId: 100, difficulty: "Employee" });
+  render(
+    <BuildGenerators
+      game={game}
+      onBack={jest.fn()}
+      onBuildGenerator={jest.fn()}
+      onSpeedChange={jest.fn()}
+    />,
+  );
+
+  const compare = screen.getAllByRole("button", { name: "Compare" });
+  fireEvent.click(compare[0]);
+  fireEvent.click(compare[1]);
+  expect(
+    screen.getByRole("region", { name: "Generator comparison" }),
+  ).toHaveTextContent("Comparing 2/3");
 });

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Card,
   CardHeader,
+  Chip,
   Collapse,
   Dialog,
   DialogActions,
@@ -15,6 +16,7 @@ import {
   Menu,
   MenuItem,
   Slider,
+  Stack,
   Table,
   TableBody,
   TableCell,
@@ -61,6 +63,7 @@ import { formatMass } from "../../helpers/Units";
 import ManualLink from "../base/ManualLink";
 import { useUnits } from "../base/UnitsContext";
 import ConceptIcon from "../base/ConceptIcon";
+import DecisionImpactPreview from "../base/DecisionImpactPreview";
 import {
   getBuildAvailability,
   ViableLocationsRow,
@@ -74,7 +77,44 @@ interface GeneratorBuildItemProps {
   location: LocationType;
   seed: number;
   secondaryMetric?: string;
+  forecastGapW?: number;
+  advantages?: string[];
+  compared?: boolean;
+  compareDisabled?: boolean;
+  onCompare?: () => void;
   onBuild: (financed: boolean) => void;
+}
+
+export interface GeneratorRoleType {
+  label: string;
+  detail: string;
+}
+
+export function generatorRole(
+  generator: GeneratorShoppingType,
+): GeneratorRoleType {
+  if (generator.fuel === "Hydro") {
+    return {
+      label: "Clean & dispatchable",
+      detail: "Weather-fed power that can respond when the grid needs it.",
+    };
+  }
+  if (generator.btuPerWh === 0) {
+    return {
+      label: "Clean, weather-led",
+      detail: "No direct emissions; output follows local conditions.",
+    };
+  }
+  if (generator.spinMinutes <= 30) {
+    return {
+      label: "Flexible power",
+      detail: "Can respond quickly, with fuel and emissions tradeoffs.",
+    };
+  }
+  return {
+    label: "Steady output",
+    detail: "Firm supply with a slower response and long-lived commitment.",
+  };
 }
 
 export function GeneratorBuildItem(
@@ -112,6 +152,12 @@ export function GeneratorBuildItem(
   const kgCO2ePerMWh = Math.round(
     1000000 * generator.btuPerWh * (fuel.kgCO2ePerBtu || 0),
   );
+  const typicalOutputW = generator.peakW * generator.capacityFactor;
+  const gapCoverage =
+    props.forecastGapW && props.forecastGapW > 0
+      ? Math.round((typicalOutputW / props.forecastGapW) * 100)
+      : undefined;
+  const role = generatorRole(generator);
   const toggleExpand = () => {
     setExpanded(!expanded);
   };
@@ -137,22 +183,68 @@ export function GeneratorBuildItem(
           />
         }
         action={
-          <Button
-            className="buy-button"
-            size="small"
-            variant="contained"
-            color="primary"
-            onClick={toggleOpen}
-            disabled={financingGap > 0 || !buildable}
-            startIcon={<ConceptIcon concept="buy" fontSize="small" />}
-            aria-label={`Review purchase of ${generator.name}`}
-          >
-            Review
-          </Button>
+          <Stack direction="row" spacing={0.5}>
+            {props.onCompare && (
+              <Button
+                size="small"
+                variant={props.compared ? "contained" : "outlined"}
+                aria-pressed={props.compared}
+                disabled={props.compareDisabled && !props.compared}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  props.onCompare?.();
+                }}
+              >
+                Compare
+              </Button>
+            )}
+            <Button
+              className="buy-button"
+              size="small"
+              variant="contained"
+              color="primary"
+              onClick={toggleOpen}
+              disabled={financingGap > 0 || !buildable}
+              startIcon={<ConceptIcon concept="buy" fontSize="small" />}
+              aria-label={`Review purchase of ${generator.name}`}
+            >
+              Review
+            </Button>
+          </Stack>
         }
         title={generator.name}
         subheader={secondaryText}
       />
+      <Box className="generatorDecisionLead">
+        <Typography variant="body2" sx={{ fontWeight: 700 }}>
+          {role.label}
+        </Typography>
+        <Typography variant="caption" color="textSecondary">
+          {role.detail}
+        </Typography>
+        <Stack
+          direction="row"
+          spacing={0.75}
+          useFlexGap
+          sx={{ flexWrap: "wrap" }}
+        >
+          <Chip
+            size="small"
+            variant="outlined"
+            label={`${formatWatts(typicalOutputW)} typical output`}
+          />
+          {gapCoverage !== undefined && (
+            <Chip
+              size="small"
+              color={gapCoverage >= 100 ? "success" : "default"}
+              label={`~${gapCoverage}% of peak forecast gap`}
+            />
+          )}
+          {(props.advantages || []).map((advantage) => (
+            <Chip key={advantage} size="small" label={advantage} />
+          ))}
+        </Stack>
+      </Box>
       <Box
         sx={{
           display: "grid",
@@ -414,6 +506,39 @@ export function GeneratorBuildItem(
           </IconButton>
         </DialogTitle>
         <DialogContent className="noPadding">
+          <DecisionImpactPreview
+            facts={[
+              {
+                concept: "money",
+                label: "Cash purchase",
+                value: `${formatMoneyConcise(cash)} → ${formatMoneyConcise(cash - generator.buildCost)}`,
+                detail: `Loan: ${formatMoneyConcise(cash)} → ${formatMoneyConcise(cash - downpayment)}, then ${formatMoneyConcise(monthlyPayment)}/mo`,
+              },
+              {
+                concept: "time",
+                label: "Online in",
+                value: `${Math.round(generator.yearsToBuild * 12)} months`,
+                detail: "Reserve does not change until construction finishes.",
+              },
+              {
+                concept: "supply",
+                label: "Typical supply",
+                value: `+${formatWatts(typicalOutputW)}`,
+                detail:
+                  gapCoverage === undefined
+                    ? `${formatWatts(generator.peakW)} nameplate capacity`
+                    : `About ${gapCoverage}% of the peak forecast gap`,
+              },
+              {
+                concept: kgCO2ePerMWh > 0 ? "danger" : "goal",
+                label: "Direct emissions",
+                value:
+                  kgCO2ePerMWh > 0
+                    ? `${formatMass(kgCO2ePerMWh, units)}/MWh`
+                    : "None",
+              },
+            ]}
+          />
           <TableContainer>
             <Table size="small">
               <TableBody>
@@ -521,6 +646,49 @@ function GeneratorMetric(props: {
   );
 }
 
+function GeneratorComparison(props: {
+  generators: GeneratorShoppingType[];
+  onClear: () => void;
+}): React.JSX.Element | null {
+  if (props.generators.length === 0) {
+    return null;
+  }
+  return (
+    <section className="generatorComparison" aria-label="Generator comparison">
+      <div className="generatorComparisonHeader">
+        <Typography variant="subtitle2" sx={{ fontWeight: 800 }}>
+          Comparing {props.generators.length}/3
+        </Typography>
+        <Button size="small" onClick={props.onClear}>
+          Clear
+        </Button>
+      </div>
+      <div className="generatorComparisonChoices">
+        {props.generators.map((generator) => (
+          <div className="generatorComparisonChoice" key={generator.name}>
+            <img
+              src={`/images/${generator.name.toLowerCase()}.svg`}
+              alt=""
+              aria-hidden
+            />
+            <Typography variant="body2" sx={{ fontWeight: 800 }}>
+              {generator.name}
+            </Typography>
+            <Typography variant="caption">
+              {formatMoneyConcise(generator.buildCost)} ·{" "}
+              {Math.round(generator.yearsToBuild * 12)} mo
+            </Typography>
+            <Typography variant="caption" color="textSecondary">
+              {formatWatts(generator.peakW * generator.capacityFactor)} typical
+              · {formatMoneyConcise(generator.lcWh * 1000000)}/MWh
+            </Typography>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 const sortOptions = [
   ["buildCost", "Build Cost"],
   ["yearsToBuild", "Build Time"],
@@ -571,6 +739,7 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
   );
   const [sort, setSort] = React.useState<string>("buildCost");
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const [comparedNames, setComparedNames] = React.useState<string[]>([]);
 
   if (!now) {
     return <span />;
@@ -597,6 +766,35 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
     offshoreWindSpeeds,
     airborneWindSpeeds,
   ).sort((a, b) => (a[sort] > b[sort] ? 1 : -1));
+  const forecastGapW = Math.max(
+    0,
+    ...forecastedTimeline.map((tick) => tick.demandW - tick.supplyW),
+  );
+  const buildableGenerators = generators.filter(
+    (generator) => generator.available && generator.peakW <= generator.maxPeakW,
+  );
+  const lowestBuildCost = Math.min(
+    ...buildableGenerators.map((generator) => generator.buildCost),
+  );
+  const fastestBuild = Math.min(
+    ...buildableGenerators.map((generator) => generator.yearsToBuild),
+  );
+  const lowestEnergyCost = Math.min(
+    ...buildableGenerators.map((generator) => generator.lcWh),
+  );
+  const comparedGenerators = generators.filter((generator) =>
+    comparedNames.includes(generator.name),
+  );
+
+  const toggleCompare = (name: string) => {
+    setComparedNames((current) =>
+      current.includes(name)
+        ? current.filter((candidate) => candidate !== name)
+        : current.length < 3
+          ? [...current, name]
+          : current,
+    );
+  };
 
   const onSlider = (_event: Event, newValue: number | number[]) => {
     if (Array.isArray(newValue)) {
@@ -704,23 +902,41 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
           })}
         </Menu>
       </Toolbar>
+      <GeneratorComparison
+        generators={comparedGenerators}
+        onClear={() => setComparedNames([])}
+      />
       <List dense className="scrollable cardList">
-        {generators.map((g: GeneratorShoppingType, i: number) => (
-          <GeneratorBuildItem
-            date={game.date}
-            seed={game.seed}
-            location={game.location}
-            interestRate={game.interestRate}
-            generator={g}
-            key={i}
-            cash={cash}
-            secondaryMetric={sort === "buildCost" ? "yearsToBuild" : sort}
-            onBuild={(financed: boolean) => {
-              props.onBuildGenerator(g, financed);
-              onBack();
-            }}
-          />
-        ))}
+        {generators.map((g: GeneratorShoppingType, i: number) => {
+          const advantages = [
+            g.buildCost === lowestBuildCost ? "Lowest upfront cost" : undefined,
+            g.yearsToBuild === fastestBuild ? "Fastest online" : undefined,
+            g.lcWh === lowestEnergyCost ? "Lowest lifetime cost" : undefined,
+            g.btuPerWh === 0 ? "No direct emissions" : undefined,
+          ].filter((value): value is string => Boolean(value));
+          const compared = comparedNames.includes(g.name);
+          return (
+            <GeneratorBuildItem
+              date={game.date}
+              seed={game.seed}
+              location={game.location}
+              interestRate={game.interestRate}
+              generator={g}
+              key={i}
+              cash={cash}
+              secondaryMetric={sort === "buildCost" ? "yearsToBuild" : sort}
+              forecastGapW={forecastGapW}
+              advantages={advantages.slice(0, 2)}
+              compared={compared}
+              compareDisabled={comparedNames.length >= 3}
+              onCompare={() => toggleCompare(g.name)}
+              onBuild={(financed: boolean) => {
+                props.onBuildGenerator(g, financed);
+                onBack();
+              }}
+            />
+          );
+        })}
       </List>
     </div>
   );

--- a/src/components/views/BuildGeneratorsContainer.tsx
+++ b/src/components/views/BuildGeneratorsContainer.tsx
@@ -2,6 +2,9 @@ import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigate } from "../../reducers/Card";
 import { setSpeed, buildFacility } from "../../reducers/Game";
+import { selectFacility, snackbarOpen } from "../../reducers/UI";
+import { getStore } from "../../StoreRegistry";
+import { buildConsequenceMessage } from "../../helpers/BuildConsequences";
 import { AppStateType, GeneratorShoppingType, SpeedType } from "../../Types";
 import BuildGenerators, { DispatchProps, StateProps } from "./BuildGenerators";
 
@@ -17,7 +20,27 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
       dispatch(navigate("FACILITIES"));
     },
     onBuildGenerator: (facility: GeneratorShoppingType, financed: boolean) => {
+      const beforeIds = new Set(
+        getStore()
+          .getState()
+          .game.facilities.map((candidate) => candidate.id),
+      );
       dispatch(buildFacility({ facility, financed }));
+      const built = getStore()
+        .getState()
+        .game.facilities.find((candidate) => !beforeIds.has(candidate.id));
+      if (built) {
+        dispatch(selectFacility(built.id));
+        dispatch(
+          snackbarOpen({
+            message: buildConsequenceMessage(facility, financed),
+            open: true,
+            timeout: 8000,
+            actionLabel: "Events",
+            action: () => dispatch(navigate("EVENTS")),
+          }),
+        );
+      }
     },
     onSpeedChange: (speed: SpeedType) => {
       dispatch(setSpeed(speed));

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -32,6 +32,7 @@ import { getMonthlyPayment } from "../../helpers/Financials";
 import {
   formatMoneyConcise,
   formatMoneyStable,
+  formatWattHours,
   formatWatts,
 } from "../../helpers/Format";
 import { DOWNPAYMENT_PERCENT, LOAN_MONTHS } from "../../Constants";
@@ -39,6 +40,7 @@ import { STORAGE } from "../../data/Facilities";
 import { MANUAL_ENTRY } from "../../data/Manual";
 import ManualLink from "../base/ManualLink";
 import ConceptIcon from "../base/ConceptIcon";
+import DecisionImpactPreview from "../base/DecisionImpactPreview";
 import {
   getBuildAvailability,
   ViableLocationsRow,
@@ -188,6 +190,34 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
           </IconButton>
         </DialogTitle>
         <DialogContent className="noPadding">
+          <DecisionImpactPreview
+            facts={[
+              {
+                concept: "money",
+                label: "Cash purchase",
+                value: `${formatMoneyConcise(cash)} → ${formatMoneyConcise(cash - storage.buildCost)}`,
+                detail: `Loan: ${formatMoneyConcise(cash)} → ${formatMoneyConcise(cash - downpayment)}, then ${formatMoneyConcise(monthlyPayment)}/mo`,
+              },
+              {
+                concept: "time",
+                label: "Online in",
+                value: `${Math.round(storage.yearsToBuild * 12)} months`,
+                detail:
+                  "Grid flexibility does not change until construction finishes.",
+              },
+              {
+                concept: "storage",
+                label: "Grid flexibility",
+                value: `+${formatWattHours(storage.peakWh)} storage`,
+                detail: `${formatWatts(storage.peakW)} maximum charge or discharge`,
+              },
+              {
+                concept: "supply",
+                label: "Round-trip efficiency",
+                value: `${Math.round(storage.roundTripEfficiency * 100)}%`,
+              },
+            ]}
+          />
           <TableContainer>
             <Table size="small">
               <TableBody>

--- a/src/components/views/BuildStorageContainer.tsx
+++ b/src/components/views/BuildStorageContainer.tsx
@@ -3,6 +3,9 @@ import { connect } from "react-redux";
 import { navigate } from "../../reducers/Card";
 import { setSpeed } from "../../reducers/Game";
 import { buildFacility } from "../../reducers/Game";
+import { selectFacility, snackbarOpen } from "../../reducers/UI";
+import { getStore } from "../../StoreRegistry";
+import { buildConsequenceMessage } from "../../helpers/BuildConsequences";
 import { AppStateType, SpeedType, StorageShoppingType } from "../../Types";
 import BuildStorage, { DispatchProps, StateProps } from "./BuildStorage";
 
@@ -18,7 +21,27 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
       dispatch(navigate("FACILITIES"));
     },
     onBuildStorage: (facility: StorageShoppingType, financed: boolean) => {
+      const beforeIds = new Set(
+        getStore()
+          .getState()
+          .game.facilities.map((candidate) => candidate.id),
+      );
       dispatch(buildFacility({ facility, financed }));
+      const built = getStore()
+        .getState()
+        .game.facilities.find((candidate) => !beforeIds.has(candidate.id));
+      if (built) {
+        dispatch(selectFacility(built.id));
+        dispatch(
+          snackbarOpen({
+            message: buildConsequenceMessage(facility, financed),
+            open: true,
+            timeout: 8000,
+            actionLabel: "Events",
+            action: () => dispatch(navigate("EVENTS")),
+          }),
+        );
+      }
     },
     onSpeedChange: (speed: SpeedType) => {
       dispatch(setSpeed(speed));

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -48,6 +48,15 @@ describe("NewGame", () => {
     ).toContainElement(rows[0]);
   });
 
+  it("turns scored scenarios into visual postcards of their starting fleets", () => {
+    render(<NewGame {...props()} />);
+    expect(
+      screen.getByRole("img", {
+        name: "Carbon Fee starting grid: Coal, Natural Gas",
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("highlights the first incomplete tutorial without replacing its subtitle", () => {
     recordPlayed(TUTORIALS[0].id);
     render(<NewGame {...props()} />);

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -25,6 +25,7 @@ import {
   TUTORIALS,
 } from "../../data/Scenarios";
 import { GameType, ScenarioType } from "../../Types";
+import ScenarioArtwork from "../base/ScenarioArtwork";
 
 export interface StateProps {
   game: GameType;
@@ -71,7 +72,7 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
   return (
     <Card
       data-testid={`mission-row-${s.id}`}
-      className={`build-list-item${next ? " tutorialNext" : ""}`}
+      className={`build-list-item${s.briefing ? " scenarioPostcard" : ""}${next ? " tutorialNext" : ""}`}
     >
       <CardActionArea
         onClick={onSelect}
@@ -83,9 +84,10 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
         }
       >
         <CardHeader
+          className={s.briefing ? "scenarioPostcardHeader" : undefined}
           avatar={
             <Badge
-              overlap="circular"
+              overlap={s.briefing ? "rectangular" : "circular"}
               anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
               badgeContent={
                 completed ? (
@@ -99,7 +101,11 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
                 ) : undefined
               }
             >
-              <Avatar src={`/images/${s.icon.toLowerCase()}.svg`} />
+              {s.briefing ? (
+                <ScenarioArtwork scenario={s} compact />
+              ) : (
+                <Avatar src={`/images/${s.icon.toLowerCase()}.svg`} />
+              )}
             </Badge>
           }
           title={<span>{s.name}</span>}

--- a/src/components/views/NewGameDetails.test.tsx
+++ b/src/components/views/NewGameDetails.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { GameType } from "../../Types";
 import NewGameDetails, { Props } from "./NewGameDetails";
 
@@ -65,6 +66,22 @@ describe("NewGameDetails leaderboard", () => {
     await screen.findByText("Play the scenario to set a high score");
   });
 
+  it("leads with the scenario fantasy, stakes, and target", async () => {
+    render(<NewGameDetails {...props()} />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Lead a legacy utility through a clean-energy transition.",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Objective")).toBeInTheDocument();
+    expect(screen.getByText("Constraint")).toBeInTheDocument();
+    expect(screen.getByText("Threat")).toBeInTheDocument();
+    expect(screen.getByText("Winning looks like")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start mission" })).toBeVisible();
+    await screen.findByText("Play the scenario to set a high score");
+  });
+
   it("is always visible and follows the selected difficulty", async () => {
     const { rerender } = render(<NewGameDetails {...props()} />);
 
@@ -102,5 +119,25 @@ describe("NewGameDetails leaderboard", () => {
     expect(cells[1]).toHaveTextContent("Your best");
     expect(cells[2]).toHaveTextContent("432");
     expect(cells[1]).not.toHaveTextContent("432");
+  });
+
+  it("keeps the leaderboard secondary until the player asks for all rows", async () => {
+    mockGetDocs.mockResolvedValue({
+      docs: Array.from({ length: 5 }, (_, index) => ({
+        data: () => ({
+          score: 500 - index,
+          displayName: `Player ${index + 1}`,
+        }),
+      })),
+    });
+    render(<NewGameDetails {...props()} />);
+
+    await screen.findByText("Player 3");
+    expect(screen.queryByText("Player 4")).toBeNull();
+    await userEvent.click(
+      screen.getByRole("button", { name: "View all 5 scores" }),
+    );
+    expect(screen.getByText("Player 4")).toBeInTheDocument();
+    expect(screen.getByText("Player 5")).toBeInTheDocument();
   });
 });

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -10,6 +10,7 @@ import {
   limit,
 } from "firebase/firestore";
 import {
+  Box,
   Button,
   IconButton,
   MenuItem,
@@ -27,6 +28,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Stack,
 } from "@mui/material";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import CloseIcon from "@mui/icons-material/Close";
@@ -34,6 +36,8 @@ import InfoIcon from "@mui/icons-material/Info";
 import PlayCircleIcon from "@mui/icons-material/PlayCircleOutlined";
 import CircularProgress from "@mui/material/CircularProgress";
 import VictoryConditions from "../base/VictoryConditions";
+import ConceptIcon, { ConceptNameType } from "../base/ConceptIcon";
+import ScenarioArtwork from "../base/ScenarioArtwork";
 import { DIFFICULTIES } from "../../Constants";
 import { getDb, login } from "../../Globals";
 import { getScenario } from "../../data/Scenarios";
@@ -86,9 +90,28 @@ interface State {
   victoryDialogOpen?: boolean;
   // The replay currently being fetched, so its row can show a spinner instead of the play button
   loadingReplayId?: string;
+  leaderboardExpanded?: boolean;
 }
 
 export interface Props extends StateProps, DispatchProps {}
+
+function BriefingFact(props: {
+  concept: ConceptNameType;
+  label: string;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <div className="scenarioBriefingFact">
+      <ConceptIcon concept={props.concept} fontSize="small" />
+      <div>
+        <Typography variant="overline" component="div">
+          {props.label}
+        </Typography>
+        <Typography variant="body2">{props.children}</Typography>
+      </div>
+    </div>
+  );
+}
 
 export default class NewGameDetails extends React.Component<Props, State> {
   private boardRequestId = 0;
@@ -264,6 +287,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
       location,
       victoryDialogOpen,
       boardFailed,
+      leaderboardExpanded,
     } = this.state;
 
     const toggleVictoryDialog = (e: React.SyntheticEvent) => {
@@ -288,6 +312,18 @@ export default class NewGameDetails extends React.Component<Props, State> {
       );
     }
 
+    const briefing = scenario.briefing || {
+      fantasy: scenario.summary || scenario.name,
+      objective: "Keep the lights on and finish the term.",
+      constraint: `${scenario.ownership}-owned scoring rewards a balanced grid.`,
+      threat: "Blackouts and insolvency can end the run early.",
+      target: "A reliable grid and a healthy company.",
+    };
+    const endYear =
+      scenario.startingYear + Math.floor(scenario.durationMonths / 12);
+    const visibleScores =
+      scores && !leaderboardExpanded ? scores.slice(0, 3) : scores;
+
     return (
       <div id="listCard" className="flexContainer">
         <div id="topbar">
@@ -307,78 +343,106 @@ export default class NewGameDetails extends React.Component<Props, State> {
           </Toolbar>
         </div>
         <div className="scrollable">
-          <div
-            style={{
-              textAlign: "center",
-              margin: "20px 0",
-              lineHeight: "30px",
-            }}
+          <section
+            className="scenarioDossier"
+            aria-labelledby="scenario-fantasy"
           >
-            <Typography variant="h5" component="h2" sx={{ fontWeight: 800 }}>
-              Your challenge
-            </Typography>
-            <Typography sx={{ maxWidth: 560, mx: "auto", mb: 1 }}>
-              {scenario.summary}
-            </Typography>
-            Goal: keep the lights on, protect your finances, and meet the{" "}
-            {scenario.ownership.toLowerCase()}-owned scoring targets
-            <IconButton
-              onClick={toggleVictoryDialog}
-              aria-label="Victory conditions"
-              color="primary"
-              size="small"
-            >
-              <InfoIcon />
-            </IconButton>
-            <br />
-            <strong>Length:</strong> {scenario.durationMonths / 12} years (
-            {scenario.startingYear} to{" "}
-            {scenario.startingYear + Math.floor(scenario.durationMonths / 12)}
-            )<br />
-            <strong>Location:</strong> {location.name}
-            <br />
-            <strong>Difficulty:</strong>&nbsp;
-            <Select
-              value={game.difficulty}
-              onChange={(e: SelectChangeEvent<DifficultyType>) =>
-                onDelta({ difficulty: e.target.value as DifficultyType })
-              }
-            >
-              {Object.keys(DIFFICULTIES).map((d: string) => {
-                return (
-                  <MenuItem value={d} key={d}>
-                    <Tooltip
-                      title={DIFFICULTIES[d].description}
-                      placement="right"
-                    >
-                      <span>
-                        {DIFFICULTY_LABELS[d]} ({d})
-                      </span>
-                    </Tooltip>
-                  </MenuItem>
-                );
-              })}
-            </Select>
-            <Typography
-              variant="body2"
-              color="textSecondary"
-              sx={{ maxWidth: 560, mx: "auto", mt: 1 }}
-            >
-              {DIFFICULTIES[game.difficulty].description}
-            </Typography>
-          </div>
-
-          <div style={{ textAlign: "center" }}>
-            <Button
-              size="large"
-              variant="contained"
-              color="primary"
-              onClick={() => onStart(scenario.id)}
-              autoFocus
-            >
-              Start {scenario.name}
-            </Button>
-          </div>
+            <ScenarioArtwork scenario={scenario} />
+            <div className="scenarioDossierCopy">
+              <Typography variant="overline" component="div">
+                {location.name} · {scenario.startingYear}-{endYear} ·{" "}
+                {scenario.durationMonths / 12} years
+              </Typography>
+              <Typography
+                id="scenario-fantasy"
+                variant="h4"
+                component="h2"
+                sx={{ fontWeight: 800, lineHeight: 1.1 }}
+              >
+                {briefing.fantasy}
+              </Typography>
+              <Typography variant="body1" color="textSecondary">
+                {scenario.summary}
+              </Typography>
+              <div className="scenarioBriefingFacts">
+                <BriefingFact concept="goal" label="Objective">
+                  {briefing.objective}
+                </BriefingFact>
+                <BriefingFact concept="finances" label="Constraint">
+                  {briefing.constraint}
+                </BriefingFact>
+                <BriefingFact concept="danger" label="Threat">
+                  {briefing.threat}
+                </BriefingFact>
+              </div>
+              <Box className="scenarioTarget">
+                <ConceptIcon concept="supply" fontSize="small" />
+                <div>
+                  <Typography variant="overline" component="div">
+                    Winning looks like
+                  </Typography>
+                  <Typography variant="body2">{briefing.target}</Typography>
+                </div>
+                <IconButton
+                  onClick={toggleVictoryDialog}
+                  aria-label="Victory conditions"
+                  color="primary"
+                  size="small"
+                >
+                  <InfoIcon />
+                </IconButton>
+              </Box>
+              <Stack
+                className="scenarioStartControls"
+                direction={{ xs: "column", sm: "row" }}
+                spacing={1.5}
+                sx={{ alignItems: { xs: "stretch", sm: "center" } }}
+              >
+                <div>
+                  <Typography variant="caption" component="div">
+                    Difficulty
+                  </Typography>
+                  <Select
+                    value={game.difficulty}
+                    size="small"
+                    onChange={(e: SelectChangeEvent<DifficultyType>) =>
+                      onDelta({ difficulty: e.target.value as DifficultyType })
+                    }
+                  >
+                    {Object.keys(DIFFICULTIES).map((d: string) => (
+                      <MenuItem value={d} key={d}>
+                        <Tooltip
+                          title={DIFFICULTIES[d].description}
+                          placement="right"
+                        >
+                          <span>
+                            {DIFFICULTY_LABELS[d]} ({d})
+                          </span>
+                        </Tooltip>
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </div>
+                <Typography
+                  variant="body2"
+                  color="textSecondary"
+                  sx={{ flex: 1 }}
+                >
+                  {DIFFICULTIES[game.difficulty].description}
+                </Typography>
+                <Button
+                  size="large"
+                  variant="contained"
+                  color="primary"
+                  onClick={() => onStart(scenario.id)}
+                  autoFocus
+                  startIcon={<PlayCircleIcon />}
+                >
+                  Start mission
+                </Button>
+              </Stack>
+            </div>
+          </section>
 
           <Dialog
             open={victoryDialogOpen || false}
@@ -462,8 +526,8 @@ export default class NewGameDetails extends React.Component<Props, State> {
                     </TableCell>
                   </TableRow>
                 )}
-                {scores &&
-                  scores.map((score: ScoreType, i: number) => {
+                {visibleScores &&
+                  visibleScores.map((score: ScoreType, i: number) => {
                     const mine = Boolean(uid) && score.uid === uid;
                     return (
                       <TableRow
@@ -486,6 +550,20 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   })}
               </TableBody>
             </Table>
+            {scores && scores.length > 3 && (
+              <div className="leaderboardToggle">
+                <Button
+                  size="small"
+                  onClick={() =>
+                    this.setState({ leaderboardExpanded: !leaderboardExpanded })
+                  }
+                >
+                  {leaderboardExpanded
+                    ? "Show top 3"
+                    : `View all ${scores.length} scores`}
+                </Button>
+              </div>
+            )}
           </div>
           {/* Below the board rather than in place of it: the board is the reason to log in */}
           {!uid && (

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -82,3 +82,22 @@ describe("tutorial mission metadata", () => {
     ).toHaveTextContent("variable O&M whenever it generates");
   });
 });
+
+describe("authored scenario briefings", () => {
+  it("gives every scored scenario a reusable story, stakes, and target", () => {
+    SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
+      (scenario) => {
+        expect(scenario.briefing).toEqual(
+          expect.objectContaining({
+            tone: expect.any(String),
+            fantasy: expect.any(String),
+            objective: expect.any(String),
+            constraint: expect.any(String),
+            threat: expect.any(String),
+            target: expect.any(String),
+          }),
+        );
+      },
+    );
+  });
+});

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -508,6 +508,14 @@ export const SCENARIOS = [
     icon: "solar",
     locationId: "SF",
     summary: `New limits have been placed on pollution - can you modernize the company?`,
+    briefing: {
+      tone: "transition",
+      fantasy: "Lead a legacy utility through a clean-energy transition.",
+      objective: "Modernize the fleet without sacrificing reliability.",
+      constraint: "A $50/t CO2 fee makes every dirty MWh more expensive.",
+      threat: "Aging coal assets and thin margins leave little room for delay.",
+      target: "A reliable, lower-carbon grid that still creates value.",
+    },
     ownership: "Investor",
     startingYear: 2020,
     cash: 330000000,
@@ -525,6 +533,16 @@ export const SCENARIOS = [
     icon: "natural gas",
     locationId: "PIT",
     summary: `Cheap natural gas has been discovered nearby - are you ready for the boom?`,
+    briefing: {
+      tone: "boom",
+      fantasy: "Turn an energy boom into durable advantage.",
+      objective:
+        "Use cheap gas to grow without betting the company on one fuel.",
+      constraint:
+        "Coal dominates the starting fleet and new plants last decades.",
+      threat: "Fuel prices can turn before a rushed buildout pays for itself.",
+      target: "A flexible fleet that can survive the boom's next turn.",
+    },
     ownership: "Investor",
     startingYear: 2006,
     cash: 220000000,
@@ -539,6 +557,15 @@ export const SCENARIOS = [
     icon: "wind",
     locationId: "HNL",
     summary: "A beautiful island - with a complex grid.",
+    briefing: {
+      tone: "island",
+      fantasy: "Keep an island paradise bright without mainland backup.",
+      objective: "Replace expensive oil while matching a volatile island load.",
+      constraint:
+        "Every fuel shipment and every build dollar matters more offshore.",
+      threat: "One weak link can leave the whole island in the dark.",
+      target: "A diverse island grid powered by local resources.",
+    },
     ownership: "Investor",
     startingYear: 2004,
     cash: 275000000,
@@ -557,6 +584,16 @@ export const SCENARIOS = [
     icon: "geothermal",
     locationId: "SF",
     summary: "Technology is advancing rapidly - can you keep up?",
+    briefing: {
+      tone: "innovation",
+      fantasy: "Ride the first great wave of modern renewable power.",
+      objective: "Retire aging oil and build the technologies of the future.",
+      constraint:
+        "Promising options arrive at different times and price points.",
+      threat:
+        "Move too early and overpay; move too late and fall behind demand.",
+      target: "A modern fleet ready for the next energy era.",
+    },
     ownership: "Investor",
     startingYear: 2002,
     cash: 220000000,
@@ -574,6 +611,14 @@ export const SCENARIOS = [
     icon: "wind",
     locationId: "SJU",
     summary: "A remote island, with expensive fuel and destructive weather.",
+    briefing: {
+      tone: "storm",
+      fantasy: "Run a fragile island grid through relentless storm seasons.",
+      objective: "Build enough resilience to keep essential power flowing.",
+      constraint: "Remote fuel is costly and replacement capacity takes time.",
+      threat: "Extreme weather can turn a narrow reserve into a crisis.",
+      target: "A resilient, diversified grid that can weather the next storm.",
+    },
     ownership: "Public",
     startingYear: 2000,
     cash: 220000000,
@@ -592,6 +637,16 @@ export const SCENARIOS = [
     icon: "coal",
     locationId: "PIT",
     summary: "Your coal business faces new challenges - and opportunities.",
+    briefing: {
+      tone: "legacy",
+      fantasy: "Decide what comes after a century built on coal.",
+      objective:
+        "Evolve the business before its aging fleet becomes a liability.",
+      constraint: "Most of your capital and operating knowledge sits in coal.",
+      threat:
+        "Old plants, new competitors and long build times punish hesitation.",
+      target: "A profitable successor to the coal empire you inherited.",
+    },
     ownership: "Investor",
     startingYear: 1980,
     cash: 198000000,

--- a/src/helpers/BuildConsequences.test.tsx
+++ b/src/helpers/BuildConsequences.test.tsx
@@ -1,0 +1,19 @@
+import { GeneratorShoppingType } from "../Types";
+import { buildConsequenceMessage } from "./BuildConsequences";
+
+const generator = {
+  name: "Natural Gas",
+  buildCost: 150000000,
+  yearsToBuild: 1,
+  peakW: 200000000,
+  capacityFactor: 0.45,
+} as GeneratorShoppingType;
+
+it("connects the commitment to construction and expected supply", () => {
+  expect(buildConsequenceMessage(generator, false)).toBe(
+    "$150M committed → Natural Gas online in 12 mo → +90MW typical supply",
+  );
+  expect(buildConsequenceMessage(generator, true)).toContain(
+    "$30M down payment",
+  );
+});

--- a/src/helpers/BuildConsequences.tsx
+++ b/src/helpers/BuildConsequences.tsx
@@ -1,0 +1,21 @@
+import { DOWNPAYMENT_PERCENT } from "../Constants";
+import { FacilityShoppingType, GeneratorShoppingType } from "../Types";
+import { formatMoneyConcise, formatWattHours, formatWatts } from "./Format";
+
+export function buildConsequenceMessage(
+  facility: FacilityShoppingType,
+  financed: boolean,
+): string {
+  const committed = financed
+    ? facility.buildCost * DOWNPAYMENT_PERCENT
+    : facility.buildCost;
+  const months = Math.round(facility.yearsToBuild * 12);
+  const contribution = facility.peakWh
+    ? `${formatWatts(facility.peakW)} output / ${formatWattHours(facility.peakWh)} storage`
+    : `${formatWatts(
+        facility.peakW * (facility as GeneratorShoppingType).capacityFactor,
+      )} typical supply`;
+  return `${formatMoneyConcise(committed)} ${
+    financed ? "down payment" : "committed"
+  } → ${facility.name} online in ${months} mo → +${contribution}`;
+}

--- a/src/helpers/Debrief.test.tsx
+++ b/src/helpers/Debrief.test.tsx
@@ -1,0 +1,54 @@
+import { SCENARIOS } from "../data/Scenarios";
+import { GameEventType, MonthlyHistoryType } from "../Types";
+import { buildVictoryDebrief } from "./Debrief";
+
+const summary = {
+  cash: 500000000,
+  customers: 1200000,
+  supplyWh: 99,
+  demandWh: 100,
+  kgco2e: 2000000000,
+} as MonthlyHistoryType;
+
+it("captures a plain then-versus-now story and the latest meaningful beats", () => {
+  const scenario = SCENARIOS.find((candidate) => candidate.id === 100)!;
+  const events = [
+    {
+      id: 2,
+      kind: "CONSTRUCTION",
+      label: "Jan 2028",
+      message: "Construction complete: Solar",
+    },
+    {
+      id: 1,
+      kind: "BUILD",
+      label: "Jan 2027",
+      message: "Building Solar",
+      importance: "NOTABLE",
+    },
+  ] as GameEventType[];
+  const debrief = buildVictoryDebrief(
+    scenario,
+    summary,
+    [
+      { fuel: "Coal", peakW: 300000000, yearsToBuildLeft: 0 },
+      { fuel: "Sun", peakW: 400000000, yearsToBuildLeft: 0 },
+      { fuel: "Wind", peakW: 500000000, yearsToBuildLeft: 1 },
+    ],
+    events,
+  );
+
+  expect(debrief.startingFleet).toEqual([
+    { fuel: "Coal", watts: 300000000 },
+    { fuel: "Natural Gas", watts: 200000000 },
+  ]);
+  expect(debrief.finalFleet).toEqual([
+    { fuel: "Sun", watts: 400000000 },
+    { fuel: "Coal", watts: 300000000 },
+  ]);
+  expect(debrief.reliability).toBe(0.99);
+  expect(debrief.highlights.map((event) => event.label)).toEqual([
+    "Jan 2027",
+    "Jan 2028",
+  ]);
+});

--- a/src/helpers/Debrief.tsx
+++ b/src/helpers/Debrief.tsx
@@ -1,0 +1,85 @@
+import {
+  FacilityShoppingType,
+  FuelNameType,
+  GameEventType,
+  MonthlyHistoryType,
+  ScenarioType,
+  VictoryDebriefType,
+  VictoryFleetCapacityType,
+} from "../Types";
+
+type FleetAssetType = Partial<FacilityShoppingType> & {
+  yearsToBuildLeft?: number;
+};
+
+export function fleetCapacity(
+  facilities: FleetAssetType[],
+  operationalOnly = false,
+): VictoryFleetCapacityType[] {
+  const totals: Partial<Record<FuelNameType, number>> = {};
+  facilities.forEach((facility) => {
+    const fuel = facility.fuel as FuelNameType | undefined;
+    if (
+      !fuel ||
+      !facility.peakW ||
+      (operationalOnly && (facility.yearsToBuildLeft || 0) > 0)
+    ) {
+      return;
+    }
+    totals[fuel] = (totals[fuel] || 0) + facility.peakW;
+  });
+  return (Object.entries(totals) as [FuelNameType, number][])
+    .map(([fuel, watts]) => ({ fuel, watts }))
+    .sort((a, b) => b.watts - a.watts);
+}
+
+function debriefHighlights(events: GameEventType[]) {
+  const seen = new Set<string>();
+  return events
+    .filter(
+      (event) =>
+        event.importance ||
+        event.kind === "BLACKOUT" ||
+        event.kind === "BLACKOUT_OVER" ||
+        event.kind === "CONSTRUCTION",
+    )
+    .filter((event) => {
+      if (seen.has(event.message)) {
+        return false;
+      }
+      seen.add(event.message);
+      return true;
+    })
+    .slice(0, 3)
+    .reverse()
+    .map(({ kind, label, message, importance }) => ({
+      kind,
+      label,
+      message,
+      importance,
+    }));
+}
+
+export function buildVictoryDebrief(
+  scenario: ScenarioType,
+  summary: MonthlyHistoryType,
+  facilities: FleetAssetType[],
+  events: GameEventType[],
+): VictoryDebriefType {
+  const unservedWh = Math.max(0, summary.demandWh - summary.supplyWh);
+  const reliability =
+    summary.demandWh > 0
+      ? Math.max(0, Math.min(1, summary.supplyWh / summary.demandWh))
+      : 1;
+  return {
+    startingFleet: fleetCapacity(scenario.facilities),
+    finalFleet: fleetCapacity(facilities, true),
+    startingCash: scenario.cash,
+    finalCash: summary.cash,
+    finalCustomers: summary.customers,
+    reliability,
+    unservedWh,
+    kgco2e: summary.kgco2e,
+    highlights: debriefHighlights(events),
+  };
+}

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -36,6 +36,8 @@ import {
 import { arrayMove, newSeed } from "../helpers/Math";
 import { computeScoreBreakdown, totalScore } from "../helpers/Scoring";
 import { formatLargeMass } from "../helpers/Units";
+import { buildConsequenceMessage } from "../helpers/BuildConsequences";
+import { buildVictoryDebrief } from "../helpers/Debrief";
 import {
   getAirborneWindOutputFactor,
   getAirborneWindReferenceKph,
@@ -851,7 +853,8 @@ function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
   logGameEvent(
     state,
     "BUILD",
-    `Building ${built.name}, ${built.peakWh ? formatWattHours(built.peakWh) : formatWatts(built.peakW)}${payload.financed ? " (financed)" : ""}`,
+    buildConsequenceMessage(built, payload.financed),
+    { importance: "NOTABLE", actionTarget: "FACILITIES" },
   );
   state = buildFacilityHelper(state, built, payload.financed);
   // Assigned rather than spread into a new object: this is an immer draft, so a fresh object
@@ -1166,6 +1169,12 @@ export function tickState(state: GameType) {
         const { id: scoredScenarioId, name: scenarioName } = scenario;
         const submitsScore = ranked;
         const replay = submitsScore ? serializeReplay(state) : undefined;
+        const debrief = buildVictoryDebrief(
+          scenario,
+          summary,
+          state.facilities,
+          state.eventLog,
+        );
 
         if (!isReplay) {
           logEvent("scenario_end", {
@@ -1203,6 +1212,7 @@ export function tickState(state: GameType) {
               ranked,
               previousBest,
               outcome,
+              debrief,
             }),
           );
           if (submitsScore) {

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -118,6 +118,14 @@ describe("ending a scenario from inside the reducer", () => {
     expect(victory).not.toBeNull();
     expect(victory?.scenarioName).toBe("A Test Run");
     expect(Object.keys(victory?.breakdown || {}).length).toBeGreaterThan(0);
+    expect(victory?.debrief).toEqual(
+      expect.objectContaining({
+        startingFleet: expect.any(Array),
+        finalFleet: expect.any(Array),
+        reliability: expect.any(Number),
+        highlights: expect.any(Array),
+      }),
+    );
     // Every custom game shares one id, so its score belongs to nothing comparable
     expect(victory?.ranked).toBe(false);
     // Opening the score screen stops the clock, the way any other dialog does


### PR DESCRIPTION
## Summary

Advances #45 by turning four of the design review’s shared recommendations into one connected player loop:

- give every scored scenario a distinct postcard and dossier-style briefing;
- make generator selection decision-first, with roles, forecast-gap coverage, advantages, and a 2–3 option comparison tray;
- preview exact cash, construction, supply/storage, and emissions consequences before generator or storage purchases;
- carry the decision through after purchase by selecting the construction row and logging/showing the same `cash → online date → grid effect` chain;
- finish scored runs with a “then vs now” debrief showing fleet transition, reliability, customers, cash, emissions, unserved energy, and important turning points.

## Scenario identity

- Adds authored `fantasy`, `objective`, `constraint`, `threat`, `target`, and limited-palette tone metadata for all six scored scenarios.
- Reuses the existing scenario/fuel icons to generate compact mission-list postcards and a larger responsive dossier visual, so new bitmap assets are not required for each scenario.
- Makes the scenario CTA read `Start mission` and collapses the global leaderboard to its top three scores until requested.

## Decision clarity and consequence choreography

- Generator cards now lead with an actionable role (`Clean, weather-led`, `Flexible power`, `Steady output`, or `Clean & dispatchable`), typical output, share of the peak forecast gap, and useful extrema such as lowest upfront/lifetime cost or fastest online.
- Players can pin up to three generators into a persistent comparison tray.
- Generator and storage confirmation dialogs use a common expected-impact component for exact before/after cash or financing, online timing, capacity/output, reserve caveats, efficiency, and direct emissions.
- Generator/storage builds create a durable event-log entry and an 8-second snackbar with an Events action. The newly created facility is selected on return so the player sees the affected construction row immediately.

## End-of-run debrief

- Captures starting and final operational fleet mix, starting/final cash, customers, reliability, unserved energy, and CO2e before the game draft is finalized.
- Renders accessible stacked fleet bars and up to three meaningful event-log highlights as `Turning points` before the score breakdown.
- Keeps the debrief derived from authoritative scenario/run state; no new scoring or simulation behavior is introduced.

## Follow-ups

- #249 — compact objective HUD plus unguided capstones for each training mission
- #250 — sparse, deterministic story beats authored for every scored scenario

## Validation

- `node ../../node_modules/typescript/bin/tsc --noEmit`
- `node ../../node_modules/eslint/bin/eslint.js "src/**/*.{ts,tsx}" --max-warnings=0`
- `node ../../node_modules/prettier/bin/prettier.cjs --check "src/**/*.{ts,tsx,js,jsx,css,scss,json}"`
- `node ../../node_modules/react-scripts/scripts/test.js --watchAll=false --runInBand` — **79 suites / 793 tests passed**
- `node scripts/sim.js --all` — all tutorials/scenarios preserved every simulation invariant
- `node ../../node_modules/react-scripts/scripts/build.js` — production build completed
- Manual browser QA at the normal desktop viewport and at 390×844: mission browser, Carbon Fee dossier, generator comparison, purchase preview, post-build selected row/snackbar, keyboard/accessible DOM labels, and responsive layout

The branch is rebased onto the Oil variable-O&M work merged in #248; both upstream Oil coverage and this PR’s generator-decision coverage are retained.
