### PR TITLE
Model minimum stable generator output

### DIFF
--- a/docs/facilities-economics.md
+++ b/docs/facilities-economics.md
@@ -205,6 +205,27 @@ Start tracking and start charges are deliberately separate capabilities:
 | Enhanced Geothermal | Yes           | None                                               | Same FOM treatment, without commercial start-cost observations                          |
 | Oil                 | No            | None                                               | Reciprocating-engine service follows use; starts do not change its maintenance schedule |
 
+Thermal generators also carry a minimum stable output. These technology-level values are
+representative production-cost inputs rather than limits for every individual unit:
+
+| Facility            | Minimum stable output | Basis                                                                                   |
+| ------------------- | --------------------: | --------------------------------------------------------------------------------------- |
+| Coal                |                   40% | GE Energy/HNEI ancillary-services study: 35-40% typical turndown level                  |
+| Nuclear             |                   50% | NREL production-cost modeling; individual IAEA load-following examples can reach 20-30% |
+| Natural Gas         |                   50% | Representative heavy-duty simple-cycle value within the published 15-70% range          |
+| Oil                 |                   50% | GE Energy/HNEI reciprocating-engine value                                               |
+| Biomass             |                   40% | GE Energy/HNEI ancillary-services study: 35-40%                                         |
+| Geothermal          |                   15% | GE Energy/HNEI ancillary-services study: 12-15%                                         |
+| Enhanced Geothermal |                   15% | Same thermally stable turndown assumption pending commercial fleet data                 |
+
+The dispatcher first forecasts the unconstrained merit-order request for each facility. When an
+online plant is no longer requested, it scans that facility's upcoming requests and accumulates
+the fuel, carbon, and variable O&M cost of remaining at minimum output. It stays online only when
+it is needed again before those costs reach the next-start charge. The scan aborts immediately
+once shutdown is cheaper; if the plant is not needed again inside the forecast, it shuts down.
+Fixed O&M is omitted because the company pays it in either state. Startup fuel, hot/warm/cold
+state, minimum up/down times, and part-load heat-rate penalties remain outside this model.
+
 Coal uses NREL's conservative hot-start values for 500-1,300 MW supercritical units: $54/MW-start
 of capitalized cycling and maintenance plus $5.81/MW-start of auxiliary operations, chemicals,
 water, and additives. Converting 2011 dollars with CPI-U (`304.702 / 224.939`) gives
@@ -254,6 +275,8 @@ No additional facility type is added in this pass:
 - [Lawrence Berkeley National Laboratory, U.S. wind-plant performance with age](https://emp.lbl.gov/publications/how-does-wind-project-performance)
 - [BLS, annual CPI-U indexes](https://www.bls.gov/regions/mid-atlantic/data/ConsumerPriceIndexAnnualandSemiAnnual_Table.htm)
 - [NREL, Power Plant Cycling Costs](https://docs.nrel.gov/docs/fy12osti/55433.pdf)
+- [GE Energy/HNEI, Ancillary Services Definitions and Capability Study](https://www.hnei.hawaii.edu/wp-content/uploads/Ancillary-Services-Definitions-and-Capability-Study.pdf)
+- [NREL, Operational Analysis of the Eastern Interconnection at Very High Renewable Penetrations](https://docs.nrel.gov/docs/fy18osti/71465.pdf)
 - [IAEA, Non-baseload Operation in Nuclear Power Plants](https://www-pub.iaea.org/MTCD/Publications/PDF/P1756_web.pdf)
 - [NREL 2024 ATB, Geothermal](https://atb.nrel.gov/electricity/2024/geothermal)
 - [DOE, Geothermal Basics](https://www.energy.gov/hgeo/geothermal/geothermal-basics)

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -112,6 +112,7 @@ export function parseSave(raw: unknown): SaveGameType | null {
       const optionalNumbersInvalid = [
         current.costPerStart,
         current.lifetimeStarts,
+        current.minimumStableOutput,
         current.variableOperatingCostPerMWh,
       ].some(
         (value) =>
@@ -119,12 +120,15 @@ export function parseSave(raw: unknown): SaveGameType | null {
           (typeof value !== "number" || !Number.isFinite(value) || value < 0),
       );
       const optionalBooleansInvalid = [
+        current.committed,
         current.tracksStarts,
         current.generatingLastRealTick,
       ].some((value) => value !== undefined && typeof value !== "boolean");
       return (
         requiredNumbersInvalid ||
         optionalNumbersInvalid ||
+        (typeof current.minimumStableOutput === "number" &&
+          current.minimumStableOutput > 1) ||
         optionalBooleansInvalid
       );
     }) ||

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -271,6 +271,10 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     // The exponentially smoothed bill customers respond to, rather than the slider's latest value
     customerRate: number;
     supplyByFuel: FuelProductionType;
+    // The unconstrained dispatch request for each facility in the most recent forecast pass.
+    // Kept on forecast ticks so minimum-load generators can decide whether avoiding a future
+    // start is worth remaining online; it is intentionally not copied into monthly history.
+    dispatchTargetWByFacility: Record<number, number>;
   };
 
 export type DerivedHistoryKeysType = keyof DerivedHistoryType;
@@ -325,8 +329,12 @@ export interface GeneratorOperatingType
   // Set when construction completes; absent while the facility is still being built.
   minuteOperational?: number;
   paused: boolean;
+  // Unit commitment is distinct from instantaneous output: a plant ramps through outputs below
+  // its stable minimum while starting and stopping, but cannot remain there indefinitely.
+  committed?: boolean;
   // Last real-tick state for start edge detection. Forecast/pre-roll dispatch mutates currentW,
-  // so currentW alone cannot distinguish a player-visible start from a synthetic one.
+  // so currentW alone cannot distinguish a player-visible start from a synthetic one. For
+  // minimum-load plants this records commitment rather than a literal positive currentW.
   generatingLastRealTick?: boolean;
   reservoirWh?: number;
   hydroLastInflowWh?: number;
@@ -392,6 +400,9 @@ export interface GeneratorShoppingType extends SharedShoppingType {
   annualOutputDegradation?: number;
   spinMinutes: number; // 1 for renewables, to avoid eating up CPU on coersing to 1 in case it doesn't exist
   btuPerWh: number; // Heat Rate, but per W for less math per frame
+  // Lowest steady output as a fraction of nameplate. Starting and shutdown ramps may pass below
+  // it transiently; an online unit otherwise produces at least this much.
+  minimumStableOutput?: number;
   // Explicit because neither purchased fuel nor a start charge identifies every thermal plant:
   // geothermal buys no fuel, while the Oil facility is an internal-combustion generator.
   tracksStarts?: boolean;

--- a/src/components/base/FacilityDetails.tsx
+++ b/src/components/base/FacilityDetails.tsx
@@ -119,6 +119,8 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
   const variableOperatingCostPerMWh = (
     facility as Partial<GeneratorOperatingType>
   ).variableOperatingCostPerMWh;
+  const minimumStableOutput = (facility as Partial<GeneratorOperatingType>)
+    .minimumStableOutput;
   const isStorage = facility.peakWh > 0;
   const accentColor = facilityColor(fuel);
   const underConstruction = facility.yearsToBuildLeft > 0;
@@ -201,6 +203,12 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
           <Stat
             label="Equivalent operating hours"
             value={Math.round(equivalentOperatingHours).toLocaleString()}
+          />
+        )}
+        {minimumStableOutput !== undefined && (
+          <Stat
+            label="Minimum stable output"
+            value={`${percent(minimumStableOutput)} · ${formatWatts(facility.peakW * minimumStableOutput)}`}
           />
         )}
         {variableOperatingCostPerMWh !== undefined && (

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -345,6 +345,23 @@ export function GeneratorBuildItem(
                   {formatWatts(generator.peakW * generator.capacityFactor)}
                 </TableCell>
               </TableRow>
+              {generator.minimumStableOutput !== undefined && (
+                <TableRow>
+                  <TableCell>
+                    Minimum stable output
+                    <ManualLink entry={MANUAL_ENTRY.RAMP_RATE} />
+                    <Typography variant="body2" color="textSecondary">
+                      While the plant remains online
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">
+                    {Math.round(generator.minimumStableOutput * 100)}% ·{" "}
+                    {formatWatts(
+                      generator.peakW * generator.minimumStableOutput,
+                    )}
+                  </TableCell>
+                </TableRow>
+              )}
               <TableRow>
                 <TableCell>
                   {hasVariableOM ? "Fixed O&M" : "Base O&M"}

--- a/src/data/Facilities.test.tsx
+++ b/src/data/Facilities.test.tsx
@@ -162,6 +162,24 @@ describe("current facility economics", () => {
     expect(byName("Enhanced Geothermal")?.costPerStart).toBeUndefined();
   });
 
+  it("assigns technology-specific minimum stable outputs only to thermal plants", () => {
+    const generators = GENERATORS(stateAt(iceland, 2030), 50000000, [], []);
+    const minimum = (name: string) =>
+      generators.find((generator) => generator.name === name)
+        ?.minimumStableOutput;
+
+    expect(minimum("Coal")).toBe(0.4);
+    expect(minimum("Nuclear")).toBe(0.5);
+    expect(minimum("Natural Gas")).toBe(0.5);
+    expect(minimum("Oil")).toBe(0.5);
+    expect(minimum("Biomass")).toBe(0.4);
+    expect(minimum("Geothermal")).toBe(0.15);
+    expect(minimum("Enhanced Geothermal")).toBe(0.15);
+    expect(minimum("Hydro")).toBeUndefined();
+    expect(minimum("Wind")).toBeUndefined();
+    expect(minimum("Solar")).toBeUndefined();
+  });
+
   it("uses the 2024 ATB midpoint for ten-hour pumped hydro", () => {
     const pumpedHydro = STORAGE(stateAt(iceland, 2024), 1000000000).find(
       (facility) => facility.name === "Pumped Hydro",

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -74,6 +74,25 @@ export const START_TRACKING_FACILITY_NAMES = new Set([
   "Enhanced Geothermal",
 ]);
 
+// Representative steady-state turndown limits. These are deliberately technology-level inputs,
+// not claims that every individual unit has the same operating envelope. The GE Energy/HNEI
+// ancillary-services study reports 35-40% for coal and biomass, 12-15% for geothermal, 15-70%
+// for heavy-duty simple-cycle gas turbines and 50% for reciprocating engines. NREL production-
+// cost studies commonly model coal/nuclear and gas units in the 30-60% range. Midpoints keep the
+// gameplay legible while preventing a nominally online thermal plant from idling at trace output.
+// Existing saves use this map during resume migration.
+export const MINIMUM_STABLE_OUTPUT_BY_FACILITY: Readonly<
+  Record<string, number>
+> = {
+  Coal: 0.4,
+  Nuclear: 0.5,
+  "Natural Gas": 0.5,
+  Oil: 0.5,
+  Biomass: 0.4,
+  Geothermal: 0.15,
+  "Enhanced Geothermal": 0.15,
+};
+
 /** Exponential interpolation between two real-cost observations, held flat outside them. */
 function costBetween(
   year: number,
@@ -231,6 +250,7 @@ export function GENERATORS(
       // 6 hours - https://spectrum.ieee.org/green-tech/wind/taming-wind-power-with-better-forecasts
       // 4-8 hours - https://www.reuters.com/article/coal-power-generation/column-to-...wer-plants-must-become-more-flexible-kemp-idUSL5N0J42YG20131119
       annualOperatingCost: annualOperatingCost(peakW, 0.68, 61.6, 6.4),
+      minimumStableOutput: MINIMUM_STABLE_OUTPUT_BY_FACILITY.Coal,
       tracksStarts: true,
       // NREL's conservative hot-start case, normalized from 2011$ to 2023$ with annual-average
       // CPI-U and scaled by nameplate MW. Fuel input and EFOR effects are deliberately excluded.
@@ -260,6 +280,7 @@ export function GENERATORS(
       btuPerWh: 10.608,
       spinMinutes: 600,
       annualOperatingCost: annualOperatingCost(peakW, 0.93, 156.2, 2.52),
+      minimumStableOutput: MINIMUM_STABLE_OUTPUT_BY_FACILITY.Nuclear,
       tracksStarts: true,
       yearsToBuild: 6 + magnitude / 3,
       // AEO2025 reference lead time is 84 months and operating life is 40 years.
@@ -286,6 +307,7 @@ export function GENERATORS(
       btuPerWh: 9.142,
       spinMinutes: 10,
       annualOperatingCost: annualOperatingCost(peakW, 0.45, 6.87, 1.24),
+      minimumStableOutput: MINIMUM_STABLE_OUTPUT_BY_FACILITY["Natural Gas"],
       tracksStarts: true,
       // EIA AEO2025 Case 4 reports this separately from both fixed and variable O&M:
       // $23,100 per equivalent start for its 419 MW H-class simple-cycle reference plant.
@@ -322,6 +344,7 @@ export function GENERATORS(
       // https://www.eia.gov/analysis/studies/buildings/distrigen/pdf/dg_chp.pdf
       annualOperatingCost:
         (peakW / 1000) * OIL_FIXED_OPERATING_COST_PER_KW_YEAR,
+      minimumStableOutput: MINIMUM_STABLE_OUTPUT_BY_FACILITY.Oil,
       variableOperatingCostPerMWh: OIL_VARIABLE_OPERATING_COST_PER_MWH,
       yearsToBuild: 1 + magnitude / 3,
       // https://www.eia.gov/outlooks/aeo/assumptions/pdf/table_8.2.pdf
@@ -353,6 +376,7 @@ export function GENERATORS(
       // has one annual O&M field, so both are converted to 2018 dollars and variable O&M is
       // annualized at the observed 60.2% capacity factor.
       annualOperatingCost: 0.14471 * peakW,
+      minimumStableOutput: MINIMUM_STABLE_OUTPUT_BY_FACILITY.Biomass,
       tracksStarts: true,
       yearsToBuild: 5,
       // 2022 U.S. "other biomass" fleet average; wood was 57.9% in the same table.
@@ -544,6 +568,7 @@ export function GENERATORS(
       // ~800MW, except for one outlier - https://en.wikipedia.org/wiki/List_of_largest_power_stations#Geothermal
       btuPerWh: 0,
       annualOperatingCost: annualOperatingCost(peakW, 0.88, 150.6, 0),
+      minimumStableOutput: MINIMUM_STABLE_OUTPUT_BY_FACILITY.Geothermal,
       tracksStarts: true,
       yearsToBuild: 3,
       // EIA AEO2025 reference lead time is 36 months and operating life is 40 years.
@@ -564,6 +589,8 @@ export function GENERATORS(
       maxPeakW: 500000000,
       btuPerWh: 0,
       annualOperatingCost: 0.16 * peakW,
+      minimumStableOutput:
+        MINIMUM_STABLE_OUTPUT_BY_FACILITY["Enhanced Geothermal"],
       tracksStarts: true,
       yearsToBuild: 3 + magnitude / 4,
       spinMinutes: 1,

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -540,6 +540,14 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           moving.
         </p>
         <p>
+          Thermal plants also have a <strong>minimum stable output</strong>.
+          While online they cannot sit at a trace output: depending on the
+          technology, Electrify holds them at 15% to 50% of nameplate. When
+          demand falls below that level, dispatch compares the forecasted cost
+          of running at minimum with the next start cost, then either keeps the
+          plant online or begins shutting it down.
+        </p>
+        <p>
           Demand can swing by a third between 4am and 6pm, so a fleet has to be
           able to follow it. A slow plant is only useful for the demand that's
           there all day, which is why ramp rate, not price, is usually what

--- a/src/helpers/Commitment.test.tsx
+++ b/src/helpers/Commitment.test.tsx
@@ -1,0 +1,67 @@
+import { shouldKeepGeneratorCommitted } from "./Commitment";
+import { TickPresentFutureType } from "../Types";
+
+function tick(target: number | undefined): TickPresentFutureType {
+  return {
+    dispatchTargetWByFacility: target === undefined ? {} : { 7: target },
+  } as TickPresentFutureType;
+}
+
+describe("generator commitment optimization", () => {
+  it("stays online when forecasted use returns before minimum-load cost reaches a start", () => {
+    const minimumOperatingCost = jest.fn(() => 20);
+
+    expect(
+      shouldKeepGeneratorCommitted({
+        facilityId: 7,
+        forecast: [tick(0), tick(0), tick(1)],
+        fromIndex: 0,
+        startCost: 50,
+        minimumOperatingCost,
+      }),
+    ).toBe(true);
+    expect(minimumOperatingCost).toHaveBeenCalledTimes(1);
+  });
+
+  it("shuts down as soon as minimum-load cost reaches the next-start charge", () => {
+    const minimumOperatingCost = jest.fn(() => 20);
+
+    expect(
+      shouldKeepGeneratorCommitted({
+        facilityId: 7,
+        forecast: [tick(0), tick(0), tick(0), tick(0), tick(1)],
+        fromIndex: 0,
+        startCost: 40,
+        minimumOperatingCost,
+      }),
+    ).toBe(false);
+    expect(minimumOperatingCost).toHaveBeenCalledTimes(2);
+  });
+
+  it("shuts down immediately when restarting has no modeled cost", () => {
+    const minimumOperatingCost = jest.fn(() => 20);
+
+    expect(
+      shouldKeepGeneratorCommitted({
+        facilityId: 7,
+        forecast: [tick(0), tick(1)],
+        fromIndex: 0,
+        startCost: 0,
+        minimumOperatingCost,
+      }),
+    ).toBe(false);
+    expect(minimumOperatingCost).not.toHaveBeenCalled();
+  });
+
+  it("shuts down when the plant is not needed again inside the forecast", () => {
+    expect(
+      shouldKeepGeneratorCommitted({
+        facilityId: 7,
+        forecast: [tick(0), tick(0), tick(0)],
+        fromIndex: 0,
+        startCost: 100,
+        minimumOperatingCost: () => 20,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/helpers/Commitment.tsx
+++ b/src/helpers/Commitment.tsx
@@ -1,0 +1,46 @@
+import { TickPresentFutureType } from "../Types";
+
+interface KeepCommittedOptions {
+  facilityId: number;
+  forecast: TickPresentFutureType[];
+  fromIndex: number;
+  startCost: number;
+  minimumOperatingCost: (tick: TickPresentFutureType) => number;
+}
+
+/**
+ * Whether an otherwise-idle generator should remain committed until its next forecasted use.
+ *
+ * Staying online only wins if the plant is requested again before minimum-load running costs
+ * reach the next-start charge. Once that threshold is crossed, the exact next-use time cannot
+ * change the decision, so the scan stops immediately instead of walking the rest of the horizon.
+ */
+export function shouldKeepGeneratorCommitted({
+  facilityId,
+  forecast,
+  fromIndex,
+  startCost,
+  minimumOperatingCost,
+}: KeepCommittedOptions): boolean {
+  if (startCost <= 0) {
+    return false;
+  }
+
+  let runningCost = 0;
+  for (let i = fromIndex + 1; i < forecast.length; i++) {
+    const dispatchTarget = forecast[i].dispatchTargetWByFacility?.[facilityId];
+    if (dispatchTarget === undefined) {
+      continue;
+    }
+    if (dispatchTarget > 0) {
+      return true;
+    }
+    runningCost += minimumOperatingCost(forecast[i]);
+    if (runningCost >= startCost) {
+      return false;
+    }
+  }
+
+  // No forecasted need means there is no avoided start inside the known horizon.
+  return false;
+}

--- a/src/reducers/FacilityLifetime.test.tsx
+++ b/src/reducers/FacilityLifetime.test.tsx
@@ -106,6 +106,7 @@ describe("per-facility lifetime totals", () => {
     const state = play(createGame({ scenarioId: 103 }), 8);
     const coal = state.facilities[0];
     coal.currentW = 0;
+    coal.committed = false;
     coal.generatingLastRealTick = false;
     coal.annualOperatingCost = 0;
     coal.btuPerWh = 0;
@@ -152,6 +153,7 @@ describe("per-facility lifetime totals", () => {
       facility.annualOperatingCost = 0;
       facility.btuPerWh = 0;
       facility.currentW = 0;
+      facility.committed = false;
       facility.paused = facility.id !== coal.id;
     });
     coal.generatingLastRealTick = false;
@@ -332,6 +334,7 @@ describe("per-facility lifetime totals", () => {
         facility.annualOperatingCost = 0;
         facility.btuPerWh = 0;
         facility.currentW = 0;
+        facility.committed = false;
         facility.paused = facility.id !== coal.id;
       });
       coal.name = name;

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -88,12 +88,14 @@ import {
 } from "../Constants";
 import {
   GENERATORS,
+  MINIMUM_STABLE_OUTPUT_BY_FACILITY,
   OIL_FIXED_OPERATING_COST_PER_KW_YEAR,
   OIL_VARIABLE_OPERATING_COST_PER_MWH,
   START_TRACKING_FACILITY_NAMES,
   STORAGE,
   windAnnualOutputDegradation,
 } from "../data/Facilities";
+import { shouldKeepGeneratorCommitted } from "../helpers/Commitment";
 import { getViableLocationsRemaining } from "../data/FacilitySites";
 import { logEvent } from "../Globals";
 import { getPlayedScenarioIds, recordScenarioPlayed } from "../LocalStorage";
@@ -713,6 +715,23 @@ export const gameSlice = createSlice({
           facility.tracksStarts = true;
           facility.lifetimeStarts = facility.lifetimeStarts || 0;
           facility.generatingLastRealTick = facility.currentW > 0;
+        }
+        const minimumStableOutput =
+          MINIMUM_STABLE_OUTPUT_BY_FACILITY[facility.name];
+        if (
+          facility.minimumStableOutput === undefined &&
+          minimumStableOutput !== undefined
+        ) {
+          facility.minimumStableOutput = minimumStableOutput;
+        }
+        if (
+          facility.minimumStableOutput !== undefined &&
+          facility.committed === undefined
+        ) {
+          facility.committed = !facility.paused && facility.currentW > 0;
+          if (facility.tracksStarts) {
+            facility.generatingLastRealTick = facility.committed;
+          }
         }
       });
       // The tick loop's module-level locals have to line up with the state being restored.
@@ -1542,6 +1561,38 @@ function reforecastDemand(state: GameType): TickPresentFutureType[] {
   });
 }
 
+/** Variable cost of holding one generator at its minimum stable output for one game tick. */
+function minimumStableOperatingCost(
+  state: GameType,
+  generator: GeneratorOperatingType,
+  tick: TickPresentFutureType,
+): number {
+  const minimumW = generator.peakW * (generator.minimumStableOutput || 0);
+  const generatedWh = (minimumW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+  const variableOM =
+    (generatedWh / 1000000) * (generator.variableOperatingCostPerMWh || 0);
+  const fuel = FUELS[generator.fuel];
+  if (!fuel) {
+    return variableOM;
+  }
+  const fuelBtu =
+    ((minimumW * (generator.btuPerWh || 0)) / TICKS_PER_HOUR) *
+    GAME_TO_REAL_YEARS;
+  const fuelCost = (fuelBtu * (tick[generator.fuel] ?? 0)) / 1000000;
+  const carbonCost = fuelBtu * fuel.kgCO2ePerBtu * state.feePerKgCO2e;
+  return variableOM + fuelCost + carbonCost;
+}
+
+function forecastIndexAt(state: GameType, minute: number): number {
+  if (state.timeline.length === 0) {
+    return 0;
+  }
+  return Math.max(
+    0,
+    Math.round((minute - state.timeline[0].minute) / TICK_MINUTES),
+  );
+}
+
 // Updates game state and now in place
 function updateSupplyFacilitiesFinances(
   state: GameType,
@@ -1549,6 +1600,7 @@ function updateSupplyFacilitiesFinances(
   now: TickPresentFutureType,
   simulated?: boolean,
   preRoll?: boolean,
+  optimizeCommitment = true,
 ) {
   const { facilities, date } = state;
   const tickDate = getDateFromMinute(now.minute, state.startingYear);
@@ -1611,11 +1663,17 @@ function updateSupplyFacilitiesFinances(
   let hydroSpillWh = 0;
   let hydroMandatedReleaseW = 0;
   const startedFacilityIds = new Set<number>();
+  now.dispatchTargetWByFacility = {};
   facilities.forEach((g: FacilityOperatingType, i: number) => {
     const previousW = g.currentW;
-    const previouslyGenerating = simulated
-      ? previousW > 0
-      : (g.generatingLastRealTick ?? previousW > 0);
+    const generator = g as GeneratorOperatingType;
+    const hasMinimumStableOutput =
+      !g.peakWh && (generator.minimumStableOutput || 0) > 0;
+    const previouslyCommitted = simulated
+      ? (generator.committed ?? previousW > 0)
+      : (generator.generatingLastRealTick ??
+        generator.committed ??
+        previousW > 0);
     let dispatchPeakW = g.peakW;
     const outputFactor = facilityOutputFactor(g, now.minute);
     let mandatedW = 0;
@@ -1672,6 +1730,10 @@ function updateSupplyFacilitiesFinances(
       storageLossWh += lossWh;
     }
     if (g.paused) {
+      now.dispatchTargetWByFacility[g.id] = 0;
+      if (hasMinimumStableOutput) {
+        generator.committed = false;
+      }
       g.currentW = Math.max(
         0,
         g.currentW - (g.peakW * TICK_MINUTES) / g.spinMinutes,
@@ -1684,7 +1746,9 @@ function updateSupplyFacilitiesFinances(
         hydroReservoirCapacityWh += g.reservoirCapacityWh || 0;
       }
       if (!simulated && g.tracksStarts) {
-        g.generatingLastRealTick = g.currentW > 0;
+        g.generatingLastRealTick = hasMinimumStableOutput
+          ? !!generator.committed
+          : g.currentW > 0;
       }
       return;
     }
@@ -1710,39 +1774,53 @@ function updateSupplyFacilitiesFinances(
             g.currentW = g.peakW * airborneWindOutputFactor;
             break;
           default: // on-demand produces up to demand + reserve margin
-            if (
-              requiredTargetW > g.currentW ||
-              i < indexOfLastUnchargedBattery
-            ) {
-              // spinning up
-              // If there's a battery to charge after me, output as much as possible to charge it beyond demand
-              if (
-                indexOfLastUnchargedBattery >= 0 &&
+            // If there's a battery after this plant, the dispatch request includes the extra
+            // output the existing storage policy would use to charge it beyond current demand.
+            const dispatchTargetW = Math.min(
+              dispatchPeakW,
+              indexOfLastUnchargedBattery >= 0 &&
                 i < indexOfLastUnchargedBattery
-              ) {
-                g.currentW = Math.min(
-                  now.demandW + totalChargeNeeded - charge,
-                  dispatchPeakW,
-                  g.currentW + (g.peakW * TICK_MINUTES) / g.spinMinutes,
-                );
-              } else {
-                // Otherwise just try to fulfill demand + reserve margin
-                g.currentW = Math.min(
-                  dispatchPeakW,
-                  requiredTargetW,
-                  g.currentW + (g.peakW * TICK_MINUTES) / g.spinMinutes,
-                );
+                ? now.demandW + totalChargeNeeded - charge
+                : requiredTargetW,
+            );
+            now.dispatchTargetWByFacility[g.id] = dispatchTargetW;
+
+            let committedTargetW = dispatchTargetW;
+            if (hasMinimumStableOutput) {
+              if (dispatchTargetW > 0) {
+                generator.committed = true;
+              } else if (generator.committed) {
+                const keepOnline =
+                  !optimizeCommitment ||
+                  shouldKeepGeneratorCommitted({
+                    facilityId: g.id,
+                    forecast: state.timeline,
+                    fromIndex: forecastIndexAt(state, now.minute),
+                    startCost:
+                      (generator.costPerStart || 0) * GAME_TO_REAL_YEARS,
+                    minimumOperatingCost: (futureTick) =>
+                      minimumStableOperatingCost(state, generator, futureTick),
+                  });
+                generator.committed = keepOnline;
               }
-            } else {
-              g.currentW = Math.min(
-                dispatchPeakW,
-                Math.max(
-                  0,
-                  requiredTargetW,
-                  g.currentW - (g.peakW * TICK_MINUTES) / g.spinMinutes,
-                ),
-              );
+              committedTargetW = generator.committed
+                ? Math.max(
+                    dispatchTargetW,
+                    Math.min(
+                      dispatchPeakW,
+                      g.peakW * (generator.minimumStableOutput || 0),
+                    ),
+                  )
+                : 0;
             }
+
+            const rampW = (g.peakW * TICK_MINUTES) / g.spinMinutes;
+            g.currentW = Math.min(
+              dispatchPeakW,
+              committedTargetW > g.currentW
+                ? Math.min(committedTargetW, g.currentW + rampW)
+                : Math.max(committedTargetW, g.currentW - rampW),
+            );
             break;
         }
         supply += g.currentW;
@@ -1756,13 +1834,15 @@ function updateSupplyFacilitiesFinances(
         if (
           g.tracksStarts &&
           !preRoll &&
-          !previouslyGenerating &&
-          g.currentW > 0
+          !previouslyCommitted &&
+          (hasMinimumStableOutput ? generator.committed : g.currentW > 0)
         ) {
           startedFacilityIds.add(g.id);
         }
         if (!simulated && g.tracksStarts) {
-          g.generatingLastRealTick = g.currentW > 0;
+          g.generatingLastRealTick = hasMinimumStableOutput
+            ? !!generator.committed
+            : g.currentW > 0;
         }
       }
       if (g.peakWh) {
@@ -1977,9 +2057,10 @@ function updateSupplyFacilitiesFinances(
   return now;
 }
 
-function reforecastSupply(
+function supplyForecastPass(
   state: GameType,
   simulated?: boolean,
+  withoutMinimumStableOutput = false,
 ): TickPresentFutureType[] {
   // updateSupplyFacilitiesFinances ramps generators, charges batteries and pays down loans by
   // mutating the facilities in place, so forecasting has to run against a copy of them. A shallow
@@ -1987,13 +2068,27 @@ function reforecastSupply(
   // its end-of-horizon state -- resuming a paused nuclear plant snapped straight to full output
   // instead of ramping, and every reforecast silently aged construction and loans by a whole day.
   const newState = { ...state, facilities: cloneDeep(state.facilities) };
+  if (withoutMinimumStableOutput) {
+    newState.facilities.forEach((facility) => {
+      if (!facility.peakWh) {
+        (facility as GeneratorOperatingType).minimumStableOutput = undefined;
+      }
+    });
+  }
   const current = getTimeFromTimeline(state.date.minute, state.timeline);
   const currentCash = current?.cash;
   const currentCustomers = current?.customers;
   let prev = newState.timeline[0];
   return newState.timeline.map((t: TickPresentFutureType) => {
     if (t.minute >= state.date.minute) {
-      t = updateSupplyFacilitiesFinances(newState, prev, { ...t }, simulated);
+      t = updateSupplyFacilitiesFinances(
+        newState,
+        prev,
+        { ...t },
+        simulated,
+        undefined,
+        !withoutMinimumStableOutput,
+      );
       // The current tick already happened. Reforecast its supply against the player's action,
       // but keep the transaction and customer balance that caused this reforecast. Otherwise
       // rebuilding from the previous tick erases a purchase refund (and, symmetrically, a cost).
@@ -2010,6 +2105,18 @@ function reforecastSupply(
     prev = t;
     return t;
   });
+}
+
+function reforecastSupply(
+  state: GameType,
+  simulated?: boolean,
+): TickPresentFutureType[] {
+  // First record the merit-order request each generator would receive without minimum-load
+  // constraints. The optimized pass then scans those per-facility requests to compare the cost
+  // of remaining online with the cost of the next start. Keeping this as two linear passes avoids
+  // recursively re-simulating the fleet for every plant on every tick.
+  const baseline = supplyForecastPass(state, true, true);
+  return supplyForecastPass({ ...state, timeline: baseline }, simulated);
 }
 
 export function generateNewTimeline(
@@ -2082,6 +2189,7 @@ export function generateNewTimeline(
       hydroMandatedReleaseW: 0,
       storageLossWh: 0,
       supplyByFuel: {} as FuelProductionType,
+      dispatchTargetWByFacility: {},
       // Asserted because FuelPricesType carries a `[index: string]: number` index signature,
       // which a fresh object literal with a non-number field cannot satisfy. Same reason
       // reforecastWeatherAndPrices asserts its own tick literal.
@@ -2171,6 +2279,10 @@ function buildFacilityHelper(
           0,
         ) + 1,
       currentW: newGame && g.peakWh === undefined ? g.peakW : 0,
+      committed:
+        g.minimumStableOutput !== undefined && g.peakWh === undefined
+          ? newGame
+          : undefined,
       generatingLastRealTick:
         g.tracksStarts && newGame && g.peakWh === undefined,
       yearsToBuildLeft: newGame ? 0 : g.yearsToBuild,

--- a/src/reducers/GeneratorCommitment.test.tsx
+++ b/src/reducers/GeneratorCommitment.test.tsx
@@ -1,0 +1,65 @@
+import { TICK_MINUTES } from "../Constants";
+import { getTimeFromTimeline } from "../helpers/DateTime";
+import { createGame } from "../testing/Simulator";
+import { GeneratorOperatingType, GameType } from "../Types";
+import { tickState } from "./Game";
+
+function isolatedOnlineCoal(): {
+  state: GameType;
+  coal: GeneratorOperatingType;
+  nextIndex: number;
+} {
+  const state = createGame({ scenarioId: 103, difficulty: "CEO" });
+  tickState(state);
+  const coal = state.facilities.find(
+    (facility) => facility.name === "Coal",
+  ) as GeneratorOperatingType;
+  state.facilities = [coal];
+  coal.currentW = coal.peakW * (coal.minimumStableOutput || 0);
+  coal.committed = true;
+  coal.generatingLastRealTick = true;
+
+  const nextMinute = state.date.minute + TICK_MINUTES;
+  const nextIndex = state.timeline.findIndex(
+    (tick) => tick.minute === nextMinute,
+  );
+  for (let i = nextIndex; i < state.timeline.length; i++) {
+    state.timeline[i].demandW = 0;
+    state.timeline[i].dispatchTargetWByFacility = { [coal.id]: 0 };
+  }
+  return { state, coal, nextIndex };
+}
+
+describe("minimum stable generator dispatch", () => {
+  it("holds an online plant at its minimum when avoiding the next start is cheaper", () => {
+    const { state, coal, nextIndex } = isolatedOnlineCoal();
+    coal.costPerStart = 1000000000;
+    state.timeline[nextIndex + 2].dispatchTargetWByFacility[coal.id] = 1;
+
+    tickState(state);
+
+    expect(coal.committed).toBe(true);
+    expect(coal.currentW).toBeCloseTo(
+      coal.peakW * (coal.minimumStableOutput || 0),
+      5,
+    );
+    expect(
+      getTimeFromTimeline(state.date.minute, state.timeline)?.supplyW,
+    ).toBeCloseTo(coal.currentW, 5);
+  });
+
+  it("begins shutting down when minimum-load cost exceeds the avoided start", () => {
+    const { state, coal, nextIndex } = isolatedOnlineCoal();
+    coal.costPerStart = 1;
+    coal.variableOperatingCostPerMWh = 1000000000;
+    state.timeline[nextIndex + 3].dispatchTargetWByFacility[coal.id] = 1;
+    const minimumW = coal.currentW;
+
+    tickState(state);
+
+    expect(coal.committed).toBe(false);
+    expect(coal.currentW).toBeLessThan(minimumW);
+    // Sub-minimum output is allowed only as the transient shutdown ramp continues toward zero.
+    expect(coal.currentW).toBeGreaterThan(0);
+  });
+});

--- a/src/reducers/Resume.test.tsx
+++ b/src/reducers/Resume.test.tsx
@@ -63,6 +63,8 @@ describe("resume", () => {
     coal.tracksStarts = undefined;
     coal.costPerStart = undefined;
     coal.lifetimeStarts = undefined;
+    coal.minimumStableOutput = undefined;
+    coal.committed = undefined;
     coal.generatingLastRealTick = undefined;
 
     const restored = restore(oldSave);
@@ -72,6 +74,8 @@ describe("resume", () => {
     expect(restoredCoal.tracksStarts).toBe(true);
     expect(restoredCoal.costPerStart).toBeUndefined();
     expect(restoredCoal.lifetimeStarts).toBe(0);
+    expect(restoredCoal.minimumStableOutput).toBe(0.4);
+    expect(restoredCoal.committed).toBe(restoredCoal.currentW > 0);
     expect(restoredCoal.generatingLastRealTick).toBe(restoredCoal.currentW > 0);
   });
 


### PR DESCRIPTION
## Summary

- add technology-specific minimum stable outputs for coal, nuclear, natural gas, oil, biomass, geothermal, and enhanced geothermal
- forecast each facility's unconstrained merit-order request, then keep an idle unit committed only when minimum-load fuel, carbon, and variable O&M remain cheaper than its next start
- stop the look-ahead as soon as shutdown is economically preferred, and preserve transient sub-minimum output only during startup or shutdown ramps
- expose minimum output in generator and facility details, document the assumptions, and migrate existing saves safely

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -- --watchAll=false --runInBand` (82 suites, 807 tests)
- `npm run build`
