### PR TITLE
Complete tutorial capstones for all missions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ pids
 lib-cov
 coverage
 .nyc_output
+playwright-report/
+test-results/
 
 # Compiled outputs & binary addons (http://nodejs.org/api/addons.html)
 build/Release

--- a/e2e/tutorial-capstone.spec.ts
+++ b/e2e/tutorial-capstone.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+
+test("guided objective reaches a retryable capstone and succeeds", async ({
+  page,
+}, testInfo) => {
+  await page.addInitScript(() => window.localStorage.clear());
+  await page.goto("/");
+  await page.getByRole("button", { name: "Play", exact: true }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Mission objective" }),
+  ).toBeVisible();
+  await expect(page.getByText("Your goal: keep the lights on")).toBeVisible();
+
+  await page.getByRole("button", { name: "Next" }).click();
+  await expect(
+    page.getByText("Blue supply must stay above demand"),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Next" }).click();
+  await expect(page.getByText("Your plants make electricity")).toBeVisible();
+  await page.getByRole("button", { name: "Next" }).click();
+  await expect(page.getByText("Tap 1× to start time")).toBeVisible();
+
+  if (testInfo.project.name === "mobile-390px") {
+    await expect(page.getByRole("button", { name: "Insights" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Events" })).toBeVisible();
+  }
+
+  await page.getByRole("button", { name: "fast speed" }).click();
+  await expect(page.getByText("Watch one full day go by")).toBeVisible();
+  await expect(
+    page.getByText("Your turn: keep the lights on for a full day"),
+  ).toBeVisible();
+
+  // Remove firm capacity so the first attempt demonstrates consequence feedback and retry.
+  await page.locator(".facilityRow", { hasText: "Natural Gas" }).click();
+  await page.getByRole("button", { name: "Pause Natural Gas" }).click();
+  await page.getByRole("button", { name: "fast speed" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Capstone needs another try" }),
+  ).toBeVisible();
+  await expect(page.getByText("Demand outran available supply")).toBeVisible();
+
+  await page.getByRole("button", { name: "Retry capstone" }).click();
+  await expect(
+    page.getByText("Your turn: keep the lights on for a full day"),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Pause Natural Gas" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "fast speed" }).click();
+  await expect(
+    page.getByText("Capstone complete - positive reserve kept demand covered"),
+  ).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+        "@playwright/test": "^1.62.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
@@ -4652,6 +4653,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -15524,6 +15541,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@playwright/test": "^1.62.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
@@ -47,6 +48,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:e2e": "playwright test",
     "sim": "node scripts/sim.js",
     "fetch-weather": "node scripts/fetch-weather.js",
     "fetch-watersheds": "node scripts/fetch-watersheds.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 45000,
+  expect: { timeout: 12000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "desktop-chromium",
+      use: { browserName: "chromium", viewport: { width: 1280, height: 800 } },
+    },
+    {
+      name: "mobile-390px",
+      use: {
+        browserName: "chromium",
+        hasTouch: true,
+        isMobile: true,
+        viewport: { width: 390, height: 844 },
+      },
+    },
+  ],
+  webServer: {
+    command: "npm start",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+    env: {
+      BROWSER: "none",
+      HOST: "127.0.0.1",
+      PORT: "3000",
+    },
+  },
+});

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -461,6 +461,15 @@ export interface TutorialStepType {
   // giving it a deterministic, retryable state instead of inheriting whatever the guided portion
   // changed. Success advances normally; failure pauses for consequence-specific feedback.
   capstone?: {
+    // Optional authored checkpoint overrides. The normal tutorial and its capstone can therefore
+    // teach with different starting economics while still rebuilding the whole Game slice through
+    // initGame on entry/retry. Anything omitted inherits the mission's scenario-level value.
+    checkpoint?: {
+      cash?: number;
+      dollarsPerkWh?: number;
+      facilities?: ScenarioFacilityType[];
+      startingCustomers?: number;
+    };
     success: (state: AppStateType) => boolean;
     failure?: (state: AppStateType) => boolean;
     successMessage: string;

--- a/src/components/views/LoadingContainer.test.tsx
+++ b/src/components/views/LoadingContainer.test.tsx
@@ -1,0 +1,26 @@
+import { UnknownAction } from "@reduxjs/toolkit";
+import { TUTORIALS } from "../../data/Scenarios";
+import { restoreTutorialAfterLoading } from "./LoadingContainer";
+
+it("restores a capstone's authored pane after rebuilding its scenario", () => {
+  const finances = TUTORIALS.find((tutorial) => tutorial.id === 4)!;
+  const capstone = finances.tutorialSteps!.findIndex((step) => step.capstone);
+  const dispatched: UnknownAction[] = [];
+
+  restoreTutorialAfterLoading(
+    ((action: UnknownAction) => {
+      dispatched.push(action);
+      return action;
+    }) as never,
+    finances.tutorialSteps!,
+    capstone,
+  );
+
+  expect(dispatched).toEqual([
+    expect.objectContaining({ type: "card/navigate", payload: "INSIGHTS" }),
+    expect.objectContaining({
+      type: "game/delta",
+      payload: { tutorialStep: capstone },
+    }),
+  ]);
+});

--- a/src/components/views/LoadingContainer.tsx
+++ b/src/components/views/LoadingContainer.tsx
@@ -7,10 +7,26 @@ import { initWeather } from "../../data/Weather";
 import { getStartingCustomers } from "../../data/LocationProfiles";
 import { getScenarioLocation } from "../../helpers/Locations";
 import { getScenario } from "../../data/Scenarios";
+import { navigate } from "../../reducers/Card";
 import { initGame, loaded, delta } from "../../reducers/Game";
 import { isResumedGame } from "../../SaveGame";
-import { AppStateType, GameType } from "../../Types";
+import { AppStateType, GameType, TutorialStepType } from "../../Types";
 import Loading, { DispatchProps, StateProps } from "./Loading";
+
+export function restoreTutorialAfterLoading(
+  dispatch: AppDispatch,
+  tutorialSteps: TutorialStepType[],
+  tutorialStep: number,
+): void {
+  const destination = tutorialSteps[tutorialStep]?.card;
+  // loaded() always mounts Facilities first. Reapply the selected objective's authored pane after
+  // a capstone reset so Finances/Pricing retries do not strand their HUD on the fleet, and so
+  // future capstones can safely start anywhere.
+  if (destination) {
+    dispatch(navigate(destination));
+  }
+  dispatch(delta({ tutorialStep }));
+}
 
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
@@ -120,7 +136,15 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
           // step already selected. Preserve it; a normal tutorial still arrives with -1 and
           // starts at the first objective after the card transition has mounted its controls.
           const tutorialStep = game.tutorialStep >= 0 ? game.tutorialStep : 0;
-          setTimeout(() => dispatch(delta({ tutorialStep })), 300);
+          setTimeout(
+            () =>
+              restoreTutorialAfterLoading(
+                dispatch,
+                scenario.tutorialSteps!,
+                tutorialStep,
+              ),
+            300,
+          );
         }
       } catch (error) {
         reportError(

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -82,20 +82,14 @@ describe("tutorial mission metadata", () => {
     ).toHaveTextContent("variable O&M whenever it generates");
   });
 
-  it("stages deterministic unguided capstones in the first two missions", () => {
-    const pilot = TUTORIALS.slice(0, 2);
-    pilot.forEach((tutorial) => {
+  it("gives every mission one deterministic unguided capstone", () => {
+    TUTORIALS.forEach((tutorial) => {
       expect(tutorial.seed).toEqual(expect.any(Number));
       const capstones = tutorial.tutorialSteps!.filter((step) => step.capstone);
       expect(capstones).toHaveLength(1);
       expect(capstones[0].target).toBeUndefined();
       expect(capstones[0].hint).toBeTruthy();
     });
-    expect(
-      TUTORIALS.slice(2).flatMap((tutorial) =>
-        tutorial.tutorialSteps!.filter((step) => step.capstone),
-      ),
-    ).toEqual([]);
   });
 });
 

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -20,6 +20,61 @@ const generatorCapstoneSucceeded = (state: AppStateType) => {
   );
 };
 
+const latestMonthProfit = (state: AppStateType) => {
+  const month = state.game.monthlyHistory[0];
+  return month
+    ? month.revenue -
+        month.expensesFuel -
+        month.expensesOM -
+        month.expensesCarbonFee -
+        month.expensesInterest
+    : undefined;
+};
+
+const storageCapstoneSucceeded = (state: AppStateType) => {
+  const storage = state.game.facilities.find(
+    (facility) => "currentWh" in facility,
+  );
+  // Authored storage starts empty, so delivered lifetime energy proves that it first charged from
+  // surplus and later discharged. Merely buying a battery cannot satisfy the objective.
+  return !!(
+    storage &&
+    state.game.date.minute >= 1440 &&
+    storage.lifetimeWh > 0 &&
+    !hasBlackout(state)
+  );
+};
+
+const financesCapstoneSucceeded = (state: AppStateType) =>
+  state.game.date.monthsEllapsed >= 1 &&
+  (latestMonthProfit(state) || 0) > 0 &&
+  !hasBlackout(state);
+
+const pricingCapstoneSucceeded = (state: AppStateType) => {
+  const now = getTimeFromTimeline(state.game.date.minute, state.game.timeline);
+  const startingCustomers = state.game.customerMarketSize / 2;
+  return !!(
+    now &&
+    state.game.date.monthsEllapsed >= 6 &&
+    state.game.dollarsPerkWh < 0.07 &&
+    now.customers >= startingCustomers * 1.05 &&
+    (latestMonthProfit(state) || 0) > 0 &&
+    !hasBlackout(state)
+  );
+};
+
+const forecastingCapstoneSucceeded = (state: AppStateType) => {
+  const addedGenerator = state.game.facilities.some(
+    (facility) =>
+      facility.id > 1 &&
+      !("currentWh" in facility) &&
+      facility.yearsToBuildLeft <= 0,
+  );
+  return (
+    state.game.date.monthsEllapsed >= 7 && addedGenerator && !hasBlackout(state)
+  );
+};
+
 export const SCENARIOS = [
   {
     id: 0, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
@@ -219,6 +274,7 @@ export const SCENARIOS = [
     summary: "Store energy for later",
     locationId: "SF",
     ownership: "Investor",
+    seed: 249003,
     startingYear: 2019,
     cash: 220000000,
     feePerKgCO2e: 0,
@@ -291,6 +347,32 @@ export const SCENARIOS = [
           />
         ),
       },
+      {
+        card: "FACILITIES",
+        content: (
+          <TutorialPrompt
+            concepts={["storage", "supply", "time"]}
+            text="Your turn: charge from spare supply, then discharge through an evening peak within two days without a blackout."
+          />
+        ),
+        hint: "Run the clock and watch the storage bar and power readout. Stored energy should rise off-peak, then fall while storage supplies the grid at peak.",
+        capstone: {
+          checkpoint: {
+            facilities: [
+              { name: "Pumped Hydro", peakWh: 500000000 },
+              { fuel: "Coal", peakW: 375000000 },
+            ],
+          },
+          success: storageCapstoneSucceeded,
+          failure: (s: AppStateType) =>
+            hasBlackout(s) ||
+            (s.game.date.minute >= 2880 && !storageCapstoneSucceeded(s)),
+          successMessage:
+            "Capstone complete - surplus charged storage, and its later discharge carried demand through the peak without unserved energy.",
+          failureMessage:
+            "Storage did not complete a charge-and-discharge cycle before the deadline, or demand went unserved. Watch its state of charge and dispatch order before retrying.",
+        },
+      },
     ],
   },
   {
@@ -300,6 +382,7 @@ export const SCENARIOS = [
     summary: "Read the books",
     locationId: "SF",
     ownership: "Investor",
+    seed: 249004,
     startingYear: 2019,
     cash: 220000000,
     feePerKgCO2e: 0,
@@ -364,6 +447,26 @@ export const SCENARIOS = [
           />
         ),
       },
+      {
+        card: "INSIGHTS",
+        content: (
+          <TutorialPrompt
+            concepts={["finances", "rate", "money"]}
+            text="Your turn: turn the projected loss into a profitable month without causing a blackout."
+          />
+        ),
+        hint: "Compare revenue with fuel and O&M expenses. The rate control changes revenue per unit sold; choose a rate that makes the next month profitable.",
+        capstone: {
+          checkpoint: { dollarsPerkWh: 0.03 },
+          success: financesCapstoneSucceeded,
+          failure: (s: AppStateType) =>
+            s.game.date.monthsEllapsed >= 1 && !financesCapstoneSucceeded(s),
+          successMessage:
+            "Capstone complete - revenue covered fuel and operating costs, leaving a positive monthly profit while the grid stayed reliable.",
+          failureMessage:
+            "Revenue did not cover fuel, O&M and financing costs for the month, or demand went unserved. Use the financial layers to set a sustainable rate before retrying.",
+        },
+      },
     ],
   },
   {
@@ -373,6 +476,7 @@ export const SCENARIOS = [
     summary: "Grow your customers",
     locationId: "SF",
     ownership: "Investor",
+    seed: 249005,
     startingYear: 2019,
     cash: 220000000,
     feePerKgCO2e: 0,
@@ -439,6 +543,26 @@ export const SCENARIOS = [
           />
         ),
       },
+      {
+        card: "INSIGHTS",
+        content: (
+          <TutorialPrompt
+            concepts={["rate", "customers", "money"]}
+            text="Your turn: grow customers by at least 5% in six months while staying profitable and reliable."
+          />
+        ),
+        hint: "A modest discount below the market rate attracts customers. Check the financial forecast too: a rate that is too low can grow sales while losing money.",
+        capstone: {
+          success: pricingCapstoneSucceeded,
+          failure: (s: AppStateType) =>
+            hasBlackout(s) ||
+            (s.game.date.monthsEllapsed >= 6 && !pricingCapstoneSucceeded(s)),
+          successMessage:
+            "Capstone complete - the lower rate grew the customer base by 5% while monthly revenue still covered costs and every unit of demand was served.",
+          failureMessage:
+            "The customer target, positive monthly profit and reliable supply did not all hold for six months. Balance the rate against both demand growth and cost before retrying.",
+        },
+      },
     ],
   },
   {
@@ -448,6 +572,7 @@ export const SCENARIOS = [
     summary: "See what's coming",
     locationId: "SF",
     ownership: "Investor",
+    seed: 249006,
     startingYear: 2020,
     cash: 220000000,
     feePerKgCO2e: 0,
@@ -557,6 +682,27 @@ export const SCENARIOS = [
             action={["play"]}
           />
         ),
+      },
+      {
+        card: "FACILITIES",
+        content: (
+          <TutorialPrompt
+            concepts={["forecast", "build", "blackout"]}
+            text="Your turn: commission enough generation before the forecast summer shortage, then reach month seven without a blackout."
+          />
+        ),
+        hint: "Inspect the supply-and-demand forecast, then choose any generator with enough capacity and a construction time shorter than the shortage deadline.",
+        capstone: {
+          success: forecastingCapstoneSucceeded,
+          failure: (s: AppStateType) =>
+            hasBlackout(s) ||
+            (s.game.date.monthsEllapsed >= 7 &&
+              !forecastingCapstoneSucceeded(s)),
+          successMessage:
+            "Capstone complete - construction finished before the forecast peak, and the added generator prevented the projected summer shortage.",
+          failureMessage:
+            "Demand reached available capacity before enough new generation was online. Recheck the forecast gap and construction time, then commission earlier.",
+        },
       },
     ],
   },

--- a/src/data/TutorialCapstones.test.tsx
+++ b/src/data/TutorialCapstones.test.tsx
@@ -1,0 +1,135 @@
+import { getStore } from "../StoreRegistry";
+import { AppStateType, GameType, ScenarioType } from "../Types";
+import gameReducer, {
+  delta,
+  initGame,
+  start,
+  tickState,
+} from "../reducers/Game";
+import { createGame } from "../testing/Simulator";
+import { TUTORIALS } from "./Scenarios";
+
+function tutorial(id: number): ScenarioType {
+  return TUTORIALS.find((scenario) => scenario.id === id) as ScenarioType;
+}
+
+function capstone(id: number) {
+  return tutorial(id).tutorialSteps!.find((step) => step.capstone)!.capstone!;
+}
+
+function appState(game: GameType): AppStateType {
+  return { ...getStore().getState(), game };
+}
+
+function tickUntil(
+  game: GameType,
+  predicate: (state: AppStateType) => boolean,
+  maxTicks = 2000,
+): boolean {
+  for (let i = 0; i < maxTicks; i++) {
+    tickState(game);
+    if (predicate(appState(game))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("authored tutorial capstones", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("cycles storage through charge and discharge before Mission 3's deadline", () => {
+    const scenario = {
+      ...tutorial(2),
+      id: 9998,
+      facilities: capstone(2).checkpoint!.facilities!,
+    };
+    const game = createGame({ scenarioId: scenario.id, scenario });
+    const objective = capstone(2);
+
+    expect(tickUntil(game, objective.success, 192)).toBe(true);
+    expect(objective.failure?.(appState(game))).toBe(false);
+    const storage = game.facilities.find(
+      (facility) => "currentWh" in facility,
+    )!;
+    expect(storage.lifetimeWh).toBeGreaterThan(0);
+  });
+
+  it("starts Mission 4's capstone from its authored loss-making checkpoint", () => {
+    const scenario = tutorial(4);
+    const capstoneIndex = scenario.tutorialSteps!.findIndex(
+      (step) => step.capstone,
+    );
+    // createGame loads the scenario's weather/economy fixtures used by initGame below.
+    const baseline = createGame({ scenarioId: scenario.id });
+    let game = gameReducer(undefined, start(scenario.id));
+    game = gameReducer(game, delta({ tutorialStep: capstoneIndex }));
+    game = gameReducer(
+      game,
+      initGame({
+        facilities: scenario.facilities,
+        cash: scenario.cash,
+        customers: baseline.customerMarketSize / 2,
+        location: baseline.location,
+        seed: scenario.seed,
+      }),
+    );
+
+    expect(game.dollarsPerkWh).toBe(0.03);
+    expect(game.customerRate).toBe(0.03);
+    expect(game.seed).toBe(249004);
+    expect(game.eventLog).toEqual([]);
+    expect(game.tutorialStep).toBe(capstoneIndex);
+  });
+
+  it("accepts a sustainable Mission 4 rate and rejects the checkpoint rate", () => {
+    const objective = capstone(4);
+    const scenario = {
+      ...tutorial(4),
+      id: 9999,
+      durationMonths: 2,
+    };
+    const sustainable = createGame({
+      scenarioId: scenario.id,
+      scenario,
+      dollarsPerkWh: 0.06,
+    });
+    const lossMaking = createGame({
+      scenarioId: scenario.id,
+      scenario,
+      dollarsPerkWh: 0.03,
+    });
+
+    expect(tickUntil(sustainable, objective.success, 120)).toBe(true);
+    expect(tickUntil(lossMaking, objective.failure!, 120)).toBe(true);
+    expect(objective.success(appState(lossMaking))).toBe(false);
+  });
+
+  it("rewards profitable customer growth and rejects an unsustainable discount", () => {
+    const objective = capstone(3);
+    const balanced = createGame({ scenarioId: 3, dollarsPerkWh: 0.06 });
+    const tooCheap = createGame({ scenarioId: 3, dollarsPerkWh: 0.03 });
+
+    expect(tickUntil(balanced, objective.success, 700)).toBe(true);
+    expect(tickUntil(tooCheap, objective.failure!, 700)).toBe(true);
+    expect(objective.success(appState(tooCheap))).toBe(false);
+  });
+
+  it("lets timely capacity prevent Mission 6's forecast shortage", () => {
+    const objective = capstone(5);
+    const prepared = createGame({
+      scenarioId: 5,
+      initialBuild: { name: "Oil", peakW: 100000000, financed: false },
+    });
+    const unprepared = createGame({ scenarioId: 5 });
+
+    expect(tickUntil(prepared, objective.success, 800)).toBe(true);
+    expect(objective.failure?.(appState(prepared))).toBe(false);
+    expect(tickUntil(unprepared, objective.failure!, 800)).toBe(true);
+    expect(objective.success(appState(unprepared))).toBe(false);
+  });
+});

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -555,26 +555,36 @@ export const gameSlice = createSlice({
       state.seed = a.seed !== undefined ? a.seed : newSeed();
       const scenario =
         getScenario(state.scenarioId, state.customScenario) || SCENARIOS[0];
+      const checkpoint =
+        scenario.tutorialSteps?.[state.tutorialStep]?.capstone?.checkpoint;
+      const startingCash = checkpoint?.cash ?? a.cash;
+      const startingCustomers = checkpoint?.startingCustomers ?? a.customers;
+      const startingFacilities = checkpoint?.facilities ?? a.facilities;
+      const startingRate = checkpoint?.dollarsPerkWh ?? scenario.dollarsPerkWh;
       state.date = getDateFromMinute(0, scenario.startingYear);
       state.startingYear = scenario.startingYear;
       // A company on day one has no track record, no debt and nothing but cash, so it borrows at
       // whatever prime was in the year the scenario opens -- 4.75% in 2019, 21.5% in 1980. It is
       // repriced against its own results at the first month rollover, and every one after.
       state.creditPremium = getCreditPremium(
-        getCreditInputs([], a.cash, a.cash, []),
+        getCreditInputs([], startingCash, startingCash, []),
       );
       state.interestRate =
         getPrimeRate(state.date, state.seed) * state.creditPremium;
       state.feePerKgCO2e = scenario.feePerKgCO2e;
       // The rate the scenario advertises on the new game screen, and the rate Public scenarios are
       // scored against, so the game has to actually start there rather than at the slice default
-      state.dollarsPerkWh = scenario.dollarsPerkWh;
-      state.customerRate = scenario.dollarsPerkWh;
-      state.customerMarketSize = a.customers * CUSTOMER_MARKET_MULTIPLIER;
+      state.dollarsPerkWh = startingRate;
+      state.customerRate = startingRate;
+      state.customerMarketSize = startingCustomers * CUSTOMER_MARKET_MULTIPLIER;
       state.location = a.location;
-      state.timeline = generateNewTimeline(state, a.cash, a.customers);
+      state.timeline = generateNewTimeline(
+        state,
+        startingCash,
+        startingCustomers,
+      );
 
-      a.facilities.forEach((search: ScenarioFacilityType) => {
+      startingFacilities.forEach((search: ScenarioFacilityType) => {
         // Age is scenario metadata rather than a catalog property, so exclude it from the exact
         // technology match and pass it to the completed operating asset separately.
         const { initialAgeYears = 0, ...facilitySearch } = search;

--- a/src/reducers/Tutorial.tsx
+++ b/src/reducers/Tutorial.tsx
@@ -52,6 +52,18 @@ export function changeTutorialStep(
   }
 
   const entering = steps[toStep];
+  // Steps declare the card their target lives on, and every step change navigates there
+  // regardless of direction. Otherwise Back leaves the player on whatever card the
+  // forward step navigated to, where the objective's target treatment cannot find its control
+  const destination = entering?.card;
+  if (destination) {
+    const name =
+      typeof destination === "string" ? destination : destination.name;
+    if (name !== currentCard) {
+      dispatch(navigate(destination));
+    }
+  }
+
   if (toStep > fromStep && entering?.capstone) {
     restartTutorialAtStep(dispatch, scenarioId, toStep);
     return;
@@ -61,18 +73,6 @@ export function changeTutorialStep(
   // player can read it instead of letting the scenario clock race on to its separate end dialog.
   if (toStep > fromStep && leaving?.capstone) {
     dispatch(setSpeed("PAUSED"));
-  }
-
-  // Steps declare the card their target lives on, and every step change navigates there
-  // regardless of direction. Otherwise Back leaves the player on whatever card the
-  // forward step navigated to, where the objective's target treatment cannot find its control
-  const destination = steps[toStep] && steps[toStep].card;
-  if (destination) {
-    const name =
-      typeof destination === "string" ? destination : destination.name;
-    if (name !== currentCard) {
-      dispatch(navigate(destination));
-    }
   }
 
   dispatch(delta({ tutorialStep: toStep }));


### PR DESCRIPTION
## Summary
- complete the objective-HUD rollout with unguided capstones for Missions 3–6: storage cycling, sustainable finances, profitable customer growth, and forecast-led capacity planning
- add authored capstone checkpoint overrides so retries restore capstone-specific fleets, economics, RNG state, and the objective's authored pane
- add simulation-backed success/failure coverage for every new capstone and Playwright coverage for guided objective → capstone → retry/success on desktop and 390px mobile

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -- --watchAll=false --coverage` (82 suites / 806 tests)
- `npm run test:e2e` (desktop Chromium and 390px mobile)
- `npm run build`

Closes #249
