### PR TITLE
Add Shale Boom story pilot

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -121,12 +121,48 @@ export type CardNameType =
   | "SETTINGS"
   | "CUSTOM_GAME";
 
+export type ConceptNameType =
+  | "money"
+  | "supply"
+  | "demand"
+  | "blackout"
+  | "customers"
+  | "generator"
+  | "storage"
+  | "build"
+  | "buy"
+  | "reorder"
+  | "pause"
+  | "play"
+  | "time"
+  | "construction"
+  | "finances"
+  | "forecast"
+  | "rate"
+  | "fuel"
+  | "weather"
+  | "danger"
+  | "goal";
+
+export type StoryActionTargetType =
+  | {
+      card: "FACILITIES";
+      view?: "FLEET" | "BUILD_GENERATORS";
+      fuel?: FuelNameType;
+    }
+  | {
+      card: "INSIGHTS";
+      layer?: "FINANCES" | "SUPPLY_DEMAND" | "FUEL_PRICES";
+    }
+  | { card: "EVENTS" };
+
 // What the card reducer's navigate action accepts, beyond a bare card name
 export interface NavigateActionType {
   name: CardNameType;
   dontRemember?: boolean;
   // Manual entry to open and scroll to, for deep links from terms the game shows elsewhere
   entry?: string;
+  storyTarget?: StoryActionTargetType;
 }
 
 export interface CardType {
@@ -135,6 +171,7 @@ export interface CardType {
   history?: CardNameType[];
   toPrevious?: boolean;
   entry?: string;
+  storyTarget?: StoryActionTargetType;
 }
 
 // The per-category points that sum to `score`. Investor and public-ownership scenarios are
@@ -581,7 +618,8 @@ export type GameEventKindType =
   | "SELL"
   | "LOAN"
   | "FUEL_PRICE"
-  | "FUEL_CROSSOVER";
+  | "FUEL_CROSSOVER"
+  | "WORLD_EVENT";
 
 export type GameEventImportanceType = "ROUTINE" | "NOTABLE" | "CRITICAL";
 
@@ -602,7 +640,12 @@ export interface GameEventType {
   // Most entries are passive history. Important entries can interrupt the clock, stand out in
   // the log and take the player to the screen where the consequence can be investigated.
   importance?: GameEventImportanceType;
-  actionTarget?: CardNameType;
+  actionTarget?: StoryActionTargetType;
+  title?: string;
+  details?: string;
+  concept?: ConceptNameType;
+  storyPhaseKey?: string;
+  turningPointPriority?: number;
 }
 
 export interface WorldEventEffectsType {

--- a/src/app.scss
+++ b/src/app.scss
@@ -2010,6 +2010,32 @@ html[data-theme="dark"] .uplot {
     list-style: none;
   }
 
+  .upcomingEvents,
+  .eventLogHistoryTitle {
+    padding-top: size(small);
+
+    > .MuiTypography-root {
+      padding: 0 size(base) size(tiny);
+    }
+  }
+
+  .eventLogHistoryTitle {
+    padding-right: size(base);
+    padding-left: size(base);
+  }
+
+  .eventLogImportance {
+    display: inline-block;
+    margin-left: size(tiny);
+    padding: 0 size(tiny);
+    border: 1px solid currentColor;
+    border-radius: 3px;
+    font-size: 0.65rem;
+    font-weight: 700;
+    line-height: 1.4;
+    text-transform: uppercase;
+  }
+
   .eventLogItem {
     display: grid;
     grid-template-columns: 20px 1fr;

--- a/src/components/base/ConceptIcon.tsx
+++ b/src/components/base/ConceptIcon.tsx
@@ -19,33 +19,13 @@ import SwapVertIcon from "@mui/icons-material/SwapVert";
 import WarningIcon from "@mui/icons-material/Warning";
 import WbSunnyIcon from "@mui/icons-material/WbSunny";
 import * as React from "react";
+import { ConceptNameType } from "../../Types";
+
+export type { ConceptNameType } from "../../Types";
 
 // The game's symbol vocabulary: one glyph per concept, everywhere a concept appears.
 // Consistency is what lets the symbols teach themselves - a player who met "blackout"
 // in Mission 1 recognizes it in an event row or a dialog without reading anything.
-export type ConceptNameType =
-  | "money"
-  | "supply"
-  | "demand"
-  | "blackout"
-  | "customers"
-  | "generator"
-  | "storage"
-  | "build"
-  | "buy"
-  | "reorder"
-  | "pause"
-  | "play"
-  | "time"
-  | "construction"
-  | "finances"
-  | "forecast"
-  | "rate"
-  | "fuel"
-  | "weather"
-  | "danger"
-  | "goal";
-
 export const CONCEPT_NAMES: ConceptNameType[] = [
   "money",
   "supply",

--- a/src/components/base/VictoryDialog.tsx
+++ b/src/components/base/VictoryDialog.tsx
@@ -88,6 +88,7 @@ const EVENT_CONCEPTS: Record<GameEventKindType, ConceptNameType> = {
   LOAN: "finances",
   FUEL_PRICE: "fuel",
   FUEL_CROSSOVER: "fuel",
+  WORLD_EVENT: "forecast",
 };
 
 function FleetMix(props: {

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -54,6 +54,7 @@ import {
   DateType,
   GameType,
   GeneratorShoppingType,
+  FuelNameType,
   LocationType,
   SpeedType,
 } from "../../Types";
@@ -746,6 +747,7 @@ function valueLabelFormat(x: number) {
 
 export interface StateProps {
   game: GameType;
+  focusFuel?: FuelNameType;
 }
 
 export interface DispatchProps {
@@ -797,7 +799,17 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
     solarIrradiances,
     offshoreWindSpeeds,
     airborneWindSpeeds,
-  ).sort((a, b) => a[sort] - b[sort]);
+  ).sort((a, b) => {
+    if (props.focusFuel && a.fuel !== b.fuel) {
+      if (a.fuel === props.focusFuel) {
+        return -1;
+      }
+      if (b.fuel === props.focusFuel) {
+        return 1;
+      }
+    }
+    return a[sort] - b[sort];
+  });
   const forecastGapW = Math.max(
     0,
     ...forecastedTimeline.map((tick) => tick.demandW - tick.supplyW),

--- a/src/components/views/BuildGeneratorsContainer.tsx
+++ b/src/components/views/BuildGeneratorsContainer.tsx
@@ -11,6 +11,10 @@ import BuildGenerators, { DispatchProps, StateProps } from "./BuildGenerators";
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
     game: state.game,
+    focusFuel:
+      state.card.storyTarget?.card === "FACILITIES"
+        ? state.card.storyTarget.fuel
+        : undefined,
   };
 };
 

--- a/src/components/views/EventLog.test.tsx
+++ b/src/components/views/EventLog.test.tsx
@@ -20,4 +20,38 @@ describe("EventLog", () => {
     expect(screen.getByText(/Blackouts, finished construction/)).toBeVisible();
     expect(() => view.unmount()).not.toThrow();
   });
+
+  it("renders authored upcoming phases with timing and a keyboard action", () => {
+    const onSelect = jest.fn();
+    render(
+      <EventLog
+        events={[]}
+        upcoming={[
+          {
+            key: "story:103:shale-boom:freeze",
+            label: "Jan 2014",
+            title: "Winter gas squeeze",
+            message: "Gas prices and available output will change.",
+            concept: "danger",
+            importance: "CRITICAL",
+            actionTarget: { card: "INSIGHTS", layer: "FUEL_PRICES" },
+          },
+        ]}
+        onOpen={jest.fn()}
+        onSelect={onSelect}
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: /winter gas squeeze/i });
+    expect(screen.getByText("Upcoming")).toBeVisible();
+    expect(screen.getByText("Jan 2014")).toBeVisible();
+    row.focus();
+    row.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    expect(onSelect).toHaveBeenCalledWith({
+      card: "INSIGHTS",
+      layer: "FUEL_PRICES",
+    });
+  });
 });

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -1,8 +1,14 @@
 import * as React from "react";
 import { Typography } from "@mui/material";
 import GameCard from "../base/GameCard";
-import { GameEventKindType, GameEventType } from "../../Types";
-import ConceptIcon, { ConceptNameType } from "../base/ConceptIcon";
+import {
+  ConceptNameType,
+  GameEventImportanceType,
+  GameEventKindType,
+  GameEventType,
+  StoryActionTargetType,
+} from "../../Types";
+import ConceptIcon from "../base/ConceptIcon";
 
 /**
  * What has happened to the company, in the order it happened.
@@ -22,21 +28,34 @@ const KIND_CONCEPTS: { [k in GameEventKindType]: ConceptNameType } = {
   LOAN: "finances",
   FUEL_PRICE: "fuel",
   FUEL_CROSSOVER: "fuel",
+  WORLD_EVENT: "forecast",
 };
+
+export interface UpcomingStoryEventType {
+  key: string;
+  label: string;
+  title?: string;
+  message: string;
+  details?: string;
+  concept?: ConceptNameType;
+  importance?: GameEventImportanceType;
+  actionTarget?: StoryActionTargetType;
+}
 
 export interface StateProps {
   events: GameEventType[];
+  upcoming?: UpcomingStoryEventType[];
 }
 
 export interface DispatchProps {
   onOpen: () => void;
-  onSelect: (event: GameEventType) => void;
+  onSelect: (target?: StoryActionTargetType) => void;
 }
 
 export interface Props extends StateProps, DispatchProps {}
 
 export default function EventLog(props: Props): React.JSX.Element {
-  const { events, onOpen, onSelect } = props;
+  const { events, onOpen, onSelect, upcoming = [] } = props;
   // An effect may only return a cleanup function. Redux dispatch returns the dispatched action,
   // so the expression-bodied form returned an object here; React later tried to call that object
   // while unmounting this phone-only pane and crashed the app to a blank screen.
@@ -46,6 +65,83 @@ export default function EventLog(props: Props): React.JSX.Element {
   return (
     <GameCard className="eventLog" title="Events" id="eventsPane">
       <div className="scrollable">
+        {upcoming.length > 0 && (
+          <section
+            className="upcomingEvents"
+            aria-labelledby="upcomingEventsTitle"
+          >
+            <Typography id="upcomingEventsTitle" variant="subtitle2">
+              Upcoming
+            </Typography>
+            <ul className="eventLogList">
+              {upcoming.map((event) => (
+                <li
+                  className={`eventLogItem upcoming importance-${event.importance || "ROUTINE"}${event.actionTarget ? " actionable" : ""}`}
+                  key={event.key}
+                  onClick={() => onSelect(event.actionTarget)}
+                  onKeyDown={(e: React.KeyboardEvent<HTMLLIElement>) => {
+                    if (
+                      event.actionTarget &&
+                      (e.key === "Enter" || e.key === " ")
+                    ) {
+                      e.preventDefault();
+                      onSelect(event.actionTarget);
+                    }
+                  }}
+                  role={event.actionTarget ? "button" : undefined}
+                  tabIndex={event.actionTarget ? 0 : undefined}
+                >
+                  <span className="eventLogIcon">
+                    <ConceptIcon
+                      concept={event.concept || "forecast"}
+                      fontSize="small"
+                    />
+                  </span>
+                  <span>
+                    {event.title && <strong>{event.title}</strong>}
+                    {event.importance && event.importance !== "ROUTINE" && (
+                      <span className="eventLogImportance">
+                        {event.importance === "CRITICAL"
+                          ? "Critical"
+                          : "Notable"}
+                      </span>
+                    )}
+                    <Typography
+                      variant="body2"
+                      component="span"
+                      sx={{ display: "block" }}
+                    >
+                      {event.message}
+                    </Typography>
+                    {event.details && (
+                      <Typography
+                        variant="caption"
+                        color="textSecondary"
+                        component="span"
+                        sx={{ display: "block" }}
+                      >
+                        {event.details}
+                      </Typography>
+                    )}
+                  </span>
+                  <Typography
+                    className="eventLogWhen"
+                    variant="body2"
+                    color="textSecondary"
+                    component="span"
+                  >
+                    {event.label}
+                  </Typography>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {upcoming.length > 0 && (
+          <Typography className="eventLogHistoryTitle" variant="subtitle2">
+            History
+          </Typography>
+        )}
         {events.length === 0 && (
           <Typography
             className="eventLogEmpty"
@@ -61,14 +157,14 @@ export default function EventLog(props: Props): React.JSX.Element {
             <li
               className={`eventLogItem kind-${event.kind} importance-${event.importance || "ROUTINE"}${event.actionTarget ? " actionable" : ""}`}
               key={event.id}
-              onClick={() => onSelect(event)}
+              onClick={() => onSelect(event.actionTarget)}
               onKeyDown={(e: React.KeyboardEvent<HTMLLIElement>) => {
                 if (
                   event.actionTarget &&
                   (e.key === "Enter" || e.key === " ")
                 ) {
                   e.preventDefault();
-                  onSelect(event);
+                  onSelect(event.actionTarget);
                 }
               }}
               role={event.actionTarget ? "button" : undefined}
@@ -76,13 +172,35 @@ export default function EventLog(props: Props): React.JSX.Element {
             >
               <span className="eventLogIcon">
                 <ConceptIcon
-                  concept={KIND_CONCEPTS[event.kind]}
+                  concept={event.concept || KIND_CONCEPTS[event.kind]}
                   fontSize="small"
                 />
               </span>
-              <Typography variant="body2" component="span">
-                {event.message}
-              </Typography>
+              <span>
+                {event.title && <strong>{event.title}</strong>}
+                {event.importance && event.importance !== "ROUTINE" && (
+                  <span className="eventLogImportance">
+                    {event.importance === "CRITICAL" ? "Critical" : "Notable"}
+                  </span>
+                )}
+                <Typography
+                  variant="body2"
+                  component="span"
+                  sx={{ display: "block" }}
+                >
+                  {event.message}
+                </Typography>
+                {event.details && (
+                  <Typography
+                    variant="caption"
+                    color="textSecondary"
+                    component="span"
+                    sx={{ display: "block" }}
+                  >
+                    {event.details}
+                  </Typography>
+                )}
+              </span>
               <Typography
                 className="eventLogWhen"
                 variant="body2"

--- a/src/components/views/EventLogContainer.test.tsx
+++ b/src/components/views/EventLogContainer.test.tsx
@@ -1,0 +1,30 @@
+import { navigationForStoryTarget } from "./EventLogContainer";
+
+describe("story action targets", () => {
+  it("routes a generator target to the quote screen and preserves its fuel", () => {
+    const target = {
+      card: "FACILITIES" as const,
+      view: "BUILD_GENERATORS" as const,
+      fuel: "Natural Gas" as const,
+    };
+    expect(navigationForStoryTarget(target)).toEqual({
+      name: "BUILD_GENERATORS",
+      storyTarget: target,
+    });
+  });
+
+  it("routes insight and event targets to their panes", () => {
+    const insights = {
+      card: "INSIGHTS" as const,
+      layer: "FUEL_PRICES" as const,
+    };
+    expect(navigationForStoryTarget(insights)).toEqual({
+      name: "INSIGHTS",
+      storyTarget: insights,
+    });
+    expect(navigationForStoryTarget({ card: "EVENTS" })).toEqual({
+      name: "EVENTS",
+      storyTarget: { card: "EVENTS" },
+    });
+  });
+});

--- a/src/components/views/EventLogContainer.tsx
+++ b/src/components/views/EventLogContainer.tsx
@@ -1,21 +1,125 @@
 import { connect } from "react-redux";
-import { AppStateType, GameEventType } from "../../Types";
+import {
+  AppStateType,
+  NavigateActionType,
+  StoryActionTargetType,
+} from "../../Types";
 import EventLog, { DispatchProps, StateProps } from "./EventLog";
 import type { AppDispatch } from "../../Store";
 import { markEventsRead } from "../../reducers/Game";
 import { navigate } from "../../reducers/Card";
+import {
+  STORY_ARC_DEFINITIONS,
+  upcomingStoryPhases,
+} from "../../data/WorldEvents";
+import { buildStorySnapshot } from "../../helpers/Story";
+import { getDateFromMinute } from "../../helpers/DateTime";
+import { UpcomingStoryEventType } from "./EventLog";
+
+export function navigationForStoryTarget(
+  target: StoryActionTargetType,
+): NavigateActionType {
+  return {
+    name:
+      target.card === "FACILITIES" && target.view === "BUILD_GENERATORS"
+        ? "BUILD_GENERATORS"
+        : target.card,
+    storyTarget: target,
+  };
+}
+
+let upcomingCache:
+  { key: string; events: UpcomingStoryEventType[] } | undefined;
+const NO_UPCOMING: UpcomingStoryEventType[] = [];
+
+function selectUpcoming(state: AppStateType): UpcomingStoryEventType[] {
+  const game = state.game;
+  if (
+    !STORY_ARC_DEFINITIONS.some((arc) => arc.scenarioId === game.scenarioId)
+  ) {
+    return NO_UPCOMING;
+  }
+  const fleetKey = game.facilities
+    .map((facility) =>
+      [
+        facility.id,
+        facility.name,
+        facility.fuel,
+        facility.peakW,
+        facility.yearsToBuildLeft > 0,
+        facility.paused,
+        facility.minuteOperational,
+      ].join(":"),
+    )
+    .join("|");
+  const historyKey = game.monthlyHistory
+    .slice(0, 12)
+    .map((month) =>
+      [
+        month.year,
+        month.month,
+        month.demandWh,
+        month.supplyWh,
+        month.revenue,
+        month.expensesFuel,
+        month.expensesOM,
+        month.expensesCarbonFee,
+        month.expensesInterest,
+        month.peakDemandW,
+        Object.entries(month.deliveredWhByFuel)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([fuel, wh]) => `${fuel}:${wh}`)
+          .join(","),
+      ].join(":"),
+    )
+    .join("|");
+  const key = [
+    game.seed,
+    game.scenarioId,
+    game.difficulty,
+    game.date.monthsElapsed,
+    game.startingYear,
+    game.location.id,
+    historyKey,
+    fleetKey,
+  ].join("|");
+  if (upcomingCache?.key === key) {
+    return upcomingCache.events;
+  }
+  const events = upcomingStoryPhases({
+    seed: game.seed,
+    scenarioId: game.scenarioId,
+    difficulty: game.difficulty,
+    date: game.date,
+    location: game.location,
+    snapshot: buildStorySnapshot(
+      game.monthlyHistory,
+      game.facilities,
+      game.date.minute,
+    ),
+  }).map((event) => {
+    const date = getDateFromMinute(event.startsMinute, game.startingYear);
+    return {
+      ...event,
+      label: `${date.month} ${date.year}`,
+    };
+  });
+  upcomingCache = { key, events };
+  return events;
+}
 
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
     events: state.game.eventLog,
+    upcoming: selectUpcoming(state),
   };
 };
 
 const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => ({
   onOpen: () => dispatch(markEventsRead()),
-  onSelect: (event: GameEventType) => {
-    if (event.actionTarget) {
-      dispatch(navigate(event.actionTarget));
+  onSelect: (target?: StoryActionTargetType) => {
+    if (target) {
+      dispatch(navigate(navigationForStoryTarget(target)));
     }
   },
 });

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -243,6 +243,7 @@ interface ProjectionView {
 export interface StateProps {
   game: GameType;
   selectedFacilityId: number | null;
+  focusLayer?: InsightLayerId;
 }
 
 export interface DispatchProps {
@@ -421,6 +422,9 @@ export default class Insights extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     const layers = withRequiredLayers(storedLayers(), props.game.scenarioId);
+    if (props.focusLayer && !layers.includes(props.focusLayer)) {
+      layers.push(props.focusLayer);
+    }
     this.state = {
       range: getStorageChoice(RANGE_KEY, rangeOptions(props.game), "next1"),
       layers,
@@ -438,8 +442,19 @@ export default class Insights extends React.Component<Props, State> {
       nextProps.game.dollarsPerkWh !== this.props.game.dollarsPerkWh ||
       nextProps.game.feePerKgCO2e !== this.props.game.feePerKgCO2e ||
       nextProps.selectedFacilityId !== this.props.selectedFacilityId ||
+      nextProps.focusLayer !== this.props.focusLayer ||
       facilitySignature(nextProps.game) !== facilitySignature(this.props.game)
     );
+  }
+
+  public componentDidUpdate(previousProps: Props) {
+    if (
+      this.props.focusLayer &&
+      this.props.focusLayer !== previousProps.focusLayer &&
+      !this.state.layers.includes(this.props.focusLayer)
+    ) {
+      this.setLayers([...this.state.layers, this.props.focusLayer]);
+    }
   }
 
   private setRange(range: InsightRange) {

--- a/src/components/views/InsightsContainer.tsx
+++ b/src/components/views/InsightsContainer.tsx
@@ -2,11 +2,25 @@ import { connect } from "react-redux";
 import type { AppDispatch } from "../../Store";
 import { delta } from "../../reducers/Game";
 import { AppStateType, GameType } from "../../Types";
-import Insights, { DispatchProps, StateProps } from "./Insights";
+import Insights, {
+  DispatchProps,
+  InsightLayerId,
+  StateProps,
+} from "./Insights";
+
+const STORY_INSIGHT_LAYERS: Record<string, InsightLayerId> = {
+  FINANCES: "financeDetails",
+  SUPPLY_DEMAND: "supplyDemand",
+  FUEL_PRICES: "fuelPrices",
+};
 
 const mapStateToProps = (state: AppStateType): StateProps => ({
   game: state.game,
   selectedFacilityId: state.ui.selectedFacilityId,
+  focusLayer:
+    state.card.storyTarget?.card === "INSIGHTS" && state.card.storyTarget.layer
+      ? STORY_INSIGHT_LAYERS[state.card.storyTarget.layer]
+      : undefined,
 });
 
 const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => ({

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -5,9 +5,13 @@ import {
   combineStoryEffects,
   resolveStoryAtDate,
   resolveStoryScheduleMonth,
+  SHALE_BOOM_BALANCE,
+  STORY_ARC_DEFINITIONS,
   StoryArcDefinitionType,
   storyPhaseKey,
+  upcomingStoryPhases,
 } from "./WorldEvents";
+import { DifficultyType } from "../Types";
 
 const EMPTY_SNAPSHOT: StorySnapshotType = {
   deliveredWhByFuel12m: {},
@@ -183,5 +187,87 @@ describe("story effect composition", () => {
         { effects: { carbonFeePerKgCO2e: 0.1 } },
       ]),
     ).toThrow(/overlapping story carbon-fee/i);
+  });
+});
+
+describe("The Shale Boom pilot arc", () => {
+  const shaleContext = (
+    month: number,
+    difficulty: DifficultyType = "Manager",
+  ) => ({
+    ...context(month),
+    difficulty,
+  });
+
+  it("uses the authored fixed schedule and stacks the freeze price once", () => {
+    expect(
+      resolveStoryAtDate(shaleContext(12)).occurrences.map(
+        (event) => event.key,
+      ),
+    ).toEqual(["story:103:shale-boom:regional-glut-warning"]);
+    expect(resolveStoryAtDate(shaleContext(48)).effects).toMatchObject({
+      fuelPriceMultipliers: { "Natural Gas": 0.75 },
+    });
+
+    const freeze = resolveStoryAtDate(shaleContext(96));
+    expect(freeze.occurrences[0]).toMatchObject({
+      key: "story:103:shale-boom:freeze",
+      importance: "CRITICAL",
+      attributes: {
+        effectiveGasPriceMultiplier: 1.35,
+        freezeGasOutput: 0.7,
+      },
+    });
+    expect(freeze.effects).toMatchObject({
+      fuelPriceMultipliers: { "Natural Gas": 1.35 },
+      facilityOutputMultipliersByFuel: { "Natural Gas": 0.7 },
+    });
+    expect(resolveStoryAtDate(shaleContext(99)).effects).toEqual({
+      demandMultiplier: 1,
+      temperatureOffsetC: 0,
+      fuelPriceMultipliers: { "Natural Gas": 0.75 },
+    });
+    expect(resolveStoryAtDate(shaleContext(122)).effects).toEqual({});
+  });
+
+  it("checks in exact Manager values and monotonic difficulty scaling", () => {
+    expect(SHALE_BOOM_BALANCE.Manager).toEqual({
+      boomGasMultiplier: 0.75,
+      freezeSurcharge: 1.8,
+      freezeGasOutput: 0.7,
+    });
+    const ordered: DifficultyType[] = [
+      "Intern",
+      "Employee",
+      "Manager",
+      "VP",
+      "CEO",
+    ];
+    const values = ordered.map((difficulty) => SHALE_BOOM_BALANCE[difficulty]);
+    expect(values.map((value) => value.boomGasMultiplier)).toEqual([
+      0.7, 0.725, 0.75, 0.775, 0.8,
+    ]);
+    expect(values.map((value) => value.freezeSurcharge)).toEqual([
+      1.5, 1.65, 1.8, 1.95, 2.1,
+    ]);
+    expect(values.map((value) => value.freezeGasOutput)).toEqual([
+      0.8, 0.75, 0.7, 0.65, 0.6,
+    ]);
+  });
+
+  it("shows future phases without treating upcoming rows as active effects", () => {
+    const upcoming = upcomingStoryPhases(shaleContext(47));
+    expect(upcoming.map((phase) => phase.key)).toEqual([
+      "story:103:shale-boom:regional-glut",
+      "story:103:shale-boom:freeze-warning",
+      "story:103:shale-boom:freeze",
+      "story:103:shale-boom:normalization",
+    ]);
+    expect(resolveStoryAtDate(shaleContext(47)).effects).toEqual({});
+  });
+
+  it("authors only the scored Shale scenario in this pilot", () => {
+    expect(STORY_ARC_DEFINITIONS.map((arc) => arc.scenarioId)).toEqual([103]);
+    expect(resolveStoryAtDate(context(48, 999)).occurrences).toEqual([]);
   });
 });

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -1,12 +1,13 @@
 import {
   ActiveWorldEventType,
-  CardNameType,
+  ConceptNameType,
   DateType,
   DifficultyType,
   GameEventImportanceType,
   GameEventKindType,
   LocationType,
   StorySnapshotType,
+  StoryActionTargetType,
   WorldEventEffectsType,
 } from "../Types";
 import { MINUTES_PER_MONTH } from "../helpers/DateTime";
@@ -31,10 +32,13 @@ export type StoryScheduleType =
 export type StoryRandomType = (attribute: string) => number;
 
 export interface StoryPhaseDescriptionType {
+  title?: string;
   message: string;
+  details?: string;
+  concept?: ConceptNameType;
   kind: GameEventKindType;
   importance?: GameEventImportanceType;
-  actionTarget?: CardNameType;
+  actionTarget?: StoryActionTargetType;
   attributes?: Record<string, string | number>;
   effects?: WorldEventEffectsType;
 }
@@ -64,9 +68,154 @@ export interface ResolvedStoryType {
   effects: WorldEventEffectsType;
 }
 
-// Foundation only. Scenario content is deliberately delivered in the later, separately balanced
-// PRs listed by issue #250.
-export const STORY_ARC_DEFINITIONS: StoryArcDefinitionType[] = [];
+export interface ShaleBoomBalanceType {
+  boomGasMultiplier: number;
+  freezeSurcharge: number;
+  freezeGasOutput: number;
+}
+
+export const SHALE_BOOM_BALANCE: Record<DifficultyType, ShaleBoomBalanceType> =
+  {
+    Intern: {
+      boomGasMultiplier: 0.7,
+      freezeSurcharge: 1.5,
+      freezeGasOutput: 0.8,
+    },
+    Employee: {
+      boomGasMultiplier: 0.725,
+      freezeSurcharge: 1.65,
+      freezeGasOutput: 0.75,
+    },
+    Manager: {
+      boomGasMultiplier: 0.75,
+      freezeSurcharge: 1.8,
+      freezeGasOutput: 0.7,
+    },
+    VP: {
+      boomGasMultiplier: 0.775,
+      freezeSurcharge: 1.95,
+      freezeGasOutput: 0.65,
+    },
+    CEO: {
+      boomGasMultiplier: 0.8,
+      freezeSurcharge: 2.1,
+      freezeGasOutput: 0.6,
+    },
+  };
+
+const FUEL_PRICE_TARGET: StoryActionTargetType = {
+  card: "INSIGHTS",
+  layer: "FUEL_PRICES",
+};
+
+const SHALE_BOOM_ARC: StoryArcDefinitionType = {
+  id: "shale-boom",
+  scenarioId: 103,
+  phases: [
+    {
+      id: "regional-glut-warning",
+      schedule: { atMonth: 12 },
+      describe: () => ({
+        title: "Regional gas boom forecast",
+        message:
+          "New shale production is expected to push natural gas prices down in Jan 2010.",
+        details:
+          "The discount is temporary. Compare flexible gas capacity with alternatives that are less exposed to fuel prices.",
+        concept: "fuel",
+        kind: "WORLD_EVENT",
+        importance: "NOTABLE",
+        actionTarget: FUEL_PRICE_TARGET,
+      }),
+    },
+    {
+      id: "regional-glut",
+      schedule: { atMonth: 48 },
+      durationMonths: 74,
+      describe: ({ difficulty }) => {
+        const { boomGasMultiplier } = SHALE_BOOM_BALANCE[difficulty];
+        return {
+          title: "Regional gas glut",
+          message: `Natural gas prices fall ${Math.round((1 - boomGasMultiplier) * 100)}% through Feb 2016.`,
+          details: `Difficulty-adjusted gas-price multiplier: ${boomGasMultiplier.toFixed(3).replace(/0+$/, "").replace(/\.$/, "")}×.`,
+          concept: "fuel",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: FUEL_PRICE_TARGET,
+          attributes: { boomGasMultiplier },
+          effects: {
+            fuelPriceMultipliers: { "Natural Gas": boomGasMultiplier },
+          },
+        };
+      },
+    },
+    {
+      id: "freeze-warning",
+      schedule: { atMonth: 95 },
+      describe: ({ difficulty }) => {
+        const { freezeGasOutput, freezeSurcharge } =
+          SHALE_BOOM_BALANCE[difficulty];
+        return {
+          title: "Winter gas squeeze warning",
+          message: `A Jan–Mar 2014 freeze could raise gas prices and cap gas generation at ${Math.round(freezeGasOutput * 100)}% output.`,
+          details: `The freeze surcharge will be ${freezeSurcharge.toFixed(2).replace(/0$/, "")}×, stacked with the continuing shale discount.`,
+          concept: "danger",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: FUEL_PRICE_TARGET,
+        };
+      },
+    },
+    {
+      id: "freeze",
+      schedule: { atMonth: 96 },
+      durationMonths: 3,
+      describe: ({ difficulty }) => {
+        const balance = SHALE_BOOM_BALANCE[difficulty];
+        const effectiveMultiplier =
+          balance.boomGasMultiplier * balance.freezeSurcharge;
+        return {
+          title: "Winter gas squeeze",
+          message: `Gas is ${Math.round(Math.abs(effectiveMultiplier - 1) * 100)}% ${effectiveMultiplier >= 1 ? "above" : "below"} normal and all gas plants are capped at ${Math.round(balance.freezeGasOutput * 100)}% output through Mar 2014.`,
+          details: `${balance.boomGasMultiplier.toFixed(3).replace(/0+$/, "").replace(/\.$/, "")}× shale price × ${balance.freezeSurcharge.toFixed(2).replace(/0$/, "")}× freeze surcharge = ${effectiveMultiplier.toFixed(3).replace(/0+$/, "").replace(/\.$/, "")}× effective gas price.`,
+          concept: "danger",
+          kind: "WORLD_EVENT",
+          importance: "CRITICAL",
+          actionTarget: FUEL_PRICE_TARGET,
+          attributes: {
+            freezeSurcharge: balance.freezeSurcharge,
+            freezeGasOutput: balance.freezeGasOutput,
+            effectiveGasPriceMultiplier: effectiveMultiplier,
+          },
+          effects: {
+            fuelPriceMultipliers: {
+              "Natural Gas": balance.freezeSurcharge,
+            },
+            facilityOutputMultipliersByFuel: {
+              "Natural Gas": balance.freezeGasOutput,
+            },
+          },
+        };
+      },
+    },
+    {
+      id: "normalization",
+      schedule: { atMonth: 122 },
+      describe: () => ({
+        title: "Gas market normalization",
+        message:
+          "Regional natural gas prices return to normal after the shale glut.",
+        details:
+          "Review how much of the grid now depends on gas before the next market cycle.",
+        concept: "fuel",
+        kind: "WORLD_EVENT",
+        importance: "ROUTINE",
+        actionTarget: FUEL_PRICE_TARGET,
+      }),
+    },
+  ],
+};
+
+export const STORY_ARC_DEFINITIONS: StoryArcDefinitionType[] = [SHALE_BOOM_ARC];
 
 /** Stable 32-bit address for a string, independent of definition and facility array order. */
 export function storyHash(value: string): number {
@@ -170,7 +319,7 @@ export function combineStoryEffects(
   return combined;
 }
 
-function resolvePhase(
+export function resolveStoryPhase(
   arc: StoryArcDefinitionType,
   phase: StoryPhaseDefinitionType,
   context: StoryContextType,
@@ -226,7 +375,7 @@ export function resolveStoryAtDate(
       ),
     )
     .forEach(({ arc, phase }) => {
-      const resolved = resolvePhase(arc, phase, context);
+      const resolved = resolveStoryPhase(arc, phase, context);
       const scheduledMonth = resolved.attributes.scheduledMonth as number;
       if (context.date.monthsElapsed === scheduledMonth) {
         occurrences.push(resolved);
@@ -239,6 +388,26 @@ export function resolveStoryAtDate(
       }
     });
   return { occurrences, active, effects: combineStoryEffects(active) };
+}
+
+/** Future authored phases for presentation only; these never participate in effect aggregation. */
+export function upcomingStoryPhases(
+  context: StoryContextType,
+  definitions: StoryArcDefinitionType[] = STORY_ARC_DEFINITIONS,
+): Array<ActiveWorldEventType & StoryPhaseDescriptionType> {
+  return definitions
+    .filter((arc) => arc.scenarioId === context.scenarioId)
+    .flatMap((arc) =>
+      arc.phases.map((phase) => resolveStoryPhase(arc, phase, context)),
+    )
+    .filter(
+      (phase) =>
+        (phase.attributes.scheduledMonth as number) >
+        context.date.monthsElapsed,
+    )
+    .sort(
+      (a, b) => a.startsMinute - b.startsMinute || a.key.localeCompare(b.key),
+    );
 }
 
 export function activeWorldEventEffects(

--- a/src/reducers/Card.tsx
+++ b/src/reducers/Card.tsx
@@ -40,6 +40,7 @@ export const cardSlice = createSlice({
         // Cleared rather than carried over, so a plain visit to the manual doesn't reopen
         // whichever entry the last deep link pointed at
         entry: a.entry,
+        storyTarget: a.storyTarget,
         history: [
           a.dontRemember ? state.name : a.name,
           ...(state.history || []),

--- a/src/reducers/EventLog.test.tsx
+++ b/src/reducers/EventLog.test.tsx
@@ -163,7 +163,10 @@ describe("the event log", () => {
     expect(kinds(game)).toContain("FUEL_CROSSOVER");
     expect(messages(game)[0]).toContain(`${dearer} is now more expensive`);
     expect(game.eventLog[0].importance).toEqual("NOTABLE");
-    expect(game.eventLog[0].actionTarget).toEqual("FACILITIES");
+    expect(game.eventLog[0].actionTarget).toEqual({
+      card: "FACILITIES",
+      view: "FLEET",
+    });
     expect(game.speed).toEqual("PAUSED");
 
     // Even after recreating the same edge, the persistent per-fuel key suppresses it.

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -128,7 +128,6 @@ import {
   TickPresentFutureType,
   FuelProductionType,
   ReplayActionType,
-  CardNameType,
   VictoryType,
 } from "../Types";
 
@@ -206,7 +205,12 @@ function logGameEvent(
   message: string,
   options: {
     importance?: GameEventImportanceType;
-    actionTarget?: CardNameType;
+    actionTarget?: GameEventType["actionTarget"];
+    title?: string;
+    details?: string;
+    concept?: GameEventType["concept"];
+    storyPhaseKey?: string;
+    turningPointPriority?: number;
     reportedKey?: string;
     pause?: boolean;
   } = {},
@@ -225,6 +229,11 @@ function logGameEvent(
     message,
     importance: options.importance,
     actionTarget: options.actionTarget,
+    title: options.title,
+    details: options.details,
+    concept: options.concept,
+    storyPhaseKey: options.storyPhaseKey,
+    turningPointPriority: options.turningPointPriority,
   });
   if (options.reportedKey) {
     state.reportedEventKeys.push(options.reportedKey);
@@ -250,7 +259,10 @@ const FUEL_PRICE_SPIKE = 0.15;
  * A coal spike is not news to a company running on wind, and the fuel price chart in Forecasts
  * already draws every fuel for the player who wants them all.
  */
-function logFuelPriceMoves(state: GameType) {
+function logFuelPriceMoves(
+  state: GameType,
+  storyPriceFuels: ReadonlySet<FuelNameType> = new Set(),
+) {
   const prices = getEffectiveFuelPrices(state.date, state);
   const previous = previousFuelPrices;
   previousFuelPrices = prices;
@@ -266,6 +278,9 @@ function logFuelPriceMoves(state: GameType) {
     }
   });
   burned.forEach((fuel: string) => {
+    if (storyPriceFuels.has(fuel as FuelNameType)) {
+      return;
+    }
     const change = (prices[fuel] - previous[fuel]) / previous[fuel];
     if (Math.abs(change) < FUEL_PRICE_SPIKE) {
       return;
@@ -378,7 +393,7 @@ export function logFuelCrossovers(state: GameType) {
         `${fuel} is now more expensive than ${otherFuel}: ${formatMoneyConcise(cost)}/MWh vs ${formatMoneyConcise(crossed[1])}/MWh`,
         {
           importance: "NOTABLE",
-          actionTarget: "FACILITIES",
+          actionTarget: { card: "FACILITIES", view: "FLEET" },
           reportedKey: `fuel-crossover:${fuel}`,
           pause: true,
         },
@@ -390,14 +405,22 @@ export function logFuelCrossovers(state: GameType) {
 const MAX_WORLD_EVENT_CHECKS = 2400;
 
 /** Starts/ends authored events before this month's forecast is built. */
-function updateWorldEvents(state: GameType) {
+function updateWorldEvents(state: GameType): Set<FuelNameType> {
+  const storyPriceFuels = new Set<FuelNameType>();
+  state.worldEvents.active.forEach((event) => {
+    if (event.endsMinute <= state.date.minute) {
+      Object.keys(event.effects.fuelPriceMultipliers || {}).forEach((fuel) =>
+        storyPriceFuels.add(fuel as FuelNameType),
+      );
+    }
+  });
   state.worldEvents.active = state.worldEvents.active.filter(
     (event) => event.endsMinute > state.date.minute,
   );
   if (
     !STORY_ARC_DEFINITIONS.some((arc) => arc.scenarioId === state.scenarioId)
   ) {
-    return;
+    return storyPriceFuels;
   }
   const resolved = resolveStoryAtDate({
     seed: state.seed,
@@ -417,9 +440,16 @@ function updateWorldEvents(state: GameType) {
     }
     state.worldEvents.checkedKeys.push(occurrence.key);
     state.worldEvents.active.push(occurrence);
+    Object.keys(occurrence.effects.fuelPriceMultipliers || {}).forEach((fuel) =>
+      storyPriceFuels.add(fuel as FuelNameType),
+    );
     logGameEvent(state, occurrence.kind, occurrence.message, {
       importance: occurrence.importance,
       actionTarget: occurrence.actionTarget,
+      title: occurrence.title,
+      details: occurrence.details,
+      concept: occurrence.concept,
+      storyPhaseKey: occurrence.key,
       reportedKey: occurrence.key,
       pause: occurrence.importance === "CRITICAL",
     });
@@ -430,6 +460,7 @@ function updateWorldEvents(state: GameType) {
       state.worldEvents.checkedKeys.length - MAX_WORLD_EVENT_CHECKS,
     );
   }
+  return storyPriceFuels;
 }
 
 /**
@@ -872,7 +903,10 @@ function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
     state,
     "BUILD",
     buildConsequenceMessage(built, payload.financed),
-    { importance: "NOTABLE", actionTarget: "FACILITIES" },
+    {
+      importance: "NOTABLE",
+      actionTarget: { card: "FACILITIES", view: "FLEET" },
+    },
   );
   state = buildFacilityHelper(state, built, payload.financed);
   // Assigned rather than spread into a new object: this is an immer draft, so a fresh object
@@ -1134,9 +1168,9 @@ export function tickState(state: GameType) {
       );
       state.interestRate =
         getPrimeRate(state.date, state.seed) * state.creditPremium;
-      updateWorldEvents(state);
+      const storyPriceFuels = updateWorldEvents(state);
       state.timeline = generateNewTimeline(state, cash, customers);
-      logFuelPriceMoves(state);
+      logFuelPriceMoves(state, storyPriceFuels);
       logFuelCrossovers(state);
 
       // Pre-roll a few frames to compensate for temperature / demand jumps across months
@@ -1659,6 +1693,7 @@ function updateSupplyFacilitiesFinances(
   let hydroSpillWh = 0;
   let hydroMandatedReleaseW = 0;
   const startedFacilityIds = new Set<number>();
+  const tickStoryEffects = storyEffectsAt(tickDate, state);
   now.dispatchTargetWByFacility = {};
   facilities.forEach((g: FacilityOperatingType, i: number) => {
     const previousW = g.currentW;
@@ -1670,7 +1705,14 @@ function updateSupplyFacilitiesFinances(
       : (generator.generatingLastRealTick ??
         generator.committed ??
         previousW > 0);
-    let dispatchPeakW = g.peakW;
+    const generatorFuel = generator.fuel as FuelNameType | undefined;
+    const fuelOutputMultiplier = generatorFuel
+      ? tickStoryEffects.facilityOutputMultipliersByFuel?.[generatorFuel] || 1
+      : 1;
+    const facilityOutputMultiplier =
+      tickStoryEffects.facilityOutputMultipliersById?.[String(g.id)] || 1;
+    let dispatchPeakW =
+      g.peakW * fuelOutputMultiplier * facilityOutputMultiplier;
     const outputFactor = facilityOutputFactor(g, now.minute);
     let mandatedW = 0;
     const hydro = g.fuel === "Hydro" && !!g.reservoirCapacityWh;

--- a/src/reducers/StoryEffects.test.tsx
+++ b/src/reducers/StoryEffects.test.tsx
@@ -1,0 +1,92 @@
+import { TICKS_PER_DAY } from "../Constants";
+import { getDateFromMinute, MINUTES_PER_MONTH } from "../helpers/DateTime";
+import { generateNewTimeline, tickState } from "./Game";
+import { createGame } from "../testing/Simulator";
+
+describe("story effects in dispatch", () => {
+  it("caps every gas plant during the Shale freeze, including a newly commissioned one", () => {
+    const game = createGame({
+      scenarioId: 103,
+      difficulty: "Manager",
+      seed: 2468,
+      initialBuild: {
+        name: "Natural Gas",
+        peakW: 500_000_000,
+        financed: true,
+      },
+    });
+    const gas = game.facilities.find(
+      (facility) => facility.fuel === "Natural Gas",
+    )!;
+    game.facilities = [gas];
+    gas.yearsToBuildLeft = 0;
+    gas.currentW = 0;
+    gas.minuteOperational = 96 * MINUTES_PER_MONTH;
+    game.date = getDateFromMinute(96 * MINUTES_PER_MONTH, game.startingYear);
+
+    const freeze = generateNewTimeline(
+      game,
+      1_000_000_000,
+      2_000_000,
+      TICKS_PER_DAY,
+    );
+    expect(
+      Math.max(...freeze.map((tick) => tick.supplyByFuel["Natural Gas"] || 0)),
+    ).toBeLessThanOrEqual(gas.peakW * 0.7);
+
+    game.date = getDateFromMinute(99 * MINUTES_PER_MONTH, game.startingYear);
+    const restored = generateNewTimeline(
+      game,
+      1_000_000_000,
+      2_000_000,
+      TICKS_PER_DAY,
+    );
+    expect(
+      Math.max(
+        ...restored.map((tick) => tick.supplyByFuel["Natural Gas"] || 0),
+      ),
+    ).toBeGreaterThan(gas.peakW * 0.7);
+  });
+
+  it("pauses exactly once at freeze onset and logs the authored price change once", () => {
+    const game = createGame({
+      scenarioId: 103,
+      difficulty: "Manager",
+      seed: 1357,
+      initialBuild: {
+        name: "Natural Gas",
+        peakW: 500_000_000,
+        financed: true,
+      },
+    });
+    game.speed = "NORMAL";
+    while (game.date.monthsElapsed < 95) {
+      tickState(game);
+    }
+    expect(game.speed).toBe("NORMAL");
+
+    while (game.date.monthsElapsed < 96) {
+      tickState(game);
+    }
+    expect(game.speed).toBe("PAUSED");
+    expect(
+      game.eventLog.filter(
+        (event) => event.storyPhaseKey === "story:103:shale-boom:freeze",
+      ),
+    ).toHaveLength(1);
+    expect(
+      game.eventLog.filter(
+        (event) => event.label === "Jan 2014" && event.kind === "FUEL_PRICE",
+      ),
+    ).toHaveLength(0);
+
+    for (let tick = 0; tick < 10; tick++) {
+      tickState(game);
+    }
+    expect(
+      game.eventLog.filter(
+        (event) => event.storyPhaseKey === "story:103:shale-boom:freeze",
+      ),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Advances #250 with the second staged PR from the issue delivery plan.

- author the complete Shale Boom schedule with checked-in Intern through CEO balance values
- apply the 2010–2016 gas discount and the Jan–Mar 2014 stacked price and output squeeze in both live play and forecasts
- cap all operational gas generation during the freeze, including plants commissioned after onset
- add an Upcoming section to Events with timing, icons, text importance, and keyboard-accessible structured deep links
- route story targets to Fuel Prices, generator quotes, fleet, and Events without overloading card names
- preserve stable phase identity, pause only once at the critical freeze onset, and suppress duplicate generic price-move rows on authored transitions

## Verification

- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false --runInBand — 88 suites / 739 tests passed
- npm run sim -- --scenario 103 --seed 424242 — no simulation invariant violations
- npm run build — production build completed
- manual desktop and 390 px QA, including keyboard navigation to the Fuel Prices layer

## Scope boundary

The Mar 2016 normalization phase currently reports the market return without a state-dependent branch. The prior-12-month normalization checkpoint and intentional debrief selection remain stage three, per the delivery plan.