### PR TITLE
Replace tutorial modals with objective HUD pilot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hotkeys": "^2.0.0",
-        "react-joyride": "^3.2.0",
         "react-redux": "^9.3.0",
         "react-transition-group": "^4.4.5",
         "redux": "^5.0.1",
@@ -2768,22 +2767,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@fastify/deepmerge": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
-      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@firebase/ai": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.15.0.tgz",
@@ -3423,71 +3406,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.7.tgz",
       "integrity": "sha512-phBFwieDLvkZGYN9CE9ZFNEIoBVksprzsnCzQejCmCHtgwCXReeuRpoEGN9C4EbhONztv8NRV1tau6Rb9pONwQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
-      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.8.0",
-        "@floating-ui/utils": "^0.2.12"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
-      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.8.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
-      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
-      "license": "MIT"
-    },
-    "node_modules/@gilbarbara/deep-equal": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
-      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==",
-      "license": "MIT"
-    },
-    "node_modules/@gilbarbara/hooks": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
-      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@gilbarbara/deep-equal": "^0.4.1"
-      },
-      "peerDependencies": {
-        "react": "16.8 - 19"
-      }
-    },
-    "node_modules/@gilbarbara/types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
-      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^4.1.0"
-      }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.16",
@@ -12374,12 +12292,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-lite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
-      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==",
-      "license": "MIT"
-    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -17504,16 +17416,6 @@
         "react": ">= 0.14.0"
       }
     },
-    "node_modules/react-innertext": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
-      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": ">=0.0.0 <=99",
-        "react": ">=0.0.0 <=99"
-      }
-    },
     "node_modules/react-is": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
@@ -17535,28 +17437,6 @@
       "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-joyride": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.2.0.tgz",
-      "integrity": "sha512-UrA/XWdWElMLNnjZt2eWmPFmpHl1IZ2CeI9XhS+PuEVvfqHMD9U4tavCq1csDAGVoj0YEGfaCDmhZwgNc9yE2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/deepmerge": "^3.2.1",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@gilbarbara/deep-equal": "^0.4.1",
-        "@gilbarbara/hooks": "^0.11.0",
-        "@gilbarbara/types": "^0.2.2",
-        "is-lite": "^2.0.0",
-        "react-innertext": "^1.1.5",
-        "scroll": "^3.0.1",
-        "scrollparent": "^2.1.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "16.8 - 19",
-        "react-dom": "16.8 - 19"
-      }
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
@@ -18461,18 +18341,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/scroll": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
-      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
-      "license": "MIT"
-    },
-    "node_modules/scrollparent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
-      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
-      "license": "ISC"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -20132,18 +20000,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hotkeys": "^2.0.0",
-    "react-joyride": "^3.2.0",
     "react-redux": "^9.3.0",
     "react-transition-group": "^4.4.5",
     "redux": "^5.0.1",

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -204,7 +204,7 @@ export function isResumedGame(game: GameType): boolean {
  *
  * isSaveableScenario is injected rather than looked up here (see the note at the top of the file);
  * pass a predicate that rejects tutorials, which are short enough not to be worth saving and would
- * need their mid-Joyride step restored too.
+ * otherwise need their short-lived objective state restored too.
  */
 export function startAutosave(
   store: AppStore,

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -434,16 +434,21 @@ export interface TutorialStepType {
   skipBeacon?: boolean;
   // The card this step's target lives on. Every step change navigates here, in both
   // directions, so stepping backwards over a step that navigated forwards still lands on
-  // the card holding the target instead of leaving Joyride with nothing to point at
+  // the card holding the target instead of leaving the objective pointing at absent UI
   card?: CardNameType | NavigateActionType;
   // A one-way side effect of leaving this step forwards, such as starting the clock. It
   // isn't replayed when stepping backwards, since nothing would undo it - navigation
   // belongs in `card`, which works in both directions
   onNext?: () => Redux.Action;
-  target: string;
+  // Optional for unguided capstones: ordinary objectives can point at a control for a restrained
+  // outline, while a capstone deliberately leaves the player to find the answer themselves.
+  target?: string;
   content: React.JSX.Element;
-  // Present = the step is action-gated ("play, don't tell"): the tooltip shows a "do it"
-  // affordance instead of a Next button, and the walkthrough advances the moment this
+  // Player-requested help. Kept outside content so the objective HUD never reveals it before the
+  // player asks, and so hiding/showing it does not affect the underlying objective gate.
+  hint?: React.ReactNode;
+  // Present = the step is action-gated ("play, don't tell"): the HUD shows a "complete
+  // objective" status instead of a Next button, and the walkthrough advances the moment this
   // returns true. Evaluated after every dispatch - including every tick - so keep it to
   // cheap field reads. Tutorial scenarios have fixed authored starting states, so
   // predicates are absolute (e.g. facilities.length >= 2), never relative to step entry
@@ -452,6 +457,15 @@ export interface TutorialStepType {
   // toggle): advance when an action with one of these types is dispatched. Either gate
   // field alone makes the step gated; both may be combined (OR)
   advanceOnAction?: string | string[];
+  // An independent application check. Entering one restarts the authored scenario at this step,
+  // giving it a deterministic, retryable state instead of inheriting whatever the guided portion
+  // changed. Success advances normally; failure pauses for consequence-specific feedback.
+  capstone?: {
+    success: (state: AppStateType) => boolean;
+    failure?: (state: AppStateType) => boolean;
+    successMessage: string;
+    failureMessage: string;
+  };
   // Above the desktop breakpoint the bottom nav is hidden and Facilities / Insights render
   // side by side, so a step whose target lives in that nav - or whose
   // selector matches more than one pane - needs a different target there, and usually
@@ -463,7 +477,7 @@ export interface TutorialStepType {
 }
 
 export function isGatedStep(step: TutorialStepType): boolean {
-  return !!(step.advanceOn || step.advanceOnAction);
+  return !!(step.advanceOn || step.advanceOnAction || step.capstone);
 }
 
 // A walkthrough moving between two steps. Both ends are named because Back and Next need

--- a/src/app.scss
+++ b/src/app.scss
@@ -356,19 +356,6 @@ button,
   padding: 16px;
 }
 
-.react-joyride__overlay {
-  cursor: auto !important;
-}
-
-// react-floater sizes the tutorial wrapper to the full viewport, then offsets it 10px from the
-// left edge. On phones that makes the document 10px wider even though the tooltip itself fits.
-@media screen and (max-width: ($abswidthmax - 1px)) {
-  .react-joyride__floater {
-    width: calc(100vw - 20px) !important;
-    max-width: calc(100vw - 20px) !important;
-  }
-}
-
 .MuiSelect-select {
   padding-top: 2px !important;
   padding-left: 6px !important;
@@ -728,10 +715,6 @@ $pane_header_height: 40px;
   display: flex;
   justify-content: center;
   align-items: center;
-}
-
-.react-joyride__spotlight {
-  background: none !important;
 }
 
 .base_main {
@@ -1604,38 +1587,6 @@ html[data-theme="dark"] .uplot {
     border-radius: 0;
   }
 
-  #tutorial-tooltip {
-    background: $bg_primary;
-    padding: size(medium);
-    margin: auto;
-    width: 90%;
-    max-width: 500px;
-    box-sizing: border-box;
-
-    .tutorialFooter {
-      display: flex;
-      align-items: center;
-      margin-top: size(medium);
-      gap: size(small);
-    }
-
-    // Pushes the buttons to the trailing edge, so the row reads progress-then-actions
-    .tutorialProgress {
-      margin-right: auto;
-      opacity: 0.6;
-      font-size: 0.85em;
-    }
-
-    // Stands in for the Next button on action-gated steps: doing the highlighted thing is
-    // what advances, so the affordance pulses instead of being clickable
-    .tutorialDoIt {
-      display: inline-flex;
-      align-items: center;
-      padding: size(tiny);
-      animation: tutorialDoItPulse 1.5s ease-in-out infinite;
-    }
-  }
-
   // Icon-led step content: symbols on top, one confirming line of text, and for gated
   // steps a "do this" chip naming the deed in the same symbols
   .tutorialPrompt {
@@ -1661,18 +1612,6 @@ html[data-theme="dark"] .uplot {
       padding: size(tiny) size(small);
       border: 1px solid var(--border-strong);
       border-radius: 100px;
-    }
-  }
-
-  @keyframes tutorialDoItPulse {
-    0%,
-    100% {
-      transform: scale(1);
-      opacity: 0.7;
-    }
-    50% {
-      transform: scale(1.25);
-      opacity: 1;
     }
   }
 
@@ -2190,6 +2129,184 @@ html[data-theme="dark"] .uplot {
 
 @include styling();
 
+// A mission objective is game chrome, not a modal: it stays out of the bottom navigation,
+// leaves the whole grid interactive and collapses to one progress-marked concept.
+.tutorialHud {
+  position: fixed;
+  z-index: 1250;
+  right: max(8px, env(safe-area-inset-right));
+  bottom: calc(56px + env(safe-area-inset-bottom) + 8px);
+  left: max(8px, env(safe-area-inset-left));
+  box-sizing: border-box;
+  max-height: calc(100vh - 80px - env(safe-area-inset-bottom));
+  overflow: auto;
+  padding: 8px 10px;
+  border: 1px solid var(--tooltip-border);
+  border-radius: 12px;
+  background: var(--tooltip-bg);
+  box-shadow: 0 8px 24px var(--tooltip-shadow);
+  color: $font_color_primary;
+  backdrop-filter: blur(10px);
+}
+
+.tutorialHud-collapsed {
+  left: auto;
+  width: min(230px, calc(100vw - 16px));
+  overflow: hidden;
+}
+
+.tutorialHudHeader {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.tutorialHudHeading {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+
+  h2 {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  span {
+    flex: 0 0 auto;
+    color: $font_color_faded;
+  }
+}
+
+.tutorialHudToggle {
+  flex: 0 0 auto;
+}
+
+.tutorialHudProgressRing {
+  position: relative;
+  display: grid;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 42px;
+  place-items: center;
+}
+
+.tutorialHudProgressRing > * {
+  grid-area: 1 / 1;
+}
+
+.tutorialHudProgressIcon {
+  display: grid;
+  place-items: center;
+
+  .conceptIcon {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.tutorialHudContent {
+  margin-top: 6px;
+
+  .tutorialPrompt {
+    gap: 4px !important;
+  }
+
+  .tutorialPromptConcepts {
+    min-height: 32px;
+    margin-bottom: 0;
+    padding: 4px 8px;
+  }
+
+  .tutorialPromptAction {
+    margin-top: 2px;
+  }
+}
+
+.tutorialHudHint {
+  margin-top: 6px;
+  padding: 6px 8px;
+  border-left: 3px solid $interactive_blue;
+  border-radius: 4px;
+  background: var(--bg-selected);
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.tutorialHudFooter {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-top: 4px;
+}
+
+.tutorialHudFooterSpacer {
+  flex: 1 1 auto;
+}
+
+.tutorialHudGate {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: $interactive_blue;
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.tutorialHudScreenReader {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+}
+
+// A restrained cue rather than a spotlight: it names the relevant control without dimming the
+// surrounding choices. Capstones never receive this class.
+.tutorialTarget {
+  outline: 3px solid var(--interactive-blue) !important;
+  outline-offset: 3px;
+  animation: tutorialTargetPulse 1.6s ease-in-out infinite;
+}
+
+@keyframes tutorialTargetPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 var(--interactive-tint);
+  }
+  50% {
+    box-shadow: 0 0 0 7px transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tutorialTarget {
+    animation: none;
+  }
+}
+
+@media screen and (min-width: $desktop_breakpoint) {
+  .tutorialHud {
+    top: calc(82px + env(safe-area-inset-top));
+    right: max(16px, env(safe-area-inset-right));
+    bottom: auto;
+    left: auto;
+    width: min(360px, calc(100vw - 32px));
+    max-height: calc(100vh - 98px - env(safe-area-inset-top));
+  }
+
+  .tutorialHud-collapsed {
+    width: 230px;
+  }
+}
+
 // ===============================================
 // Apply scaling or fixed styling if we're on
 // a desktop. Center and border the fixed result.
@@ -2226,10 +2343,6 @@ $sizemap: (
     height: 100%;
     max-width: 100%;
     max-height: 100%;
-  }
-
-  #tutorial-tooltip {
-    width: auto;
   }
 }
 

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -5,19 +5,9 @@ import {
   DialogContent,
   DialogTitle,
   Snackbar,
-  Typography,
 } from "@mui/material";
-import TouchAppIcon from "@mui/icons-material/TouchApp";
 import * as React from "react";
 import { GlobalHotKeys, configure } from "react-hotkeys";
-import {
-  ACTIONS,
-  EVENTS,
-  Joyride,
-  type EventData,
-  type Step,
-  type TooltipRenderProps,
-} from "react-joyride";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { CARD_TRANSITION_ANIMATION_MS, NAV_CARDS } from "../Constants";
 import {
@@ -34,6 +24,7 @@ import AudioContainer from "./base/AudioContainer";
 import DesktopPanes from "./base/DesktopPanes";
 import DisplayNameDialogContainer from "./base/DisplayNameDialogContainer";
 import InstallAppButton from "./base/InstallAppButton";
+import TutorialHud from "./base/TutorialHud";
 import EventLogContainer from "./views/EventLogContainer";
 import NavigationContainer from "./base/NavigationContainer";
 import GameAppBarContainer from "./base/GameAppBar";
@@ -266,66 +257,6 @@ const shortcutHandlers = {
   ),
 };
 
-function Tooltip(props: TooltipRenderProps): React.JSX.Element {
-  const {
-    index,
-    size,
-    step,
-    backProps,
-    closeProps,
-    primaryProps,
-    tooltipProps,
-    isLastStep,
-  } = props;
-  const isString = typeof step.content === "string";
-  // Presentation flags baked in by stepsForViewport: a gated step has no Next button -
-  // doing the highlighted deed is what advances it - and Back is hidden next to a gate,
-  // since backing into a satisfied one would instantly re-advance
-  const flags = (step.data || {}) as { gated?: boolean; hideBack?: boolean };
-  // tooltipProps carries role="alertdialog" + aria-modal, which require an accessible name;
-  // without one screen readers announce an anonymous dialog
-  return (
-    <div id="tutorial-tooltip" aria-label="Tutorial" {...tooltipProps}>
-      {step.title && (
-        <Typography variant="h6" gutterBottom>
-          {step.title}
-        </Typography>
-      )}
-      {isString ? (
-        <Typography variant="body1">{step.content}</Typography>
-      ) : (
-        step.content
-      )}
-      <div className="tutorialFooter">
-        {/* Joyride's own showProgress only applies to its built-in tooltip */}
-        <span className="tutorialProgress">
-          Step {index + 1} of {size}
-        </span>
-        <Button {...closeProps} color="primary" size="small">
-          Exit tutorial
-        </Button>
-        {index > 0 && !flags.hideBack && (
-          <Button {...backProps} color="primary">
-            Back
-          </Button>
-        )}
-        {flags.gated ? (
-          <span
-            className="tutorialDoIt"
-            aria-label="Do the highlighted action to continue"
-          >
-            <TouchAppIcon color="primary" />
-          </span>
-        ) : (
-          <Button {...primaryProps} variant="contained" color="primary">
-            {isLastStep ? "Play" : "Next"}
-          </Button>
-        )}
-      </div>
-    </div>
-  );
-}
-
 export interface StateProps {
   card: CardType;
   settings: SettingsType;
@@ -355,10 +286,6 @@ export function isNavCard(name: CardNameType) {
 
 export default class Compositor extends React.Component<Props, {}> {
   private resizeTimeout: ReturnType<typeof setTimeout> | undefined;
-  private tutorialScrollTimeout: ReturnType<typeof setTimeout> | undefined;
-  private stepsCache:
-    | { source: TutorialStepType[]; desktop: boolean; resolved: Step[] }
-    | undefined;
 
   // react-transition-group falls back to ReactDOM.findDOMNode when no nodeRef is given, and
   // React 19 removed findDOMNode outright. TransitionGroup holds the exiting and the entering
@@ -375,39 +302,6 @@ export default class Compositor extends React.Component<Props, {}> {
     return ref;
   }
 
-  // Applies each step's desktop override when the panes are side by side, and drops the key
-  // either way so Joyride only ever sees a plain step. The result is cached because Joyride
-  // reloads its steps whenever the array isn't identical, which loses the current step -- but
-  // it still recomputes when handleResize carries the layout across the breakpoint
-  private stepsForViewport(steps: TutorialStepType[]): Step[] {
-    const desktop = isDesktopScreen();
-    const cache = this.stepsCache;
-    if (cache && cache.source === steps && cache.desktop === desktop) {
-      return cache.resolved;
-    }
-    const resolved = steps.map((step, i) => {
-      // The gate fields and onNext are engine concerns; Joyride only needs the
-      // presentation, plus flags telling the tooltip which buttons make sense here
-      const {
-        desktop: override,
-        advanceOn: _advanceOn,
-        advanceOnAction: _advanceOnAction,
-        onNext: _onNext,
-        ...rest
-      } = step;
-      const merged = desktop && override ? { ...rest, ...override } : rest;
-      return {
-        ...merged,
-        data: {
-          gated: isGatedStep(step),
-          hideBack: isGatedStep(step) || (i > 0 && isGatedStep(steps[i - 1])),
-        },
-      } as Step;
-    });
-    this.stepsCache = { source: steps, desktop, resolved };
-    return resolved;
-  }
-
   // isDesktopScreen() is read straight from the DOM rather than from state, so a resize needs
   // its own trigger -- forceUpdate skips shouldComponentUpdate, which otherwise blocks re-renders
   // when nothing about the current card has changed
@@ -418,80 +312,21 @@ export default class Compositor extends React.Component<Props, {}> {
 
   public componentDidMount() {
     window.addEventListener("resize", this.handleResize);
-    this.scrollTutorialTargetIntoView();
-  }
-
-  public componentDidUpdate(prevProps: Props) {
-    if (
-      prevProps.tutorialStep !== this.props.tutorialStep ||
-      prevProps.card.name !== this.props.card.name
-    ) {
-      this.scrollTutorialTargetIntoView();
-    }
   }
 
   public componentWillUnmount() {
     window.removeEventListener("resize", this.handleResize);
     clearTimeout(this.resizeTimeout);
-    clearTimeout(this.tutorialScrollTimeout);
   }
 
-  /** Joyride scrolling hangs inside card panes, so move their real scroll container ourselves. */
-  private scrollTutorialTargetIntoView() {
-    clearTimeout(this.tutorialScrollTimeout);
-    this.tutorialScrollTimeout = setTimeout(() => {
-      const steps = this.props.tutorialSteps;
-      const index = this.props.tutorialStep;
-      if (!steps || index < 0 || index >= steps.length) {
-        return;
-      }
-      const target = this.stepsForViewport(steps)[index]?.target;
-      if (typeof target !== "string") {
-        return;
-      }
-      const element = document.querySelector(target);
-      if (element && typeof element.scrollIntoView === "function") {
-        element.scrollIntoView({ block: "center", inline: "nearest" });
-      }
-    }, 50);
-  }
-
-  public handleJoyrideCallback = (data: EventData) => {
-    const { action, index, type } = data;
-    // Esc: leave the walkthrough without crediting it as done, so it's still offered on the
-    // scenario list. Has to come first, since closing also reports STEP_AFTER
-    if (action === ACTIONS.CLOSE) {
-      this.props.onTutorialEnd(this.props.tutorialSteps);
-      return;
-    }
-    // A gated step advances only by its deed. Skipping it on a missing target would wave
-    // the player past the very thing the step exists to make them do - and the deed itself
-    // often removes the target for a frame (buying closes the build screen), which Joyride
-    // reports as TARGET_NOT_FOUND while the gate middleware is already landing the next step
-    const current =
-      this.props.tutorialStep >= 0 && this.props.tutorialSteps
-        ? this.props.tutorialSteps[this.props.tutorialStep]
-        : undefined;
-    if (type === EVENTS.TARGET_NOT_FOUND && current && isGatedStep(current)) {
-      return;
-    }
-    const advancingEvents: string[] = [
-      EVENTS.STEP_AFTER,
-      EVENTS.TARGET_NOT_FOUND,
-    ];
-    // Quitting tears the walkthrough's targets out of the DOM, and Joyride reports that as
-    // TARGET_NOT_FOUND on the way out. Advancing on it navigated the just-reset game back onto
-    // the step's card, which then rendered nothing because the game was over - a blank screen
-    // where the main menu should be. tutorialStep is only >= 0 while a walkthrough is live
-    if (advancingEvents.includes(type) && this.props.tutorialStep >= 0) {
-      this.props.onTutorialStep({
-        fromStep: index,
-        toStep: index + (action === ACTIONS.PREV ? -1 : 1),
-        tutorialSteps: this.props.tutorialSteps,
-        scenarioId: this.props.scenarioId,
-        currentCard: this.props.card.name,
-      });
-    }
+  public moveTutorial = (toStep: number) => {
+    this.props.onTutorialStep({
+      fromStep: this.props.tutorialStep,
+      toStep,
+      tutorialSteps: this.props.tutorialSteps,
+      scenarioId: this.props.scenarioId,
+      currentCard: this.props.card.name,
+    });
   };
 
   public snackbarActionClicked(e: React.MouseEvent<HTMLElement>) {
@@ -596,6 +431,16 @@ export default class Compositor extends React.Component<Props, {}> {
   public render() {
     const { tutorialStep, ui, closeDialog, tutorialSteps, closeSnackbar } =
       this.props;
+    const currentTutorialStep =
+      tutorialSteps && tutorialStep >= 0 && tutorialStep < tutorialSteps.length
+        ? tutorialSteps[tutorialStep]
+        : undefined;
+    const canGoBack = !!(
+      currentTutorialStep &&
+      tutorialStep > 0 &&
+      !isGatedStep(currentTutorialStep) &&
+      !isGatedStep(tutorialSteps![tutorialStep - 1])
+    );
 
     // The pane layouts don't slide between their own cards: on desktop nothing about the screen
     // changes, and on two columns only the second one does -- sliding the pinned fleet off the
@@ -638,37 +483,20 @@ export default class Compositor extends React.Component<Props, {}> {
             </main>
           </CSSTransition>
         </TransitionGroup>
-        {tutorialSteps && (
-          <Joyride
-            // Swapping in the desktop targets hands Joyride a different steps array, which it
-            // reloads mid-tour and ends up showing no tooltip behind a blocking overlay.
-            // Remounting instead resumes cleanly, since it starts from the stepIndex prop
-            key={isDesktopScreen() ? "desktop" : "compact"}
-            onEvent={this.handleJoyrideCallback}
-            continuous={true}
-            run={tutorialStep >= 0 && tutorialStep < tutorialSteps.length}
-            tooltipComponent={Tooltip}
-            stepIndex={tutorialStep}
-            steps={this.stepsForViewport(tutorialSteps)}
-            // v3 folded the old top-level styles.options, and the standalone
-            // disableOverlayClose prop, into this single options prop
-            options={{
-              beaconSize: 48,
-              // Enough separation to make the highlighted control unmistakable while keeping
-              // the surrounding dashboard legible as context for what the prompt is teaching.
-              overlayColor: "rgba(0, 0, 0, 0.38)",
-              // Joyride traps Tab inside the tooltip, so Esc is the way back out for
-              // keyboard users -- WCAG 2.1.2. Overlay clicks still don't close, since
-              // those are far too easy to trigger by accident mid-walkthrough
-              overlayClickAction: false,
-              // v3 scrolls each target into view and waits for a scroll:end that never
-              // arrives for targets inside the non-scrolling card panes, which hangs the
-              // tour on step 4 of the generators walkthrough. Every target is already in
-              // view, so there is nothing to scroll to
-              skipScroll: true,
-            }}
-          />
-        )}
+        {tutorialSteps &&
+          currentTutorialStep &&
+          this.props.card.name !== "LOADING" && (
+            <TutorialHud
+              desktop={isDesktopScreen()}
+              step={currentTutorialStep}
+              stepIndex={tutorialStep}
+              totalSteps={tutorialSteps.length}
+              canGoBack={canGoBack}
+              onBack={() => this.moveTutorial(tutorialStep - 1)}
+              onNext={() => this.moveTutorial(tutorialStep + 1)}
+              onExit={() => this.props.onTutorialEnd(tutorialSteps)}
+            />
+          )}
         <Dialog
           open={ui.dialog.open}
           // v9 replaced `disableEscapeKeyDown` with filtering on the close reason. A

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -2,12 +2,10 @@ import * as fs from "fs";
 import * as path from "path";
 import * as React from "react";
 import { UnknownAction } from "redux";
-import { ACTIONS, EVENTS, EventData } from "react-joyride";
 import type { AppDispatch } from "../Store";
 import { SCENARIOS } from "../data/Scenarios";
 import { reprioritizeFacility, togglePauseFacility } from "../reducers/Game";
 import { CardNameType, NavigateActionType, TutorialStepType } from "../Types";
-import Compositor, { Props as CompositorProps } from "./Compositor";
 import { mapDispatchToProps } from "./CompositorContainer";
 
 // Where `loaded` drops the player, and so where every walkthrough starts
@@ -98,8 +96,8 @@ describe("onTutorialStep", () => {
   /**
    * Regression test. Back used to dispatch the previous step's onNext, which only ever modelled
    * moving forwards, so nothing undid the navigation the forward step performed: the player was
-   * left on the build screen while the step's target lived on Facilities, Joyride found no
-   * target, and the walkthrough appeared to die with no tooltip anywhere.
+   * left on the build screen while the step's target lived on Facilities, so the objective had
+   * no relevant control to identify.
    */
   it("navigates back onto the card holding the previous step's target", () => {
     const dispatched = step({
@@ -169,6 +167,26 @@ describe("onTutorialStep", () => {
         step({ steps, fromStep: 1, toStep: 0, currentCard: "INSIGHTS" }),
       ).not.toContainEqual(sideEffect);
     });
+  });
+
+  it("starts an unguided capstone from its authored scenario state", () => {
+    const capstone = generators.findIndex((candidate) => candidate.capstone);
+    expect(capstone).toBeGreaterThan(0);
+
+    const dispatched = step({
+      steps: generators,
+      fromStep: capstone - 1,
+      toStep: capstone,
+      currentCard: "FACILITIES",
+    });
+
+    expect(dispatched.map((action) => action.type)).toEqual([
+      "game/quit",
+      "game/start",
+      "game/delta",
+    ]);
+    expect(dispatched[1].payload).toBe(1);
+    expect(dispatched[2].payload).toEqual({ tutorialStep: capstone });
   });
 });
 
@@ -263,7 +281,7 @@ describe("walkthrough steps", () => {
     });
 
     // Walk the whole thing forwards and then all the way back, tracking the card the store
-    // would be showing. Any step whose target isn't on the current card would show no tooltip
+    // would be showing. Any step whose target isn't on the current card would point at nothing
     it(`${scenario.name} shows each step's card in both directions`, () => {
       let card: CardNameType = STARTING_CARD;
       expect(cardOf(steps[0])).toBe(card);
@@ -292,12 +310,9 @@ describe("walkthrough steps", () => {
     });
 
     /**
-     * Joyride reports a selector matching nothing as TARGET_NOT_FOUND, which the walkthrough
-     * handles by moving straight on - so a step pointing at markup that has since been renamed
-     * quietly vanishes rather than failing. The move off Victory took `.VictoryContainer` with
-     * it exactly that way, and the tutorial lost its tour of the supply/demand graph without a
-     * single red test. Rendering every card would be the airtight check; scanning the source
-     * for the id or class each selector names catches the same kind of rename far cheaper.
+     * A selector matching nothing silently loses the restrained target treatment. Rendering every
+     * card would be the airtight check; scanning the source for the id or class each selector names
+     * catches that kind of rename far cheaper.
      */
     it(`${scenario.name} points every step at markup that still exists`, () => {
       targetsOf(steps).forEach((target) => {
@@ -306,63 +321,5 @@ describe("walkthrough steps", () => {
         });
       });
     });
-  });
-});
-
-describe("handleJoyrideCallback", () => {
-  const steps = walkthrough("Mission 2: Generators");
-
-  function fire(tutorialStep: number, event: Partial<EventData>) {
-    const onTutorialStep = jest.fn();
-    const onTutorialEnd = jest.fn();
-    const compositor = new Compositor({
-      tutorialStep,
-      tutorialSteps: steps,
-      scenarioId: 1,
-      card: { name: STARTING_CARD, ts: 0 },
-      onTutorialStep,
-      onTutorialEnd,
-    } as unknown as CompositorProps);
-    compositor.handleJoyrideCallback(event as EventData);
-    return { onTutorialStep, onTutorialEnd };
-  }
-
-  it("advances past a target that never turns up mid-walkthrough", () => {
-    const { onTutorialStep } = fire(1, {
-      action: ACTIONS.NEXT,
-      index: 1,
-      type: EVENTS.TARGET_NOT_FOUND,
-    });
-    expect(onTutorialStep).toHaveBeenCalled();
-  });
-
-  it("does not skip a gated deed when its target is temporarily missing", () => {
-    const { onTutorialStep } = fire(2, {
-      action: ACTIONS.NEXT,
-      index: 2,
-      type: EVENTS.TARGET_NOT_FOUND,
-    });
-    expect(onTutorialStep).not.toHaveBeenCalled();
-  });
-
-  // Quitting takes the targets out of the DOM, which Joyride reports the same way. Acting on it
-  // navigated the freshly reset game back onto the walkthrough's card, which had nothing left to
-  // render - a blank screen where the main menu should be
-  it("ignores targets disappearing once the walkthrough is over", () => {
-    const { onTutorialStep } = fire(-1, {
-      action: ACTIONS.NEXT,
-      index: 2,
-      type: EVENTS.TARGET_NOT_FOUND,
-    });
-    expect(onTutorialStep).not.toHaveBeenCalled();
-  });
-
-  it("still ends the walkthrough when the player closes it", () => {
-    const { onTutorialEnd } = fire(2, {
-      action: ACTIONS.CLOSE,
-      index: 2,
-      type: EVENTS.STEP_AFTER,
-    });
-    expect(onTutorialEnd).toHaveBeenCalledWith(steps);
   });
 });

--- a/src/components/base/TutorialHud.test.tsx
+++ b/src/components/base/TutorialHud.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { TutorialStepType } from "../../Types";
+import TutorialHud, { TutorialHudProps } from "./TutorialHud";
+import TutorialPrompt from "./TutorialPrompt";
+
+function objective(
+  overrides: Partial<TutorialStepType> = {},
+): TutorialStepType {
+  return {
+    card: "FACILITIES",
+    target: "#tutorial-target",
+    content: (
+      <TutorialPrompt
+        concepts={["supply", "demand"]}
+        text="Keep supply above demand."
+      />
+    ),
+    ...overrides,
+  };
+}
+
+function props(overrides: Partial<TutorialHudProps> = {}): TutorialHudProps {
+  return {
+    desktop: false,
+    onBack: jest.fn(),
+    onExit: jest.fn(),
+    onNext: jest.fn(),
+    step: objective(),
+    stepIndex: 0,
+    totalSteps: 3,
+    canGoBack: false,
+    ...overrides,
+  };
+}
+
+describe("TutorialHud", () => {
+  it("exposes the current objective, progress and ordinary navigation", async () => {
+    const user = userEvent.setup();
+    const hudProps = props({ canGoBack: true, stepIndex: 1 });
+    render(<TutorialHud {...hudProps} />);
+
+    expect(
+      screen.getByRole("region", { name: "Mission objective" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Objective 2 of 3")).toBeInTheDocument();
+    expect(screen.getByText("Keep supply above demand.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Exit" }));
+    expect(hudProps.onBack).toHaveBeenCalledTimes(1);
+    expect(hudProps.onNext).toHaveBeenCalledTimes(1);
+    expect(hudProps.onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps collapsed state across objective changes and expands on focus", async () => {
+    const user = userEvent.setup();
+    const hudProps = props();
+    const { rerender } = render(<TutorialHud {...hudProps} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Collapse objective" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Expand objective" }),
+    ).toHaveAttribute("aria-expanded", "false");
+
+    rerender(
+      <TutorialHud
+        {...hudProps}
+        step={objective({
+          content: (
+            <TutorialPrompt concepts={["money"]} text="Protect your cash." />
+          ),
+        })}
+        stepIndex={1}
+      />,
+    );
+    const expand = screen.getByRole("button", { name: "Expand objective" });
+    fireEvent.focus(expand);
+    expect(
+      screen.getByRole("button", { name: "Collapse objective" }),
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Protect your cash.")).toBeInTheDocument();
+  });
+
+  it("reveals help only when requested and has no redundant Next for gates", async () => {
+    const user = userEvent.setup();
+    render(
+      <TutorialHud
+        {...props({
+          step: objective({
+            advanceOn: () => false,
+            hint: "Look at the reserve readout.",
+          }),
+        })}
+      />,
+    );
+
+    expect(screen.queryByText("Look at the reserve readout.")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Next" })).toBeNull();
+    expect(screen.getByText("Complete objective")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Hint" }));
+    expect(screen.getByRole("note")).toHaveTextContent(
+      "Look at the reserve readout.",
+    );
+    expect(screen.getByRole("button", { name: "Hide hint" })).toHaveFocus();
+  });
+
+  it("outlines guided targets but never points out a capstone answer", () => {
+    const target = document.createElement("button");
+    target.id = "tutorial-target";
+    document.body.appendChild(target);
+
+    const hudProps = props();
+    const { rerender, unmount } = render(<TutorialHud {...hudProps} />);
+    expect(target).toHaveClass("tutorialTarget");
+
+    rerender(
+      <TutorialHud
+        {...hudProps}
+        step={objective({
+          capstone: {
+            success: () => false,
+            successMessage: "Ready in time.",
+            failureMessage: "Capacity arrived late.",
+          },
+        })}
+      />,
+    );
+    expect(target).not.toHaveClass("tutorialTarget");
+    expect(
+      screen.getByRole("region", { name: "Your turn" }),
+    ).toBeInTheDocument();
+
+    unmount();
+    target.remove();
+  });
+});

--- a/src/components/base/TutorialHud.tsx
+++ b/src/components/base/TutorialHud.tsx
@@ -1,0 +1,211 @@
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import FlagIcon from "@mui/icons-material/Flag";
+import TouchAppIcon from "@mui/icons-material/TouchApp";
+import {
+  Button,
+  CircularProgress,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import * as React from "react";
+import { TutorialStepType, isGatedStep } from "../../Types";
+import ConceptIcon from "./ConceptIcon";
+import TutorialPrompt, { TutorialPromptProps } from "./TutorialPrompt";
+
+export interface TutorialHudProps {
+  desktop: boolean;
+  onBack: () => void;
+  onExit: () => void;
+  onNext: () => void;
+  step: TutorialStepType;
+  stepIndex: number;
+  totalSteps: number;
+  canGoBack: boolean;
+}
+
+/** The viewport-specific content and target, without turning presentation into game state. */
+function resolveStep(step: TutorialStepType, desktop: boolean) {
+  const override = desktop ? step.desktop : undefined;
+  return {
+    content: override?.content || step.content,
+    target: override?.target || step.target,
+  };
+}
+
+function promptProps(
+  content: React.ReactNode,
+): TutorialPromptProps | undefined {
+  return React.isValidElement<TutorialPromptProps>(content) &&
+    content.type === TutorialPrompt
+    ? content.props
+    : undefined;
+}
+
+/**
+ * A non-modal tutorial objective that leaves the game visible and interactive.
+ *
+ * Expansion is local UI state, so it survives card navigation without leaking into saves. The
+ * target treatment is likewise presentation-only and cleaned up whenever the step changes.
+ */
+export default function TutorialHud({
+  desktop,
+  onBack,
+  onExit,
+  onNext,
+  step,
+  stepIndex,
+  totalSteps,
+  canGoBack,
+}: TutorialHudProps): React.JSX.Element {
+  const [expanded, setExpanded] = React.useState(true);
+  const [hintVisible, setHintVisible] = React.useState(false);
+  const pointerOpened = React.useRef(false);
+  const { content, target } = resolveStep(step, desktop);
+  const prompt = promptProps(content);
+  const primaryConcept = prompt?.concepts[0];
+  const progress = ((stepIndex + 1) / totalSteps) * 100;
+  const progressText = `Objective ${stepIndex + 1} of ${totalSteps}`;
+
+  React.useEffect(() => setHintVisible(false), [stepIndex]);
+
+  React.useEffect(() => {
+    if (!target || step.capstone) {
+      return;
+    }
+    let targets: Element[] = [];
+    try {
+      targets = Array.from(document.querySelectorAll(target));
+      targets.forEach((element) => element.classList.add("tutorialTarget"));
+    } catch {
+      // An invalid or temporarily absent selector must not take down the game or objective HUD.
+    }
+    return () =>
+      targets.forEach((element) => element.classList.remove("tutorialTarget"));
+  }, [step, target]);
+
+  const toggleExpanded = () => {
+    // Pointer focus happens before click. Remember that it was the focus which opened the HUD so
+    // the same tap does not immediately collapse it again after React commits the focus update.
+    if (pointerOpened.current) {
+      pointerOpened.current = false;
+      setExpanded(true);
+      return;
+    }
+    setExpanded((value) => !value);
+  };
+
+  return (
+    <section
+      className={`tutorialHud ${expanded ? "tutorialHud-expanded" : "tutorialHud-collapsed"}${step.capstone ? " tutorialHud-capstone" : ""}`}
+      aria-labelledby="tutorial-objective-title"
+    >
+      <div className="tutorialHudHeader">
+        {!expanded && (
+          <div className="tutorialHudProgressRing" aria-hidden>
+            <CircularProgress
+              variant="determinate"
+              value={progress}
+              size={42}
+              thickness={4}
+            />
+            <span className="tutorialHudProgressIcon">
+              {primaryConcept ? (
+                <ConceptIcon concept={primaryConcept} fontSize="small" />
+              ) : (
+                <FlagIcon fontSize="small" />
+              )}
+            </span>
+          </div>
+        )}
+        <div className="tutorialHudHeading">
+          <Typography
+            id="tutorial-objective-title"
+            component="h2"
+            variant="subtitle2"
+          >
+            {step.capstone ? "Your turn" : "Mission objective"}
+          </Typography>
+          <Typography
+            variant="caption"
+            component="span"
+            aria-label={progressText}
+          >
+            {stepIndex + 1} / {totalSteps}
+          </Typography>
+        </div>
+        <IconButton
+          className="tutorialHudToggle"
+          size="small"
+          aria-expanded={expanded}
+          aria-controls="tutorial-objective-content"
+          aria-label={expanded ? "Collapse objective" : "Expand objective"}
+          onPointerDown={() => {
+            pointerOpened.current = !expanded;
+          }}
+          onFocus={() => {
+            if (!expanded) {
+              setExpanded(true);
+            }
+          }}
+          onClick={toggleExpanded}
+        >
+          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
+      </div>
+
+      <div
+        id="tutorial-objective-content"
+        className={expanded ? "tutorialHudContent" : "tutorialHudScreenReader"}
+        aria-live="polite"
+      >
+        {content}
+      </div>
+
+      {expanded && hintVisible && step.hint && (
+        <div className="tutorialHudHint" role="note">
+          <strong>Hint:</strong> {step.hint}
+        </div>
+      )}
+
+      {expanded && (
+        <div className="tutorialHudFooter">
+          <Button color="primary" size="small" onClick={onExit}>
+            Exit
+          </Button>
+          {step.hint && (
+            <Button
+              color="primary"
+              size="small"
+              aria-expanded={hintVisible}
+              onClick={() => setHintVisible((value) => !value)}
+            >
+              {hintVisible ? "Hide hint" : "Hint"}
+            </Button>
+          )}
+          <span className="tutorialHudFooterSpacer" />
+          {canGoBack && (
+            <Button color="primary" size="small" onClick={onBack}>
+              Back
+            </Button>
+          )}
+          {isGatedStep(step) ? (
+            <span className="tutorialHudGate" role="status">
+              <TouchAppIcon fontSize="small" aria-hidden />
+              Complete objective
+            </span>
+          ) : (
+            <Button
+              color="primary"
+              size="small"
+              variant="contained"
+              onClick={onNext}
+            >
+              Next
+            </Button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/base/TutorialPrompt.tsx
+++ b/src/components/base/TutorialPrompt.tsx
@@ -10,7 +10,7 @@ export interface TutorialPromptProps {
   // At most one short sentence - the symbols carry the teaching, the words only confirm it
   text?: string;
   // For gated steps: the deed being asked for, as a "do this" chip matching the pulsing
-  // affordance in the tooltip footer
+  // affordance in the objective HUD
   action?: ConceptNameType[];
 }
 

--- a/src/components/views/LoadingContainer.tsx
+++ b/src/components/views/LoadingContainer.tsx
@@ -116,7 +116,11 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
 
         // Tutorials are never autosaved, so a resumed game shouldn't restart a walkthrough
         if (scenario.tutorialSteps && !resumed && !replaying) {
-          setTimeout(() => dispatch(delta({ tutorialStep: 0 })), 300);
+          // A capstone retry comes through the same clean scenario-start path with its authored
+          // step already selected. Preserve it; a normal tutorial still arrives with -1 and
+          // starts at the first objective after the card transition has mounted its controls.
+          const tutorialStep = game.tutorialStep >= 0 ? game.tutorialStep : 0;
+          setTimeout(() => dispatch(delta({ tutorialStep })), 300);
         }
       } catch (error) {
         reportError(

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -81,6 +81,22 @@ describe("tutorial mission metadata", () => {
       screen.getByText(/Oil pays fixed O&M even when idle/),
     ).toHaveTextContent("variable O&M whenever it generates");
   });
+
+  it("stages deterministic unguided capstones in the first two missions", () => {
+    const pilot = TUTORIALS.slice(0, 2);
+    pilot.forEach((tutorial) => {
+      expect(tutorial.seed).toEqual(expect.any(Number));
+      const capstones = tutorial.tutorialSteps!.filter((step) => step.capstone);
+      expect(capstones).toHaveLength(1);
+      expect(capstones[0].target).toBeUndefined();
+      expect(capstones[0].hint).toBeTruthy();
+    });
+    expect(
+      TUTORIALS.slice(2).flatMap((tutorial) =>
+        tutorial.tutorialSteps!.filter((step) => step.capstone),
+      ),
+    ).toEqual([]);
+  });
 });
 
 describe("authored scenario briefings", () => {

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -2,6 +2,23 @@ import * as React from "react";
 
 import TutorialPrompt from "../components/base/TutorialPrompt";
 import { AppStateType, ScenarioType } from "../Types";
+import { getTimeFromTimeline } from "../helpers/DateTime";
+
+const hasBlackout = (state: AppStateType) =>
+  state.game.eventLog.some((event) => event.kind === "BLACKOUT");
+
+const generatorCapstoneSucceeded = (state: AppStateType) => {
+  const now = getTimeFromTimeline(state.game.date.minute, state.game.timeline);
+  return !!(
+    now &&
+    state.game.facilities.length >= 2 &&
+    state.game.facilities
+      .slice(1)
+      .some((facility) => facility.yearsToBuildLeft <= 0) &&
+    now.supplyW >= now.demandW &&
+    now.cash >= 0
+  );
+};
 
 export const SCENARIOS = [
   {
@@ -11,6 +28,8 @@ export const SCENARIOS = [
     summary: "Meet your grid",
     locationId: "SF",
     ownership: "Investor",
+    // Capstone retries rebuild the exact same weather, demand and market conditions.
+    seed: 249001,
     startingYear: 2019,
     cash: 220000000,
     feePerKgCO2e: 0,
@@ -77,6 +96,25 @@ export const SCENARIOS = [
           />
         ),
       },
+      {
+        card: "FACILITIES",
+        content: (
+          <TutorialPrompt
+            concepts={["goal", "supply", "time"]}
+            text="Your turn: keep the lights on for a full day with no blackout."
+          />
+        ),
+        hint: "Check the reserve readout, then choose a speed. Positive reserve means available capacity exceeds demand right now.",
+        capstone: {
+          success: (s: AppStateType) =>
+            s.game.date.minute >= 1440 && !hasBlackout(s),
+          failure: hasBlackout,
+          successMessage:
+            "Capstone complete - positive reserve kept demand covered for the full day.",
+          failureMessage:
+            "Demand outran available supply, so some electricity went unserved. Watch reserve before running the clock and retry from the same forecast.",
+        },
+      },
     ],
   },
   {
@@ -86,6 +124,7 @@ export const SCENARIOS = [
     summary: "Build a generator",
     locationId: "SF",
     ownership: "Investor",
+    seed: 249002,
     startingYear: 2019,
     cash: 220000000,
     feePerKgCO2e: 0,
@@ -151,6 +190,25 @@ export const SCENARIOS = [
             action={["play"]}
           />
         ),
+      },
+      {
+        card: "FACILITIES",
+        content: (
+          <TutorialPrompt
+            concepts={["forecast", "build", "supply"]}
+            text="Your turn: commission enough capacity to cover demand within nine months and stay solvent."
+          />
+        ),
+        hint: "Compare the forecast peak with your current capacity, then choose any generator whose cost and construction time fit the deadline.",
+        capstone: {
+          success: generatorCapstoneSucceeded,
+          failure: (s: AppStateType) =>
+            s.game.date.monthsEllapsed >= 9 && !generatorCapstoneSucceeded(s),
+          successMessage:
+            "Capstone complete - new capacity came online before the deadline and covered demand without exhausting cash.",
+          failureMessage:
+            "The added capacity was not online and covering demand by the nine-month deadline. Compare construction time, capacity and financing before trying again.",
+        },
       },
     ],
   },

--- a/src/reducers/CustomGame.test.tsx
+++ b/src/reducers/CustomGame.test.tsx
@@ -173,10 +173,10 @@ describe("a custom game", () => {
     });
     expect(getPlayedScenarioIds()).not.toContain(CUSTOM_SCENARIO_ID);
 
-    // The same run of an authored scenario does get recorded, so the assertion above isn't
-    // passing because nothing reaches the end
-    runSimulation({ scenarioId: 4 }); // 104: Finances, also one month long
-    expect(getPlayedScenarioIds()).toContain(4);
+    // A tutorial is also withheld until its final objective succeeds. Letting the one-month
+    // Finances clock expire must not award completion or bypass a future capstone.
+    runSimulation({ scenarioId: 4 });
+    expect(getPlayedScenarioIds()).not.toContain(4);
   });
 
   // The point of a scenario carrying a whole location rather than an id: a place the game has

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1144,6 +1144,9 @@ export function tickState(state: GameType) {
       const scenario =
         getScenario(state.scenarioId, state.customScenario) || SCENARIOS[0];
       const isTutorial = Boolean(scenario.tutorialSteps);
+      const activeTutorialCapstone = Boolean(
+        scenario.tutorialSteps?.[state.tutorialStep]?.capstone,
+      );
       // The leaderboard is keyed on scenario id alone, so custom runs - whatever cash, duration
       // and rules the player gave themselves - would be scored against each other as if they
       // were the same scenario. Replays likewise belong to the original player, not the viewer.
@@ -1285,14 +1288,14 @@ export function tickState(state: GameType) {
           );
         }
       } else if (
-        state.date.monthsEllapsed === (scenario.durationMonths || 12 * 20)
+        state.date.monthsEllapsed === (scenario.durationMonths || 12 * 20) &&
+        !activeTutorialCapstone
       ) {
         // Success: Survived duration
         // Every custom game shares one id, so recording it would light up a completion marker for
-        // a scenario nobody authored, and its score belongs to nothing comparable
-        if (ranked) {
-          // Tutorials are already marked played once their walkthrough ends, so this is a
-          // no-op for the ones the player sat all the way through
+        // a scenario nobody authored. Tutorials are recorded only when their final objective is
+        // satisfied, so merely letting their scenario clock expire cannot bypass a capstone.
+        if (ranked && !isTutorial) {
           recordScenarioPlayed(scenarioId);
         }
 
@@ -1303,6 +1306,9 @@ export function tickState(state: GameType) {
           const { id: scoredScenarioId, endTitle, endMessage } = scenario;
           const difficulty = state.difficulty;
           const nextTutorial = getNextTutorial(scoredScenarioId);
+          const capstoneIndex =
+            scenario.tutorialSteps?.findIndex((step) => step.capstone) ?? -1;
+          const endingMinute = state.date.minute;
           if (!isReplay) {
             logEvent("scenario_end", {
               id: scoredScenarioId,
@@ -1312,6 +1318,18 @@ export function tickState(state: GameType) {
             });
           }
           setTimeout(() => {
+            const live = getStore().getState().game;
+            // Entering a capstone rebuilds the same scenario from minute zero. A completion
+            // callback queued by the final tick of the guided run must not celebrate over that
+            // freshly authored checkpoint merely because both runs share a scenario id.
+            if (
+              capstoneIndex >= 0 &&
+              live.scenarioId === scenarioId &&
+              live.tutorialStep === capstoneIndex &&
+              live.date.minute < endingMinute
+            ) {
+              return;
+            }
             if (!isReplay) {
               clearSaveFor(scenarioId);
             }

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -7,6 +7,7 @@ import {
   TUTORIALS,
 } from "../data/Scenarios";
 import { getStore } from "../StoreRegistry";
+import { getPlayedScenarioIds } from "../LocalStorage";
 import { createGame } from "../testing/Simulator";
 import {
   loaded,
@@ -321,5 +322,28 @@ describe("finishing a tutorial", () => {
     const state = getStore().getState();
     expect(state.card.name).toBe("MAIN_MENU");
     expect(state.ui.dialog.open).toBe(false);
+  });
+
+  it("lets an active capstone own completion at the scenario boundary", () => {
+    window.localStorage.clear();
+    const capstoneIndex = tutorial.tutorialSteps!.findIndex(
+      (step) => step.capstone,
+    );
+    const state = createGame({ scenarioId: tutorial.id });
+    state.tutorialStep = capstoneIndex;
+
+    // Mission 1's one-day capstone and one-month scenario boundary are the same game instant.
+    // The capstone success must pause and explain the result instead of racing a second, stale
+    // scenario-complete dialog onto the screen.
+    playOutOnTheStore(state, tutorial.durationMonths);
+    jest.runOnlyPendingTimers();
+
+    const completed = getStore().getState();
+    expect(completed.ui.dialog.open).toBe(false);
+    expect(completed.ui.snackbar.message).toBe(
+      tutorial.tutorialSteps![capstoneIndex].capstone!.successMessage,
+    );
+    expect(completed.game.speed).toBe("PAUSED");
+    expect(getPlayedScenarioIds()).toContain(tutorial.id);
   });
 });

--- a/src/reducers/Tutorial.test.tsx
+++ b/src/reducers/Tutorial.test.tsx
@@ -1,12 +1,17 @@
 import { configureStore, UnknownAction } from "@reduxjs/toolkit";
 import * as React from "react";
 import { getPlayedScenarioIds } from "../LocalStorage";
-import { AppStateType, CardNameType, TutorialStepType } from "../Types";
+import {
+  AppStateType,
+  CardNameType,
+  GameType,
+  TutorialStepType,
+} from "../Types";
 import { DEFAULT_CUSTOM_SCENARIO, CUSTOM_SCENARIO_ID } from "../data/Scenarios";
 import cardReducer from "./Card";
 import gameReducer from "./Game";
 import settingsReducer from "./Settings";
-import { tutorialGateMiddleware } from "./Tutorial";
+import { restartTutorialAtStep, tutorialGateMiddleware } from "./Tutorial";
 import uiReducer from "./UI";
 import userReducer from "./User";
 
@@ -20,7 +25,11 @@ function informational(card: "FACILITIES" | "INSIGHTS" = "FACILITIES") {
 
 function initialState(
   steps: TutorialStepType[],
-  options: { rate?: number; tutorialStep?: number } = {},
+  options: {
+    rate?: number;
+    speed?: GameType["speed"];
+    tutorialStep?: number;
+  } = {},
 ): AppStateType {
   const init = { type: "test/init" };
   return {
@@ -36,6 +45,7 @@ function initialState(
         tutorialSteps: steps,
       },
       dollarsPerkWh: options.rate ?? 0.07,
+      speed: options.speed ?? "PAUSED",
       tutorialStep: options.tutorialStep || 0,
     },
     settings: settingsReducer(undefined, init),
@@ -63,6 +73,15 @@ function reducer(
       },
     };
   }
+  if (action.type === "game/setSpeed") {
+    return {
+      ...state,
+      game: {
+        ...state.game,
+        speed: action.payload as GameType["speed"],
+      },
+    };
+  }
   if (action.type === "card/navigate") {
     const payload = action.payload as
       string | { name: AppStateType["card"]["name"] };
@@ -86,12 +105,22 @@ function reducer(
       },
     };
   }
+  if (action.type === "ui/dialogOpen") {
+    return {
+      ...state,
+      ui: uiReducer(state.ui, action),
+    };
+  }
   return state;
 }
 
 function tutorialStore(
   steps: TutorialStepType[],
-  options?: { rate?: number; tutorialStep?: number },
+  options?: {
+    rate?: number;
+    speed?: GameType["speed"];
+    tutorialStep?: number;
+  },
 ) {
   return configureStore({
     reducer,
@@ -190,5 +219,77 @@ describe("tutorialGateMiddleware", () => {
     expect(store.getState().ui.snackbar).toEqual(
       expect.objectContaining({ open: true, actionLabel: "Missions" }),
     );
+  });
+
+  it("completes a capstone from its deterministic state predicate", () => {
+    const steps: TutorialStepType[] = [
+      {
+        ...informational(),
+        capstone: {
+          success: (state) => state.game.dollarsPerkWh < 0.07,
+          successMessage: "Capacity arrived before the peak.",
+          failureMessage: "Capacity arrived after the peak.",
+        },
+      },
+    ];
+    const store = tutorialStore(steps, { rate: 0.06 });
+
+    store.dispatch({ type: "test/check-capstone" });
+
+    expect(store.getState().game.tutorialStep).toBe(1);
+    expect(store.getState().ui.snackbar.message).toBe(
+      "Capacity arrived before the peak.",
+    );
+  });
+
+  it("pauses a failed capstone with consequence feedback and retry controls", () => {
+    const steps: TutorialStepType[] = [
+      {
+        ...informational(),
+        capstone: {
+          success: () => false,
+          failure: (state) => state.game.dollarsPerkWh < 0.07,
+          successMessage: "Capacity arrived before the peak.",
+          failureMessage: "Construction finished after the forecast peak.",
+        },
+      },
+    ];
+    const store = tutorialStore(steps, { rate: 0.06, speed: "FAST" });
+
+    store.dispatch({ type: "test/check-capstone" });
+
+    expect(store.getState().game.tutorialStep).toBe(0);
+    expect(store.getState().game.speed).toBe("PAUSED");
+    expect(store.getState().ui.dialog).toEqual(
+      expect.objectContaining({
+        open: true,
+        title: "Capstone needs another try",
+        message: "Construction finished after the forecast peak.",
+        actionLabel: "Retry capstone",
+        secondaryLabel: "Exit tutorial",
+      }),
+    );
+  });
+});
+
+describe("restartTutorialAtStep", () => {
+  it("rebuilds the authored scenario and preserves the capstone objective", () => {
+    const dispatched: UnknownAction[] = [];
+    restartTutorialAtStep(
+      ((action: UnknownAction) => {
+        dispatched.push(action);
+        return action;
+      }) as never,
+      1,
+      5,
+    );
+
+    expect(dispatched.map((action) => action.type)).toEqual([
+      "game/quit",
+      "game/start",
+      "game/delta",
+    ]);
+    expect(dispatched[1].payload).toBe(1);
+    expect(dispatched[2].payload).toEqual({ tutorialStep: 5 });
   });
 });

--- a/src/reducers/Tutorial.tsx
+++ b/src/reducers/Tutorial.tsx
@@ -9,10 +9,28 @@ import {
   isGatedStep,
 } from "../Types";
 import { navigate } from "./Card";
-import { delta, quit } from "./Game";
-import { snackbarOpen } from "./UI";
+import { delta, quit, setSpeed, start } from "./Game";
+import { dialogOpen, snackbarOpen } from "./UI";
 
-// Moves a live walkthrough between two steps, whether a tooltip button or a satisfied gate
+/**
+ * Restores a capstone's authored state while keeping the player on the capstone objective.
+ *
+ * Tutorial scenarios are not autosaved. Reusing their normal start path is consequently both
+ * faster and safer than maintaining a second partial snapshot format: cash, clock, fleet, event
+ * log and all derived forecasts are rebuilt together, and a scenario seed makes the rebuild
+ * deterministic. LoadingContainer preserves the requested step instead of reopening step zero.
+ */
+export function restartTutorialAtStep(
+  dispatch: AppDispatch,
+  scenarioId: number,
+  tutorialStep: number,
+): void {
+  dispatch(quit());
+  dispatch(start(scenarioId));
+  dispatch(delta({ tutorialStep }));
+}
+
+// Moves a live walkthrough between two steps, whether a HUD button or a satisfied gate
 // asked for it - both paths need the same side effects, in the same order
 export function changeTutorialStep(
   dispatch: AppDispatch,
@@ -33,9 +51,21 @@ export function changeTutorialStep(
     dispatch(leaving.onNext());
   }
 
+  const entering = steps[toStep];
+  if (toStep > fromStep && entering?.capstone) {
+    restartTutorialAtStep(dispatch, scenarioId, toStep);
+    return;
+  }
+
+  // A capstone is the mission's proof point. Freeze the authored consequence at success so the
+  // player can read it instead of letting the scenario clock race on to its separate end dialog.
+  if (toStep > fromStep && leaving?.capstone) {
+    dispatch(setSpeed("PAUSED"));
+  }
+
   // Steps declare the card their target lives on, and every step change navigates there
   // regardless of direction. Otherwise Back leaves the player on whatever card the
-  // forward step navigated to, where Joyride can't find the target and shows no tooltip
+  // forward step navigated to, where the objective's target treatment cannot find its control
   const destination = steps[toStep] && steps[toStep].card;
   if (destination) {
     const name =
@@ -57,7 +87,9 @@ export function changeTutorialStep(
   recordScenarioPlayed(scenarioId);
   dispatch(
     snackbarOpen({
-      message: "Walkthrough complete - keep practicing, or move on",
+      message:
+        leaving?.capstone?.successMessage ||
+        "Walkthrough complete - keep practicing, or move on",
       actionLabel: "Missions",
       action: () => dispatch(quit({ toScenarioList: true })),
       open: true,
@@ -119,10 +151,42 @@ export const tutorialGateMiddleware: Middleware =
         }
         const byAction = freshAction && matchesActionGate(step, actionType);
         let byState = false;
+        let capstoneFailed = false;
         try {
-          byState = !!(step.advanceOn && step.advanceOn(state));
+          byState = !!(
+            (step.advanceOn && step.advanceOn(state)) ||
+            (step.capstone && step.capstone.success(state))
+          );
+          capstoneFailed = !!(
+            step.capstone?.failure && step.capstone.failure(state)
+          );
         } catch {
           // A broken gate must not kill the dispatch it rides on
+        }
+        if (!byState && capstoneFailed && step.capstone) {
+          const { failureMessage } = step.capstone;
+          // Freeze the failed state before presenting it. Otherwise a fast clock can keep
+          // mutating the consequence behind the modal while the player is deciding what to do.
+          (api.dispatch as AppDispatch)(setSpeed("PAUSED"));
+          api.dispatch(
+            dialogOpen({
+              title: "Capstone needs another try",
+              message: failureMessage,
+              open: true,
+              notCancellable: true,
+              secondaryLabel: "Exit tutorial",
+              secondaryAction: () =>
+                (api.dispatch as AppDispatch)(quit({ toScenarioList: true })),
+              actionLabel: "Retry capstone",
+              action: () =>
+                restartTutorialAtStep(
+                  api.dispatch as AppDispatch,
+                  state.game.scenarioId,
+                  stepIndex,
+                ),
+            }),
+          );
+          break;
         }
         if (!byAction && !byState) {
           break;


### PR DESCRIPTION
## Summary
- replace the Joyride modal overlay with an accessible, responsive objective HUD that supports progress, collapse/expand, hints, exit, back/forward navigation, and reduced-motion target cues
- add a reusable unguided capstone contract with consequence-specific success/failure feedback and deterministic authored-state retry
- stage the issue's permitted two-mission pilot: Mission 1 asks players to maintain reserve for a full day, and Mission 2 asks them to commission sufficient capacity within nine months
- make capstone completion own tutorial bookkeeping at scenario boundaries and remove the unused react-joyride dependency

## Validation
- npm run check (typecheck, lint, formatting, 80 suites / 799 tests)
- npm run build
- node scripts/sim.js --scenario 0 --months 1 --full
- node scripts/sim.js --scenario 1 --months 9 --build Oil --build-mw 100 --full
- manually exercised desktop and 390px layouts, keyboard-accessible HUD controls, the guided-to-capstone transition, failure feedback, deterministic retry, and success completion

This intentionally implements the explicitly allowed Missions 1-2 pilot. Missions 3-6 remain to be authored and tracked in the parent issue.

Progresses #249