### PR TITLE
Add deterministic story arc foundation

### DIFF
--- a/src/Replay.test.tsx
+++ b/src/Replay.test.tsx
@@ -1,6 +1,7 @@
 import {
   decodeReplay,
   encodeReplay,
+  replayVersionError,
   MAX_REPLAY_ACTIONS,
   recordReplayAction,
   recordedDelta,
@@ -199,6 +200,13 @@ describe("decodeReplay", () => {
     expect(
       decodeReplay(encodeReplay(aReplay({ version: REPLAY_VERSION + 1 }))),
     ).toBeNull();
+  });
+
+  it("explains that older simulation replays cannot be migrated", () => {
+    const old = encodeReplay(aReplay({ version: REPLAY_VERSION - 1 }));
+    expect(replayVersionError(old)).toMatch(
+      /created by an older simulation version/,
+    );
   });
 
   it("ignores a replay missing the fields the run is rebuilt from", () => {

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -28,8 +28,22 @@ import {
  * reducers/ImportOrder.test.tsx guards against.
  */
 
-// This is the initial release schema. Increment it for breaking post-release changes.
-export const REPLAY_VERSION = 1;
+// v2 corresponds to the story-enabled simulation/history schema. Older actions cannot reproduce
+// the same monthly facts and are rejected rather than partially migrated.
+export const REPLAY_VERSION = 2;
+
+export function replayVersionError(raw: unknown): string | undefined {
+  if (typeof raw !== "object" || raw === null) {
+    return undefined;
+  }
+  const version = (raw as { version?: unknown }).version;
+  if (typeof version !== "number" || version === REPLAY_VERSION) {
+    return undefined;
+  }
+  return version < REPLAY_VERSION
+    ? "That replay was created by an older simulation version and can't be played."
+    : "That replay was created by a newer simulation version and can't be played.";
+}
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/SaveFile.test.tsx
+++ b/src/SaveFile.test.tsx
@@ -151,7 +151,15 @@ describe("SaveFile", () => {
         saveFile({ ...serializeSave(fakeGame()), version: SAVE_VERSION + 1 }),
       );
       expect(save).toBeUndefined();
-      expect(error).toMatch(/compatible Electrify save/);
+      expect(error).toMatch(/newer simulation version/);
+    });
+
+    it("explains that an older simulation save cannot be migrated", async () => {
+      const { save, error } = await readSaveFile(
+        saveFile({ ...serializeSave(fakeGame()), version: SAVE_VERSION - 1 }),
+      );
+      expect(save).toBeUndefined();
+      expect(error).toMatch(/created by an older simulation version/);
     });
 
     it("rejects a save whose scenario this build doesn't have", async () => {

--- a/src/SaveFile.tsx
+++ b/src/SaveFile.tsx
@@ -1,5 +1,10 @@
 import { getScenario } from "./data/Scenarios";
-import { parseSave, readSave, SaveGameType } from "./SaveGame";
+import {
+  parseSave,
+  readSave,
+  SaveGameType,
+  saveVersionError,
+} from "./SaveGame";
 import { ScenarioType } from "./Types";
 
 /**
@@ -100,6 +105,10 @@ export async function readSaveFile(file: File): Promise<ImportedSaveType> {
     parsed = JSON.parse(text);
   } catch (_err) {
     return { error: "That file isn't an Electrify save game." };
+  }
+  const versionError = saveVersionError(parsed);
+  if (versionError) {
+    return { error: versionError };
   }
   const save = parseSave(parsed);
   if (!save) {

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -102,6 +102,20 @@ describe("SaveGame", () => {
     }
   });
 
+  it("rejects current-version monthly history without story simulation facts", () => {
+    const save = serializeSave(game);
+    const month = { ...save.game.monthlyHistory[0] } as Partial<
+      GameType["monthlyHistory"][number]
+    >;
+    delete month.deliveredWhByFuel;
+    expect(
+      parseSave({
+        ...save,
+        game: { ...save.game, monthlyHistory: [month] },
+      }),
+    ).toBeNull();
+  });
+
   it("rejects a current-version save with incomplete facility totals", () => {
     const save = serializeSave(game);
     const facility = { ...save.game.facilities[0] } as Partial<

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -24,8 +24,21 @@ import type { AppStore } from "./Store";
  */
 
 export const SAVE_KEY = "savedGame";
-// This is the initial release schema. Increment it for breaking post-release changes.
-export const SAVE_VERSION = 1;
+// v2 persists fuel-specific delivery and peak demand for deterministic story checkpoints.
+export const SAVE_VERSION = 2;
+
+export function saveVersionError(raw: unknown): string | undefined {
+  if (typeof raw !== "object" || raw === null) {
+    return undefined;
+  }
+  const version = (raw as { version?: unknown }).version;
+  if (typeof version !== "number" || version === SAVE_VERSION) {
+    return undefined;
+  }
+  return version < SAVE_VERSION
+    ? "That save was created by an older simulation version and can't be resumed."
+    : "That save was created by a newer simulation version and can't be resumed.";
+}
 
 export interface SaveGameType {
   version: number;
@@ -133,6 +146,23 @@ export function parseSave(raw: unknown): SaveGameType | null {
     }) ||
     !Array.isArray(game.timeline) ||
     !Array.isArray(game.monthlyHistory) ||
+    game.monthlyHistory.some((month) => {
+      if (typeof month !== "object" || month === null) {
+        return true;
+      }
+      const record = month as Partial<GameType["monthlyHistory"][number]>;
+      return (
+        typeof record.deliveredWhByFuel !== "object" ||
+        record.deliveredWhByFuel === null ||
+        Object.values(record.deliveredWhByFuel).some(
+          (value) =>
+            typeof value !== "number" || !Number.isFinite(value) || value < 0,
+        ) ||
+        typeof record.peakDemandW !== "number" ||
+        !Number.isFinite(record.peakDemandW) ||
+        record.peakDemandW < 0
+      );
+    }) ||
     !Array.isArray(game.eventLog) ||
     !Array.isArray(game.reportedEventKeys) ||
     typeof game.eventLogReadThroughId !== "number"

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -277,7 +277,11 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     dispatchTargetWByFacility: Record<number, number>;
   };
 
-export type DerivedHistoryKeysType = keyof DerivedHistoryType;
+export type DerivedHistoryKeysType = {
+  [Key in keyof DerivedHistoryType]: DerivedHistoryType[Key] extends number
+    ? Key
+    : never;
+}[keyof DerivedHistoryType];
 export interface DerivedHistoryType extends MonthlyHistoryType {
   profit: number;
   profitPerkWh: number;
@@ -292,6 +296,10 @@ export interface MonthlyHistoryType extends HistoryForecastShared {
   month: number;
   supplyWh: number; // total
   demandWh: number; // total
+  // Persisted simulation facts used by story checkpoints. These are deliberately raw totals,
+  // not narrative classifications such as "reliable" or "gas-heavy".
+  deliveredWhByFuel: FuelProductionType;
+  peakDemandW: number;
 }
 
 interface HistoryForecastShared {
@@ -598,9 +606,35 @@ export interface GameEventType {
 }
 
 export interface WorldEventEffectsType {
-  fuelPriceMultipliers?: Partial<FuelPricesType>;
+  fuelPriceMultipliers?: Partial<Record<FuelNameType, number>>;
   temperatureOffsetC?: number;
   demandMultiplier?: number;
+  // An override rather than a multiplier. Content validation rejects overlapping policy phases.
+  carbonFeePerKgCO2e?: number;
+  buildCostMultipliersByFuel?: Partial<Record<FuelNameType, number>>;
+  operatingCostMultipliersByFuel?: Partial<Record<FuelNameType, number>>;
+  facilityOutputMultipliersByFuel?: Partial<Record<FuelNameType, number>>;
+  facilityOutputMultipliersById?: Record<string, number>;
+}
+
+/** Pure simulation summary exposed to authored story phases. */
+export interface StorySnapshotType {
+  deliveredWhByFuel12m: Partial<Record<FuelNameType, number>>;
+  demandWh12m: number;
+  unservedWh12m: number;
+  netIncome12m: number;
+  peakDemandW12m: number;
+  firmPeakW: number;
+  storagePeakW: number;
+  storagePeakWh: number;
+  facilities: Array<{
+    id: number;
+    name: string;
+    fuel?: FuelNameType;
+    ageYears: number;
+    peakW: number;
+    operational: boolean;
+  }>;
 }
 
 /** One deterministic, time-bounded occurrence created by the world-event engine. */

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -43,7 +43,7 @@ import { getDb, login } from "../../Globals";
 import { getScenario } from "../../data/Scenarios";
 import { getScenarioLocation } from "../../helpers/Locations";
 import { prefetchScenarioData } from "../../helpers/OfflineData";
-import { decodeReplay } from "../../Replay";
+import { decodeReplay, replayVersionError } from "../../Replay";
 import {
   DifficultyType,
   GameType,
@@ -208,11 +208,14 @@ export default class NewGameDetails extends React.Component<Props, State> {
     this.setState({ loadingReplayId: replayId });
     try {
       const snapshot = await getDoc(doc(getDb(), "replays", replayId));
-      const replay = snapshot.exists() ? decodeReplay(snapshot.data()) : null;
+      const data = snapshot.exists() ? snapshot.data() : undefined;
+      const replay = data ? decodeReplay(data) : null;
       if (replay) {
         this.props.onWatchReplay(replay);
       } else {
-        this.props.onReplayError("Sorry, that replay couldn't be loaded.");
+        this.props.onReplayError(
+          replayVersionError(data) || "Sorry, that replay couldn't be loaded.",
+        );
       }
     } catch (err) {
       console.warn("Couldn't load the replay: ", err);

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -1,43 +1,187 @@
-import { getDateFromMinute } from "../helpers/DateTime";
 import { LOCATIONS } from "../Constants";
-import { resolveWorldEvent, WorldEventDefinitionType } from "./WorldEvents";
+import { getDateFromMinute, MINUTES_PER_MONTH } from "../helpers/DateTime";
+import { StorySnapshotType } from "../Types";
+import {
+  combineStoryEffects,
+  resolveStoryAtDate,
+  resolveStoryScheduleMonth,
+  StoryArcDefinitionType,
+  storyPhaseKey,
+} from "./WorldEvents";
 
-const definition: WorldEventDefinitionType = {
-  id: "test-storm",
-  probabilityPerMonth: 1,
-  durationMonths: 1,
-  describe: (_context, random) => {
-    const size = Math.round(10 + random("size") * 90);
-    return {
-      kind: "FUEL_PRICE",
-      message: `Test storm ${size}`,
-      attributes: { size },
-      effects: { demandMultiplier: 1 + size / 1000 },
-    };
-  },
+const EMPTY_SNAPSHOT: StorySnapshotType = {
+  deliveredWhByFuel12m: {},
+  demandWh12m: 0,
+  unservedWh12m: 0,
+  netIncome12m: 0,
+  peakDemandW12m: 0,
+  firmPeakW: 0,
+  storagePeakW: 0,
+  storagePeakWh: 0,
+  facilities: [],
 };
 
-function occurrence(seed: number, location = LOCATIONS.SF, minute = 0) {
-  return resolveWorldEvent(definition, {
+const definition: StoryArcDefinitionType = {
+  id: "test-arc",
+  scenarioId: 103,
+  phases: [
+    {
+      id: "warning",
+      schedule: { atMonth: 2 },
+      describe: () => ({ kind: "FUEL_PRICE", message: "Warning" }),
+    },
+    {
+      id: "onset",
+      schedule: {
+        seededMonthRange: { firstMonth: 4, lastMonth: 8 },
+        randomKey: "onset-month",
+      },
+      durationMonths: 3,
+      describe: (_context, random) => {
+        const size = Math.round(10 + random("size") * 90);
+        return {
+          kind: "FUEL_PRICE",
+          message: `Change ${size}`,
+          attributes: { size },
+          effects: {
+            demandMultiplier: 1.1,
+            fuelPriceMultipliers: { "Natural Gas": 0.75 },
+          },
+        };
+      },
+    },
+  ],
+};
+
+function context(month: number, scenarioId = 103, seed = 12345) {
+  return {
     seed,
-    location,
-    date: getDateFromMinute(minute, 2020),
-  }).occurrence;
+    scenarioId,
+    difficulty: "Manager" as const,
+    date: getDateFromMinute(month * MINUTES_PER_MONTH, 2006),
+    location: LOCATIONS.PIT,
+    snapshot: EMPTY_SNAPSHOT,
+  };
 }
 
-describe("deterministic world events", () => {
-  it("replays the same occurrence and attributes for the same seed, place and time", () => {
-    expect(occurrence(12345)).toEqual(occurrence(12345));
+describe("deterministic story schedules", () => {
+  it("resolves fixed months relative to the scenario start", () => {
+    const result = resolveStoryAtDate(context(2), [definition]);
+    expect(result.occurrences.map((event) => event.key)).toEqual([
+      "story:103:test-arc:warning",
+    ]);
   });
 
-  it("addresses randomness by location, time and seed", () => {
-    const baseline = occurrence(12345);
-    expect(occurrence(54321)?.attributes).not.toEqual(baseline?.attributes);
-    expect(occurrence(12345, LOCATIONS.PIT)?.attributes).not.toEqual(
-      baseline?.attributes,
+  it("keeps seeded timing and attributes stable for a seed", () => {
+    const key = storyPhaseKey(103, "test-arc", "onset");
+    const month = resolveStoryScheduleMonth(
+      definition.phases[1].schedule,
+      12345,
+      key,
     );
-    expect(occurrence(12345, LOCATIONS.SF, 43200)?.attributes).not.toEqual(
-      baseline?.attributes,
+    const first = resolveStoryAtDate(context(month), [definition]);
+    const second = resolveStoryAtDate(context(month), [definition]);
+    expect(first).toEqual(second);
+    expect(month).toBeGreaterThanOrEqual(4);
+    expect(month).toBeLessThanOrEqual(8);
+  });
+
+  it("varies a seeded schedule across a seed sample", () => {
+    const key = storyPhaseKey(103, "test-arc", "onset");
+    const months = new Set(
+      Array.from({ length: 20 }, (_, seed) =>
+        resolveStoryScheduleMonth(definition.phases[1].schedule, seed + 1, key),
+      ),
     );
+    expect(months.size).toBeGreaterThan(1);
+  });
+
+  it("is independent of definition order", () => {
+    const other: StoryArcDefinitionType = {
+      id: "unrelated",
+      scenarioId: 103,
+      phases: [
+        {
+          id: "phase",
+          schedule: {
+            seededMonthRange: { firstMonth: 1, lastMonth: 20 },
+            randomKey: "other",
+          },
+          describe: () => ({ kind: "FUEL_PRICE", message: "Other" }),
+        },
+      ],
+    };
+    const key = storyPhaseKey(103, "test-arc", "onset");
+    const month = resolveStoryScheduleMonth(
+      definition.phases[1].schedule,
+      12345,
+      key,
+    );
+    const expected = resolveStoryAtDate(context(month), [definition, other]);
+    const reordered = resolveStoryAtDate(context(month), [other, definition]);
+    expect(reordered).toEqual(expected);
+  });
+
+  it("scopes definitions to their authored scenario, including custom games", () => {
+    expect(
+      resolveStoryAtDate(context(2, 100), [definition]).occurrences,
+    ).toEqual([]);
+    expect(
+      resolveStoryAtDate(context(2, 999), [definition]).occurrences,
+    ).toEqual([]);
+  });
+
+  it("returns the same scheduled effect throughout its forecast window", () => {
+    const key = storyPhaseKey(103, "test-arc", "onset");
+    const month = resolveStoryScheduleMonth(
+      definition.phases[1].schedule,
+      12345,
+      key,
+    );
+    expect(resolveStoryAtDate(context(month), [definition]).effects).toEqual(
+      resolveStoryAtDate(context(month + 2), [definition]).effects,
+    );
+    expect(
+      resolveStoryAtDate(context(month + 3), [definition]).effects,
+    ).toEqual({});
+  });
+});
+
+describe("story effect composition", () => {
+  it("multiplies multipliers, adds temperature offsets and preserves one override", () => {
+    expect(
+      combineStoryEffects([
+        {
+          effects: {
+            demandMultiplier: 1.2,
+            temperatureOffsetC: -4,
+            fuelPriceMultipliers: { "Natural Gas": 0.75 },
+            carbonFeePerKgCO2e: 0.1,
+          },
+        },
+        {
+          effects: {
+            demandMultiplier: 1.1,
+            temperatureOffsetC: 2,
+            fuelPriceMultipliers: { "Natural Gas": 1.8 },
+            carbonFeePerKgCO2e: 0.1,
+          },
+        },
+      ]),
+    ).toEqual({
+      demandMultiplier: 1.32,
+      temperatureOffsetC: -2,
+      fuelPriceMultipliers: { "Natural Gas": 1.35 },
+      carbonFeePerKgCO2e: 0.1,
+    });
+  });
+
+  it("rejects overlapping carbon-fee overrides", () => {
+    expect(() =>
+      combineStoryEffects([
+        { effects: { carbonFeePerKgCO2e: 0.08 } },
+        { effects: { carbonFeePerKgCO2e: 0.1 } },
+      ]),
+    ).toThrow(/overlapping story carbon-fee/i);
   });
 });

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -2,57 +2,74 @@ import {
   ActiveWorldEventType,
   CardNameType,
   DateType,
+  DifficultyType,
   GameEventImportanceType,
   GameEventKindType,
   LocationType,
+  StorySnapshotType,
   WorldEventEffectsType,
 } from "../Types";
 import { MINUTES_PER_MONTH } from "../helpers/DateTime";
 import { randomAt, RANDOM_STREAM } from "../helpers/Math";
 
-export interface WorldEventContextType {
+export interface StoryContextType {
   seed: number;
+  scenarioId: number;
+  difficulty: DifficultyType;
   date: DateType;
   location: LocationType;
+  snapshot: StorySnapshotType;
 }
 
-export type WorldEventRandomType = (attribute: string) => number;
+export type StoryScheduleType =
+  | { atMonth: number }
+  | {
+      seededMonthRange: { firstMonth: number; lastMonth: number };
+      randomKey: string;
+    };
 
-export interface WorldEventDescriptionType {
+export type StoryRandomType = (attribute: string) => number;
+
+export interface StoryPhaseDescriptionType {
   message: string;
   kind: GameEventKindType;
   importance?: GameEventImportanceType;
   actionTarget?: CardNameType;
-  attributes: Record<string, string | number>;
+  attributes?: Record<string, string | number>;
   effects?: WorldEventEffectsType;
 }
 
-/**
- * Authored rule for a discrete occurrence. No rule ships yet: this is the engine contract future
- * wildfire, hail and policy content plugs into without taking randomness from a running sequence.
- */
-export interface WorldEventDefinitionType {
+export interface StoryPhaseDefinitionType {
   id: string;
-  probabilityPerMonth: number;
-  durationMonths: number;
-  applies?: (context: WorldEventContextType) => boolean;
+  schedule: StoryScheduleType;
+  /** Zero (the default) logs a point-in-time phase without applying lasting effects. */
+  durationMonths?: number;
   describe: (
-    context: WorldEventContextType,
-    random: WorldEventRandomType,
-  ) => WorldEventDescriptionType;
+    context: StoryContextType,
+    random: StoryRandomType,
+  ) => StoryPhaseDescriptionType;
 }
 
-export interface ResolvedWorldEventType {
-  checkedKey: string;
-  occurrence?: ActiveWorldEventType & WorldEventDescriptionType;
+export interface StoryArcDefinitionType {
+  id: string;
+  scenarioId: number;
+  phases: StoryPhaseDefinitionType[];
 }
 
-// Deliberately empty for this first slice. Adding a phenomenon is content, balancing and a new
-// icon/message contract; the engine can now support it without pretending one exists yet.
-export const WORLD_EVENT_DEFINITIONS: WorldEventDefinitionType[] = [];
+export interface ResolvedStoryType {
+  /** Phases whose scheduled month is the requested date, suitable for live persistence/logging. */
+  occurrences: Array<ActiveWorldEventType & StoryPhaseDescriptionType>;
+  /** Scheduled phases whose effect window contains the requested date. */
+  active: Array<ActiveWorldEventType & StoryPhaseDescriptionType>;
+  effects: WorldEventEffectsType;
+}
 
-/** A stable 32-bit address for a string, independent of array order or other event definitions. */
-function hash(value: string): number {
+// Foundation only. Scenario content is deliberately delivered in the later, separately balanced
+// PRs listed by issue #250.
+export const STORY_ARC_DEFINITIONS: StoryArcDefinitionType[] = [];
+
+/** Stable 32-bit address for a string, independent of definition and facility array order. */
+export function storyHash(value: string): number {
   let result = 2166136261;
   for (let i = 0; i < value.length; i++) {
     result ^= value.charCodeAt(i);
@@ -61,80 +78,176 @@ function hash(value: string): number {
   return result | 0;
 }
 
-function locationKey(location: LocationType): string {
-  // Coordinates disambiguate custom locations whose user-facing id may have been reused.
-  return `${location.id}|${location.lat.toFixed(5)}|${location.long.toFixed(5)}`;
-}
-
-export function worldEventCheckKey(
-  context: WorldEventContextType,
-  definitionId: string,
+export function storyPhaseKey(
+  scenarioId: number,
+  arcId: string,
+  phaseId: string,
 ): string {
-  return `${definitionId}|${locationKey(context.location)}|${context.date.year}-${context.date.monthNumber}`;
+  return `story:${scenarioId}:${arcId}:${phaseId}`;
 }
 
-/**
- * Checks one event rule for one month. Every draw is addressed by seed + location + month + rule
- * + attribute, so replaying that world produces the same occurrence and the same size/details,
- * even if unrelated event rules are inserted or reordered later.
- */
-export function resolveWorldEvent(
-  definition: WorldEventDefinitionType,
-  context: WorldEventContextType,
-): ResolvedWorldEventType {
-  const checkedKey = worldEventCheckKey(context, definition.id);
-  const draw = (attribute: string) =>
+export function resolveStoryScheduleMonth(
+  schedule: StoryScheduleType,
+  seed: number,
+  stableKey: string,
+): number {
+  if ("atMonth" in schedule) {
+    return schedule.atMonth;
+  }
+  const { firstMonth, lastMonth } = schedule.seededMonthRange;
+  if (lastMonth < firstMonth) {
+    throw new Error(`Invalid seeded story schedule for ${stableKey}`);
+  }
+  const count = lastMonth - firstMonth + 1;
+  return (
+    firstMonth +
+    Math.floor(
+      randomAt(
+        seed,
+        RANDOM_STREAM.worldEvents,
+        storyHash(`${stableKey}|${schedule.randomKey}`),
+      ) * count,
+    )
+  );
+}
+
+function multiplyEffects<T extends Partial<Record<string, number>>>(
+  target: T | undefined,
+  source: T | undefined,
+): T | undefined {
+  if (!source) {
+    return target;
+  }
+  const result = (target || {}) as T;
+  Object.entries(source).forEach(([key, multiplier]) => {
+    if (multiplier !== undefined) {
+      result[key as keyof T] = ((result[key] || 1) * multiplier) as T[keyof T];
+    }
+  });
+  return result;
+}
+
+/** Explicit composition semantics shared by persisted live occurrences and forecast resolution. */
+export function combineStoryEffects(
+  occurrences: Array<{ effects: WorldEventEffectsType }>,
+): WorldEventEffectsType {
+  const combined: WorldEventEffectsType = {};
+  occurrences.forEach(({ effects }) => {
+    combined.temperatureOffsetC =
+      (combined.temperatureOffsetC || 0) + (effects.temperatureOffsetC || 0);
+    combined.demandMultiplier =
+      (combined.demandMultiplier || 1) * (effects.demandMultiplier || 1);
+    combined.fuelPriceMultipliers = multiplyEffects(
+      combined.fuelPriceMultipliers,
+      effects.fuelPriceMultipliers,
+    );
+    combined.buildCostMultipliersByFuel = multiplyEffects(
+      combined.buildCostMultipliersByFuel,
+      effects.buildCostMultipliersByFuel,
+    );
+    combined.operatingCostMultipliersByFuel = multiplyEffects(
+      combined.operatingCostMultipliersByFuel,
+      effects.operatingCostMultipliersByFuel,
+    );
+    combined.facilityOutputMultipliersByFuel = multiplyEffects(
+      combined.facilityOutputMultipliersByFuel,
+      effects.facilityOutputMultipliersByFuel,
+    );
+    combined.facilityOutputMultipliersById = multiplyEffects(
+      combined.facilityOutputMultipliersById,
+      effects.facilityOutputMultipliersById,
+    );
+    if (effects.carbonFeePerKgCO2e !== undefined) {
+      if (
+        combined.carbonFeePerKgCO2e !== undefined &&
+        combined.carbonFeePerKgCO2e !== effects.carbonFeePerKgCO2e
+      ) {
+        throw new Error("Overlapping story carbon-fee overrides");
+      }
+      combined.carbonFeePerKgCO2e = effects.carbonFeePerKgCO2e;
+    }
+  });
+  return combined;
+}
+
+function resolvePhase(
+  arc: StoryArcDefinitionType,
+  phase: StoryPhaseDefinitionType,
+  context: StoryContextType,
+): ActiveWorldEventType & StoryPhaseDescriptionType {
+  const key = storyPhaseKey(arc.scenarioId, arc.id, phase.id);
+  const scheduledMonth = resolveStoryScheduleMonth(
+    phase.schedule,
+    context.seed,
+    key,
+  );
+  const random = (attribute: string) =>
     randomAt(
       context.seed,
       RANDOM_STREAM.worldEvents,
-      hash(`${checkedKey}|${attribute}`),
+      storyHash(`${key}|${attribute}`),
     );
-  if (
-    (definition.applies && !definition.applies(context)) ||
-    draw("occurs") >= definition.probabilityPerMonth
-  ) {
-    return { checkedKey };
-  }
-  const description = definition.describe(context, draw);
+  const description = phase.describe(context, random);
+  const startsMinute = scheduledMonth * MINUTES_PER_MONTH;
   return {
-    checkedKey,
-    occurrence: {
-      key: checkedKey,
-      definitionId: definition.id,
-      startsMinute: context.date.minute,
-      endsMinute:
-        context.date.minute + definition.durationMonths * MINUTES_PER_MONTH,
-      ...description,
-      effects: description.effects || {},
+    key,
+    definitionId: `${arc.id}:${phase.id}`,
+    startsMinute,
+    endsMinute: startsMinute + (phase.durationMonths || 0) * MINUTES_PER_MONTH,
+    ...description,
+    attributes: {
+      scheduledMonth,
+      ...(description.attributes || {}),
     },
+    effects: description.effects || {},
   };
+}
+
+/**
+ * Pure story resolver used at both live monthly rollover and every date in a forecast. It never
+ * mutates checked keys, occurrences, logs, snackbars, recovery state, facilities, or speed.
+ */
+export function resolveStoryAtDate(
+  context: StoryContextType,
+  definitions: StoryArcDefinitionType[] = STORY_ARC_DEFINITIONS,
+): ResolvedStoryType {
+  const occurrences: ResolvedStoryType["occurrences"] = [];
+  const active: ResolvedStoryType["active"] = [];
+  definitions
+    // This explicit equality is the scenario boundary. Custom games (id 999) cannot inherit
+    // authored content by sharing a location or starting year with one of the scored scenarios.
+    .filter((arc) => arc.scenarioId === context.scenarioId)
+    .flatMap((arc) => arc.phases.map((phase) => ({ arc, phase })))
+    // Persisted occurrence order is part of save/replay determinism too, so content-file order is
+    // not allowed to decide it.
+    .sort((a, b) =>
+      storyPhaseKey(a.arc.scenarioId, a.arc.id, a.phase.id).localeCompare(
+        storyPhaseKey(b.arc.scenarioId, b.arc.id, b.phase.id),
+      ),
+    )
+    .forEach(({ arc, phase }) => {
+      const resolved = resolvePhase(arc, phase, context);
+      const scheduledMonth = resolved.attributes.scheduledMonth as number;
+      if (context.date.monthsElapsed === scheduledMonth) {
+        occurrences.push(resolved);
+      }
+      if (
+        context.date.minute >= resolved.startsMinute &&
+        context.date.minute < resolved.endsMinute
+      ) {
+        active.push(resolved);
+      }
+    });
+  return { occurrences, active, effects: combineStoryEffects(active) };
 }
 
 export function activeWorldEventEffects(
   events: ActiveWorldEventType[] | undefined,
   minute: number,
 ): WorldEventEffectsType {
-  const effects: WorldEventEffectsType = {};
-  (events || []).forEach((event: ActiveWorldEventType) => {
-    if (minute < event.startsMinute || minute >= event.endsMinute) {
-      return;
-    }
-    effects.temperatureOffsetC =
-      (effects.temperatureOffsetC || 0) +
-      (event.effects.temperatureOffsetC || 0);
-    effects.demandMultiplier =
-      (effects.demandMultiplier || 1) * (event.effects.demandMultiplier || 1);
-    if (event.effects.fuelPriceMultipliers) {
-      effects.fuelPriceMultipliers = effects.fuelPriceMultipliers || {};
-      Object.entries(event.effects.fuelPriceMultipliers).forEach(
-        ([fuel, multiplier]) => {
-          if (multiplier !== undefined) {
-            effects.fuelPriceMultipliers![fuel] =
-              (effects.fuelPriceMultipliers![fuel] || 1) * multiplier;
-          }
-        },
-      );
-    }
-  });
-  return effects;
+  return combineStoryEffects(
+    (events || []).filter(
+      (event) => minute >= event.startsMinute && minute < event.endsMinute,
+    ),
+  );
 }

--- a/src/helpers/DateTime.test.tsx
+++ b/src/helpers/DateTime.test.tsx
@@ -9,7 +9,13 @@ import {
   summarizeTimeline,
   summarizeTimelineByMonth,
 } from "./DateTime";
-import { LOCATIONS, TICK_MINUTES, TICKS_PER_MONTH } from "../Constants";
+import {
+  GAME_TO_REAL_YEARS,
+  LOCATIONS,
+  TICK_MINUTES,
+  TICKS_PER_HOUR,
+  TICKS_PER_MONTH,
+} from "../Constants";
 import {
   DateType,
   LocationType,
@@ -144,8 +150,9 @@ describe("summarizeTimeline", () => {
       (cash: number, i: number) =>
         ({
           minute: i * TICK_MINUTES,
-          supplyW: 0,
-          demandW: 0,
+          supplyW: 100 + i * 50,
+          demandW: 200 + i * 100,
+          supplyByFuel: { Coal: 60 + i * 10, Wind: 40 + i * 40 },
           cash,
           customers: 1000 + i,
           netWorth: cash * 2,
@@ -169,6 +176,13 @@ describe("summarizeTimeline", () => {
     expect(summary.interestRate).toBeCloseTo(0.042, 10);
     expect(summary.revenue).toEqual(30);
     expect(summary.expensesFuel).toEqual(3);
+    expect(summary.peakDemandW).toEqual(400);
+    expect(summary.deliveredWhByFuel.Coal).toBeCloseTo(
+      ((60 + 70 + 80) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS,
+    );
+    expect(summary.deliveredWhByFuel.Wind).toBeCloseTo(
+      ((40 + 80 + 120) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS,
+    );
   });
 
   it("ends on the last tick the filter kept, not the last one in the array", () => {
@@ -180,6 +194,20 @@ describe("summarizeTimeline", () => {
     expect(summary.cash).toEqual(300);
     expect(summary.revenue).toEqual(30);
   });
+
+  it("does not attribute curtailed oversupply as delivered fuel energy", () => {
+    const oversupplied = ticks([100]);
+    oversupplied[0].supplyW = 200;
+    oversupplied[0].demandW = 100;
+    oversupplied[0].supplyByFuel = { Coal: 120, Wind: 80 };
+    const summary = summarizeTimeline(oversupplied, 2020);
+    expect(
+      Object.values(summary.deliveredWhByFuel).reduce<number>(
+        (total, delivered) => total + (delivered || 0),
+        0,
+      ),
+    ).toBeCloseTo(summary.supplyWh);
+  });
 });
 
 describe("summarizeHistory", () => {
@@ -189,6 +217,8 @@ describe("summarizeHistory", () => {
       (cash: number) =>
         ({
           ...EMPTY_HISTORY,
+          deliveredWhByFuel: { Coal: cash },
+          peakDemandW: cash * 10,
           cash,
           netWorth: cash * 2,
           revenue: 10,
@@ -202,6 +232,8 @@ describe("summarizeHistory", () => {
     expect(summary.cash).toEqual(300);
     expect(summary.netWorth).toEqual(600);
     expect(summary.revenue).toEqual(30);
+    expect(summary.deliveredWhByFuel.Coal).toEqual(600);
+    expect(summary.peakDemandW).toEqual(3000);
   });
 });
 

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -23,6 +23,8 @@ export const EMPTY_HISTORY = {
   year: 0,
   supplyWh: 0,
   demandWh: 0,
+  deliveredWhByFuel: {},
+  peakDemandW: 0,
   customers: 0,
   cash: 0,
   kgco2e: 0,
@@ -36,13 +38,28 @@ export const EMPTY_HISTORY = {
   inflationRate: 0,
 } as MonthlyHistoryType;
 
+function emptyHistory(): MonthlyHistoryType {
+  return { ...EMPTY_HISTORY, deliveredWhByFuel: {} };
+}
+
 // edits acc in place to avoid making tons of extra objects
 export function reduceHistories(
   acc: MonthlyHistoryType,
   t: MonthlyHistoryType,
 ): MonthlyHistoryType {
+  // Several chart reducers seed with `{ ...EMPTY_HISTORY }`. Clone the nested map on first use so
+  // one summary cannot write fuel totals into the exported constant or another summary.
+  if (acc.deliveredWhByFuel === EMPTY_HISTORY.deliveredWhByFuel) {
+    acc.deliveredWhByFuel = {};
+  }
   acc.supplyWh += t.supplyWh;
   acc.demandWh += t.demandWh;
+  Object.entries(t.deliveredWhByFuel || {}).forEach(([fuel, wh]) => {
+    if (wh !== undefined) {
+      acc.deliveredWhByFuel[fuel] = (acc.deliveredWhByFuel[fuel] || 0) + wh;
+    }
+  });
+  acc.peakDemandW = Math.max(acc.peakDemandW, t.peakDemandW || 0);
   acc.kgco2e += t.kgco2e;
   acc.revenue += t.revenue;
   acc.expensesFuel += t.expensesFuel;
@@ -93,6 +110,18 @@ function accumulateTick(
   summary.supplyWh +=
     (Math.min(t.demandW, t.supplyW) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
   summary.demandWh += (t.demandW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+  // Dispatch can briefly oversupply while a minimum-load plant ramps. Attribute only the share
+  // that demand accepted, so fuel totals describe delivered energy and never claim the curtailed
+  // excess. Storage is deliberately absent because it is not a fuel.
+  const deliveredShare = t.supplyW > 0 ? Math.min(1, t.demandW / t.supplyW) : 0;
+  Object.entries(t.supplyByFuel).forEach(([fuel, watts]) => {
+    if (watts !== undefined) {
+      summary.deliveredWhByFuel[fuel] =
+        (summary.deliveredWhByFuel[fuel] || 0) +
+        ((watts * deliveredShare) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+    }
+  });
+  summary.peakDemandW = Math.max(summary.peakDemandW, t.demandW);
   summary.kgco2e += t.kgco2e;
   summary.revenue += t.revenue;
   summary.expensesFuel += t.expensesFuel;
@@ -115,7 +144,7 @@ export function summarizeTimeline(
   startingYear: number,
   filter?: (t: TickPresentFutureType) => boolean,
 ): MonthlyHistoryType {
-  const summary = { ...EMPTY_HISTORY };
+  const summary = emptyHistory();
   // Ticks are ordered oldest first, so walk forwards: reduceHistories keeps the last value it
   // sees for the point-in-time fields, and the period should report the balances it ended on.
   // Note that summarizeHistory below walks the other way, because monthlyHistory is newest first.
@@ -152,7 +181,7 @@ export function summarizeTimelineByMonth(
     const month = Math.floor(t.minute / MINUTES_PER_MONTH);
     let summary = byMonth.get(month);
     if (!summary) {
-      summary = { ...EMPTY_HISTORY };
+      summary = emptyHistory();
       byMonth.set(month, summary);
     }
     accumulateTick(summary, t, startingYear);
@@ -166,7 +195,7 @@ export function summarizeHistory(
   timeline: MonthlyHistoryType[],
   filter?: (t: MonthlyHistoryType) => boolean,
 ): MonthlyHistoryType {
-  const summary = { ...EMPTY_HISTORY };
+  const summary = emptyHistory();
   // Months are ordered newest first (state.monthlyHistory is built by unshifting), so walking
   // backwards is what ends on the most recent one - the opposite direction to summarizeTimeline
   // above, for the opposite array order.

--- a/src/helpers/Scoring.test.tsx
+++ b/src/helpers/Scoring.test.tsx
@@ -11,6 +11,8 @@ it("gives a public utility that supplied no electricity a finite score", () => {
     month: 1,
     supplyWh: 0,
     demandWh: 1000000000000,
+    deliveredWhByFuel: {},
+    peakDemandW: 1000000000000,
     cash: -1,
     customers: 100,
     netWorth: 0,

--- a/src/helpers/Story.test.tsx
+++ b/src/helpers/Story.test.tsx
@@ -1,0 +1,69 @@
+import cloneDeep from "lodash.clonedeep";
+import { EMPTY_HISTORY, MINUTES_PER_MONTH } from "./DateTime";
+import { buildStorySnapshot } from "./Story";
+import { MonthlyHistoryType } from "../Types";
+import { createGame } from "../testing/Simulator";
+
+function month(index: number): MonthlyHistoryType {
+  return {
+    ...EMPTY_HISTORY,
+    month: index,
+    demandWh: 100,
+    supplyWh: 90,
+    revenue: 20,
+    expensesFuel: 2,
+    expensesOM: 3,
+    expensesCarbonFee: 1,
+    expensesInterest: 4,
+    deliveredWhByFuel: { Coal: index, Wind: index * 2 },
+    peakDemandW: index * 1000,
+  };
+}
+
+describe("story snapshots", () => {
+  it("summarizes only the prior twelve completed months", () => {
+    const history = Array.from({ length: 14 }, (_, index) => month(index + 1));
+    const snapshot = buildStorySnapshot(history, [], 0);
+    expect(snapshot.demandWh12m).toEqual(1200);
+    expect(snapshot.unservedWh12m).toEqual(120);
+    expect(snapshot.netIncome12m).toEqual(120);
+    expect(snapshot.deliveredWhByFuel12m).toEqual({
+      Coal: 78,
+      Wind: 156,
+    });
+    expect(snapshot.peakDemandW12m).toEqual(12000);
+  });
+
+  it("derives firm, storage and per-facility facts from the current fleet", () => {
+    const game = createGame({ scenarioId: 103 });
+    const coal = game.facilities.find((facility) => facility.fuel === "Coal")!;
+    const wind = cloneDeep(coal);
+    wind.id = coal.id + 1;
+    wind.name = "Wind";
+    wind.fuel = "Wind";
+    wind.peakW = 50;
+    wind.minuteOperational = 0;
+    const storage = cloneDeep(coal);
+    storage.id = coal.id + 2;
+    storage.name = "Battery";
+    storage.peakW = 25;
+    storage.peakWh = 100;
+    storage.minuteOperational = 0;
+    game.facilities = [coal, wind, storage];
+
+    const currentMinute = 2 * 12 * MINUTES_PER_MONTH;
+    const snapshot = buildStorySnapshot([], game.facilities, currentMinute);
+    expect(snapshot.firmPeakW).toEqual(coal.peakW);
+    expect(snapshot.storagePeakW).toEqual(25);
+    expect(snapshot.storagePeakWh).toEqual(100);
+    expect(
+      snapshot.facilities.find((facility) => facility.id === coal.id),
+    ).toMatchObject({ fuel: "Coal", operational: true });
+    expect(
+      snapshot.facilities.find((facility) => facility.id === wind.id)?.ageYears,
+    ).toBeCloseTo(2, 1);
+    expect(
+      buildStorySnapshot([], [...game.facilities].reverse(), currentMinute),
+    ).toEqual(snapshot);
+  });
+});

--- a/src/helpers/Story.tsx
+++ b/src/helpers/Story.tsx
@@ -1,0 +1,70 @@
+import {
+  FacilityOperatingType,
+  FuelNameType,
+  MonthlyHistoryType,
+  StorySnapshotType,
+} from "../Types";
+import { summarizeHistory } from "./DateTime";
+import { facilityAgeYears } from "./Financials";
+
+const VARIABLE_FUELS = new Set<FuelNameType>([
+  "Sun",
+  "Wind",
+  "Offshore Wind",
+  "Airborne Wind",
+]);
+
+/**
+ * Derives the story-facing state from authoritative simulation history and the current fleet.
+ * No narrative labels are persisted, so changing checkpoint copy cannot make an existing save
+ * disagree with the simulation facts that produced it.
+ */
+export function buildStorySnapshot(
+  monthlyHistory: MonthlyHistoryType[],
+  facilities: FacilityOperatingType[],
+  currentMinute: number,
+): StorySnapshotType {
+  const prior12Months = summarizeHistory(monthlyHistory.slice(0, 12));
+  const fleet = facilities.map((facility) => {
+    const generatorFuel = facility.peakWh ? undefined : facility.fuel;
+    return {
+      id: facility.id,
+      name: facility.name,
+      fuel: generatorFuel,
+      ageYears: facilityAgeYears(facility, currentMinute),
+      peakW: facility.peakW,
+      operational: facility.yearsToBuildLeft <= 0 && !facility.paused,
+    };
+  });
+  let firmPeakW = 0;
+  let storagePeakW = 0;
+  let storagePeakWh = 0;
+  facilities.forEach((facility, index) => {
+    if (!fleet[index].operational) {
+      return;
+    }
+    if (facility.peakWh) {
+      storagePeakW += facility.peakW;
+      storagePeakWh += facility.peakWh;
+    } else if (!VARIABLE_FUELS.has(facility.fuel)) {
+      firmPeakW += facility.peakW;
+    }
+  });
+  const expenses =
+    prior12Months.expensesFuel +
+    prior12Months.expensesOM +
+    prior12Months.expensesCarbonFee +
+    prior12Months.expensesInterest;
+  return {
+    deliveredWhByFuel12m: { ...prior12Months.deliveredWhByFuel },
+    demandWh12m: prior12Months.demandWh,
+    unservedWh12m: Math.max(0, prior12Months.demandWh - prior12Months.supplyWh),
+    netIncome12m: prior12Months.revenue - expenses,
+    peakDemandW12m: prior12Months.peakDemandW,
+    firmPeakW,
+    storagePeakW,
+    storagePeakWh,
+    // A fleet can be reordered for dispatch without changing a checkpoint's input identity.
+    facilities: fleet.sort((a, b) => a.id - b.id),
+  };
+}

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -38,6 +38,7 @@ import { computeScoreBreakdown, totalScore } from "../helpers/Scoring";
 import { formatLargeMass } from "../helpers/Units";
 import { buildConsequenceMessage } from "../helpers/BuildConsequences";
 import { buildVictoryDebrief } from "../helpers/Debrief";
+import { buildStorySnapshot } from "../helpers/Story";
 import {
   getAirborneWindOutputFactor,
   getAirborneWindReferenceKph,
@@ -48,9 +49,9 @@ import {
 import { getFuelPricesPerMBTU } from "../data/FuelPrices";
 import { DEMAND_TYPES, demandByTypeAt } from "../data/DemandProfiles";
 import {
-  activeWorldEventEffects,
-  resolveWorldEvent,
-  WORLD_EVENT_DEFINITIONS,
+  combineStoryEffects,
+  resolveStoryAtDate,
+  STORY_ARC_DEFINITIONS,
 } from "../data/WorldEvents";
 import { getWeather, getRawSolarIrradianceWM2 } from "../data/Weather";
 import {
@@ -324,7 +325,7 @@ function currentFuelCosts(
     const cost = generatorCostPerMWh(
       facility as GeneratorOperatingType,
       prices,
-      state.feePerKgCO2e,
+      effectiveCarbonFee(state.date, state),
     );
     if (cost === undefined) {
       return;
@@ -393,30 +394,35 @@ function updateWorldEvents(state: GameType) {
   state.worldEvents.active = state.worldEvents.active.filter(
     (event) => event.endsMinute > state.date.minute,
   );
-  WORLD_EVENT_DEFINITIONS.forEach((definition) => {
-    const resolved = resolveWorldEvent(definition, {
-      seed: state.seed,
-      date: state.date,
-      location: state.location,
-    });
-    if (state.worldEvents.checkedKeys.includes(resolved.checkedKey)) {
+  if (
+    !STORY_ARC_DEFINITIONS.some((arc) => arc.scenarioId === state.scenarioId)
+  ) {
+    return;
+  }
+  const resolved = resolveStoryAtDate({
+    seed: state.seed,
+    scenarioId: state.scenarioId,
+    difficulty: state.difficulty,
+    date: state.date,
+    location: state.location,
+    snapshot: buildStorySnapshot(
+      state.monthlyHistory,
+      state.facilities,
+      state.date.minute,
+    ),
+  });
+  resolved.occurrences.forEach((occurrence) => {
+    if (state.worldEvents.checkedKeys.includes(occurrence.key)) {
       return;
     }
-    state.worldEvents.checkedKeys.push(resolved.checkedKey);
-    if (resolved.occurrence) {
-      state.worldEvents.active.push(resolved.occurrence);
-      logGameEvent(
-        state,
-        resolved.occurrence.kind,
-        resolved.occurrence.message,
-        {
-          importance: resolved.occurrence.importance,
-          actionTarget: resolved.occurrence.actionTarget,
-          reportedKey: `world-event:${resolved.occurrence.key}`,
-          pause: resolved.occurrence.importance === "CRITICAL",
-        },
-      );
-    }
+    state.worldEvents.checkedKeys.push(occurrence.key);
+    state.worldEvents.active.push(occurrence);
+    logGameEvent(state, occurrence.kind, occurrence.message, {
+      importance: occurrence.importance,
+      actionTarget: occurrence.actionTarget,
+      reportedKey: occurrence.key,
+      pause: occurrence.importance === "CRITICAL",
+    });
   });
   if (state.worldEvents.checkedKeys.length > MAX_WORLD_EVENT_CHECKS) {
     state.worldEvents.checkedKeys.splice(
@@ -426,15 +432,46 @@ function updateWorldEvents(state: GameType) {
   }
 }
 
+/**
+ * Scheduled effects for any simulated date. Persisted live occurrences win over a newly resolved
+ * copy, which is what preserves facility IDs and other onset-time attributes after they are drawn.
+ */
+function storyEffectsAt(date: DateType, state: GameType) {
+  const persisted = state.worldEvents.active.filter(
+    (event) =>
+      date.minute >= event.startsMinute && date.minute < event.endsMinute,
+  );
+  if (
+    !STORY_ARC_DEFINITIONS.some((arc) => arc.scenarioId === state.scenarioId)
+  ) {
+    return combineStoryEffects(persisted);
+  }
+  const persistedKeys = new Set(persisted.map((event) => event.key));
+  const scheduled = resolveStoryAtDate({
+    seed: state.seed,
+    scenarioId: state.scenarioId,
+    difficulty: state.difficulty,
+    date,
+    location: state.location,
+    snapshot: buildStorySnapshot(
+      state.monthlyHistory,
+      state.facilities,
+      state.date.minute,
+    ),
+  }).active.filter((event) => !persistedKeys.has(event.key));
+  return combineStoryEffects([...persisted, ...scheduled]);
+}
+
+function effectiveCarbonFee(date: DateType, state: GameType): number {
+  return storyEffectsAt(date, state).carbonFeePerKgCO2e ?? state.feePerKgCO2e;
+}
+
 function getEffectiveFuelPrices(
   date: DateType,
   state: GameType,
 ): FuelPricesType {
   const prices = getFuelPricesPerMBTU(date, state.seed, state.location);
-  const multipliers = activeWorldEventEffects(
-    state.worldEvents.active,
-    date.minute,
-  ).fuelPriceMultipliers;
+  const multipliers = storyEffectsAt(date, state).fuelPriceMultipliers;
   if (!multipliers) {
     return prices;
   }
@@ -1397,7 +1434,7 @@ function getDemandW(
     40 * minutesFrom9amLogistics +
     30 * minutesFromDarkLogistics -
     65 * minutesFrom5pmLogistics;
-  const effects = activeWorldEventEffects(game.worldEvents.active, date.minute);
+  const effects = storyEffectsAt(date, game);
   const baselineDemandW =
     demandMultiple * now.customers * (effects.demandMultiplier || 1);
   now.demandByType = demandByTypeAt(
@@ -1448,10 +1485,7 @@ function reforecastWeatherAndPrices(
       const date = getDateFromMinute(t.minute, state.startingYear);
       const weather = getWeather(date, state.seed, cumulativeMegatons);
       const fuelPrices = getEffectiveFuelPrices(date, state);
-      const effects = activeWorldEventEffects(
-        state.worldEvents.active,
-        date.minute,
-      );
+      const effects = storyEffectsAt(date, state);
       const hydroKey = `${date.year}-${date.monthNumber}`;
       let hydrology = hydrologyByMonth.get(hydroKey);
       if (!hydrology) {
@@ -1535,7 +1569,13 @@ function minimumStableOperatingCost(
     ((minimumW * (generator.btuPerWh || 0)) / TICKS_PER_HOUR) *
     GAME_TO_REAL_YEARS;
   const fuelCost = (fuelBtu * (tick[generator.fuel] ?? 0)) / 1000000;
-  const carbonCost = fuelBtu * fuel.kgCO2ePerBtu * state.feePerKgCO2e;
+  const carbonCost =
+    fuelBtu *
+    fuel.kgCO2ePerBtu *
+    effectiveCarbonFee(
+      getDateFromMinute(tick.minute, state.startingYear),
+      state,
+    );
   return variableOM + fuelCost + carbonCost;
 }
 
@@ -1902,7 +1942,8 @@ function updateSupplyFacilitiesFinances(
         const facilityKgco2e = fuelBtu * FUELS[g.fuel].kgCO2ePerBtu;
         expensesFuel += facilityFuel;
         kgco2e += facilityKgco2e;
-        facilityExpenses += facilityFuel + state.feePerKgCO2e * facilityKgco2e;
+        facilityExpenses +=
+          facilityFuel + effectiveCarbonFee(tickDate, state) * facilityKgco2e;
       }
       if (g.loanAmountLeft > 0) {
         const paymentInterest = getPaymentInterest(
@@ -1955,7 +1996,7 @@ function updateSupplyFacilitiesFinances(
       }
     }
   });
-  const expensesCarbonFee = state.feePerKgCO2e * kgco2e;
+  const expensesCarbonFee = effectiveCarbonFee(tickDate, state) * kgco2e;
 
   // Customers
   // Demand is the customer count times a multiple, so a run that blacks out for long enough
@@ -2090,7 +2131,10 @@ export function generateNewTimeline(
   const state = {
     ...readOnlyState,
     facilities: cloneDeep(readOnlyState.facilities),
-    monthlyHistory: [] as MonthlyHistoryType[],
+    // Story checkpoints only need the trailing year, and scheduled forecast effects resolve from
+    // the same immutable facts as live play. Keeping twelve entries is cheap and avoids a second
+    // forecast-only narrative state.
+    monthlyHistory: readOnlyState.monthlyHistory.slice(0, 12),
     timeline: new Array(ticks) as TickPresentFutureType[],
   };
   const cumulativeMegatons = getCumulativeMegatons(

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -214,6 +214,8 @@ describe("ending a scenario from inside the reducer", () => {
       month: 0,
       supplyWh: 1,
       demandWh: 100,
+      deliveredWhByFuel: {},
+      peakDemandW: 100,
       cash: scenario.cash,
       customers: 100,
       netWorth: scenario.cash,


### PR DESCRIPTION
## Summary

Advances #250 with the first staged foundation PR from the issue delivery plan.

- persist delivered energy by fuel and peak demand in every monthly history record
- derive pure prior-12-month and current-fleet story snapshots without persisting narrative labels
- replace monthly random-event checks with fixed and addressed seeded story schedules scoped by scenario ID
- use the same pure phase/effect resolver for live rollover and future forecast dates, while persisting live onset attributes once
- define multiplicative/additive/override effect composition and reject overlapping carbon-fee overrides
- bump save and replay schemas to v2 and explain older/newer simulation incompatibility clearly
- leave authored arc definitions empty for the separately balanced scenario-content PRs required by the epic

## Determinism coverage

- stable story phase keys: story:<scenarioId>:<arcId>:<phaseId>
- seeded timing and attributes are addressed by stable keys rather than array position
- definition and fleet reordering do not change resolved output
- custom games inherit no authored scenario phases
- save validation requires the new persisted monthly facts

## Verification

- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false --runInBand — 86 suites / 728 tests passed
- npm run sim -- --all --seed 424242 — every tutorial/scenario invariant passed
- npm run build — production build completed

This PR intentionally does not close #250; the issue is a tracking epic and explicitly requires staged content, balance, UI, accessibility, and performance PRs after this foundation.