### PR TITLE
Clean up unused public assets

### DIFF
--- a/public/images/icon.png
+++ b/public/images/icon.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5675f53e0dd0eea83ac8b5b7dbe56ecf40ba5731151209a379a3ebd77cfdc369
-size 20171

--- a/public/images/icon.svg
+++ b/public/images/icon.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9dc5fe84d463eadc4614e12a2dae9013926d24cf6c1048e459e81dc2b8468ec7
-size 16177

--- a/public/images/icon/100x100.png
+++ b/public/images/icon/100x100.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05283eac18680a556152bc2f1f33d27ee603118d14eaba59f05a54e95cc56d31
-size 1931

--- a/public/images/icon/114x114.png
+++ b/public/images/icon/114x114.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7be09f5eda1ee27a436422b67bf72540c70f0b1eb1205bfb057dd2b4975ee764
-size 2215

--- a/public/images/icon/120x120.png
+++ b/public/images/icon/120x120.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2f4ecd74fed76e065d96fb863346b0bf28a4a6306923f1d48c918ae19b895e9e
-size 2327

--- a/public/images/icon/167x167.png
+++ b/public/images/icon/167x167.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:902a1524e49b870825b37ec00fc1b1e76c8b02c32d5a6a394888920e96cc32e4
-size 3192

--- a/public/images/icon/180x180.png
+++ b/public/images/icon/180x180.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:32d5a1e23a42471b4a26196f04b23b0affbad759e711dabda2cc5da713d5c5c2
-size 3409

--- a/public/images/icon/29x29.png
+++ b/public/images/icon/29x29.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01cf8af4cfb1ac68b520ff6a9558106535b60fe6e0297ab6cb853e341ca58297
-size 680

--- a/public/images/icon/36x36.png
+++ b/public/images/icon/36x36.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bc9a5e5de1c1f8cd6b5564c06329dc1e93dc2f8e4dac964e85fd7d8cbff34c4b
-size 805

--- a/public/images/icon/40x40.png
+++ b/public/images/icon/40x40.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ebbdef32c54961e3180b2a8e00f590fad5c50abc5e150ed8aaa46badb171994
-size 852

--- a/public/images/icon/48x48.png
+++ b/public/images/icon/48x48.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd3929901d89134453befa7e06545b2e38853de6794d60ec96e6fc4ac85d0f59
-size 995

--- a/public/images/icon/50x50.png
+++ b/public/images/icon/50x50.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06e2f79140ee22c461b9c77e8a435c9215e31d8c9edfe6ca5c7b1efbdad9f1f8
-size 1032

--- a/public/images/icon/57x57.png
+++ b/public/images/icon/57x57.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77daa7a1490df03a6a078d5ce8b1ab279151cb7215213d9c46b0594b26ac641b
-size 1119

--- a/public/images/icon/58x58.png
+++ b/public/images/icon/58x58.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff7b1b5e4868adc820b49e8bd71aa51a825a3013bf90f54bc872750c39395647
-size 1203

--- a/public/images/icon/60x60.png
+++ b/public/images/icon/60x60.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7eb5af5b1e4d4965a8e669994d2b323d424de121cc985d55f39ed311f375b21
-size 1192

--- a/public/images/icon/72x72.png
+++ b/public/images/icon/72x72.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb6d8ba19ec420069d30d87c3a7fc746ca3b11ffb61e15fb08bc564d876262f9
-size 1424

--- a/public/images/icon/76x76.png
+++ b/public/images/icon/76x76.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6fee4119b7bff4fa0218e39e3e86954519f9ed3e07ebbffea9819ec09b4e7f3f
-size 1522

--- a/public/images/icon/80x80.png
+++ b/public/images/icon/80x80.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bff1287edd879033949373a314f7c617c54ab002fd10c28a9168dd6f6c32c5fb
-size 1598

--- a/public/images/icon/96x96.png
+++ b/public/images/icon/96x96.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:799af74e01a053dd0a31486e4bea61d2c2a0283feadc4a96566043ff77f7596f
-size 1917

--- a/public/images/touch/apple-touch-icon-152x152.png
+++ b/public/images/touch/apple-touch-icon-152x152.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d040d5db474eccc07ca41439119d6652475b3417f4430c0bffc6b1d88162752f
-size 2959

--- a/public/images/touch/chrome-splashscreen-icon-310x310.png
+++ b/public/images/touch/chrome-splashscreen-icon-310x310.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53103e2c1dd3f89911941fc35847f1220383ffef54d3f87b81dadab76561d930
-size 5896

--- a/public/images/touch/chrome-touch-icon-192x192.png
+++ b/public/images/touch/chrome-touch-icon-192x192.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e145cf8cd35f1c79e00d1519b3f52127c2ef52eb6fa8109f041bba5693773aa
-size 3707

--- a/public/images/touch/icon-120x120.png
+++ b/public/images/touch/icon-120x120.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2f4ecd74fed76e065d96fb863346b0bf28a4a6306923f1d48c918ae19b895e9e
-size 2327

--- a/public/images/touch/ms-icon-144x144.png
+++ b/public/images/touch/ms-icon-144x144.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73061c714f37528820cf91cb3eb61519e99bf38922df618609f0805bc619f834
-size 2762

--- a/public/images/touch/ms-touch-icon-144x144-precomposed.png
+++ b/public/images/touch/ms-touch-icon-144x144-precomposed.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73061c714f37528820cf91cb3eb61519e99bf38922df618609f0805bc619f834
-size 2762

--- a/public/index.html
+++ b/public/index.html
@@ -79,13 +79,13 @@
     />
     <link
       rel="apple-touch-icon"
-      href="%PUBLIC_URL%/images/touch/apple-touch-icon-152x152.png"
+      href="%PUBLIC_URL%/images/icon/152x152.png"
     />
 
     <!-- Tile icon for Win8 (144x144) -->
     <meta
       name="msapplication-TileImage"
-      content="%PUBLIC_URL%/images/touch/ms-touch-icon-144x144-precomposed.png"
+      content="%PUBLIC_URL%/images/icon/144x144.png"
     />
   </head>
   <body unresolved class="fullbleed layout vertical center-justified">

--- a/public/logo192.png
+++ b/public/logo192.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:79ce13bf8f584fc7efd9a96c4380b7330e1369062de81d42759009c5e079ca37
-size 4153

--- a/public/logo512.png
+++ b/public/logo512.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d14a225fac5414703857891b04552be24ba49f0a51479dc5268589d3c30f0da9
-size 12066


### PR DESCRIPTION
## Summary

- remove Redux logo files left behind by the Create React App migration
- delete unreferenced legacy icon exports and duplicate touch icons
- point Apple and Windows metadata at the retained canonical Electrify icon files

## Testing

- `npm run check` (79 suites, 793 tests)
- `npm run build`