### PR TITLE
Stack home-screen actions vertically

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -1658,11 +1658,11 @@ html[data-theme="dark"] .uplot {
 
       .mainActions {
         align-items: center;
-        margin-bottom: 10px;
+        margin-bottom: 6px;
       }
 
       .discoveryActions {
-        margin-top: 2px;
+        margin-top: 6px;
       }
 
       button {

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -64,6 +64,30 @@ describe("MainMenu", () => {
     );
   });
 
+  it("puts every non-footer action on its own line with cohesive spacing", () => {
+    render(
+      <MainMenu
+        {...props({
+          audioEnabled: undefined,
+          hasSavedGame: true,
+          uid: undefined,
+        })}
+      />,
+    );
+
+    const primary = screen.getByRole("region", { name: "Primary actions" });
+    const resources = screen.getByRole("navigation", {
+      name: "Game resources",
+    });
+    const discovery = screen.getByRole("region", {
+      name: "Discovery actions",
+    });
+
+    expect(primary).toHaveStyle({ flexDirection: "column" });
+    expect(resources).toHaveStyle({ flexDirection: "column", gap: "6px" });
+    expect(discovery).toHaveStyle({ flexDirection: "column", gap: "6px" });
+  });
+
   it("keeps sharing as a compact footer icon", () => {
     render(<MainMenu {...props()} />);
 

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -92,14 +92,12 @@ const MainMenu = (props: Props): React.JSX.Element => {
         <Stack
           component="nav"
           aria-label="Game resources"
-          direction="row"
+          className="resourceActions"
+          direction="column"
+          spacing={0.75}
           useFlexGap
           sx={{
-            mx: "auto",
-            maxWidth: 440,
-            flexWrap: "wrap",
-            justifyContent: "center",
-            "& > button": { m: "0 4px 8px !important" },
+            alignItems: "center",
           }}
         >
           <Button variant="text" color="primary" onClick={props.onManual}>
@@ -120,10 +118,13 @@ const MainMenu = (props: Props): React.JSX.Element => {
           )}
         </Stack>
         <Stack
+          component="section"
+          aria-label="Discovery actions"
           className="discoveryActions"
-          direction="row"
+          direction="column"
+          spacing={0.75}
           useFlexGap
-          sx={{ flexWrap: "wrap", justifyContent: "center" }}
+          sx={{ alignItems: "center" }}
         >
           <InstallAppButton />
           {props.audioEnabled === undefined && (


### PR DESCRIPTION
Stacks every non-footer home-screen action on its own centered line, applies a consistent 6px rhythm to secondary actions, and preserves the horizontal footer layout. Adds a focused MainMenu regression test. Verified with the full npm run check suite (88 suites, 742 tests) and responsive browser checks at 360x640 and 360x320.