### PR TITLE
Clean up pre-release schemas and project documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,31 @@
 # How to contribute
 
-We welcome contributions from the community and are pleased to have them. Please follow this guide when logging issues or making code changes.
+Contributions are welcome. This guide covers issue reports and code changes.
 
-## Logging Issues
+## Reporting issues
 
-All issues should be created using the [new issue form](https://github.com/toddmedema/electrify/issues/new). Clearly describe the issue including steps to reproduce if there are any. Also, make sure to indicate what device / browser you are running it on.
+Use the [new issue form](https://github.com/toddmedema/electrify/issues/new). Include reproduction
+steps, expected and actual behavior, and the device and browser where the problem occurs.
 
-## Patching Code
+## Submitting code
 
 Code changes are welcome and should follow the guidelines below.
 
 - Fork the repository on GitHub.
-- Fix the issue, making sure that you follow the style guide (below).
-- Please leave the code nicer than you found it by including at least one new unit test for any functionality you're adding!
-- [Pull requests](http://help.github.com/send-pull-requests/) should be made to the [master branch](https://github.com/toddmedema/electrify/tree/master).
+- Create a focused branch from `master`.
+- Follow the style and testing guidance below.
+- Add tests for new behavior and regressions.
+- Open the pull request against [`master`](https://github.com/toddmedema/electrify/tree/master).
 
 ## Testing
 
 Run `npm run check` before opening a PR -- it runs types, lint, formatting and tests, which is
 exactly what CI checks. For us to consider merging your PR, all of it must pass.
 
-If your PR changes functionality that breaks a test, note it in your PR description and update the test and any other code affected.
+If a pull request intentionally changes behavior, update the affected tests and explain the change
+in the pull request description.
 
-If your PR adds new functionality, please do your best to add additional, passing tests to cover the new functionality. Or, at the very least, add test stubs to indicate what functionality and edge cases should be tested for.
-
-## Style Guide
+## Style guide
 
 All code submissions should be formatted with prettier, configured in `.prettierrc`. Run
 `npm run format` before committing, or use VSCode with the Prettier extension
@@ -44,16 +45,28 @@ rules worth knowing about, and why they are on:
   swallowing is deliberate.
 - **`eqeqeq`** (`null` exempt), **`no-var`**, **`prefer-const`**.
 
-## Pulling and pushing remote branches
+## Working with remote branches
 
 Git can get a bit confusing when it comes to pushing and pulling other folks' branches, so here's a quick reference:
 
-Add a remote repo to your git (aka someone's fork): `git remote add <username> https://github.com/<username>/electrify`
+Add a contributor's fork:
 
-Fetch all of the new branches: `git fetch`
+```sh
+git remote add <username> https://github.com/<username>/electrify.git
+```
 
-Check out a remote branch: `git checkout -b <desired local branch name> <username>/<remote branch name>`
+Fetch its branches:
+
+```sh
+git fetch <username>
+```
+
+Create a local branch from one of them:
+
+```sh
+git switch --create <local-branch> --track <username>/<remote-branch>
+```
 
 ## Questions?
 
-Email us at Contact@Fabricate.io
+Email [Contact@Fabricate.io](mailto:Contact@Fabricate.io).

--- a/README.md
+++ b/README.md
@@ -1,26 +1,29 @@
 # Electrify
 
-A mobile-friendly web game that teaches about the electricity markets in the style of a Tycoon game. Hosted at https://electrifygame.com
+A mobile-friendly tycoon game about electricity markets. Play it at
+[electrifygame.com](https://electrifygame.com).
 
-## Getting Started
+## Getting started
 
 ### Setup
 
-Requires NodeJS v21+. Check your version with `node -v`.
+Requires Node.js 24. Check your version with `node --version`.
 
-We recommend using [NVM](https://github.com/creationix/nvm) to install Node to make it easier to swap between and upgrade Node versions.
+Using a version manager such as [nvm](https://github.com/nvm-sh/nvm) makes it easier to switch
+between Node versions.
 
-Windows: must be run within a Unix-like shell (such as Git Bash).
+Development commands work in standard Windows, macOS, and Linux shells. The deployment script
+requires a POSIX-compatible shell such as Git Bash.
 
 With Node.js installed, run the following from the root of the repository:
 
 ```sh
-npm install
+npm ci
 ```
 
 To use the online high score capabilities, you will need to contact an admin to get a Firebase api key.
 
-### Development Workflow: Serve & watch
+### Serve and watch
 
 ```sh
 npm start
@@ -34,7 +37,7 @@ This runs the app at [http://localhost:3000](http://localhost:3000).
 npm test
 ```
 
-This runs the unit tests defined in files with the `.test.tsx` extension.
+This starts Jest in watch mode. Test files use the `.test.ts` or `.test.tsx` suffix.
 
 ### Check everything
 
@@ -44,11 +47,11 @@ npm run check
 
 Types, lint, formatting and tests, which is what CI runs on every pull request. Individually:
 
-| | |
-|---|---|
-| `npm run typecheck` | `tsc --noEmit` |
-| `npm run lint` | ESLint, with warnings treated as errors |
-| `npm run format` | Rewrite files with prettier |
+| Command                | Purpose                                        |
+| ---------------------- | ---------------------------------------------- |
+| `npm run typecheck`    | `tsc --noEmit`                                 |
+| `npm run lint`         | ESLint, with warnings treated as errors        |
+| `npm run format`       | Rewrite files with prettier                    |
 | `npm run format:check` | Report unformatted files without changing them |
 
 `npm test -- --coverage` reports coverage. `src/helpers` and `src/reducers` have floors set in
@@ -67,7 +70,7 @@ recorded revenue and expenses, storage can't invent electricity, and so on). Use
 check a change to the simulation in seconds rather than by playing through the UI.
 
 `npm run sim -- --scenario 103` reports one scenario month by month, and `npm run sim -- --help`
-lists the flags. See [src/testing/README.md](src/testing/README.md) for what it checks and how it
+lists the flags. See [the simulation guide](src/testing/README.md) for what it checks and how it
 works.
 
 ### Add a city to play in
@@ -99,7 +102,7 @@ in save games and replays, so it can never be changed afterwards; everything els
 
 ### Release checklist
 
-To release, you'll need to install and authenticate the `aws cli`.
+To release, install and authenticate the AWS CLI.
 
 Before deploying to production, run `./deploy.sh` and have it deploy to beta. Then check that:
 
@@ -109,4 +112,6 @@ Once functionality is verified, you can deploy prod with the same script.
 
 ### Troubleshooting
 
-If you're trying to debug the Redux store, it's wired up to use the Dev Tool extension for advanced state debugging: https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd
+The app supports the [Redux DevTools browser
+extension](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)
+for inspecting application state.

--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -203,10 +203,6 @@ export const FUELS = {
   Hydro: {
     kgCO2ePerBtu: 0,
   },
-  // TODO https://www.planete-energies.com/en/medias/close/incineration-heating-power-refuse
-  // 'Trash': {
-  //   kgCO2ePerBtu: 999,
-  // },
 } as { [fuel: string]: FuelType };
 
 export const NAV_CARDS = ["FACILITIES", "INSIGHTS", "EVENTS"] as CardNameType[];

--- a/src/Replay.test.tsx
+++ b/src/Replay.test.tsx
@@ -207,8 +207,6 @@ describe("decodeReplay", () => {
     expect(decodeReplay(doc)).toBeNull();
   });
 
-  // A scenario id no longer says where a run was played, so a replay without a location has
-  // nowhere to be re-simulated -- which is why location first bumped the replay schema
   it("ignores a replay that doesn't say where it was played", () => {
     const doc = encodeReplay(aReplay()) as unknown as Record<string, unknown>;
     delete doc.location;

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -28,20 +28,8 @@ import {
  * reducers/ImportOrder.test.tsx guards against.
  */
 
-// Bump on any breaking schema change. Mismatched replays are ignored rather than migrated.
-// 8 splits Oil's non-fuel O&M into fixed and output-dependent expenses; older replays would have
-// different Oil dispatch finances.
-// 7 extends equivalent-start tracking to thermal steam/geothermal plants and charges Coal; older
-// replays would have different Coal finances.
-// 6 adds start-based gas-turbine maintenance; older replays would have different finances.
-// 5 adds age-dependent renewable output and authored starting ages; older replays would dispatch
-// a different amount of solar and wind even if they contain exactly the same actions.
-// 4 replaces investor marketing with price-driven customer switching; older replays would grow a
-// different customer base even if they contain no explicit marketing action.
-// 3 adds offshore wind weather and generation; an older replay would simulate a different grid.
-// 2 added `location`: a v1 replay names only a scenario, and a scenario no longer pins down
-// where it is played, so there is no safe way to migrate one.
-export const REPLAY_VERSION = 8;
+// This is the initial release schema. Increment it for breaking post-release changes.
+export const REPLAY_VERSION = 1;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/SaveFile.test.tsx
+++ b/src/SaveFile.test.tsx
@@ -146,12 +146,12 @@ describe("SaveFile", () => {
       expect(error).toMatch(/isn't an Electrify save/);
     });
 
-    it("rejects a save from an incompatible version", async () => {
+    it("rejects an incompatible save", async () => {
       const { save, error } = await readSaveFile(
         saveFile({ ...serializeSave(fakeGame()), version: SAVE_VERSION + 1 }),
       );
       expect(save).toBeUndefined();
-      expect(error).toMatch(/incompatible version/);
+      expect(error).toMatch(/compatible Electrify save/);
     });
 
     it("rejects a save whose scenario this build doesn't have", async () => {

--- a/src/SaveFile.tsx
+++ b/src/SaveFile.tsx
@@ -104,8 +104,7 @@ export async function readSaveFile(file: File): Promise<ImportedSaveType> {
   const save = parseSave(parsed);
   if (!save) {
     return {
-      error:
-        "That save was made by an incompatible version of Electrify, or isn't a save at all.",
+      error: "That file isn't a compatible Electrify save game.",
     };
   }
   if (!getScenario(save.game.scenarioId, save.game.customScenario)) {
@@ -117,7 +116,7 @@ export async function readSaveFile(file: File): Promise<ImportedSaveType> {
   return { save };
 }
 
-// FileReader rather than file.text(), which older mobile Safari and jsdom both lack
+// FileReader keeps this path testable in jsdom and works across the supported browsers.
 function readText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -24,9 +24,8 @@ import type { AppStore } from "./Store";
  */
 
 export const SAVE_KEY = "savedGame";
-// Bump on any breaking schema change. Mismatched saves are ignored rather than migrated.
-// Version 6 is the launch schema; earlier values identify unsupported pre-release saves.
-export const SAVE_VERSION = 6;
+// This is the initial release schema. Increment it for breaking post-release changes.
+export const SAVE_VERSION = 1;
 
 export interface SaveGameType {
   version: number;

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -226,7 +226,7 @@ export interface DateType {
   percentOfYear: number; // 0 - 1
   month: MonthType;
   monthNumber: number; // 1 - 12
-  monthsEllapsed: number;
+  monthsElapsed: number;
   year: number;
 }
 
@@ -367,7 +367,7 @@ export interface LifetimeTotals {
   lifetimeRevenue: number; // Its pro-rata share of what the company sold
   lifetimeExpenses: number; // Its own fuel, O&M, carbon fees and loan interest
   // Representative starts: one on/off edge in the sampled day stands for every day in its month.
-  // Optional so launch saves made before start-based maintenance remain readable.
+  // Present only for generators whose maintenance model tracks starts.
   lifetimeStarts?: number;
 }
 
@@ -398,7 +398,7 @@ export interface GeneratorShoppingType extends SharedShoppingType {
   // Fraction of nameplate output permanently lost each operating year. Optional because most
   // generator types do not have a well-supported secular output decline.
   annualOutputDegradation?: number;
-  spinMinutes: number; // 1 for renewables, to avoid eating up CPU on coersing to 1 in case it doesn't exist
+  spinMinutes: number; // 1 for renewables, avoiding repeated fallback coercion in the tick loop
   btuPerWh: number; // Heat Rate, but per W for less math per frame
   // Lowest steady output as a fraction of nameplate. Starting and shutdown ramps may pass below
   // it transiently; an online unit otherwise produces at least this much.
@@ -409,8 +409,8 @@ export interface GeneratorShoppingType extends SharedShoppingType {
   // Non-fuel expense charged for one physical start. Only present when the technology's source
   // case reports a transferable amount separately from fixed and output-dependent O&M.
   costPerStart?: number;
-  // Non-fuel O&M charged against actual generation. Optional because most legacy technology
-  // records already annualize every non-fuel operating expense into annualOperatingCost.
+  // Non-fuel O&M charged against actual generation. Technologies without a separately sourced
+  // variable component annualize all non-fuel operating expense into annualOperatingCost.
   variableOperatingCostPerMWh?: number;
   // Conventional hydro only. whPerMm is calibrated against the loaded watershed record so that
   // long-run inflow lands on capacityFactor without flattening wet and dry years.
@@ -420,9 +420,9 @@ export interface GeneratorShoppingType extends SharedShoppingType {
 }
 
 interface SharedShoppingType {
-  // TODO remove: this defeats type checking on every shopping type, but the build and
-  // facilities views index these by string and treat the Storage/Generator union as
-  // interchangeable, so it cannot go until those are narrowed properly.
+  // Facility reducers and presentation components read technology-specific fields through the
+  // generator/storage union. Keep that established structural API localized here; code that
+  // dynamically selects known fields should use a keyed union instead.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [index: string]: any;
   name: string;
@@ -682,8 +682,8 @@ export type ThemeChoiceType = ThemeModeType | "system";
 
 export interface SettingsType {
   audioEnabled?: boolean;
-  // Independent buses: zero mutes one without silencing the other. audioEnabled remains the
-  // master switch (and the first-run permission), so old preferences migrate without surprise.
+  // Independent buses: zero mutes one without silencing the other. audioEnabled is the master
+  // switch and remains undefined until the player grants first-run audio permission.
   musicVolume: number;
   soundEffectsVolume: number;
   units: UnitSystemType;

--- a/src/components/base/ChartForecastDemandByType.tsx
+++ b/src/components/base/ChartForecastDemandByType.tsx
@@ -169,8 +169,7 @@ export default class ChartForecastDemandByType extends React.PureComponent<
         return;
       }
       minutes.push(tick.minute);
-      // Old saves can briefly render one pre-migration tick before the first reforecast.
-      byType.push(tick.demandByType || EMPTY_BREAKDOWN);
+      byType.push(tick.demandByType);
     });
 
     const stacked: number[][] = [];

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -141,8 +141,6 @@ function tooltip(idx: number, state: State): string {
   return `${time}\nSupply: ${formatWatts(d.supplyW)}\nDemand: ${formatWatts(d.demandW)}`;
 }
 
-// TODO how to indicate history vs reality vs forecast? Perhaps current time as a prop, and then split it in the chart
-// and don't actually differentiate between reality +  forecast in data?
 const ChartSupplyDemand = (props: Props): React.JSX.Element => {
   const { startingYear, height, legend, timeline, location } = props;
   // Figure out the boundaries of the chart data

--- a/src/components/base/FacilityDetails.tsx
+++ b/src/components/base/FacilityDetails.tsx
@@ -82,7 +82,7 @@ export function fuelPriceTrend(
   seed: number,
   location?: LocationType,
 ): number[] {
-  const months = Math.min(TREND_MONTHS, date.monthsEllapsed + 1);
+  const months = Math.min(TREND_MONTHS, date.monthsElapsed + 1);
   if (months < 2) {
     return [];
   }

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -167,12 +167,6 @@ export function GeneratorBuildItem(
     e.stopPropagation();
   };
 
-  // const monthlyInterest = getPaymentInterest(loanAmount, props.interestRate);
-  // <TableRow>
-  // <TableCell>Payments during construction (interest only)</TableCell>
-  // <TableCell align="right">{formatMoneyConcise(monthlyInterest)}/mo</TableCell>
-  // </TableRow>
-
   return (
     <Card className="build-list-item">
       <CardHeader
@@ -706,7 +700,9 @@ function GeneratorComparison(props: {
   );
 }
 
-const sortOptions = [
+type GeneratorSortKey = "buildCost" | "yearsToBuild" | "lcWh";
+
+const sortOptions: ReadonlyArray<readonly [GeneratorSortKey, string]> = [
   ["buildCost", "Build Cost"],
   ["yearsToBuild", "Build Time"],
   ["lcWh", "Cost per MWh"],
@@ -754,7 +750,7 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
   const [sliderTick, setSliderTick] = React.useState<number>(
     getTickFromW(mostRecentBuiltValue),
   );
-  const [sort, setSort] = React.useState<string>("buildCost");
+  const [sort, setSort] = React.useState<GeneratorSortKey>("buildCost");
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
   const [comparedNames, setComparedNames] = React.useState<string[]>([]);
 
@@ -782,7 +778,7 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
     solarIrradiances,
     offshoreWindSpeeds,
     airborneWindSpeeds,
-  ).sort((a, b) => (a[sort] > b[sort] ? 1 : -1));
+  ).sort((a, b) => a[sort] - b[sort]);
   const forecastGapW = Math.max(
     0,
     ...forecastedTimeline.map((tick) => tick.demandW - tick.supplyW),
@@ -820,7 +816,7 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
     setSliderTick(newValue);
   };
 
-  const onSort = (newValue: string) => {
+  const onSort = (newValue: GeneratorSortKey) => {
     setSort(newValue);
     onSortClose();
   };

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -82,12 +82,6 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
     e.stopPropagation();
   };
 
-  // const monthlyInterest = getPaymentInterest(loanAmount, props.interestRate);
-  // <TableRow>
-  // <TableCell>Payments during construction (interest only)</TableCell>
-  // <TableCell align="right">{formatMoneyConcise(monthlyInterest)}/mo</TableCell>
-  // </TableRow>
-
   return (
     <Card className="build-list-item">
       <CardHeader
@@ -300,7 +294,9 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
   );
 }
 
-const sortOptions = [
+type StorageSortKey = "buildCost" | "yearsToBuild";
+
+const sortOptions: ReadonlyArray<readonly [StorageSortKey, string]> = [
   ["buildCost", "Build Cost"],
   ["yearsToBuild", "Build Time"],
 ];
@@ -344,7 +340,7 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
   const [sliderTick, setSliderTick] = React.useState<number>(
     getTickFromW(mostRecentBuiltValue),
   );
-  const [sort, setSort] = React.useState<string>("buildCost");
+  const [sort, setSort] = React.useState<StorageSortKey>("buildCost");
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
 
   if (!now) {
@@ -352,8 +348,8 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
   }
 
   const cash = now.cash;
-  const storage = STORAGE(game, getW(sliderTick)).sort((a, b) =>
-    a[sort] > b[sort] ? 1 : -1,
+  const storage = STORAGE(game, getW(sliderTick)).sort(
+    (a, b) => a[sort] - b[sort],
   );
 
   const handleSliderChange = (_event: Event, newValue: number | number[]) => {
@@ -363,7 +359,7 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
     setSliderTick(newValue);
   };
 
-  const onSort = (newValue: string) => {
+  const onSort = (newValue: StorageSortKey) => {
     setSort(newValue);
     onSortClose();
   };

--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -82,7 +82,7 @@ async function choose(select: HTMLElement, option: string) {
 // end of game machinery (dialogs, high scores) fires while the pane is under test
 function playMonths(months: number): GameType {
   let state = createGame({ scenarioId: 100 });
-  while (state.date.monthsEllapsed < months) {
+  while (state.date.monthsElapsed < months) {
     state = produce(state, (draft: GameType) => {
       tickState(draft);
     });

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -603,7 +603,7 @@ export default class Finances extends React.Component<Props, State> {
 
     const key = [
       this.state.range,
-      date.monthsEllapsed,
+      date.monthsElapsed,
       game.monthlyHistory.length,
       game.dollarsPerkWh,
       game.facilities.map((f) => `${f.id}${f.paused ? "p" : ""}`).join(","),

--- a/src/components/views/FinancesSmallMultiples.test.tsx
+++ b/src/components/views/FinancesSmallMultiples.test.tsx
@@ -54,7 +54,7 @@ function tile(label: string): HTMLElement {
 
 function playMonths(months: number): GameType {
   let state = createGame({ scenarioId: 100 });
-  while (state.date.monthsEllapsed < months) {
+  while (state.date.monthsElapsed < months) {
     state = produce(state, (draft: GameType) => {
       tickState(draft);
     });

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -433,8 +433,8 @@ export default class Insights extends React.Component<Props, State> {
   public shouldComponentUpdate(nextProps: Props, nextState: State) {
     return (
       nextState !== this.state ||
-      nextProps.game.date.monthsEllapsed !==
-        this.props.game.date.monthsEllapsed ||
+      nextProps.game.date.monthsElapsed !==
+        this.props.game.date.monthsElapsed ||
       nextProps.game.dollarsPerkWh !== this.props.game.dollarsPerkWh ||
       nextProps.game.feePerKgCO2e !== this.props.game.feePerKgCO2e ||
       nextProps.selectedFacilityId !== this.props.selectedFacilityId ||
@@ -552,7 +552,7 @@ export default class Insights extends React.Component<Props, State> {
       years > 0 ? years * 12 : Math.max(0, 12 - game.date.monthNumber);
     const key = [
       this.state.range,
-      game.date.monthsEllapsed,
+      game.date.monthsElapsed,
       game.monthlyHistory.length,
       game.dollarsPerkWh,
       game.feePerKgCO2e,

--- a/src/components/views/LoadingContainer.tsx
+++ b/src/components/views/LoadingContainer.tsx
@@ -111,8 +111,7 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
         ]);
         reportProgress("Starting your mission…");
         if (!resumed) {
-          // Otherwise, generate from scratch
-          // TODO different scenarios - for example, start with Natural Gas if year is 2000+, otherwise coal
+          // A new game uses the scenario's authored opening fleet.
           dispatch(
             initGame({
               facilities: scenario.facilities,

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -29,9 +29,10 @@ describe("MainMenu", () => {
 
   it("starts a new game from the primary play action", async () => {
     const onStart = jest.fn();
+    const user = userEvent.setup();
     render(<MainMenu {...props({ onStart })} />);
 
-    await userEvent.click(screen.getByRole("button", { name: "Play" }));
+    await user.click(screen.getByRole("button", { name: "Play" }));
     expect(onStart).toHaveBeenCalled();
     expect(screen.queryByText("Continue")).not.toBeInTheDocument();
   });

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -71,7 +71,6 @@ const MainMenu = (props: Props): React.JSX.Element => {
               variant="contained"
               color="primary"
               onClick={props.onContinue}
-              autoFocus={true}
             >
               Continue your game
             </Button>
@@ -81,7 +80,6 @@ const MainMenu = (props: Props): React.JSX.Element => {
             variant={props.hasSavedGame ? "outlined" : "contained"}
             color="primary"
             onClick={props.onStart}
-            autoFocus={!props.hasSavedGame}
           >
             {startLabel}
           </Button>

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -94,25 +94,6 @@ function SettingsSection({
 
 export default function Settings(props: Props): React.JSX.Element {
   const installedApp = useIsInstalledApp();
-  // TODO: font size, auto-pause while looking at build options, keyboard shortcuts, ...?
-  // const fontSizeIdx = fontSizeValues.indexOf(props.settings.fontSize);
-
-  // <Checkbox id="help" label="Show Help" value={props.settings.showHelp} onChange={props.onShowHelpChange}>
-  //   {(props.settings.showHelp) ? 'Setup and combat hints are shown.' : 'Setup and combat hints are hidden.'}
-  // </Checkbox>
-
-  // <Checkbox id="vibration" label="Vibration" value={props.settings.vibration} onChange={props.onVibrationChange}>
-  //   {(props.settings.vibration) ? 'Vibrate on touch.' : 'Do not vibrate.'}
-  // </Checkbox>
-
-  // <Picker label="Font Size" value={fontSizeValues[fontSizeIdx]} onDelta={(i: number) => props.onFontSizeDelta(fontSizeIdx, i)}>
-  //   Takes effect once you leave settings.
-  // </Picker>
-
-  // <Checkbox id="experimental" label="Experimental" value={props.settings.experimental} onChange={props.onExperimentalChange}>
-  //   {(props.settings.experimental) ? 'Experimental features are currently enabled.' : 'Experimental features are currently disabled.'}
-  // </Checkbox>
-
   // The file picker is driven by the Import button rather than wrapping it, so that both buttons
   // are plainly buttons and the disabled Export one behaves like one
   const fileInput = React.useRef<HTMLInputElement>(null);

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -63,24 +63,12 @@ const COAL_START_COST_PER_MW_2023 = (54 + 5.81) * (304.702 / 224.939);
 export const OIL_FIXED_OPERATING_COST_PER_KW_YEAR = 24 * CPI_2015_TO_2023;
 export const OIL_VARIABLE_OPERATING_COST_PER_MWH = 20 * CPI_2015_TO_2023;
 
-// Used only to upgrade current-version saves written before start tracking was added to these
-// technologies. New shopping and operating records carry the explicit tracksStarts field below.
-export const START_TRACKING_FACILITY_NAMES = new Set([
-  "Natural Gas",
-  "Coal",
-  "Nuclear",
-  "Biomass",
-  "Geothermal",
-  "Enhanced Geothermal",
-]);
-
 // Representative steady-state turndown limits. These are deliberately technology-level inputs,
 // not claims that every individual unit has the same operating envelope. The GE Energy/HNEI
 // ancillary-services study reports 35-40% for coal and biomass, 12-15% for geothermal, 15-70%
 // for heavy-duty simple-cycle gas turbines and 50% for reciprocating engines. NREL production-
 // cost studies commonly model coal/nuclear and gas units in the 30-60% range. Midpoints keep the
 // gameplay legible while preventing a nominally online thermal plant from idling at trace output.
-// Existing saves use this map during resume migration.
 export const MINIMUM_STABLE_OUTPUT_BY_FACILITY: Readonly<
   Record<string, number>
 > = {
@@ -351,7 +339,6 @@ export function GENERATORS(
       capacityFactor: 0.2,
       // https://www.eia.gov/todayinenergy/detail.php?id=31232
       lifespanYears: 30,
-      // TODO
     },
     {
       name: "Biomass",
@@ -506,30 +493,6 @@ export function GENERATORS(
       // ~10-25% duty cycle - https://sunmetrix.com/what-is-capacity-factor-and-how-does-solar-energy-compare/
       lifespanYears: 35,
     },
-    // {
-    //   // as of 2018 very limited location options for these, and only two in the world are >20MW
-    //   // TODO revisit, a lot's changed
-    //   name: 'Tidal',
-    //   fuel: 'Tides',
-    //   description: 'Stable output except 4 times per day',
-    // available: true,
-    //   buildCost: 200000000,
-    //     // TODO
-    //   peakW,
-    //   maxPeakW: 250000000,
-    //     // ~250MW - https://en.wikipedia.org/wiki/List_of_largest_power_stations#Tide
-    //   btuPerWh: 0,
-    //   annualOperatingCost: 1000000,
-    //     // TODO
-    //   yearsToBuild: 1,
-    //     // TODO
-    //   spinMinutes: 1,
-    //   capacityFactor: 0.26,
-    //     // 24% - https://en.wikipedia.org/wiki/Sihwa_Lake_Tidal_Power_Station
-    //     // 28% - https://en.wikipedia.org/wiki/Rance_Tidal_Power_Station
-    //   lifespanYears: 30,
-    //     // TODO
-    // },
     {
       name: "Hydro",
       fuel: "Hydro",
@@ -575,7 +538,6 @@ export function GENERATORS(
       spinMinutes: 1,
       capacityFactor: 0.88,
       lifespanYears: 40,
-      // TODO
     },
     {
       name: "Enhanced Geothermal",
@@ -667,8 +629,6 @@ export function STORAGE(state: GameType, peakWh: number) {
       roundTripEfficiency: 0.85,
       // https://www.nrel.gov/docs/fy19osti/73222.pdf
       hourlyLoss: 0.0001,
-      // TODO #'s
-      // TODO implement mechanic
       annualOperatingCost: 0.01 * peakWh,
       // EIA's $10/kWh-year includes augmentation for about 1.5% annual degradation.
       yearsToBuild: 0.57 + magnitude / 3,
@@ -694,15 +654,12 @@ export function STORAGE(state: GameType, peakWh: number) {
       roundTripEfficiency: 0.8,
       // https://en.wikipedia.org/wiki/Pumped-storage_hydroelectricity#Economic_efficiency
       hourlyLoss: 0.001,
-      // TODO #'s
-      // TODO implement mechanic
       annualOperatingCost: 0.0019 * peakWh,
       // NREL 2024 ATB fixed O&M is $19/kW-year, or $1.90/kWh-year at ten hours.
       yearsToBuild: 6 + magnitude,
       // 6-10 years to build - https://cleantechnica.com/2020/01/03/120-gigawatts-of-energy-storage-by-2050-we-got-this/
       spinMinutes: 10,
     },
-    // TODO thermal storage, hydrogen, ...
   ] as StorageShoppingType[];
 
   // update with calculations that occur across all entries, like difficulty multipliers

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -46,7 +46,7 @@ const storageCapstoneSucceeded = (state: AppStateType) => {
 };
 
 const financesCapstoneSucceeded = (state: AppStateType) =>
-  state.game.date.monthsEllapsed >= 1 &&
+  state.game.date.monthsElapsed >= 1 &&
   (latestMonthProfit(state) || 0) > 0 &&
   !hasBlackout(state);
 
@@ -55,7 +55,7 @@ const pricingCapstoneSucceeded = (state: AppStateType) => {
   const startingCustomers = state.game.customerMarketSize / 2;
   return !!(
     now &&
-    state.game.date.monthsEllapsed >= 6 &&
+    state.game.date.monthsElapsed >= 6 &&
     state.game.dollarsPerkWh < 0.07 &&
     now.customers >= startingCustomers * 1.05 &&
     (latestMonthProfit(state) || 0) > 0 &&
@@ -71,7 +71,7 @@ const forecastingCapstoneSucceeded = (state: AppStateType) => {
       facility.yearsToBuildLeft <= 0,
   );
   return (
-    state.game.date.monthsEllapsed >= 7 && addedGenerator && !hasBlackout(state)
+    state.game.date.monthsElapsed >= 7 && addedGenerator && !hasBlackout(state)
   );
 };
 
@@ -258,7 +258,7 @@ export const SCENARIOS = [
         capstone: {
           success: generatorCapstoneSucceeded,
           failure: (s: AppStateType) =>
-            s.game.date.monthsEllapsed >= 9 && !generatorCapstoneSucceeded(s),
+            s.game.date.monthsElapsed >= 9 && !generatorCapstoneSucceeded(s),
           successMessage:
             "Capstone complete - new capacity came online before the deadline and covered demand without exhausting cash.",
           failureMessage:
@@ -460,7 +460,7 @@ export const SCENARIOS = [
           checkpoint: { dollarsPerkWh: 0.03 },
           success: financesCapstoneSucceeded,
           failure: (s: AppStateType) =>
-            s.game.date.monthsEllapsed >= 1 && !financesCapstoneSucceeded(s),
+            s.game.date.monthsElapsed >= 1 && !financesCapstoneSucceeded(s),
           successMessage:
             "Capstone complete - revenue covered fuel and operating costs, leaving a positive monthly profit while the grid stayed reliable.",
           failureMessage:
@@ -556,7 +556,7 @@ export const SCENARIOS = [
           success: pricingCapstoneSucceeded,
           failure: (s: AppStateType) =>
             hasBlackout(s) ||
-            (s.game.date.monthsEllapsed >= 6 && !pricingCapstoneSucceeded(s)),
+            (s.game.date.monthsElapsed >= 6 && !pricingCapstoneSucceeded(s)),
           successMessage:
             "Capstone complete - the lower rate grew the customer base by 5% while monthly revenue still covered costs and every unit of demand was served.",
           failureMessage:
@@ -696,7 +696,7 @@ export const SCENARIOS = [
           success: forecastingCapstoneSucceeded,
           failure: (s: AppStateType) =>
             hasBlackout(s) ||
-            (s.game.date.monthsEllapsed >= 7 &&
+            (s.game.date.monthsElapsed >= 7 &&
               !forecastingCapstoneSucceeded(s)),
           successMessage:
             "Capstone complete - construction finished before the forecast peak, and the added generator prevented the projected summer shortage.",
@@ -862,7 +862,6 @@ export const SCENARIOS = [
       { fuel: "Coal", peakW: 300000000, initialAgeYears: 10 },
     ],
   },
-  // TODO more public-ownership scenarios, such as in LA or Nebraska
 ] as ScenarioType[];
 
 // The opening missions, in the order a new player should work through them

--- a/src/data/Weather.tsx
+++ b/src/data/Weather.tsx
@@ -445,7 +445,8 @@ export function getWeather(
 // (hoping that day length alone is a sufficient proxy / ideally don't need to make it any more complex)
 // https://earthobservatory.nasa.gov/features/EnergyBalance/page2.php
 // indicates a roughly linear correlation that each degree off from 0*N/S = 0.7% less sunlight
-// TODO fix the pointiness, esp in shorter winter months - Maybe by factoring in day lenght to determine the shape of the curve?
+// Monthly interpolation remains visibly sharp in short winter months; daylight length should be
+// part of the eventual smoothing model.
 // Day length / minutes from dark used as proxy for season / max sun height
 // Rough approximation of solar output: https://www.wolframalpha.com/input?i=plot+1%2F%281+%2B+e+%5E+%28-0.015+*+%28x+-+200%29%29%29+from+0+to+420
 // Potential more complex model for solar panels: https://pro.arcgis.com/en/pro-app/3.1/tool-reference/spatial-analyst/how-solar-radiation-is-calculated.htm

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -218,7 +218,7 @@ export function formatMinuteAsMonthAxis(
   multiyear: boolean,
 ): string {
   return formatMonthChartAxis(
-    getDateFromMinute(minute, startingYear).monthsEllapsed + 12 * startingYear,
+    getDateFromMinute(minute, startingYear).monthsElapsed + 12 * startingYear,
     multiyear,
   );
 }
@@ -356,7 +356,7 @@ export function getDateFromMinute(
   const hourOfDay = Math.floor(minuteOfDay / 60);
   const dayOfGame = Math.floor(minute / 1440);
   const dayOfYear = dayOfGame % DAYS_PER_YEAR;
-  const monthsEllapsed = Math.floor(dayOfGame / DAYS_PER_MONTH);
+  const monthsElapsed = Math.floor(dayOfGame / DAYS_PER_MONTH);
   const yearsEllapsed = Math.floor(dayOfGame / DAYS_PER_YEAR);
   const year = yearsEllapsed + startingYear;
   const monthNumber = Math.floor(dayOfYear / DAYS_PER_MONTH) + 1;
@@ -375,7 +375,7 @@ export function getDateFromMinute(
     percentOfYear: percentOfYear || 0.00001,
     month,
     monthNumber,
-    monthsEllapsed,
+    monthsElapsed,
     year,
   };
 }

--- a/src/helpers/Energy.tsx
+++ b/src/helpers/Energy.tsx
@@ -78,10 +78,9 @@ export function getAirborneWindOutputFactor(wind100mKph: number): number {
   return curve * AIRBORNE_SYSTEM_AVAILABILITY;
 }
 
-// Since solar panel nameplate wattages are usually rated at peak output at equator noon, we use that as baseline
-// Solar panels slightly less efficient in warm weather, declining about 1% efficiency per 1C starting at 10C
-// TODO what about rain and snow, esp panels covered in snow? We should update irradianceWM2 based on weather when it's originally calculated...
-// but that still means we'd need to track some additional historic value of "even though it's not currently snowing, they're still covered in snow"
+// Solar nameplate wattages use peak irradiance as their baseline. Panel efficiency declines by
+// about 1% per degree above 10 C. Snow cover is not modeled because it would require persistent
+// accumulation state rather than only the current hour's weather.
 export function getSolarOutputFactor(
   irradianceWM2: number,
   temepratureC: number,

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -134,7 +134,7 @@ export function getCreditInputs(
   };
 }
 
-// TODO extrapolate future fuel prices over plant lifetime
+// Fuel prices stay at the current forecast value across the quoted lifetime.
 export function LCWH(
   g: GeneratorShoppingType,
   date: DateType,

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -88,10 +88,6 @@ import {
 } from "../Constants";
 import {
   GENERATORS,
-  MINIMUM_STABLE_OUTPUT_BY_FACILITY,
-  OIL_FIXED_OPERATING_COST_PER_KW_YEAR,
-  OIL_VARIABLE_OPERATING_COST_PER_MWH,
-  START_TRACKING_FACILITY_NAMES,
   STORAGE,
   windAnnualOutputDegradation,
 } from "../data/Facilities";
@@ -691,59 +687,6 @@ export const gameSlice = createSlice({
     });
     builder.addCase(resume, (_state, action) => {
       const restored = cloneDeep(action.payload);
-      restored.facilities.forEach((facility) => {
-        // The former Oil model stored one annual expense equal to $0.05/W-year. Recover the
-        // facility's already-applied difficulty and build-date inflation multiplier, then use it
-        // for both halves of the sourced fixed/variable split. Historical books are untouched.
-        if (
-          facility.name === "Oil" &&
-          facility.variableOperatingCostPerMWh === undefined
-        ) {
-          const legacyBaseAnnualCost = 0.05 * facility.peakW;
-          const recoveredMultiplier =
-            legacyBaseAnnualCost > 0
-              ? facility.annualOperatingCost / legacyBaseAnnualCost
-              : 1;
-          const multiplier =
-            Number.isFinite(recoveredMultiplier) && recoveredMultiplier >= 0
-              ? recoveredMultiplier
-              : 1;
-          facility.annualOperatingCost =
-            (facility.peakW / 1000) *
-            OIL_FIXED_OPERATING_COST_PER_KW_YEAR *
-            multiplier;
-          facility.variableOperatingCostPerMWh =
-            OIL_VARIABLE_OPERATING_COST_PER_MWH * multiplier;
-        }
-        // Save v6 predates the explicit capability for these technologies. Upgrade the facility
-        // snapshot once on resume, starting from its actual generating state so loading an online
-        // plant does not invent an opening start. Historical starts and charges remain unknown.
-        if (
-          facility.tracksStarts === undefined &&
-          START_TRACKING_FACILITY_NAMES.has(facility.name)
-        ) {
-          facility.tracksStarts = true;
-          facility.lifetimeStarts = facility.lifetimeStarts || 0;
-          facility.generatingLastRealTick = facility.currentW > 0;
-        }
-        const minimumStableOutput =
-          MINIMUM_STABLE_OUTPUT_BY_FACILITY[facility.name];
-        if (
-          facility.minimumStableOutput === undefined &&
-          minimumStableOutput !== undefined
-        ) {
-          facility.minimumStableOutput = minimumStableOutput;
-        }
-        if (
-          facility.minimumStableOutput !== undefined &&
-          facility.committed === undefined
-        ) {
-          facility.committed = !facility.paused && facility.currentW > 0;
-          if (facility.tracksStarts) {
-            facility.generatingLastRealTick = facility.committed;
-          }
-        }
-      });
       // The tick loop's module-level locals have to line up with the state being restored.
       // Unlike initGame, this one keeps the month: clearing it would make the first tick record a
       // second history entry for a month that's already in the log.
@@ -1317,7 +1260,7 @@ export function tickState(state: GameType) {
           );
         }
       } else if (
-        state.date.monthsEllapsed === (scenario.durationMonths || 12 * 20) &&
+        state.date.monthsElapsed === (scenario.durationMonths || 12 * 20) &&
         !activeTutorialCapstone
       ) {
         // Success: Survived duration
@@ -1472,10 +1415,10 @@ const KG_PER_MEGATON = 1000000000;
  * Everything the player has emitted so far, in megatons of CO2e, which is what the weather warms
  * and destabilises in proportion to.
  *
- * Summed from the monthly history rather than carried as its own field so that it needs no
- * migration, no place in a save, and no chance of disagreeing with the emissions the player is
- * actually scored on. The history is one entry per month -- a few hundred at the very most -- and
- * this runs once per reforecast, not once per tick.
+ * Summed from the monthly history rather than carried as its own field, keeping it out of the
+ * persisted shape and preventing it from disagreeing with the emissions the player is actually
+ * scored on. The history is one entry per month -- a few hundred at the very most -- and this
+ * runs once per reforecast, not once per tick.
  */
 function getCumulativeMegatons(monthlyHistory: MonthlyHistoryType[]): number {
   let kgco2e = 0;
@@ -1897,10 +1840,10 @@ function updateSupplyFacilitiesFinances(
   now.hydroMandatedReleaseW = hydroMandatedReleaseW;
 
   // Update finances
-  // TODO have starting dollarsPerkWh rate by location, based on historic prices (not as fulfilling) - or at least use to double check
   const supplyWh =
-    (Math.min(now.supplyW, now.demandW) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS; // Output-dependent #'s converted to real months, since we don't simulate every day
-  const demandWh = (now.demandW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS; // Output-dependent #'s converted to real months, since we don't simulate every day
+    (Math.min(now.supplyW, now.demandW) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+  // Scale the representative simulated day to the real month it stands for.
+  const demandWh = (now.demandW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
   const revenue = (supplyWh / 1000) * state.dollarsPerkWh;
 
   // Facilities expenses

--- a/src/reducers/Replay.test.tsx
+++ b/src/reducers/Replay.test.tsx
@@ -19,8 +19,8 @@ const OPTIONS = { scenarioId: 101, seed: 20260824 };
 const PLAYED_MONTHS = 12;
 
 function runMonths(state: GameType, months: number) {
-  const until = state.date.monthsEllapsed + months;
-  while (state.date.monthsEllapsed < until) {
+  const until = state.date.monthsElapsed + months;
+  while (state.date.monthsElapsed < until) {
     tickState(state);
   }
 }

--- a/src/reducers/Resume.test.tsx
+++ b/src/reducers/Resume.test.tsx
@@ -3,10 +3,6 @@ import gameReducer, { loaded, resume, start, tickState } from "./Game";
 import { parseSave, serializeSave } from "../SaveGame";
 import { createGame } from "../testing/Simulator";
 import { GameType } from "../Types";
-import {
-  OIL_FIXED_OPERATING_COST_PER_KW_YEAR,
-  OIL_VARIABLE_OPERATING_COST_PER_MWH,
-} from "../data/Facilities";
 
 jest.setTimeout(60000);
 
@@ -15,8 +11,8 @@ const OPTIONS = { scenarioId: 101, seed: 8675309 };
 const PLAYED_MONTHS = 6;
 
 function runMonths(state: GameType, months: number) {
-  const until = state.date.monthsEllapsed + months;
-  while (state.date.monthsEllapsed < until) {
+  const until = state.date.monthsElapsed + months;
+  while (state.date.monthsElapsed < until) {
     tickState(state);
   }
 }
@@ -53,56 +49,6 @@ describe("resume", () => {
     expect(restored.speed).toBe("PAUSED");
     expect(restored.inGame).toBe(false);
     expect(gameReducer(restored, loaded()).inGame).toBe(true);
-  });
-
-  it("upgrades old thermal facilities without inventing an opening start", () => {
-    const oldSave = serialized(createGame({ scenarioId: 103, seed: 8675309 }));
-    const coal = oldSave.facilities.find(
-      (facility) => facility.name === "Coal",
-    )!;
-    coal.tracksStarts = undefined;
-    coal.costPerStart = undefined;
-    coal.lifetimeStarts = undefined;
-    coal.minimumStableOutput = undefined;
-    coal.committed = undefined;
-    coal.generatingLastRealTick = undefined;
-
-    const restored = restore(oldSave);
-    const restoredCoal = restored.facilities.find(
-      (facility) => facility.name === "Coal",
-    )!;
-    expect(restoredCoal.tracksStarts).toBe(true);
-    expect(restoredCoal.costPerStart).toBeUndefined();
-    expect(restoredCoal.lifetimeStarts).toBe(0);
-    expect(restoredCoal.minimumStableOutput).toBe(0.4);
-    expect(restoredCoal.committed).toBe(restoredCoal.currentW > 0);
-    expect(restoredCoal.generatingLastRealTick).toBe(restoredCoal.currentW > 0);
-  });
-
-  it("migrates legacy Oil O&M with its saved difficulty and vintage multiplier", () => {
-    const oldSave = serialized(createGame({ scenarioId: 101, seed: 8675309 }));
-    const oil = oldSave.facilities.find((facility) => facility.name === "Oil")!;
-    const multiplier = 1.37;
-    const historicalExpenses = oil.lifetimeExpenses;
-    oil.annualOperatingCost = 0.05 * oil.peakW * multiplier;
-    oil.variableOperatingCostPerMWh = undefined;
-
-    const restoredOil = restore(oldSave).facilities.find(
-      (facility) => facility.name === "Oil",
-    )!;
-    expect(restoredOil.annualOperatingCost).toBeCloseTo(
-      (restoredOil.peakW / 1000) *
-        OIL_FIXED_OPERATING_COST_PER_KW_YEAR *
-        multiplier,
-      6,
-    );
-    expect(restoredOil.variableOperatingCostPerMWh).toBeCloseTo(
-      OIL_VARIABLE_OPERATING_COST_PER_MWH * multiplier,
-      10,
-    );
-    expect(restoredOil.lifetimeExpenses).toBe(historicalExpenses);
-    expect(Number.isFinite(restoredOil.annualOperatingCost)).toBe(true);
-    expect(Number.isFinite(restoredOil.variableOperatingCostPerMWh)).toBe(true);
   });
 
   /**

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -71,7 +71,7 @@ function playOutOnTheStore(state: GameType, untilMonth: number) {
     // hanging the suite
     for (
       let i = 0;
-      i < 10000 && getStore().getState().game.date.monthsEllapsed < untilMonth;
+      i < 10000 && getStore().getState().game.date.monthsElapsed < untilMonth;
       i++
     ) {
       wallClockMs += TICK_MS.FAST * 2;
@@ -80,7 +80,7 @@ function playOutOnTheStore(state: GameType, untilMonth: number) {
   } finally {
     now.mockRestore();
   }
-  expect(getStore().getState().game.date.monthsEllapsed).toBe(untilMonth);
+  expect(getStore().getState().game.date.monthsElapsed).toBe(untilMonth);
 }
 
 describe("ending a scenario from inside the reducer", () => {
@@ -95,7 +95,7 @@ describe("ending a scenario from inside the reducer", () => {
   it("survives to the end of the term without reading the revoked draft", () => {
     const scenario = customScenario({ durationMonths: 2 });
     let state = createGame({ scenarioId: CUSTOM_SCENARIO_ID, scenario });
-    while (state.date.monthsEllapsed < (scenario.durationMonths as number)) {
+    while (state.date.monthsElapsed < (scenario.durationMonths as number)) {
       state = tick(state);
     }
     expect(() => jest.runOnlyPendingTimers()).not.toThrow();
@@ -110,7 +110,7 @@ describe("ending a scenario from inside the reducer", () => {
     getStore().dispatch(quit());
     const scenario = customScenario({ durationMonths: 2, name: "A Test Run" });
     let state = createGame({ scenarioId: CUSTOM_SCENARIO_ID, scenario });
-    while (state.date.monthsEllapsed < (scenario.durationMonths as number)) {
+    while (state.date.monthsElapsed < (scenario.durationMonths as number)) {
       state = tick(state);
     }
     jest.runOnlyPendingTimers();
@@ -147,7 +147,7 @@ describe("ending a scenario from inside the reducer", () => {
     const duration = scenario.durationMonths as number;
     let state = createGame({ scenarioId: scenario.id });
     // Cheap up to the second to last month, then the store drives the one that ends the run
-    while (state.date.monthsEllapsed < duration - 1) {
+    while (state.date.monthsElapsed < duration - 1) {
       state = tick(state);
     }
     playOutOnTheStore(state, duration);
@@ -168,7 +168,7 @@ describe("ending a scenario from inside the reducer", () => {
       scenario,
       dollarsPerkWh: 0,
     });
-    while (state.date.monthsEllapsed < 2) {
+    while (state.date.monthsElapsed < 2) {
       state = tick(state);
     }
     expect(state.monthlyHistory[0].cash).toBeLessThan(0);
@@ -282,7 +282,7 @@ describe("finishing a tutorial", () => {
   // Runs the tutorial out to its end and hands back the dialog the reducer opened for it
   function finishTutorial() {
     let state = createGame({ scenarioId: tutorial.id });
-    while (state.date.monthsEllapsed < tutorial.durationMonths) {
+    while (state.date.monthsElapsed < tutorial.durationMonths) {
       state = tick(state);
     }
     jest.runOnlyPendingTimers();

--- a/src/reducers/Settings.tsx
+++ b/src/reducers/Settings.tsx
@@ -17,8 +17,6 @@ function storedVolume(key: string): number {
 
 export const initialSettings: SettingsType = {
   audioEnabled: getStorageBooleanOrUndefined("audioEnabled"),
-  // Saves from before separate buses have neither key, which preserves their old full-volume
-  // behaviour. audioEnabled still decides whether either bus is allowed to play.
   musicVolume: storedVolume("musicVolume"),
   soundEffectsVolume: storedVolume("soundEffectsVolume"),
   // getStorageChoice rather than getStorageString so a hand-edited or outdated value falls back

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -13,8 +13,8 @@ jest.setTimeout(120000);
 // Ticks a state forwards without the simulator around it, for tests that care about where the
 // game ends up rather than about how it played
 function runMonths(state: GameType, months: number) {
-  const until = state.date.monthsEllapsed + months;
-  while (state.date.monthsEllapsed < until) {
+  const until = state.date.monthsElapsed + months;
+  while (state.date.monthsElapsed < until) {
     tickState(state);
   }
 }

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -346,8 +346,8 @@ export function runSimulation(options: SimOptionsType): SimResultType {
 
   // tickState fires the game's end-of-run dialogs through setTimeout, which never run here, so the
   // loop watches state directly instead and stops on the same conditions the player would hit:
-  // monthsEllapsed reaching the scenario duration, negative cash, or chronic blackouts.
-  while (state.date.monthsEllapsed < resolved.months) {
+  // monthsElapsed reaching the scenario duration, negative cash, or chronic blackouts.
+  while (state.date.monthsElapsed < resolved.months) {
     tickState(state);
     ticks++;
 
@@ -386,19 +386,19 @@ export function runSimulation(options: SimOptionsType): SimResultType {
     checkMonth(collector, state.monthlyHistory[0], formatWhen(state));
 
     if (now.cash < 0) {
-      bankruptAtMonth = state.date.monthsEllapsed;
+      bankruptAtMonth = state.date.monthsElapsed;
       break; // The real game forces a restart here, so anything past it isn't a reachable state
     }
 
     if (hasChronicBlackouts(state.monthlyHistory)) {
-      firedAtMonth = state.date.monthsEllapsed;
+      firedAtMonth = state.date.monthsElapsed;
       break;
     }
 
     if (
       resolved.sellFacilityId !== null &&
       resolved.sellAtMonth > 0 &&
-      state.date.monthsEllapsed === resolved.sellAtMonth
+      state.date.monthsElapsed === resolved.sellAtMonth
     ) {
       state = cloneDeep(
         gameReducer(state, sellFacility(resolved.sellFacilityId)),
@@ -409,7 +409,7 @@ export function runSimulation(options: SimOptionsType): SimResultType {
       const toBuild = pickFacilityToBuild(state, state.monthlyHistory[0]);
       if (toBuild) {
         builds.push({
-          month: state.date.monthsEllapsed,
+          month: state.date.monthsElapsed,
           name: toBuild.name,
           buildCost: toBuild.buildCost,
         });


### PR DESCRIPTION
## Summary

- reset save and replay schemas to their initial release versions and remove pre-release resume migrations
- correct the persisted monthsElapsed field name across production code and tests
- type build-screen sort keys, remove dead commented code and stale TODOs, and clean up explanatory comments
- refresh setup and contribution documentation to match Node 24 and the current workflow
- remove menu autofocus ripple noise and use the current user-event test API

## Compatibility

This intentionally invalidates pre-release saves and replays. No migration path is retained.

## Verification

- npm run check (84 suites, 811 tests)
- npm run build
- npm run sim -- --all (all scenarios hold every invariant)