### PR TITLE
Embed Google Form for player feedback

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -123,18 +123,35 @@
         </ul>
       </section>
 
-      <section class="panel panel--contact">
-        <div>
+      <section class="panel panel--contact" id="feedback">
+        <div class="panel__intro">
           <span class="panel__number" aria-hidden="true">03</span>
-          <h2>Let’s build a better grid</h2>
+          <h2 id="feedback-title">Help us build a better grid</h2>
           <p>
-            Questions, feedback, or an idea for collaboration? We’d love to hear
-            from you.
+            Found a bug, have an idea, or want to tell us what worked? Send it
+            straight to the Electrify team—no email app required.
+          </p>
+          <p class="feedback-privacy">
+            Your feedback is submitted through Google Forms. Only include
+            contact details if you would like a reply.
           </p>
         </div>
-        <div class="panel__actions">
-          <a class="button button--primary" href="mailto:todd@fabricate.io"
-            >Send us an email</a
+        <div class="feedback-form">
+          <iframe
+            src="https://docs.google.com/forms/d/e/1FAIpQLSdQIq1zDnyGCgDVzLq9WmHVVP9l3K6QLWufVvrhPM20EUa6ug/viewform?embedded=true"
+            title="Electrify feedback form"
+            loading="lazy"
+          >
+            <a href="https://forms.gle/nSpkVzcFcXMQMMgb9"
+              >Open the Electrify feedback form</a
+            >
+          </iframe>
+          <a
+            class="feedback-form__fallback"
+            href="https://forms.gle/nSpkVzcFcXMQMMgb9"
+            target="_blank"
+            rel="noreferrer"
+            >Open the form in a new tab</a
           >
         </div>
       </section>

--- a/public/legal.css
+++ b/public/legal.css
@@ -340,9 +340,42 @@ a:hover {
 .panel--contact {
   grid-column: 1 / -1;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
+  grid-template-columns: minmax(14rem, 0.72fr) minmax(20rem, 1.28fr);
+  align-items: start;
   gap: 2rem;
+}
+
+.panel--contact:target {
+  scroll-margin-top: 5.5rem;
+}
+
+.panel__intro {
+  position: sticky;
+  top: 5.5rem;
+}
+
+.feedback-privacy {
+  font-size: 0.85rem;
+}
+
+.feedback-form {
+  min-width: 0;
+}
+
+.feedback-form iframe {
+  display: block;
+  width: 100%;
+  height: min(48rem, 80vh);
+  min-height: 38rem;
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  background: #ffffff;
+}
+
+.feedback-form__fallback {
+  display: inline-block;
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
 }
 
 .panel__number {
@@ -533,6 +566,15 @@ a:hover {
 
   .panel--contact .panel__actions {
     margin-top: 0;
+  }
+
+  .panel__intro {
+    position: static;
+  }
+
+  .feedback-form iframe {
+    height: 46rem;
+    min-height: 0;
   }
 
   .summary-card {

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -78,9 +78,9 @@
           <h2 id="choices">Your choices</h2>
           <p>
             You can play without signing in, clear local game data through your
-            browser, and contact
-            <a href="mailto:todd@fabricate.io">todd@fabricate.io</a> to ask
-            about leaderboard data or deletion.
+            browser, and use the
+            <a href="/about.html#feedback">feedback form</a> to ask about
+            leaderboard data or deletion.
           </p>
         </section>
       </article>

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -224,7 +224,7 @@ export function GameAppBar(props: Props) {
           >
             Scenario details
           </MenuItem>
-          <MenuItem onClick={() => openWindow("mailto:todd@fabricate.io")}>
+          <MenuItem onClick={() => openWindow("/about.html#feedback")}>
             Send feedback
           </MenuItem>
           {/* Mid-tutorial, the thing a player who has seen enough wants is the next tutorial,

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -73,4 +73,13 @@ describe("MainMenu", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Share game" })).toBeNull();
   });
+
+  it("opens the embedded feedback form without exposing an email address", () => {
+    render(<MainMenu {...props()} />);
+
+    expect(screen.getByRole("link", { name: "Send feedback" })).toHaveAttribute(
+      "href",
+      "/about.html#feedback",
+    );
+  });
 });

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -157,7 +157,7 @@ const MainMenu = (props: Props): React.JSX.Element => {
         )}
         <IconButton
           color="primary"
-          href="mailto:todd@fabricate.io"
+          href="/about.html#feedback"
           aria-label="Send feedback"
           size="large"
         >

--- a/src/components/views/Manual.test.tsx
+++ b/src/components/views/Manual.test.tsx
@@ -123,7 +123,7 @@ describe("Manual", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Let us know" })).toHaveAttribute(
       "href",
-      expect.stringContaining("mailto:"),
+      "/about.html#feedback",
     );
   });
 

--- a/src/components/views/Manual.tsx
+++ b/src/components/views/Manual.tsx
@@ -320,8 +320,7 @@ export default function Manual(props: Props): React.JSX.Element {
               No entries match "{searchTerm}".
             </Typography>
             <Typography variant="body2">
-              Think it belongs in here? <a href={FEEDBACK_URL}>Let us know</a>
-              .
+              Think it belongs in here? <a href={FEEDBACK_URL}>Let us know</a>.
             </Typography>
           </div>
         )}

--- a/src/components/views/Manual.tsx
+++ b/src/components/views/Manual.tsx
@@ -35,7 +35,7 @@ export interface DispatchProps {
 
 export interface Props extends StateProps, DispatchProps {}
 
-const FEEDBACK_EMAIL = "mailto:todd@fabricate.io";
+const FEEDBACK_URL = "/about.html#feedback";
 
 // Pinned first, then by group in the order the groups are declared, then alphabetically. Sorted
 // once here rather than on every keystroke
@@ -320,7 +320,7 @@ export default function Manual(props: Props): React.JSX.Element {
               No entries match "{searchTerm}".
             </Typography>
             <Typography variant="body2">
-              Think it belongs in here? <a href={FEEDBACK_EMAIL}>Let us know</a>
+              Think it belongs in here? <a href={FEEDBACK_URL}>Let us know</a>
               .
             </Typography>
           </div>


### PR DESCRIPTION
Embeds the Electrify feedback Google Form on the About page with responsive styling and a direct-link fallback. Routes all existing feedback and privacy-contact links to the form, removing the exposed email address. Adds coverage for the main-menu and manual feedback links. Tests: 25 focused tests passed; npm run typecheck; npm run lint; npm run build; desktop and mobile visual verification.