### PR TITLE
Harden game mechanics and responsive UI

### DIFF
--- a/e2e/responsive-320.spec.ts
+++ b/e2e/responsive-320.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+
+test("custom setup and settings stay usable on a 320px phone", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "mobile-320px");
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem(
+      "plays",
+      JSON.stringify({
+        plays: [{ scenarioId: 0, date: new Date().toString() }],
+      }),
+    );
+  });
+  await page.goto("/");
+  await page.getByRole("button", { name: "Play", exact: true }).click();
+  await page.getByRole("button", { name: "View Custom Game details" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Custom Game Setup" }),
+  ).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Location" })).toBeVisible();
+  const setupOverflow = await page
+    .locator("#gameSetupTable")
+    .locator("..")
+    .evaluate((element) =>
+      Math.max(0, element.scrollWidth - element.clientWidth),
+    );
+  expect(setupOverflow).toBeLessThanOrEqual(1);
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Options" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Keyboard shortcuts" }),
+  ).toBeVisible();
+  const settingsOverflow = await page
+    .locator(".scrollable")
+    .evaluate((element) =>
+      Math.max(0, element.scrollWidth - element.clientWidth),
+    );
+  expect(settingsOverflow).toBeLessThanOrEqual(1);
+});
+
+test("main-menu resources do not sit behind the footer at low height", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "mobile-320px");
+  await page.setViewportSize({ width: 360, height: 320 });
+  await page.goto("/");
+
+  const resources = await page
+    .getByRole("navigation", { name: "Game resources" })
+    .boundingBox();
+  const footer = await page.locator(".mainMenuFooter").boundingBox();
+  expect(resources).not.toBeNull();
+  expect(footer).not.toBeNull();
+  const overlap = Math.max(
+    0,
+    Math.min(resources!.y + resources!.height, footer!.y + footer!.height) -
+      Math.max(resources!.y, footer!.y),
+  );
+  expect(overlap).toBe(0);
+  expect(
+    await page
+      .locator("#menuCard")
+      .evaluate((element) => element.scrollHeight > element.clientHeight),
+  ).toBe(true);
+});

--- a/e2e/tutorial-capstone.spec.ts
+++ b/e2e/tutorial-capstone.spec.ts
@@ -21,6 +21,15 @@ test("guided objective reaches a retryable capstone and succeeds", async ({
   await page.getByRole("button", { name: "Next" }).click();
   await expect(page.getByText("Tap 1× to start time")).toBeVisible();
 
+  if (testInfo.project.name.startsWith("mobile-")) {
+    const speedButtons = page.locator("#speedChangeButtons button");
+    for (let i = 0; i < (await speedButtons.count()); i++) {
+      const box = await speedButtons.nth(i).boundingBox();
+      expect(box?.width).toBeGreaterThanOrEqual(44);
+      expect(box?.height).toBeGreaterThanOrEqual(44);
+    }
+  }
+
   if (testInfo.project.name === "mobile-390px") {
     await expect(page.getByRole("button", { name: "Insights" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Events" })).toBeVisible();
@@ -33,7 +42,15 @@ test("guided objective reaches a retryable capstone and succeeds", async ({
   ).toBeVisible();
 
   // Remove firm capacity so the first attempt demonstrates consequence feedback and retry.
-  await page.locator(".facilityRow", { hasText: "Natural Gas" }).click();
+  if (testInfo.project.name === "mobile-320px") {
+    await page.getByRole("button", { name: "Collapse objective" }).click();
+  }
+  const naturalGas = page.locator(".facilityRow", { hasText: "Natural Gas" });
+  if (testInfo.project.name === "mobile-320px") {
+    await naturalGas.click({ position: { x: 12, y: 12 } });
+  } else {
+    await naturalGas.click();
+  }
   await page.getByRole("button", { name: "Pause Natural Gas" }).click();
   await page.getByRole("button", { name: "fast speed" }).click();
   await expect(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,6 +27,15 @@ export default defineConfig({
         viewport: { width: 390, height: 844 },
       },
     },
+    {
+      name: "mobile-320px",
+      use: {
+        browserName: "chromium",
+        hasTouch: true,
+        isMobile: true,
+        viewport: { width: 320, height: 568 },
+      },
+    },
   ],
   webServer: {
     command: "npm start",

--- a/src/Globals.tsx
+++ b/src/Globals.tsx
@@ -145,25 +145,14 @@ export function isDesktopScreen(): boolean {
  * desktop breakpoint the bottom nav, supplied by the layout around them -- rather than as one
  * full-screen card carrying its own chrome.
  *
- * True from $abswidthmax up, which is also where the frame stops being phone-width: between
- * there and the desktop breakpoint the layout is Facilities pinned beside Insights or Events,
- * which is a laptop and a landscape tablet.
+ * True from $pane_breakpoint up: between there and the desktop breakpoint the layout is
+ * Facilities pinned beside Insights or Events. Narrower portrait tablets keep the single-pane
+ * navigation because a facility row and its controls do not fit in the default split.
  *
- * @returns {boolean} - Returns true if the screen is wider than a phone, otherwise false.
+ * @returns {boolean} - Returns true if the screen is at least 1024px wide, otherwise false.
  */
 export function isPaneLayout(): boolean {
-  return isBigScreen();
-}
-
-/**
- * This function checks whether there is room for a fourth column beside the three panes, which
- * is where the event log goes -- keep in sync with $ultrawide_breakpoint in app.scss. Below
- * this, a fourth column comes out of the width the three that carry the game are using.
- *
- * @returns {boolean} - Returns true if the screen width is at least 1800, otherwise false.
- */
-export function isUltrawideScreen(): boolean {
-  return getViewportWidth() >= 1800;
+  return getViewportWidth() >= 1024;
 }
 
 export function getHistoryApi(): HistoryApi {

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -273,6 +273,19 @@ describe("SaveGame", () => {
       stop();
     });
 
+    it("flushes player actions made while the clock stays paused", () => {
+      const store = fakeStore(quit);
+      const stop = startAutosave(store as never, () => true);
+      const running = playing(game, 2020, 0);
+
+      store.set(running);
+      store.set({ ...running, speed: "PAUSED" });
+      store.set(quit);
+
+      expect(readSave()!.game.speed).toBe("PAUSED");
+      stop();
+    });
+
     // Bankrupt and fired clear the save and then quit, and the flush must not undo that
     it("doesn't resurrect a save the scenario ending cleared", () => {
       const store = fakeStore(quit);

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -217,15 +217,17 @@ export function startAutosave(
   // the subscriber sees it, so flushing on the way out needs the state as it was, not as it is.
   let live: GameType | undefined;
   let savedYear = -1;
-  // What was actually written, so the flush below can tell whether anything has happened since
-  let savedMinute = -1;
+  // The exact Redux snapshot that was written. Time is not enough to identify a change: while
+  // paused, a player can still build, sell, reorder, change rates, or pause a facility without
+  // advancing the minute.
+  let saved: GameType | undefined;
   // A full disk fails every year; saying so once is a warning, saying so every year is a bug
   let warnedAboutFailure = false;
 
   const write = (game: GameType) => {
     if (writeSave(game)) {
       savedYear = game.date.year;
-      savedMinute = game.date.minute;
+      saved = game;
     } else if (!warnedAboutFailure) {
       warnedAboutFailure = true;
       store.dispatch(
@@ -244,7 +246,7 @@ export function startAutosave(
    * back from the dead.
    */
   const flush = () => {
-    if (!live || live.date.minute === savedMinute) {
+    if (!live || live === saved) {
       return;
     }
     if (readSave()?.game.scenarioId !== live.scenarioId) {
@@ -270,7 +272,7 @@ export function startAutosave(
       // A game just started or resumed, and nothing of it is written yet. Saving immediately is
       // what lets the flush above treat a missing save as "the scenario ended".
       savedYear = -1;
-      savedMinute = -1;
+      saved = undefined;
     }
     live = game;
     if (game.date.year !== savedYear) {

--- a/src/app.scss
+++ b/src/app.scss
@@ -186,8 +186,9 @@ $absmaxdimension: 1025px;
 // Wide enough to show Facilities/Finances/Forecasts side by side -- keep in sync with
 // isDesktopScreen() in Globals.tsx. Below this, panes render too narrow to be worth it.
 $desktop_breakpoint: 1300px;
-// And wide enough for the event log beside them -- keep in sync with isUltrawideScreen()
-$ultrawide_breakpoint: 1800px;
+// Below this, the default two-pane split makes a facility row narrower than its data and controls.
+// Keep in sync with isPaneLayout() in Globals.tsx.
+$pane_breakpoint: 1024px;
 
 $sizemap: (
   large: 6vmin,
@@ -278,8 +279,8 @@ button,
   .MuiButton-root,
   .MuiIconButton-root,
   .MuiToggleButton-root {
-    min-width: 44px;
-    min-height: 44px;
+    min-width: 44px !important;
+    min-height: 44px !important;
   }
 }
 
@@ -487,6 +488,10 @@ $topbar_height: 56px;
   #topbar .gameMenuButton {
     margin-left: 0;
     padding: 10px;
+  }
+
+  #topbar .MuiIconButton-edgeStart {
+    margin-left: 0;
   }
 
   #topbar .gameStatus {
@@ -1667,6 +1672,10 @@ html[data-theme="dark"] .uplot {
   }
 
   .mainMenuFooter {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
     box-sizing: border-box;
     padding-bottom: env(safe-area-inset-bottom);
     padding-left: env(safe-area-inset-left);
@@ -1684,6 +1693,36 @@ html[data-theme="dark"] .uplot {
 
     #menuCard .gameSubtitle {
       margin-bottom: 8px;
+    }
+  }
+
+  @media screen and (max-height: 450px) {
+    #menuCard {
+      display: flex;
+      flex-direction: column;
+      overflow-y: auto;
+    }
+
+    #logo {
+      position: static;
+      flex: 0 0 auto;
+      padding: 8px 24px 0;
+
+      img {
+        max-height: 72px;
+      }
+    }
+
+    #menuCard #centeredMenu {
+      position: static;
+      flex: 0 0 auto;
+      margin: 0 auto;
+    }
+
+    .mainMenuFooter {
+      position: static;
+      flex: 0 0 auto;
+      margin-top: auto;
     }
   }
 
@@ -1771,6 +1810,16 @@ html[data-theme="dark"] .uplot {
     tr {
       height: 60px;
     }
+  }
+
+  .customFacilityPicker {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 8px;
+    text-align: center;
   }
 
   #gameCard {
@@ -2129,6 +2178,75 @@ html[data-theme="dark"] .uplot {
 
 @include styling();
 
+// A 320px phone cannot fit the setup's longest row label beside a useful city picker. Stack each
+// label over its control at that last narrow breakpoint, and let build-card actions take a second
+// row instead of pushing titles and buttons past the viewport edge.
+@media screen and (max-width: 359px) {
+  #gameSetupTable {
+    width: 100%;
+    margin: 8px 0;
+    table-layout: fixed;
+
+    tr {
+      display: grid;
+      height: auto;
+      padding: 6px 0;
+    }
+
+    .MuiTableCell-root {
+      display: block;
+      box-sizing: border-box;
+      width: 100%;
+      padding: 3px 12px;
+      border-bottom: 0;
+    }
+
+    .MuiInputBase-root,
+    .MuiAutocomplete-root {
+      width: 100%;
+      min-width: 0 !important;
+      max-width: 100%;
+    }
+  }
+
+  .settingsSection {
+    grid-template-columns: minmax(0, 1fr) !important;
+    gap: 4px !important;
+
+    .shortcuts {
+      width: 100%;
+      margin: 0;
+
+      td {
+        padding: 4px;
+      }
+    }
+  }
+
+  .build-list-item .MuiCardHeader-root {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+
+    .MuiCardHeader-content {
+      min-width: 0;
+    }
+
+    .MuiCardHeader-action {
+      grid-row: 2;
+      grid-column: 1 / -1;
+      width: 100%;
+      margin: 8px 0 0 !important;
+
+      & > span,
+      .MuiStack-root {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+    }
+  }
+}
+
 // A mission objective is game chrome, not a modal: it stays out of the bottom navigation,
 // leaves the whole grid interactive and collapses to one progress-marked concept.
 .tutorialHud {
@@ -2347,13 +2465,12 @@ $sizemap: (
 }
 
 // ===============================================
-// Anything wider than a phone gets columns rather than one card at a time: two of them up to
-// $desktop_breakpoint (the fleet pinned beside whichever pane the nav is on), three above it,
-// four once there is room for the event log. The grid itself comes from DesktopPanes, since the
-// player can drag it
+// Landscape tablets and wider screens get columns rather than one card at a time: two up to
+// $desktop_breakpoint (the fleet pinned beside whichever pane the nav is on), and all three
+// destinations above it. The grid itself comes from DesktopPanes, since the player can drag it.
 // ===============================================
 
-@media screen and (min-width: $abswidthmax) {
+@media screen and (min-width: $pane_breakpoint) {
   .desktop-layout,
   .pane-layout {
     height: 100%;

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -47,7 +47,7 @@ import {
   togglePauseFacility,
 } from "../reducers/Game";
 import { snackbarOpen } from "../reducers/UI";
-import { isDesktopScreen, isPaneLayout, isUltrawideScreen } from "../Globals";
+import { isDesktopScreen, isPaneLayout } from "../Globals";
 import { store } from "../Store";
 
 // The in-game cards share one stable transition key above the desktop breakpoint. Facilities
@@ -345,14 +345,8 @@ export default class Compositor extends React.Component<Props, {}> {
           <GameAppBarContainer />
           <DesktopPanes>
             <FacilitiesContainer />
-            {this.props.card.name === "EVENTS" && !isUltrawideScreen() ? (
-              <EventLogContainer />
-            ) : (
-              <InsightsContainer />
-            )}
-            {/* An ultrawide window is otherwise three panes and a lot of nothing. Only here,
-                because below this a fourth column comes out of the three that carry the game */}
-            {isUltrawideScreen() ? <EventLogContainer /> : null}
+            <InsightsContainer />
+            <EventLogContainer />
           </DesktopPanes>
         </div>
       );

--- a/src/components/base/DesktopPanes.tsx
+++ b/src/components/base/DesktopPanes.tsx
@@ -192,6 +192,7 @@ export default function DesktopPanes(props: Props): React.JSX.Element {
   // never changes the total width the panes have to share
   const sized =
     weights.length === panes.length ? weights : loadWeights(panes.length);
+  const totalWeight = sized.reduce((sum, weight) => sum + weight, 0);
   const template = sized.map((w) => `${w}fr`).join(` ${SPLITTER_PX}px `);
 
   return (
@@ -208,6 +209,13 @@ export default function DesktopPanes(props: Props): React.JSX.Element {
               role="separator"
               aria-orientation="vertical"
               aria-label={`Resize pane ${i} and pane ${i + 1}`}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round(
+                (sized.slice(0, i).reduce((sum, weight) => sum + weight, 0) /
+                  totalWeight) *
+                  100,
+              )}
               tabIndex={0}
               onPointerDown={onPointerDown(i - 1)}
               onPointerMove={onPointerMove}

--- a/src/components/base/GameAppBar.test.tsx
+++ b/src/components/base/GameAppBar.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { createGame } from "../../testing/Simulator";
 import { GameAppBar, Props, reserveCapacityW } from "./GameAppBar";
 import { getTimeFromTimeline } from "../../helpers/DateTime";
@@ -91,5 +91,33 @@ describe("GameAppBar", () => {
     expect(screen.queryByRole("menuitem", { name: /events/i })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: /turn sound/i })).toBeNull();
     expect(screen.getByRole("menuitem", { name: "Options" })).toBeVisible();
+  });
+
+  it("gives the scenario dialog only the scenario name", () => {
+    renderAppBar();
+    fireEvent.click(screen.getByRole("button", { name: "menu" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Scenario details" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Rise of Renewables" }),
+    ).toBeVisible();
+  });
+
+  it("returns focus to the primary action after Save & Quit", () => {
+    jest.useFakeTimers();
+    const target = document.createElement("button");
+    target.dataset.mainAction = "";
+    document.body.appendChild(target);
+    const onQuit = jest.fn();
+    renderAppBar({ onQuit });
+
+    fireEvent.click(screen.getByRole("button", { name: "menu" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Save & Quit" }));
+    act(() => jest.advanceTimersByTime(350));
+
+    expect(onQuit).toHaveBeenCalled();
+    expect(target).toHaveFocus();
+    target.remove();
+    jest.useRealTimers();
   });
 });

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -176,6 +176,12 @@ export function GameAppBar(props: Props) {
   const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
     setMenuAnchorEl(event.currentTarget);
   const handleMenuClose = () => setMenuAnchorEl(null);
+  const handleQuit = React.useCallback(() => {
+    onQuit();
+    window.setTimeout(() => {
+      document.querySelector<HTMLElement>("[data-main-action]")?.focus();
+    }, 350);
+  }, [onQuit]);
 
   /**
    * The bar has to re-render every tick to keep the cash and the clock honest, which at FAST is
@@ -198,6 +204,7 @@ export function GameAppBar(props: Props) {
     () => (
       <>
         <IconButton
+          data-settings-trigger
           className="gameMenuButton"
           onClick={handleMenuClick}
           aria-label="menu"
@@ -234,7 +241,7 @@ export function GameAppBar(props: Props) {
               Next tutorial
             </MenuItem>
           )}
-          <MenuItem onClick={onQuit}>
+          <MenuItem onClick={handleQuit}>
             {isReplay ? "Exit replay" : isTutorial ? "Quit" : "Save & Quit"}
           </MenuItem>
         </Menu>
@@ -246,7 +253,7 @@ export function GameAppBar(props: Props) {
       onManual,
       onSettings,
       onNextTutorial,
-      onQuit,
+      handleQuit,
       nextTutorial,
       isReplay,
       isTutorial,

--- a/src/components/base/ScenarioDetailsDialog.tsx
+++ b/src/components/base/ScenarioDetailsDialog.tsx
@@ -43,9 +43,13 @@ export default function ScenarioDetailsDialog(props: Props): React.JSX.Element {
       : null;
 
   return (
-    <Dialog open={open} onClose={onClose}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="scenario-details-title"
+    >
       <DialogTitle>
-        {scenario.name}
+        <span id="scenario-details-title">{scenario.name}</span>
         <IconButton
           aria-label="close"
           onClick={onClose}

--- a/src/components/views/BuildGenerators.test.tsx
+++ b/src/components/views/BuildGenerators.test.tsx
@@ -147,6 +147,35 @@ it("describes clean variable generation as a strategic role", () => {
   );
 });
 
+it("submits a generator purchase only once on a double-click", () => {
+  const game = createGame({ scenarioId: 104, difficulty: "CEO" });
+  const generator = GENERATORS(game, 419000000, [], []).find(
+    (candidate) => candidate.name === "Natural Gas",
+  )!;
+  const onBuild = jest.fn();
+
+  render(
+    <GeneratorBuildItem
+      cash={1000000000}
+      date={game.date}
+      interestRate={game.interestRate}
+      generator={generator}
+      location={game.location}
+      seed={game.seed}
+      onBuild={onBuild}
+    />,
+  );
+
+  fireEvent.click(
+    screen.getByRole("button", { name: "Review purchase of Natural Gas" }),
+  );
+  const takeLoan = screen.getByRole("button", { name: "Take loan" });
+  fireEvent.click(takeLoan);
+  fireEvent.click(takeLoan);
+
+  expect(onBuild).toHaveBeenCalledTimes(1);
+});
+
 it("pins up to three current-grid choices into a comparison tray", () => {
   const game = createGame({ scenarioId: 100, difficulty: "Employee" });
   render(
@@ -158,7 +187,7 @@ it("pins up to three current-grid choices into a comparison tray", () => {
     />,
   );
 
-  const compare = screen.getAllByRole("button", { name: "Compare" });
+  const compare = screen.getAllByRole("button", { name: /^Compare / });
   fireEvent.click(compare[0]);
   fireEvent.click(compare[1]);
   expect(

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -130,6 +130,7 @@ export function GeneratorBuildItem(
   );
   const [expanded, setExpanded] = React.useState(false);
   const [open, setOpen] = React.useState(false);
+  const purchaseSubmitted = React.useRef(false);
   const downpayment = DOWNPAYMENT_PERCENT * props.generator.buildCost;
   const loanAmount = props.generator.buildCost - downpayment;
   const monthlyPayment = getMonthlyPayment(
@@ -163,8 +164,27 @@ export function GeneratorBuildItem(
   };
 
   const toggleOpen = (e: React.SyntheticEvent) => {
-    setOpen(!open);
+    setOpen((wasOpen: boolean) => {
+      if (!wasOpen) {
+        purchaseSubmitted.current = false;
+      }
+      return !wasOpen;
+    });
     e.stopPropagation();
+  };
+
+  const submitPurchase = (
+    financed: boolean,
+    e: React.MouseEvent<HTMLElement>,
+  ) => {
+    // A double-click dispatches two click events before the closing dialog has necessarily
+    // unmounted. The ref closes that tiny window synchronously.
+    if (purchaseSubmitted.current) {
+      return;
+    }
+    purchaseSubmitted.current = true;
+    props.onBuild(financed);
+    toggleOpen(e);
   };
 
   return (
@@ -183,6 +203,7 @@ export function GeneratorBuildItem(
                 size="small"
                 variant={props.compared ? "contained" : "outlined"}
                 aria-pressed={props.compared}
+                aria-label={`Compare ${generator.name}`}
                 disabled={props.compareDisabled && !props.compared}
                 onClick={(event) => {
                   event.stopPropagation();
@@ -607,10 +628,9 @@ export function GeneratorBuildItem(
             color="primary"
             disabled={cash < generator.buildCost}
             variant="contained"
-            onClick={(e: React.MouseEvent<HTMLElement>) => {
-              props.onBuild(false);
-              toggleOpen(e);
-            }}
+            onClick={(e: React.MouseEvent<HTMLElement>) =>
+              submitPurchase(false, e)
+            }
             startIcon={<ConceptIcon concept="money" fontSize="small" />}
           >
             Pay cash
@@ -618,10 +638,9 @@ export function GeneratorBuildItem(
           <Button
             color="primary"
             variant="contained"
-            onClick={(e: React.MouseEvent<HTMLElement>) => {
-              props.onBuild(true);
-              toggleOpen(e);
-            }}
+            onClick={(e: React.MouseEvent<HTMLElement>) =>
+              submitPurchase(true, e)
+            }
             startIcon={<ConceptIcon concept="finances" fontSize="small" />}
           >
             Take loan

--- a/src/components/views/BuildStorage.test.tsx
+++ b/src/components/views/BuildStorage.test.tsx
@@ -59,3 +59,23 @@ it("keeps toolbar actions inside compact viewport gutters", () => {
     "MuiIconButton-edgeEnd",
   );
 });
+
+it("submits a storage purchase only once on a double-click", () => {
+  const onBuildStorage = jest.fn();
+  render(
+    <BuildStorage
+      game={game()}
+      onBuildStorage={onBuildStorage}
+      onBack={jest.fn()}
+      onSpeedChange={jest.fn()}
+    />,
+  );
+
+  // Pumped Hydro is the first shopping card, so its price is the first purchase button.
+  fireEvent.click(screen.getAllByRole("button", { name: /^\$/ })[0]);
+  const takeLoan = screen.getByRole("button", { name: "Take loan" });
+  fireEvent.click(takeLoan);
+  fireEvent.click(takeLoan);
+
+  expect(onBuildStorage).toHaveBeenCalledTimes(1);
+});

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -58,6 +58,7 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
   const { storage, cash } = props;
   const [expanded, setExpanded] = React.useState(false);
   const [open, setOpen] = React.useState(false);
+  const purchaseSubmitted = React.useRef(false);
   const downpayment = DOWNPAYMENT_PERCENT * props.storage.buildCost;
   const loanAmount = props.storage.buildCost - downpayment;
   const monthlyPayment = getMonthlyPayment(
@@ -78,8 +79,25 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
   };
 
   const toggleOpen = (e: React.SyntheticEvent) => {
-    setOpen(!open);
+    setOpen((wasOpen: boolean) => {
+      if (!wasOpen) {
+        purchaseSubmitted.current = false;
+      }
+      return !wasOpen;
+    });
     e.stopPropagation();
+  };
+
+  const submitPurchase = (
+    financed: boolean,
+    e: React.MouseEvent<HTMLElement>,
+  ) => {
+    if (purchaseSubmitted.current) {
+      return;
+    }
+    purchaseSubmitted.current = true;
+    props.onBuild(financed);
+    toggleOpen(e);
   };
 
   return (
@@ -269,10 +287,9 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
             color="primary"
             disabled={cash < storage.buildCost}
             variant="contained"
-            onClick={(e: React.MouseEvent<HTMLElement>) => {
-              props.onBuild(false);
-              toggleOpen(e);
-            }}
+            onClick={(e: React.MouseEvent<HTMLElement>) =>
+              submitPurchase(false, e)
+            }
             startIcon={<ConceptIcon concept="money" fontSize="small" />}
           >
             Pay cash
@@ -280,10 +297,9 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
           <Button
             color="primary"
             variant="contained"
-            onClick={(e: React.MouseEvent<HTMLElement>) => {
-              props.onBuild(true);
-              toggleOpen(e);
-            }}
+            onClick={(e: React.MouseEvent<HTMLElement>) =>
+              submitPurchase(true, e)
+            }
             startIcon={<ConceptIcon concept="finances" fontSize="small" />}
           >
             Take loan

--- a/src/components/views/CustomGame.test.tsx
+++ b/src/components/views/CustomGame.test.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { DEFAULT_CUSTOM_SCENARIO } from "../../data/Scenarios";
+import { createGame } from "../../testing/Simulator";
+import CustomGame from "./CustomGame";
+
+jest.mock("../../helpers/OfflineData", () => ({
+  prefetchScenarioData: jest.fn(() => Promise.resolve()),
+}));
+
+it("opens after economic data is loaded and names every setup control", () => {
+  // createGame loads the economy, matching the path that used to make this screen crash after
+  // quitting an active game.
+  const game = createGame({ scenarioId: 100 });
+  render(
+    <CustomGame
+      game={game}
+      scenario={{ ...DEFAULT_CUSTOM_SCENARIO }}
+      onBack={jest.fn()}
+      onDelta={jest.fn()}
+      onStart={jest.fn()}
+    />,
+  );
+
+  expect(
+    screen.getByRole("heading", { name: "Custom Game Setup" }),
+  ).toBeInTheDocument();
+  [
+    "Location",
+    "Starting year",
+    "Duration",
+    "Ownership",
+    "Starting cash",
+    "Electricity rate",
+    "Carbon fee",
+    "Difficulty",
+    "Facility type",
+    "Facility size",
+  ].forEach((name) => {
+    expect(screen.getByRole("combobox", { name })).toBeInTheDocument();
+  });
+  expect(screen.getByRole("textbox", { name: "Seed" })).toBeInTheDocument();
+});

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -140,6 +140,7 @@ function technologiesFor(
   // Only the fields those two read; a full game state doesn't exist yet at setup time
   const state = {
     date: getDateFromMinute(0, scenario.startingYear),
+    startingYear: scenario.startingYear,
     difficulty,
     feePerKgCO2e: scenario.feePerKgCO2e,
     seed: 0,
@@ -352,12 +353,19 @@ export default function CustomGame(props: Props): React.JSX.Element {
                   disableClearable
                   autoHighlight
                   openOnFocus
-                  sx={{ minWidth: 200 }}
+                  sx={{ minWidth: 0, width: "100%" }}
                   renderInput={(params) => (
                     <TextField
                       {...params}
                       variant="standard"
                       placeholder="Search cities"
+                      slotProps={{
+                        ...params.slotProps,
+                        htmlInput: {
+                          ...params.slotProps.htmlInput,
+                          "aria-label": "Location",
+                        },
+                      }}
                     />
                   )}
                 />
@@ -398,6 +406,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
               <TableCell>
                 <Select
                   id="startingYear"
+                  inputProps={{ "aria-label": "Starting year" }}
                   value={scenario.startingYear}
                   onChange={(e: SelectChangeEvent<number>) =>
                     changeStartingYear(Number(e.target.value))
@@ -418,6 +427,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
               <TableCell>
                 <Select
                   id="duration"
+                  inputProps={{ "aria-label": "Duration" }}
                   value={scenario.durationMonths}
                   onChange={(e: SelectChangeEvent<number>) =>
                     change({ durationMonths: Number(e.target.value) })
@@ -448,6 +458,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
               <TableCell>
                 <Select
                   id="ownership"
+                  inputProps={{ "aria-label": "Ownership" }}
                   value={scenario.ownership}
                   onChange={(e: SelectChangeEvent<ScenarioType["ownership"]>) =>
                     change({
@@ -465,6 +476,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
               <TableCell>
                 <Select
                   id="cash"
+                  inputProps={{ "aria-label": "Starting cash" }}
                   value={scenario.cash}
                   onChange={(e: SelectChangeEvent<number>) =>
                     change({ cash: Number(e.target.value) })
@@ -485,6 +497,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
               <TableCell>
                 <Select
                   id="dollarsPerkWh"
+                  inputProps={{ "aria-label": "Electricity rate" }}
                   value={scenario.dollarsPerkWh}
                   onChange={(e: SelectChangeEvent<number>) =>
                     change({ dollarsPerkWh: Number(e.target.value) })
@@ -515,6 +528,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
               <TableCell>
                 <Select
                   id="feePerKgCO2e"
+                  inputProps={{ "aria-label": "Carbon fee" }}
                   value={scenario.feePerKgCO2e}
                   onChange={(e: SelectChangeEvent<number>) =>
                     change({ feePerKgCO2e: Number(e.target.value) })
@@ -539,6 +553,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
                     on the scenario details screen */}
                 <Select
                   id="difficulty"
+                  inputProps={{ "aria-label": "Difficulty" }}
                   value={game.difficulty}
                   onChange={(e: SelectChangeEvent<DifficultyType>) =>
                     onDelta({ difficulty: e.target.value as DifficultyType })
@@ -568,6 +583,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
                   id="seed"
                   variant="standard"
                   placeholder="Random"
+                  slotProps={{ htmlInput: { "aria-label": "Seed" } }}
                   value={scenario.seed === undefined ? "" : scenario.seed}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     const digits = e.target.value.replace(/[^0-9]/g, "");
@@ -623,9 +639,10 @@ export default function CustomGame(props: Props): React.JSX.Element {
           },
         )}
 
-        <div style={{ padding: "8px", textAlign: "center" }}>
+        <div className="customFacilityPicker">
           <Select
             id="addFacilityName"
+            inputProps={{ "aria-label": "Facility type" }}
             displayEmpty
             value={adding ? adding.name : ""}
             onChange={(e: SelectChangeEvent<string>) => {
@@ -655,9 +672,9 @@ export default function CustomGame(props: Props): React.JSX.Element {
               );
             })}
           </Select>
-          &nbsp;
           <Select
             id="addFacilitySize"
+            inputProps={{ "aria-label": "Facility size" }}
             value={sizes.indexOf(addSize) === -1 ? sizes[0] : addSize}
             disabled={!adding}
             onChange={(e: SelectChangeEvent<number>) =>
@@ -690,7 +707,6 @@ export default function CustomGame(props: Props): React.JSX.Element {
             color="primary"
             disabled={unavailable.length > 0}
             onClick={() => onStart(scenario)}
-            autoFocus
           >
             Play
           </Button>

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -67,6 +67,7 @@ const MainMenu = (props: Props): React.JSX.Element => {
         >
           {props.hasSavedGame && (
             <Button
+              data-main-action
               size="large"
               variant="contained"
               color="primary"
@@ -76,6 +77,7 @@ const MainMenu = (props: Props): React.JSX.Element => {
             </Button>
           )}
           <Button
+            data-main-action
             size="large"
             variant={props.hasSavedGame ? "outlined" : "contained"}
             color="primary"
@@ -103,7 +105,12 @@ const MainMenu = (props: Props): React.JSX.Element => {
           <Button variant="text" color="primary" onClick={props.onManual}>
             Manual
           </Button>
-          <Button variant="text" color="primary" onClick={props.onSettings}>
+          <Button
+            data-settings-trigger
+            variant="text"
+            color="primary"
+            onClick={props.onSettings}
+          >
             Options
           </Button>
           {!props.uid && (
@@ -136,10 +143,6 @@ const MainMenu = (props: Props): React.JSX.Element => {
       <footer
         className="mainMenuFooter"
         style={{
-          position: "absolute",
-          bottom: 0,
-          left: 0,
-          right: 0,
           opacity: 0.7,
         }}
       >

--- a/src/components/views/Settings.test.tsx
+++ b/src/components/views/Settings.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Settings, { Props } from "./Settings";
 import { clearAppCache } from "../../helpers/Cache";
@@ -207,5 +207,22 @@ describe("Settings", () => {
     await userEvent.click(button);
 
     expect(mockedClearAppCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns focus to the control that opened Settings", () => {
+    jest.useFakeTimers();
+    const trigger = document.createElement("button");
+    trigger.dataset.settingsTrigger = "";
+    document.body.appendChild(trigger);
+    const onBack = jest.fn();
+    renderSettings({ onBack });
+
+    fireEvent.click(screen.getByRole("button", { name: "back" }));
+    act(() => jest.advanceTimersByTime(350));
+
+    expect(onBack).toHaveBeenCalled();
+    expect(trigger).toHaveFocus();
+    trigger.remove();
+    jest.useRealTimers();
   });
 });

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -63,6 +63,7 @@ function SettingsSection({
   return (
     <Box
       component="section"
+      className="settingsSection"
       aria-labelledby={id}
       sx={{
         display: "grid",
@@ -106,13 +107,21 @@ export default function Settings(props: Props): React.JSX.Element {
       props.onImportSave(file);
     }
   };
+  const onBack = () => {
+    props.onBack();
+    // Card transitions replace the button that opened Settings. Once the previous card is back,
+    // return keyboard users to its stable replacement instead of leaving focus on <body>.
+    window.setTimeout(() => {
+      document.querySelector<HTMLElement>("[data-settings-trigger]")?.focus();
+    }, 350);
+  };
 
   return (
     <div className="flexContainer" id="gameCard">
       <div id="topbar">
         <Toolbar>
           <IconButton
-            onClick={props.onBack}
+            onClick={onBack}
             aria-label="back"
             edge="start"
             color="primary"

--- a/src/reducers/BuildFacility.test.tsx
+++ b/src/reducers/BuildFacility.test.tsx
@@ -105,6 +105,19 @@ describe("buildFacility", () => {
     });
   });
 
+  it("rejects a stale purchase when current cash no longer covers it", () => {
+    const before = createGame({ scenarioId: 103 });
+    const generator = aGeneratorToBuild(before);
+    getTimeFromTimeline(before.date.minute, before.timeline)!.cash = 0;
+
+    const after = gameReducer(
+      before,
+      buildFacility({ facility: generator, financed: true }),
+    );
+
+    expect(after.facilities).toHaveLength(before.facilities.length);
+  });
+
   it("keeps a long cash forecast finite when hydro finishes construction", () => {
     const before = createGame({ scenarioId: 103 });
     const hydro = GENERATORS(before, 50000000, [20], [500]).find(

--- a/src/reducers/EventLog.test.tsx
+++ b/src/reducers/EventLog.test.tsx
@@ -96,7 +96,7 @@ describe("the event log", () => {
     const built = cloneDeep(
       gameReducer(
         game,
-        buildFacility({ facility: generator!, financed: false }),
+        buildFacility({ facility: generator!, financed: true }),
       ),
     );
     expect(kinds(built)[0]).toEqual("BUILD");

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -812,6 +812,15 @@ function matchesFacilitySearch(
 
 function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
   const built = payload.facility;
+  const now = getTimeFromTimeline(state.date.minute, state.timeline);
+  const amountDue = payload.financed
+    ? built.buildCost * DOWNPAYMENT_PERCENT
+    : built.buildCost;
+  // The dialog's quote can be stale by the time an action lands (or a replay/import can be
+  // malformed). Never let a purchase drive cash below zero merely because the UI once enabled it.
+  if (!now || now.cash < amountDue) {
+    return;
+  }
   const viableLocationsRemaining = getViableLocationsRemaining(
     state.location,
     state.facilities,
@@ -1273,46 +1282,40 @@ export function tickState(state: GameType) {
 
         const summary = summarizeHistory(history);
         if (isTutorial) {
-          const score = computeScoreBreakdown(scenario, summary);
-          const finalScore = totalScore(score);
-          const { id: scoredScenarioId, endTitle, endMessage } = scenario;
-          const difficulty = state.difficulty;
-          const nextTutorial = getNextTutorial(scoredScenarioId);
           const capstoneIndex =
             scenario.tutorialSteps?.findIndex((step) => step.capstone) ?? -1;
-          const endingMinute = state.date.minute;
-          if (!isReplay) {
-            logEvent("scenario_end", {
-              id: scoredScenarioId,
-              type: "win",
-              difficulty,
-              score: finalScore,
-            });
-          }
-          setTimeout(() => {
-            const live = getStore().getState().game;
-            // Entering a capstone rebuilds the same scenario from minute zero. A completion
-            // callback queued by the final tick of the guided run must not celebrate over that
-            // freshly authored checkpoint merely because both runs share a scenario id.
-            if (
-              capstoneIndex >= 0 &&
-              live.scenarioId === scenarioId &&
-              live.tutorialStep === capstoneIndex &&
-              live.date.minute < endingMinute
-            ) {
-              return;
-            }
+          if (capstoneIndex >= 0) {
+            // Reaching the authored time limit is not the same as completing the mission. A
+            // player can start the clock before reading the walkthrough; pause here so they can
+            // finish the objectives and enter the capstone, which rebuilds its own checkpoint.
+            state.speed = "PAUSED";
+          } else {
+            const score = computeScoreBreakdown(scenario, summary);
+            const finalScore = totalScore(score);
+            const { id: scoredScenarioId, endTitle, endMessage } = scenario;
+            const difficulty = state.difficulty;
+            const nextTutorial = getNextTutorial(scoredScenarioId);
             if (!isReplay) {
-              clearSaveFor(scenarioId);
+              logEvent("scenario_end", {
+                id: scoredScenarioId,
+                type: "win",
+                difficulty,
+                score: finalScore,
+              });
             }
-            return getStore().dispatch(
-              tutorialCompleteDialog({
-                title: endTitle || "Mission complete!",
-                message: endMessage,
-                nextTutorial,
-              }),
-            );
-          }, 1);
+            setTimeout(() => {
+              if (!isReplay) {
+                clearSaveFor(scenarioId);
+              }
+              return getStore().dispatch(
+                tutorialCompleteDialog({
+                  title: endTitle || "Mission complete!",
+                  message: endMessage,
+                  nextTutorial,
+                }),
+              );
+            }, 1);
+          }
         } else {
           finishScoredRun(
             summary,

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -1,11 +1,5 @@
-import type * as React from "react";
 import { produce } from "immer";
-import {
-  CUSTOM_SCENARIO_ID,
-  getNextTutorial,
-  SCENARIOS,
-  TUTORIALS,
-} from "../data/Scenarios";
+import { CUSTOM_SCENARIO_ID, SCENARIOS, TUTORIALS } from "../data/Scenarios";
 import { getStore } from "../StoreRegistry";
 import { getPlayedScenarioIds } from "../LocalStorage";
 import { createGame } from "../testing/Simulator";
@@ -270,7 +264,6 @@ describe("ending a scenario from inside the reducer", () => {
 
 describe("finishing a tutorial", () => {
   const tutorial = TUTORIALS[0];
-  const next = getNextTutorial(tutorial.id) as ScenarioType;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -279,49 +272,20 @@ describe("finishing a tutorial", () => {
   });
   afterEach(() => jest.useRealTimers());
 
-  // Runs the tutorial out to its end and hands back the dialog the reducer opened for it
-  function finishTutorial() {
+  it("pauses at the duration instead of bypassing unfinished objectives", () => {
+    window.localStorage.clear();
     let state = createGame({ scenarioId: tutorial.id });
+    const initialStep = state.tutorialStep;
+    state.speed = "FAST";
     while (state.date.monthsElapsed < tutorial.durationMonths) {
       state = tick(state);
     }
     jest.runOnlyPendingTimers();
-    return getStore().getState().ui.dialog;
-  }
 
-  it("celebrates rather than showing a score", () => {
-    const dialog = finishTutorial();
-    expect(dialog.open).toBe(true);
-    expect(dialog.title).toContain(tutorial.endTitle as string);
-    // Dismissing would leave the player sitting in a scenario that's already over
-    expect(dialog.notCancellable).toBe(true);
-  });
-
-  it("leads with the next mission and keeps the main menu as the way out", () => {
-    const dialog = finishTutorial();
-    expect(dialog.actionLabel).toBe("Next mission");
-    expect(dialog.secondaryLabel).toBe("Main menu");
-  });
-
-  it("starts the next tutorial without a trip through the scenario list", () => {
-    const dialog = finishTutorial();
-    (dialog.action as (e: React.MouseEvent<HTMLElement>) => void)(
-      {} as React.MouseEvent<HTMLElement>,
-    );
-    const state = getStore().getState();
-    expect(state.game.scenarioId).toBe(next.id);
-    // The loading screen is what re-reads the weather and fuel price CSVs for the new location
-    expect(state.card.name).toBe("LOADING");
-  });
-
-  it("goes back to the title screen from the secondary button", () => {
-    const dialog = finishTutorial();
-    (dialog.secondaryAction as (e: React.MouseEvent<HTMLElement>) => void)(
-      {} as React.MouseEvent<HTMLElement>,
-    );
-    const state = getStore().getState();
-    expect(state.card.name).toBe("MAIN_MENU");
-    expect(state.ui.dialog.open).toBe(false);
+    expect(state.speed).toBe("PAUSED");
+    expect(state.tutorialStep).toBe(initialStep);
+    expect(getStore().getState().ui.dialog.open).toBe(false);
+    expect(getPlayedScenarioIds()).not.toContain(tutorial.id);
   });
 
   it("lets an active capstone own completion at the scenario boundary", () => {


### PR DESCRIPTION
## Summary

- preserve paused, same-minute player actions on Save & Quit
- prevent duplicate generator/storage purchases and reject stale unaffordable build actions
- stop tutorial duration from bypassing unfinished objectives and capstones
- fix the post-game Custom Game crash and label all setup controls
- repair 320px layouts, touch targets, low-height menus, and build-card wrapping
- keep Insights and Events reachable across desktop breakpoints and delay split panes until they fit
- restore focus after Settings and Save & Quit, and clean up dialog/splitter accessibility

## QA coverage

Five independent QA agents stressed game mechanics, desktop UI, mobile/touch layouts, breakpoint-adjacent tablet layouts, and resilience/accessibility flows. Regression coverage now includes a 320px Playwright project.

## Verification

- npm run check (85 suites, 816 tests)
- npm run test:e2e (desktop, 390px mobile, 320px mobile)
- npm run sim -- --all (all scenarios and invariants pass)