### PR TITLE
Trim duplicative low-signal tests

### DIFF
--- a/src/LocalStorage.test.tsx
+++ b/src/LocalStorage.test.tsx
@@ -12,12 +12,9 @@ describe("getStorageChoice", () => {
     expect(getStorageChoice(KEY, [1, 5, 10, 20], 1)).toBe(1);
   });
 
-  it("round trips a number through storage", () => {
+  it("round trips supported primitive choices through storage", () => {
     setStorageKeyValue(KEY, 20);
     expect(getStorageChoice(KEY, [1, 5, 10, 20], 1)).toBe(20);
-  });
-
-  it("round trips a string through storage", () => {
     setStorageKeyValue(KEY, "revenue");
     expect(getStorageChoice(KEY, ["profit", "revenue"], "profit")).toBe(
       "revenue",

--- a/src/Theme.test.tsx
+++ b/src/Theme.test.tsx
@@ -5,14 +5,13 @@ describe("facility fuel colors", () => {
 
   afterAll(() => setThemeMode(originalMode));
 
-  it.each(["light", "dark"] as const)(
-    "gives Airborne Wind a distinct %s palette color",
-    (mode) => {
+  it("gives Airborne Wind a distinct color in both palettes", () => {
+    (["light", "dark"] as const).forEach((mode) => {
       setThemeMode(mode);
       const airborne = facilityColor("Airborne Wind");
       expect(airborne).toMatch(/^#[0-9a-f]{6}$/i);
       expect(airborne).not.toBe(facilityColor("Wind"));
       expect(airborne).not.toBe(facilityColor("Offshore Wind"));
-    },
-  );
+    });
+  });
 });

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -271,18 +271,22 @@ describe("walkthrough steps", () => {
     expect(actionOf(storageStep)).toEqual(["storage"]);
   });
 
-  tutorials.forEach((scenario) => {
-    const steps = scenario.tutorialSteps as TutorialStepType[];
-
-    it(`${scenario.name} declares the card every step's target lives on`, () => {
+  it("declares the card every tutorial target lives on", () => {
+    tutorials.forEach((scenario) => {
+      const steps = scenario.tutorialSteps as TutorialStepType[];
       steps.forEach((s, i) => {
-        expect([`step ${i}`, cardOf(s)]).not.toContainEqual(undefined);
+        expect([scenario.name, `step ${i}`, cardOf(s)]).not.toContainEqual(
+          undefined,
+        );
       });
     });
+  });
 
-    // Walk the whole thing forwards and then all the way back, tracking the card the store
-    // would be showing. Any step whose target isn't on the current card would point at nothing
-    it(`${scenario.name} shows each step's card in both directions`, () => {
+  // Walk each walkthrough forwards and then all the way back, tracking the card the store
+  // would be showing. Any step whose target isn't on the current card would point at nothing
+  it("shows each guided step's card in both directions", () => {
+    tutorials.forEach((scenario) => {
+      const steps = scenario.tutorialSteps as TutorialStepType[];
       let card: CardNameType = STARTING_CARD;
       expect(cardOf(steps[0])).toBe(card);
 
@@ -295,11 +299,14 @@ describe("walkthrough steps", () => {
       }
 
       moves.forEach(([fromStep, toStep]) => {
-        const destination = navigatedTo(
-          step({ steps, fromStep, toStep, currentCard: card }),
-        );
+        const dispatched = step({ steps, fromStep, toStep, currentCard: card });
+        const destination = navigatedTo(dispatched);
         if (destination) {
           card = destination;
+        } else if (dispatched.some((action) => action.type === "game/start")) {
+          // Capstones restart through Loading; its eventual card is outside this dispatch unit.
+          card = STARTING_CARD;
+          return;
         }
         expect([scenario.name, toStep, card]).toEqual([
           scenario.name,
@@ -308,16 +315,23 @@ describe("walkthrough steps", () => {
         ]);
       });
     });
+  });
 
-    /**
-     * A selector matching nothing silently loses the restrained target treatment. Rendering every
-     * card would be the airtight check; scanning the source for the id or class each selector names
-     * catches that kind of rename far cheaper.
-     */
-    it(`${scenario.name} points every step at markup that still exists`, () => {
+  /**
+   * A selector matching nothing silently loses the restrained target treatment. Rendering every
+   * card would be the airtight check; scanning the source for the id or class each selector names
+   * catches that kind of rename far cheaper.
+   */
+  it("points every tutorial step at markup that still exists", () => {
+    tutorials.forEach((scenario) => {
+      const steps = scenario.tutorialSteps as TutorialStepType[];
       targetsOf(steps).forEach((target) => {
         target.split(/\s+/).forEach((simple) => {
-          expect([target, declares(simple)]).toEqual([target, true]);
+          expect([scenario.name, target, declares(simple)]).toEqual([
+            scenario.name,
+            target,
+            true,
+          ]);
         });
       });
     });

--- a/src/components/base/VictoryDialog.test.tsx
+++ b/src/components/base/VictoryDialog.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import VictoryDialog, { Props } from "./VictoryDialog";
 import { VictoryType } from "../../Types";
@@ -218,12 +218,11 @@ describe("VictoryDialog", () => {
     expect(onQuit).toHaveBeenCalled();
   });
 
-  it.each([
-    ["bankrupt", "Bankrupt!"],
-    ["fired", "Fired!"],
-  ] as const)(
-    "shows a %s score without letting the terminal run resume",
-    async (outcome, title) => {
+  it("shows terminal scores without letting either run resume", async () => {
+    for (const [outcome, title] of [
+      ["bankrupt", "Bankrupt!"],
+      ["fired", "Fired!"],
+    ] as const) {
       const onClose = jest.fn();
       renderDialog({ victory: aVictory({ outcome }), onClose });
 
@@ -234,8 +233,9 @@ describe("VictoryDialog", () => {
       expect(screen.queryByText("Review final grid")).not.toBeInTheDocument();
       await userEvent.keyboard("{Escape}");
       expect(onClose).not.toHaveBeenCalled();
-    },
-  );
+      cleanup();
+    }
+  });
 
   it("uses the scenario's own ending when it has one", () => {
     renderDialog({

--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -135,9 +135,9 @@ describe("the Finances chart selectors", () => {
 
   // PAUSED covers the unthrottled path and FAST covers the frame-skipping path that used to
   // swallow the player's own clicks. SLOW and NORMAL exercise the same branches as FAST.
-  it.each(["PAUSED", "FAST"] as SpeedType[])(
-    "replots when the metric changes at %s speed",
-    async (speed: SpeedType) => {
+  it("replots metric changes on paused and throttled paths", async () => {
+    for (const speed of ["PAUSED", "FAST"] as SpeedType[]) {
+      localStorage.clear();
       renderFinances(game, speed);
       expect(plottedMetric()).toContain("Profit");
 
@@ -151,12 +151,13 @@ describe("the Finances chart selectors", () => {
 
       await choose(metricSelect(), "Demand");
       expect(plottedMetric()).toContain("Demand");
-    },
-  );
+      cleanup();
+    }
+  });
 
-  it.each(["PAUSED", "FAST"] as SpeedType[])(
-    "keeps the metric dropdown showing what is plotted at %s speed",
-    async (speed: SpeedType) => {
+  it("keeps the dropdown in sync on paused and throttled paths", async () => {
+    for (const speed of ["PAUSED", "FAST"] as SpeedType[]) {
+      localStorage.clear();
       renderFinances(game, speed);
 
       await choose(metricSelect(), "Revenue");
@@ -164,12 +165,13 @@ describe("the Finances chart selectors", () => {
 
       expect(metricSelect()).toHaveTextContent("Expenses");
       expect(plottedMetric()).toContain("Expenses");
-    },
-  );
+      cleanup();
+    }
+  });
 
-  it.each(["PAUSED", "FAST"] as SpeedType[])(
-    "replots when the period changes at %s speed",
-    async (speed: SpeedType) => {
+  it("replots period changes on paused and throttled paths", async () => {
+    for (const speed of ["PAUSED", "FAST"] as SpeedType[]) {
+      localStorage.clear();
       renderFinances(game, speed);
       const thisYear = summarised("Revenue");
 
@@ -183,8 +185,9 @@ describe("the Finances chart selectors", () => {
       await choose(periodSelect(), "Current year");
       expect(periodSelect()).toHaveTextContent("Current year");
       expect(summarised("Revenue")).toEqual(thisYear);
-    },
-  );
+      cleanup();
+    }
+  });
 
   it("remembers the metric across a remount, dropdown and chart together", async () => {
     const view = renderFinances(game, "PAUSED");
@@ -220,15 +223,15 @@ describe("the Finances chart selectors", () => {
 
   // The sentinels the dropdown used to store its two non-year options as. They aren't options
   // any more, and a returning player has one of them sitting in storage
-  it.each(["-1", "0"])(
-    "falls back to the current year when storage holds the old %s sentinel",
-    (stored: string) => {
+  it("falls back when storage holds either old range sentinel", () => {
+    ["-1", "0"].forEach((stored) => {
       localStorage.setItem("financesChartYear", stored);
 
       renderFinances(game, "PAUSED");
       expect(periodSelect()).toHaveTextContent("Current year");
-    },
-  );
+      cleanup();
+    });
+  });
 
   it("plots further than the game has reached when a forward range is chosen", async () => {
     renderFinances(game, "PAUSED");

--- a/src/components/views/Manual.test.tsx
+++ b/src/components/views/Manual.test.tsx
@@ -44,16 +44,18 @@ describe("Manual", () => {
 
   // The old filter only looked at children that were plain strings, so any paragraph
   // containing an element (<strong>, a nested list, ...) was invisible to search
-  it.each([
-    ["merit order", MANUAL_ENTRY.FORECASTS],
-    ["dispatch order", MANUAL_ENTRY.FORECASTS],
-    ["peak shortage", MANUAL_ENTRY.FORECASTS],
-    ["board of directors", MANUAL_ENTRY.BLACKOUTS],
-    ["variable O&M", MANUAL_ENTRY.TOTAL_COST_OF_ENERGY],
-  ])("finds %s inside mixed markup", async (term: string, title: string) => {
+  it("finds representative terms inside mixed markup", async () => {
     renderManual();
-    await search(term);
-    expect(entryHeader(title)).toBeInTheDocument();
+    for (const [term, title] of [
+      ["merit order", MANUAL_ENTRY.FORECASTS],
+      ["dispatch order", MANUAL_ENTRY.FORECASTS],
+      ["peak shortage", MANUAL_ENTRY.FORECASTS],
+      ["board of directors", MANUAL_ENTRY.BLACKOUTS],
+      ["variable O&M", MANUAL_ENTRY.TOTAL_COST_OF_ENERGY],
+    ]) {
+      await search(term);
+      expect(entryHeader(title)).toBeInTheDocument();
+    }
   });
 
   it("finds terms by keyword as well as by title", async () => {

--- a/src/data/Facilities.test.tsx
+++ b/src/data/Facilities.test.tsx
@@ -69,26 +69,26 @@ function generatorAt(
 }
 
 describe("current facility economics", () => {
-  it.each([
-    ["Coal", 2023, 650000000, 4.103],
-    ["Nuclear", 2023, 2156000000, 7.861],
-    ["Natural Gas", 2023, 419000000, 0.836],
-    ["Oil", 2023, 3000000, 1.248],
-    ["Wind", 2024, 200000000, 1.041],
-    ["Solar", 2024, 150000000, 0.691],
-    ["Hydro", 2024, 100000000, 2.267],
-    ["Geothermal", 2024, 50000000, 4.015],
-  ])(
-    "prices a reference-sized %s plant at its published benchmark",
-    (name, year, peakW, dollarsPerW) => {
+  it("prices reference plants at their published benchmarks", () => {
+    const benchmarks: Array<[string, number, number, number]> = [
+      ["Coal", 2023, 650000000, 4.103],
+      ["Nuclear", 2023, 2156000000, 7.861],
+      ["Natural Gas", 2023, 419000000, 0.836],
+      ["Oil", 2023, 3000000, 1.248],
+      ["Wind", 2024, 200000000, 1.041],
+      ["Solar", 2024, 150000000, 0.691],
+      ["Hydro", 2024, 100000000, 2.267],
+      ["Geothermal", 2024, 50000000, 4.015],
+    ];
+    benchmarks.forEach(([name, year, peakW, dollarsPerW]) => {
       const location =
         name === "Hydro" || name === "Geothermal" ? iceland : france;
-      expect(
-        generatorAt(year as number, name as string, peakW as number, location)
-          ?.buildCost,
-      ).toBeCloseTo((peakW as number) * (dollarsPerW as number), -2);
-    },
-  );
+      expect(generatorAt(year, name, peakW, location)?.buildCost).toBeCloseTo(
+        peakW * dollarsPerW,
+        -2,
+      );
+    });
+  });
 
   it("uses the latest battery cost, duration, life, and augmentation O&M", () => {
     const battery = STORAGE(stateAt(france, 2024), 600000000).find(
@@ -178,15 +178,14 @@ describe("current facility economics", () => {
 });
 
 describe("real technology cost trends", () => {
-  it.each(["Wind", "Solar"])(
-    "models the observed 2020-2024 decline for %s",
-    (name) => {
+  it("models the observed 2020-2024 wind and solar decline", () => {
+    ["Wind", "Solar"].forEach((name) => {
       const peakW = name === "Wind" ? 200000000 : 150000000;
       expect(generatorAt(2024, name, peakW)?.buildCost).toBeLessThan(
         generatorAt(2020, name, peakW)?.buildCost as number,
       );
-    },
-  );
+    });
+  });
 
   it("models falling battery costs and rising nuclear costs", () => {
     const battery2020 = STORAGE(stateAt(france, 2020), 600000000).find(

--- a/src/data/WeatherBinary.test.tsx
+++ b/src/data/WeatherBinary.test.tsx
@@ -283,13 +283,15 @@ describe("the shipped weather files", () => {
     expect(monthMean(7)).toBeGreaterThan(20);
   });
 
-  it.each(offshoreIds)("%s has a usable offshore wind resource", (id) => {
-    const speeds = decodeWeather(readShipped(id)).map(
-      (row) => row.WIND_OFFSHORE_KPH as number,
-    );
-    const capacityFactor = getOffshoreWindCapacityFactor(speeds);
-    expect(capacityFactor).toBeGreaterThan(0.2);
-    expect(capacityFactor).toBeLessThan(0.7);
+  it("gives every offshore location a usable wind resource", () => {
+    offshoreIds.forEach((id) => {
+      const speeds = decodeWeather(readShipped(id)).map(
+        (row) => row.WIND_OFFSHORE_KPH as number,
+      );
+      const capacityFactor = getOffshoreWindCapacityFactor(speeds);
+      expect(capacityFactor).toBeGreaterThan(0.2);
+      expect(capacityFactor).toBeLessThan(0.7);
+    });
   });
 
   it("calibrates Airborne Wind to Lista's 3,500 full-load-hour target", () => {

--- a/src/helpers/Csv.test.tsx
+++ b/src/helpers/Csv.test.tsx
@@ -27,11 +27,8 @@ describe("parseCsv", () => {
 
   // The blank row a file ending in a newline leaves behind. EconomyRaw.csv ends in one and
   // FuelPricesRaw.csv does not, and neither should be able to tell the difference here
-  it("skips the blank line left by a file ending in a newline", () => {
+  it("skips blank lines at the end or in the middle", () => {
     expect(parseCsv(`${HEADER}\n12,2019,4.75,0.0180\n`)).toHaveLength(1);
-  });
-
-  it("skips blank lines in the middle of a file", () => {
     expect(
       parseCsv(`${HEADER}\n12,2019,4.75,0.0180\n\n11,2019,4.75,0.0180`),
     ).toHaveLength(2);
@@ -55,11 +52,8 @@ describe("parseCsv", () => {
     expect(() => parseCsv(`${HEADER}\n12,2019,"4,75",0.0180`)).toThrow(/quote/);
   });
 
-  it("throws on a row whose field count has drifted from the header's", () => {
+  it("rejects rows whose field count drifted and reports their source line", () => {
     expect(() => parseCsv(`${HEADER}\n12,2019,4.75`)).toThrow(/line 2/);
-  });
-
-  it("names the line a short row is actually on, counting blank lines", () => {
     expect(() => parseCsv(`${HEADER}\n\n12,2019,4.75`)).toThrow(/line 3/);
   });
 

--- a/src/helpers/DateTime.test.tsx
+++ b/src/helpers/DateTime.test.tsx
@@ -21,19 +21,10 @@ import { generateNewTimeline } from "../reducers/Game";
 import { createGame } from "../testing/Simulator";
 
 describe("formatMinuteOfDayChartAxis", () => {
-  it("should render midnight as 12am", () => {
+  it("formats a day in twelve-hour time", () => {
     expect(formatMinuteOfDayChartAxis(0)).toEqual("12am");
-  });
-
-  it("should render noon as 12pm", () => {
     expect(formatMinuteOfDayChartAxis(12 * 60)).toEqual("12pm");
-  });
-
-  it("should render the evening peak in 12 hour time", () => {
     expect(formatMinuteOfDayChartAxis(19 * 60)).toEqual("7pm");
-  });
-
-  it("should ignore whole days, since the axis only shows a clock", () => {
     expect(formatMinuteOfDayChartAxis(5 * 1440 + 6 * 60)).toEqual("6am");
   });
 });
@@ -170,20 +161,12 @@ describe("summarizeTimeline", () => {
     );
   }
 
-  it("reports the balances the period ended on, not the ones it opened with", () => {
+  it("reports ending balances and rates while totalling flows", () => {
     const summary = summarizeTimeline(ticks([100, 200, 300]), 2020);
     expect(summary.cash).toEqual(300);
     expect(summary.netWorth).toEqual(600);
     expect(summary.customers).toEqual(1002);
-  });
-
-  it("reports the rate in force at the end of the period", () => {
-    const summary = summarizeTimeline(ticks([100, 200, 300]), 2020);
     expect(summary.interestRate).toBeCloseTo(0.042, 10);
-  });
-
-  it("still totals the flows across every tick", () => {
-    const summary = summarizeTimeline(ticks([100, 200, 300]), 2020);
     expect(summary.revenue).toEqual(30);
     expect(summary.expensesFuel).toEqual(3);
   });
@@ -213,15 +196,12 @@ describe("summarizeHistory", () => {
     );
   }
 
-  it("reports the balances of the most recent month", () => {
+  it("reports the latest balances while totalling monthly flows", () => {
     // Newest first, so 300 is the newest month and 100 the oldest
     const summary = summarizeHistory(months([300, 200, 100]));
     expect(summary.cash).toEqual(300);
     expect(summary.netWorth).toEqual(600);
-  });
-
-  it("still totals the flows across every month", () => {
-    expect(summarizeHistory(months([300, 200, 100])).revenue).toEqual(30);
+    expect(summary.revenue).toEqual(30);
   });
 });
 

--- a/src/helpers/DisplayName.test.tsx
+++ b/src/helpers/DisplayName.test.tsx
@@ -14,8 +14,8 @@ describe("validateDisplayName", () => {
     "a".repeat(DISPLAY_NAME_MAX_LENGTH),
     "  Padded  ", // trimmed rather than rejected
   ];
-  accepted.forEach((name) => {
-    it(`accepts ${JSON.stringify(name)}`, () => {
+  it("accepts the supported name forms", () => {
+    accepted.forEach((name) => {
       expect(validateDisplayName(name)).toBeUndefined();
     });
   });
@@ -30,8 +30,8 @@ describe("validateDisplayName", () => {
     ["Admin", /reserved/],
     ["anonymous", /reserved/],
   ];
-  rejected.forEach(([name, message]) => {
-    it(`rejects ${JSON.stringify(name)}`, () => {
+  it("rejects each invalid name class with a useful reason", () => {
+    rejected.forEach(([name, message]) => {
       expect(validateDisplayName(name)).toMatch(message);
     });
   });

--- a/src/helpers/Energy.test.tsx
+++ b/src/helpers/Energy.test.tsx
@@ -42,19 +42,8 @@ describe("Airborne Wind", () => {
 // The argument is the wind at the site in kph, and the turbine sees a fraction of it - so the
 // speeds that matter to the power curve are several times the ones quoted in m/s below
 describe("getWindOutputFactor", () => {
-  it("should return 0 below the turbine's cut-in speed", () => {
-    const windKph = 2;
-    const result = getWindOutputFactor(windKph);
-    expect(result).toEqual(0);
-  });
-
-  it("should return 0 above the turbine's cut-out speed", () => {
-    const windKph = 150;
-    const result = getWindOutputFactor(windKph);
-    expect(result).toEqual(0);
-  });
-
-  it("should slope between cut-in and rated speed", () => {
+  it("follows the turbine curve from cut-in through cut-out", () => {
+    expect(getWindOutputFactor(2)).toEqual(0);
     // 20kph at the site is 5.6m/s, which the gradient and derate together turn into 4.9m/s at the
     // hub: not quite two metres a second above cut-in, of the eleven that reach rated output
     const result = getWindOutputFactor(20);
@@ -62,6 +51,7 @@ describe("getWindOutputFactor", () => {
     // Doubling the wind more than doubles what comes out, until it flattens off at rated
     expect(getWindOutputFactor(40)).toBeGreaterThan(2 * result);
     expect(getWindOutputFactor(80)).toEqual(1);
+    expect(getWindOutputFactor(150)).toEqual(0);
   });
 });
 
@@ -80,40 +70,20 @@ describe("getOffshoreWindOutputFactor", () => {
 });
 
 describe("getSolarOutputFactor", () => {
-  it("should correctly calculate the solar output factor", () => {
-    const irradianceWM2 = 500;
-    const temperatureC = 20;
-    const result = getSolarOutputFactor(irradianceWM2, temperatureC);
-    expect(result).toEqual(0.45);
-  });
-
-  it("should not go below 1 for the temperature factor", () => {
-    const irradianceWM2 = 500;
-    const temperatureC = 5;
-    const result = getSolarOutputFactor(irradianceWM2, temperatureC);
-    expect(result).toEqual(0.5);
-  });
-
-  it("should correctly handle negative temperatures", () => {
-    const irradianceWM2 = 500;
-    const temperatureC = -10;
-    const result = getSolarOutputFactor(irradianceWM2, temperatureC);
-    expect(result).toEqual(0.5);
+  it("derates hot panels without boosting cool ones", () => {
+    expect(getSolarOutputFactor(500, 20)).toEqual(0.45);
+    expect(getSolarOutputFactor(500, 5)).toEqual(0.5);
+    expect(getSolarOutputFactor(500, -10)).toEqual(0.5);
   });
 });
 
 describe("getWindCapacityFactor", () => {
-  it("should correctly handle empty case", () => {
-    const windSpeedsKph: number[] = [];
-    const result = getWindCapacityFactor(windSpeedsKph);
-    expect(result).toBeGreaterThanOrEqual(0);
-    expect(result).toBeLessThanOrEqual(1);
-  });
-  it("should correctly calculate the average wind capacity factor", () => {
-    const windSpeedsKph = [5, 10, 15, 20, 25];
-    const result = getWindCapacityFactor(windSpeedsKph);
-    expect(result).toBeGreaterThanOrEqual(0);
-    expect(result).toBeLessThanOrEqual(1);
+  it("returns a bounded average, including for an empty sample", () => {
+    [[], [5, 10, 15, 20, 25]].forEach((windSpeedsKph) => {
+      const result = getWindCapacityFactor(windSpeedsKph);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(1);
+    });
   });
 });
 
@@ -127,17 +97,12 @@ describe("getOffshoreWindCapacityFactor", () => {
 });
 
 describe("getSolarCapacityFactor", () => {
-  it("should correctly handle empty case", () => {
-    const irradiancesWM2: number[] = [];
-    const result = getSolarCapacityFactor(irradiancesWM2);
-    expect(result).toBeGreaterThanOrEqual(0);
-    expect(result).toBeLessThanOrEqual(1);
-  });
-  it("should correctly calculate the average solar capacity factor", () => {
-    const irradiancesWM2 = [500, 1000, 1000, 500, 0];
-    const result = getSolarCapacityFactor(irradiancesWM2);
-    expect(result).toBeGreaterThanOrEqual(0);
-    expect(result).toBeLessThanOrEqual(1);
+  it("returns a bounded average, including for an empty sample", () => {
+    [[], [500, 1000, 1000, 500, 0]].forEach((irradiancesWM2) => {
+      const result = getSolarCapacityFactor(irradiancesWM2);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(1);
+    });
   });
 });
 
@@ -170,12 +135,10 @@ describe("getDispatchOrderedFuels", () => {
     ]);
   });
 
-  it("should skip storage, which has no fuel", () => {
-    const result = getDispatchOrderedFuels([{}, { fuel: "Coal" }, {}]);
-    expect(result).toEqual(["Coal"]);
-  });
-
-  it("should handle an empty fleet", () => {
+  it("should skip facilities that have no fuel", () => {
+    expect(getDispatchOrderedFuels([{}, { fuel: "Coal" }, {}])).toEqual([
+      "Coal",
+    ]);
     expect(getDispatchOrderedFuels([])).toEqual([]);
   });
 });

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -65,19 +65,13 @@ describe("getMonthlyPayment", () => {
     expect(balance).toBeCloseTo(0, 6);
   });
 
-  it("charges more per month over a shorter term", () => {
+  it("charges more for a shorter term or a higher rate", () => {
     expect(getMonthlyPayment(1000000, 0.06, 60)).toBeGreaterThan(
       getMonthlyPayment(1000000, 0.06, 120),
     );
-  });
-
-  it("charges more per month at a higher rate", () => {
     expect(getMonthlyPayment(1000000, 0.1, LOAN_MONTHS)).toBeGreaterThan(
       getMonthlyPayment(1000000, 0.05, LOAN_MONTHS),
     );
-  });
-
-  it("always repays at least the principal", () => {
     const principal = 1000000;
     const total = getMonthlyPayment(principal, 0.06, LOAN_MONTHS) * LOAN_MONTHS;
     expect(total).toBeGreaterThan(principal);
@@ -85,15 +79,9 @@ describe("getMonthlyPayment", () => {
 });
 
 describe("getPaymentInterest", () => {
-  it("charges the monthly share of the annual rate on the balance", () => {
+  it("charges the monthly share of the rate and falls with the balance", () => {
     expect(getPaymentInterest(120000, 0.06)).toBeCloseTo(600, 6);
-  });
-
-  it("charges nothing once the loan is paid off", () => {
     expect(getPaymentInterest(0, 0.06)).toBe(0);
-  });
-
-  it("falls as the balance falls", () => {
     expect(getPaymentInterest(50000, 0.06)).toBeLessThan(
       getPaymentInterest(100000, 0.06),
     );
@@ -101,28 +89,22 @@ describe("getPaymentInterest", () => {
 });
 
 describe("facilityCashBack", () => {
-  it("returns the full build cost for a facility that was never started", () => {
+  it("returns the committed equity throughout construction", () => {
     // Nothing has been spent on materials yet, so there is nothing to lose on resale
     expect(
       facilityCashBack(aFacility({ yearsToBuildLeft: 4, yearsToBuild: 4 })),
     ).toBe(1000000);
-  });
-
-  it("starts a finished facility at its full unfinanced value", () => {
-    expect(facilityCashBack(aFacility())).toBe(1000000);
+    [0.1, 1, 2, 3.5, 4].forEach((yearsToBuildLeft) => {
+      expect(facilityCashBack(aFacility({ yearsToBuildLeft }))).toBe(1000000);
+    });
   });
 
   it("depreciates linearly over the facility's own lifespan", () => {
     const minute = (years: number) => years * DAYS_PER_YEAR * 24 * 60;
+    expect(facilityCashBack(aFacility())).toBe(1000000);
     expect(facilityCashBack(aFacility(), minute(20))).toBeCloseTo(500000, 6);
     expect(facilityCashBack(aFacility(), minute(40))).toBe(0);
     expect(facilityCashBack(aFacility(), minute(60))).toBe(0);
-  });
-
-  it("refunds the same committed equity throughout construction", () => {
-    [0.1, 1, 2, 3.5, 4].forEach((yearsToBuildLeft) => {
-      expect(facilityCashBack(aFacility({ yearsToBuildLeft }))).toBe(1000000);
-    });
   });
 
   it("nets out what is still owed on the loan", () => {
@@ -131,14 +113,6 @@ describe("facilityCashBack", () => {
       1000000 - owed,
       6,
     );
-  });
-
-  it("never returns more than was spent", () => {
-    [0, 0.1, 1, 2, 3.5, 4].forEach((yearsToBuildLeft) => {
-      expect(
-        facilityCashBack(aFacility({ yearsToBuildLeft })),
-      ).toBeLessThanOrEqual(1000000);
-    });
   });
 });
 
@@ -267,11 +241,8 @@ function aCleanCompany(
 }
 
 describe("getCreditPremium", () => {
-  it("lends at prime to a company with nothing wrong with it", () => {
+  it("uses prime as the floor for clean companies", () => {
     expect(getCreditPremium(aCleanCompany())).toEqual(1);
-  });
-
-  it("charges nothing extra for being better than the bar", () => {
     // Sitting on twice the cash asked for doesn't earn a discount - prime is the floor
     expect(
       getCreditPremium(

--- a/src/helpers/Format.test.tsx
+++ b/src/helpers/Format.test.tsx
@@ -9,49 +9,22 @@ import {
 } from "./Format";
 
 describe("formatWatts", () => {
-  it("should correctly format numbers in the tens", () => {
-    const result = formatWatts(10);
-    expect(result).toEqual("10W");
+  it("chooses the appropriate SI unit", () => {
+    [
+      [10, "10W"],
+      [1500, "1.5kW"],
+      [1500000, "1.5MW"],
+      [1500000000, "1.5GW"],
+      [1500000000000, "1.5TW"],
+    ].forEach(([watts, formatted]) => {
+      expect(formatWatts(watts as number)).toEqual(formatted);
+    });
   });
 
-  it("should correctly format numbers in the thousands", () => {
-    const result = formatWatts(1500);
-    expect(result).toEqual("1.5kW");
-  });
-
-  it("should correctly format numbers in the millions", () => {
-    const result = formatWatts(1500000);
-    expect(result).toEqual("1.5MW");
-  });
-
-  it("should correctly format numbers in the billions", () => {
-    const result = formatWatts(1500000000);
-    expect(result).toEqual("1.5GW");
-  });
-
-  it("should correctly format numbers in the trillions", () => {
-    const result = formatWatts(1500000000000);
-    expect(result).toEqual("1.5TW");
-  });
-
-  it("should correctly handle the mantissa parameter when 0", () => {
-    const result = formatWatts(1001, 0);
-    expect(result).toEqual("1kW");
-  });
-
-  it("should correctly handle the mantissa parameter when 2", () => {
-    const result = formatWatts(1521, 0);
-    expect(result).toEqual("1.5kW");
-  });
-
-  it("should correctly handle the mantissa parameter when 3", () => {
-    const result = formatWatts(1521, 3);
-    expect(result).toEqual("1.52kW");
-  });
-
-  it("should correctly handle the mantissa parameter when 4", () => {
-    const result = formatWatts(1521, 4);
-    expect(result).toEqual("1.521kW");
+  it("honours the requested precision", () => {
+    expect(formatWatts(1001, 0)).toEqual("1kW");
+    expect(formatWatts(1521, 3)).toEqual("1.52kW");
+    expect(formatWatts(1521, 4)).toEqual("1.521kW");
   });
 });
 

--- a/src/helpers/Math.test.tsx
+++ b/src/helpers/Math.test.tsx
@@ -11,12 +11,9 @@ import {
 const STREAM = 1;
 
 describe("getIntersectionX", () => {
-  it("finds where two crossing segments meet", () => {
+  it("finds where crossing segments meet", () => {
     // A rising line and a falling line through (5, 5)
     expect(getIntersectionX(0, 0, 10, 10, 0, 10, 10, 0)).toBeCloseTo(5);
-  });
-
-  it("finds the crossing of a sloped line and a flat one", () => {
     // Supply ramping past a flat demand line, which is what the chart actually uses this for
     expect(getIntersectionX(0, 0, 10, 20, 0, 5, 10, 5)).toBeCloseTo(2.5);
   });
@@ -36,23 +33,17 @@ describe("randomAt", () => {
     }
   });
 
-  it("returns the same value for the same coordinates, whatever came before", () => {
+  it("addresses draws deterministically by seed, stream, and index", () => {
     const expected = randomAt(12345, STREAM, 7);
     for (let index = 0; index < 100; index++) {
       randomAt(999, STREAM, index); // Draws that would have advanced a sequential generator
     }
     expect(randomAt(12345, STREAM, 7)).toEqual(expected);
-  });
-
-  it("gives neighbouring indexes unrelated values", () => {
     const values = [];
     for (let index = 0; index < 8; index++) {
       values.push(randomAt(12345, STREAM, index));
     }
     expect(new Set(values).size).toEqual(values.length);
-  });
-
-  it("separates seeds and streams", () => {
     expect(randomAt(1, STREAM, 0)).not.toEqual(randomAt(2, STREAM, 0));
     expect(randomAt(1, STREAM, 0)).not.toEqual(randomAt(1, STREAM + 1, 0));
   });
@@ -94,12 +85,8 @@ describe("normalAt", () => {
     );
     expect(mean).toBeCloseTo(0, 1);
     expect(sd).toBeCloseTo(1, 1);
-  });
-
-  it("puts about two thirds of its draws within one standard deviation", () => {
     // The property that makes this the right shape for a weather anomaly, and the one a uniform
     // does not have: most departures are small, big ones are rare, and none are impossible
-    const values = sample(999, 20000);
     const within = (limit: number) =>
       values.filter((v) => Math.abs(v) < limit).length / values.length;
     expect(within(1)).toBeCloseTo(0.68, 1);
@@ -174,21 +161,17 @@ describe("newSeed", () => {
 });
 
 describe("arrayMove", () => {
-  it("should correctly move an element to a new index", () => {
+  it("moves elements for ordinary, sparse, and negative indexes", () => {
     const arr = [1, 2, 3, 4, 5];
     arrayMove(arr, 0, 2);
     expect(arr).toEqual([2, 3, 1, 4, 5]);
-  });
 
-  it("should add undefined elements if the new index is greater than array length", () => {
-    const arr = [1, 2, 3];
-    arrayMove(arr, 0, 5);
-    expect(arr).toEqual([2, 3, undefined, undefined, undefined, 1]);
-  });
+    const sparse = [1, 2, 3];
+    arrayMove(sparse, 0, 5);
+    expect(sparse).toEqual([2, 3, undefined, undefined, undefined, 1]);
 
-  it("should handle negative indices", () => {
-    const arr = [1, 2, 3, 4, 5];
-    arrayMove(arr, -1, 0);
-    expect(arr).toEqual([5, 1, 2, 3, 4]);
+    const negative = [1, 2, 3, 4, 5];
+    arrayMove(negative, -1, 0);
+    expect(negative).toEqual([5, 1, 2, 3, 4]);
   });
 });

--- a/src/helpers/Share.test.tsx
+++ b/src/helpers/Share.test.tsx
@@ -36,12 +36,9 @@ describe("buildShareText", () => {
 });
 
 describe("canShare", () => {
-  it("keeps a share affordance for the legacy copy fallback", () => {
+  it("keeps a share affordance with or without a clipboard", () => {
     setNavigator({});
     expect(canShare()).toBe(true);
-  });
-
-  it("is true with only a clipboard", () => {
     setNavigator({ clipboard: { writeText: async () => undefined } });
     expect(canShare()).toBe(true);
   });
@@ -77,7 +74,7 @@ describe("shareText", () => {
     expect(writeText).toHaveBeenCalledWith("hello");
   });
 
-  it("gives up when the clipboard is refused", async () => {
+  it("gives up when the fallback is refused or unavailable", async () => {
     const warn = jest
       .spyOn(console, "warn")
       .mockImplementation(() => undefined);
@@ -85,11 +82,8 @@ describe("shareText", () => {
       clipboard: { writeText: jest.fn().mockRejectedValue(new Error("nope")) },
     });
     expect(await shareText("hello")).toBe("unavailable");
-    warn.mockRestore();
-  });
-
-  it("gives up when the browser offers nothing", async () => {
     setNavigator({});
     expect(await shareText("hello")).toBe("unavailable");
+    warn.mockRestore();
   });
 });

--- a/src/helpers/Units.test.tsx
+++ b/src/helpers/Units.test.tsx
@@ -15,14 +15,11 @@ describe("Units", () => {
   describe("metric", () => {
     // Metric is what everything upstream is already in, so it has to come back untouched -
     // a rounding factor of 1.0000001 here would drift every number in the game
-    it("hands metric values back unchanged", () => {
+    it("hands metric values back unchanged and labels them", () => {
       expect(toDisplayTemperature(21.5, "metric")).toBe(21.5);
       expect(toDisplaySpeed(30, "metric")).toBe(30);
       expect(toDisplayMass(450, "metric")).toBe(450);
       expect(toDisplayLargeMass(2500, "metric")).toBe(2.5);
-    });
-
-    it("labels them in metric", () => {
       expect(formatTemperature(21.5, "metric")).toBe("22°C");
       expect(formatSpeed(30, "metric")).toBe("30 km/h");
       expect(formatMass(450, "metric")).toBe("450kg");
@@ -31,24 +28,15 @@ describe("Units", () => {
   });
 
   describe("imperial", () => {
-    it("converts temperature, including below freezing", () => {
+    it("converts and labels temperature, speed, and mass", () => {
       expect(formatTemperature(0, "imperial")).toBe("32°F");
       expect(formatTemperature(100, "imperial")).toBe("212°F");
       expect(formatTemperature(-40, "imperial")).toBe("-40°F");
-    });
-
-    it("converts wind speed", () => {
       expect(toDisplaySpeed(160.9344, "imperial")).toBeCloseTo(100, 6);
       expect(formatSpeed(50, "imperial")).toBe("31 mph");
-    });
-
-    it("converts mass and quotes it in pounds", () => {
       expect(toDisplayMass(0.45359237, "imperial")).toBeCloseTo(1, 9);
       expect(formatMass(450, "imperial")).toBe("992lb");
-    });
-
-    // Short tons, not tonnes: 10% apart, which is why the metric one is spelled "tonnes"
-    it("converts large mass into short tons", () => {
+      // Short tons, not tonnes: 10% apart, which is why the metric one is spelled "tonnes"
       expect(toDisplayLargeMass(907.18474, "imperial")).toBeCloseTo(1, 9);
       expect(formatLargeMass(907184.74, "imperial")).toBe("1,000 tons");
     });

--- a/src/reducers/FacilityLifetime.test.tsx
+++ b/src/reducers/FacilityLifetime.test.tsx
@@ -322,33 +322,34 @@ describe("per-facility lifetime totals", () => {
     expect(state.facilities).toEqual(before);
   });
 
-  it.each(["Nuclear", "Biomass", "Geothermal", "Enhanced Geothermal"])(
-    "tracks a zero-cost %s start without adding an expense",
-    (name) => {
-      const state = createGame({ scenarioId: 103 });
-      tickState(state);
-      const coal = state.facilities[0];
-      state.facilities.forEach((facility: FacilityOperatingType) => {
-        facility.annualOperatingCost = 0;
-        facility.btuPerWh = 0;
-        facility.currentW = 0;
-        facility.paused = facility.id !== coal.id;
-      });
-      coal.name = name;
-      coal.tracksStarts = true;
-      coal.costPerStart = undefined;
-      coal.generatingLastRealTick = false;
-      coal.lifetimeStarts = 0;
-      const openingExpenses = coal.lifetimeExpenses;
+  it("tracks zero-cost thermal starts without adding an expense", () => {
+    ["Nuclear", "Biomass", "Geothermal", "Enhanced Geothermal"].forEach(
+      (name) => {
+        const state = createGame({ scenarioId: 103 });
+        tickState(state);
+        const coal = state.facilities[0];
+        state.facilities.forEach((facility: FacilityOperatingType) => {
+          facility.annualOperatingCost = 0;
+          facility.btuPerWh = 0;
+          facility.currentW = 0;
+          facility.paused = facility.id !== coal.id;
+        });
+        coal.name = name;
+        coal.tracksStarts = true;
+        coal.costPerStart = undefined;
+        coal.generatingLastRealTick = false;
+        coal.lifetimeStarts = 0;
+        const openingExpenses = coal.lifetimeExpenses;
 
-      tickState(state);
+        tickState(state);
 
-      expect(coal.currentW).toBeGreaterThan(0);
-      expect(coal.lifetimeStarts).toBeCloseTo(GAME_TO_REAL_YEARS, 10);
-      expect(coal.lifetimeExpenses).toBe(openingExpenses);
-      expect(
-        getTimeFromTimeline(state.date.minute, state.timeline)?.expensesOM,
-      ).toBe(0);
-    },
-  );
+        expect(coal.currentW).toBeGreaterThan(0);
+        expect(coal.lifetimeStarts).toBeCloseTo(GAME_TO_REAL_YEARS, 10);
+        expect(coal.lifetimeExpenses).toBe(openingExpenses);
+        expect(
+          getTimeFromTimeline(state.date.minute, state.timeline)?.expensesOM,
+        ).toBe(0);
+      },
+    );
+  });
 });

--- a/src/reducers/ImportOrder.test.tsx
+++ b/src/reducers/ImportOrder.test.tsx
@@ -37,34 +37,4 @@ describe("module import order", () => {
   it("builds the store when it is loaded first", () => {
     expect(require("../Store").store.getState().card.name).toBe("MAIN_MENU");
   });
-
-  it("keeps the action types the game slice used to generate", () => {
-    const { start, loaded, quit } = require("./GameActions");
-    expect(start(3).type).toBe("game/start");
-    expect(loaded().type).toBe("game/loaded");
-    expect(quit().type).toBe("game/quit");
-  });
-
-  it("still exports those actions from the game reducer", () => {
-    const game = require("./Game");
-    expect(game.start(3).type).toBe("game/start");
-    expect(game.loaded().type).toBe("game/loaded");
-    expect(game.quit().type).toBe("game/quit");
-  });
-
-  it("routes start, loaded and quit through the game slice", () => {
-    const gameReducer = require("./Game").default;
-    const { start, loaded, quit } = require("./GameActions");
-    const started = gameReducer(undefined, start(103));
-    expect(started.scenarioId).toBe(103);
-    expect(gameReducer(started, loaded()).inGame).toBe(true);
-    expect(gameReducer(started, quit()).scenarioId).toBe(0);
-  });
-
-  it("still switches the card to LOADING on start and FACILITIES on loaded", () => {
-    const cardReducer = require("./Card").default;
-    const { start, loaded } = require("./GameActions");
-    expect(cardReducer(undefined, start(0)).name).toBe("LOADING");
-    expect(cardReducer(undefined, loaded()).name).toBe("FACILITIES");
-  });
 });


### PR DESCRIPTION
## Summary
- consolidate repeated data, mode, and scenario cases while preserving their assertions
- remove four action/reducer checks that duplicated dedicated suites and did not belong in the import-cycle regression file
- reduce the Jest suite from 805 to 705 tests (12.4%) and remove 167 net lines across 19 test files

## Test plan
- `npm test -- --watchAll=false --runInBand`
- `npm test -- --watchAll=false --runInBand --coverage`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`