### PR TITLE
Scale custom scenario resources with starting conditions

### DIFF
--- a/src/components/views/CustomGame.test.tsx
+++ b/src/components/views/CustomGame.test.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { DEFAULT_CUSTOM_SCENARIO } from "../../data/Scenarios";
+import { RESERVE_MARGIN } from "../../Constants";
+import {
+  CUSTOM_SCENARIO_ID,
+  DEFAULT_CUSTOM_SCENARIO,
+} from "../../data/Scenarios";
 import { getFuelEscalation } from "../../data/FuelPrices";
 import { createGame } from "../../testing/Simulator";
 import CustomGame from "./CustomGame";
@@ -63,5 +67,47 @@ it("re-quotes starting cash when the starting year changes", () => {
   const expectedCash = Number((500000000 * inflation).toPrecision(2));
   expect(onStart).toHaveBeenCalledWith(
     expect.objectContaining({ startingYear: 2080, cash: expectedCash }),
+  );
+});
+
+it("scales starting nameplate capacity with starting customers", () => {
+  const onStart = jest.fn();
+  render(
+    <CustomGame
+      game={createGame({ scenarioId: 100 })}
+      scenario={{
+        ...DEFAULT_CUSTOM_SCENARIO,
+        facilities: [
+          ...DEFAULT_CUSTOM_SCENARIO.facilities,
+          { name: "Pumped Hydro", peakWh: 500000000 },
+        ],
+      }}
+      onBack={jest.fn()}
+      onDelta={jest.fn()}
+      onStart={onStart}
+    />,
+  );
+
+  fireEvent.change(screen.getByRole("slider", { name: "Starting customers" }), {
+    target: { value: 2000000 },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Play" }));
+
+  const scenario = onStart.mock.calls[0][0];
+  expect(scenario.facilities).toEqual([
+    expect.objectContaining({ name: "Natural Gas", peakW: 1000000000 }),
+    expect.objectContaining({ name: "Pumped Hydro", peakWh: 500000000 }),
+  ]);
+
+  const state = createGame({
+    scenarioId: CUSTOM_SCENARIO_ID,
+    scenario,
+  });
+  const totalNameplateW = state.facilities.reduce(
+    (total, facility) => total + (facility.peakWh ? 0 : facility.peakW),
+    0,
+  );
+  expect(totalNameplateW).toBeGreaterThanOrEqual(
+    state.timeline[0].demandW * (1 + RESERVE_MARGIN),
   );
 });

--- a/src/components/views/CustomGame.test.tsx
+++ b/src/components/views/CustomGame.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { DEFAULT_CUSTOM_SCENARIO } from "../../data/Scenarios";
+import { getFuelEscalation } from "../../data/FuelPrices";
 import { createGame } from "../../testing/Simulator";
 import CustomGame from "./CustomGame";
 
@@ -40,4 +41,27 @@ it("opens after economic data is loaded and names every setup control", () => {
     expect(screen.getByRole("combobox", { name })).toBeInTheDocument();
   });
   expect(screen.getByRole("textbox", { name: "Seed" })).toBeInTheDocument();
+});
+
+it("re-quotes starting cash when the starting year changes", () => {
+  const onStart = jest.fn();
+  render(
+    <CustomGame
+      game={createGame({ scenarioId: 100 })}
+      scenario={{ ...DEFAULT_CUSTOM_SCENARIO, cash: 500000000 }}
+      onBack={jest.fn()}
+      onDelta={jest.fn()}
+      onStart={onStart}
+    />,
+  );
+
+  fireEvent.mouseDown(screen.getByRole("combobox", { name: "Starting year" }));
+  fireEvent.click(screen.getByRole("option", { name: "2080" }));
+  fireEvent.click(screen.getByRole("button", { name: "Play" }));
+
+  const inflation = getFuelEscalation(2080) / getFuelEscalation(2020);
+  const expectedCash = Number((500000000 * inflation).toPrecision(2));
+  expect(onStart).toHaveBeenCalledWith(
+    expect.objectContaining({ startingYear: 2080, cash: expectedCash }),
+  );
 });

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -39,7 +39,11 @@ import { getStartingCustomers } from "../../data/LocationProfiles";
 import { prefetchScenarioData } from "../../helpers/OfflineData";
 import { getDateFromMinute } from "../../helpers/DateTime";
 import { getScenarioLocation } from "../../helpers/Locations";
-import { formatWattHours, formatWatts } from "../../helpers/Format";
+import {
+  formatMoneyConcise,
+  formatWattHours,
+  formatWatts,
+} from "../../helpers/Format";
 import { formatPricePerLargeMass, largeMassUnit } from "../../helpers/Units";
 import { useUnits } from "../base/UnitsContext";
 import { newSeed } from "../../helpers/Math";
@@ -78,26 +82,26 @@ const STARTING_YEARS = Array.from(
   (_v: unknown, i: number) => WEATHER_STARTING_YEAR + i * STARTING_YEAR_STEP,
 );
 const DURATION_YEARS = [1, 5, 10, 20, 40, 60, 100];
-// The era the rates and fees above are written in: cents per kilowatt hour a player recognises,
-// against the fuel prices the data ends on.
-const RATE_BASE_YEAR = 2020;
+// The era the cash, rates and fees below are written in: amounts a player recognises, against the
+// fuel prices the data ends on.
+const MONEY_BASE_YEAR = 2020;
 
 /**
- * A rate or a fee re-quoted into the money of the year the game starts in.
+ * A cash amount, rate or fee re-quoted into the money of the year the game starts in.
  *
  * Fuel is the one price the game reads at face value for the year it is in - build costs and O&M
  * are anchored on whatever year a game starts, so they always open at what the tables say. A 2080
  * game therefore opens against sixty years of escalated fuel, and offering it a literal seven
  * cents a kilowatt hour is offering a game that is bankrupt inside a quarter.
  *
- * Only forwards. A game starting before RATE_BASE_YEAR is played against real recorded prices
+ * Only forwards. A game starting before MONEY_BASE_YEAR is played against real recorded prices
  * rather than a projection, so there is no escalation to undo, and deflating those rates would
  * change every historical scenario's balance for no reason.
  */
 function inEraMoney(base: number, startingYear: number): number {
   const factor =
-    getFuelEscalation(Math.max(startingYear, RATE_BASE_YEAR)) /
-    getFuelEscalation(RATE_BASE_YEAR);
+    getFuelEscalation(Math.max(startingYear, MONEY_BASE_YEAR)) /
+    getFuelEscalation(MONEY_BASE_YEAR);
   // Two significant figures, so the offered numbers stay round enough to choose between
   return Number((base * factor).toPrecision(2));
 }
@@ -196,10 +200,15 @@ export default function CustomGame(props: Props): React.JSX.Element {
   const sizes = (adding?.storage ? STORAGE_SIZES_WH : GENERATOR_SIZES_W).filter(
     (size) => !adding || size <= adding.maxSize,
   );
-  // What a kilowatt hour may be charged at, and what a ton of CO2e may be feed, in the money of
-  // the year the game starts in. Both move with the starting year, which is why changing that
-  // year has to re-quote whatever was already chosen rather than leaving a 2020 rate on a 2080
-  // game -- see changeStartingYear below.
+  // What the utility starts with, what a kilowatt hour may be charged at, and what a ton of CO2e
+  // may be feed, in the money of the year the game starts in. All move with the starting year,
+  // which is why changing that year has to re-quote whatever was already chosen rather than
+  // leaving a 2020 amount on a 2080 game -- see changeStartingYear below.
+  const cashOptions = React.useMemo(
+    () =>
+      STARTING_CASH.map((c: number) => inEraMoney(c, scenario.startingYear)),
+    [scenario.startingYear],
+  );
   const rateOptions = React.useMemo(
     () =>
       RATES_PER_KWH.map((r: number) => inEraMoney(r, scenario.startingYear)),
@@ -277,10 +286,12 @@ export default function CustomGame(props: Props): React.JSX.Element {
    * 2080 and leaving seven cents behind would silently hand back a game that cannot be won.
    */
   const changeStartingYear = (startingYear: number) => {
+    const cash = nearestIndex(cashOptions, scenario.cash);
     const rate = nearestIndex(rateOptions, scenario.dollarsPerkWh);
     const fee = nearestIndex(feeOptions, scenario.feePerKgCO2e * 1000);
     change({
       startingYear,
+      cash: inEraMoney(STARTING_CASH[cash], startingYear),
       dollarsPerkWh: inEraMoney(RATES_PER_KWH[rate], startingYear),
       feePerKgCO2e: inEraMoney(FEES_PER_TON[fee], startingYear) / 1000,
     });
@@ -482,10 +493,10 @@ export default function CustomGame(props: Props): React.JSX.Element {
                     change({ cash: Number(e.target.value) })
                   }
                 >
-                  {STARTING_CASH.map((c: number) => {
+                  {cashOptions.map((c: number) => {
                     return (
                       <MenuItem value={c} key={c}>
-                        ${c / 1000000}M
+                        {formatMoneyConcise(c)}
                       </MenuItem>
                     );
                   })}

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -51,6 +51,7 @@ import {
   DifficultyType,
   FacilityShoppingType,
   GameType,
+  ScenarioFacilityType,
   ScenarioType,
 } from "../../Types";
 
@@ -183,6 +184,31 @@ function facilitySize(facility: Partial<FacilityShoppingType>): string {
     : formatWatts(facility.peakW || 0);
 }
 
+/**
+ * Keep the starting fleet's nameplate capacity per customer constant as its customer base moves.
+ * The default 500 MW plant for one million customers covers the opening demand plus the game's
+ * 5% reserve margin; scaling every starting generator together preserves that coverage and the
+ * player's chosen generation mix. Storage is energy capacity rather than firm generation, so it
+ * stays at the size the player selected.
+ */
+function facilitiesForStartingCustomers(
+  scenario: ScenarioType,
+  startingCustomers: number,
+): ScenarioFacilityType[] {
+  const previousCustomers =
+    scenario.startingCustomers ||
+    getStartingCustomers(getScenarioLocation(scenario));
+  if (previousCustomers <= 0 || previousCustomers === startingCustomers) {
+    return scenario.facilities;
+  }
+  const scale = startingCustomers / previousCustomers;
+  return scenario.facilities.map((facility: ScenarioFacilityType) =>
+    facility.peakW && !facility.peakWh
+      ? { ...facility, peakW: Math.round(facility.peakW * scale) }
+      : facility,
+  );
+}
+
 export default function CustomGame(props: Props): React.JSX.Element {
   const { game, onBack, onDelta, onStart } = props;
   const units = useUnits();
@@ -278,6 +304,21 @@ export default function CustomGame(props: Props): React.JSX.Element {
     setScenario({ ...scenario, ...delta });
   };
 
+  const changeStartingCustomers = (
+    startingCustomers: number,
+    delta: Partial<ScenarioType> = {},
+  ) => {
+    setScenario((currentScenario: ScenarioType) => ({
+      ...currentScenario,
+      ...delta,
+      startingCustomers,
+      facilities: facilitiesForStartingCustomers(
+        currentScenario,
+        startingCustomers,
+      ),
+    }));
+  };
+
   /**
    * Moving the game's era, and carrying the prices that are quoted in it along.
    *
@@ -354,10 +395,9 @@ export default function CustomGame(props: Props): React.JSX.Element {
                   value={location}
                   onChange={(_e: unknown, picked: CityType | null) => {
                     if (picked) {
-                      change({
+                      changeStartingCustomers(getStartingCustomers(picked), {
                         locationId: picked.id,
                         location: picked,
-                        startingCustomers: getStartingCustomers(picked),
                       });
                     }
                   }}
@@ -397,11 +437,9 @@ export default function CustomGame(props: Props): React.JSX.Element {
                   valueLabelDisplay="auto"
                   valueLabelFormat={(value: number) => value.toLocaleString()}
                   onChange={(_event: Event, value: number | number[]) =>
-                    change({
-                      startingCustomers: Array.isArray(value)
-                        ? value[0]
-                        : value,
-                    })
+                    changeStartingCustomers(
+                      Array.isArray(value) ? value[0] : value,
+                    )
                   }
                 />
                 <Typography variant="caption" color="textSecondary">


### PR DESCRIPTION
## Summary

- scale custom-scenario starting cash choices using the same era adjustment as electricity rates and carbon fees
- preserve the selected cash tier when changing the scenario starting year
- scale starting-generator nameplate capacity with starting customers, including location-driven customer defaults
- preserve the player chosen generation mix while leaving storage energy capacity unchanged
- verify the resulting starting fleet covers opening demand plus the game 5% reserve margin

## Testing

- npm test -- --watchAll=false --runTestsByPath src/components/views/CustomGame.test.tsx
- npm run typecheck
- npm run lint
- npm run format:check
- earlier full Jest run on this branch: 87 suites passed; Manual.test.tsx timed out under parallel load, then passed alone (15/15)