### PR TITLE
Complete remaining scenario story arcs

### DIFF
--- a/scripts/sim.js
+++ b/scripts/sim.js
@@ -28,6 +28,9 @@ const BOOLEAN_FLAGS = {
   "--all": "SIM_ALL",
   "--full": "SIM_FULL",
   "--finance": "SIM_FINANCE",
+  "--matrix": "SIM_MATRIX",
+  "--benchmark-stories": "SIM_STORY_BENCHMARK",
+  "--without-stories": "SIM_WITHOUT_STORIES",
 };
 
 const USAGE = `
@@ -37,6 +40,7 @@ Runs the game's simulation headlessly and reports what happened.
   npm run sim -- --all                     every scenario, one line each
   npm run sim -- --scenario 103 --full     every month of "The Shale Boom"
   npm run sim -- --year 2080 --months 240  a twenty-year run starting in 2080
+  npm run sim -- --matrix                 6 scenarios × 5 difficulties × 20 seeds, with/without stories
 
   --scenario <id>        Scenario to play (default 101). --list shows the ids
   --year <n>             Override the scenario's starting year (1980 and up)
@@ -53,6 +57,9 @@ Runs the game's simulation headlessly and reports what happened.
   --sell-id <n>          Sell one starting facility by facility id
   --sell-month <n>       Wait until this month to apply --sell-id (default 0)
   --all                  Sweep every scenario instead of reporting on one
+  --matrix               Run the deterministic story balance matrix
+  --benchmark-stories    Compare a 20-year forecast with stories enabled/disabled
+  --without-stories      Disable authored story effects for a control run
   --full                 Print every month rather than a sample
   --list                 List the scenarios and exit
 `;

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -28,9 +28,9 @@ import {
  * reducers/ImportOrder.test.tsx guards against.
  */
 
-// v2 corresponds to the story-enabled simulation/history schema. Older actions cannot reproduce
-// the same monthly facts and are rejected rather than partially migrated.
-export const REPLAY_VERSION = 2;
+// v3 corresponds to the complete story schema, including persisted resolved occurrences. Older
+// actions cannot reproduce the same monthly facts and are rejected rather than partially migrated.
+export const REPLAY_VERSION = 3;
 
 export function replayVersionError(raw: unknown): string | undefined {
   if (typeof raw !== "object" || raw === null) {

--- a/src/SaveFile.test.tsx
+++ b/src/SaveFile.test.tsx
@@ -28,7 +28,7 @@ function fakeGame(overrides: Partial<GameType> = {}): GameType {
     eventLog: [],
     reportedEventKeys: [],
     eventLogReadThroughId: 0,
-    worldEvents: { active: [], checkedKeys: [] },
+    worldEvents: { active: [], occurrences: [], checkedKeys: [] },
     ...overrides,
   } as unknown as GameType;
 }

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -24,8 +24,8 @@ import type { AppStore } from "./Store";
  */
 
 export const SAVE_KEY = "savedGame";
-// v2 persists fuel-specific delivery and peak demand for deterministic story checkpoints.
-export const SAVE_VERSION = 2;
+// v3 also persists resolved story occurrences and their onset-time facility selections.
+export const SAVE_VERSION = 3;
 
 export function saveVersionError(raw: unknown): string | undefined {
   if (typeof raw !== "object" || raw === null) {
@@ -175,6 +175,7 @@ export function parseSave(raw: unknown): SaveGameType | null {
     typeof worldEvents !== "object" ||
     worldEvents === null ||
     !Array.isArray(worldEvents.active) ||
+    !Array.isArray(worldEvents.occurrences) ||
     !Array.isArray(worldEvents.checkedKeys)
   ) {
     return null;

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -648,6 +648,9 @@ export interface GameEventType {
   turningPointPriority?: number;
 }
 
+export type StoryAttributeValueType =
+  string | number | boolean | string[] | number[];
+
 export interface WorldEventEffectsType {
   fuelPriceMultipliers?: Partial<Record<FuelNameType, number>>;
   temperatureOffsetC?: number;
@@ -680,6 +683,15 @@ export interface StorySnapshotType {
   }>;
 }
 
+/** A pure summary of an event's completed monthly window. */
+export interface StoryPeriodSnapshotType {
+  deliveredWhByFuel: Partial<Record<FuelNameType, number>>;
+  demandWh: number;
+  unservedWh: number;
+  netIncome: number;
+  peakDemandW: number;
+}
+
 /** One deterministic, time-bounded occurrence created by the world-event engine. */
 export interface ActiveWorldEventType {
   // Definition id plus location/date, stable across a replay of the same run
@@ -687,12 +699,15 @@ export interface ActiveWorldEventType {
   definitionId: string;
   startsMinute: number;
   endsMinute: number;
-  attributes: Record<string, string | number>;
+  attributes: Record<string, StoryAttributeValueType>;
   effects: WorldEventEffectsType;
 }
 
 export interface WorldEventStateType {
   active: ActiveWorldEventType[];
+  // Resolved live occurrences survive expiry so recovery copy, saves, replays, matrix reports,
+  // and debrief selection can refer to the exact onset-time attributes and facility IDs.
+  occurrences: ActiveWorldEventType[];
   // A bounded record of month/definition checks prevents a save resumed in the same month from
   // drawing (and announcing) the same occurrence twice.
   checkedKeys: string[];
@@ -734,6 +749,9 @@ export interface GameType {
   // All-in $/MWh by fuel at the last monthly rollover, used to edge-detect cost-order changes.
   fuelCostSnapshot?: Partial<Record<FuelNameType, number>>;
   worldEvents: WorldEventStateType;
+  // Headless balance harness only: baseline matrix cells run the identical strategy with authored
+  // effects disabled. Undefined means enabled and is what every browser save/replay uses.
+  storyEffectsDisabled?: boolean;
   facilities: Array<StorageOperatingType | GeneratorOperatingType>;
   // Every simulation-affecting thing the player has done this run, for the replay attached to a
   // high score. Undefined means the run isn't being recorded: before a game starts, while one is

--- a/src/app.scss
+++ b/src/app.scss
@@ -2155,6 +2155,16 @@ html[data-theme="dark"] .uplot {
       background 50ms linear;
   }
 
+  .storyDerateBadge {
+    height: 20px;
+    margin-left: size(small);
+    vertical-align: text-bottom;
+
+    .MuiChip-label {
+      padding: 0 6px;
+    }
+  }
+
   .MuiListItemAvatar-root {
     position: relative;
 

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -5,6 +5,7 @@ import Facilities from "./Facilities";
 import { tickState } from "../../reducers/Game";
 import { createGame } from "../../testing/Simulator";
 import { FacilityOperatingType, GameType } from "../../Types";
+import { MINUTES_PER_MONTH } from "../../helpers/DateTime";
 
 // The pane renders its own supply chart, which jsdom never lays out; nothing here waits on
 // anything, so a ceiling this high is a hang detector rather than something a loaded machine trips
@@ -142,6 +143,25 @@ describe("the fleet list", () => {
 
     expect(screen.getByText(/1 month left/)).toBeInTheDocument();
     expect(screen.queryByText(/1 months left/)).toBeNull();
+  });
+
+  it("labels a facility whose output is constrained by a world event", () => {
+    const constrained = createGame({ scenarioId: 104 });
+    const facility = constrained.facilities[0];
+    constrained.worldEvents.active = [
+      {
+        key: "story:104:hurricane-2008:landfall",
+        definitionId: "hurricane-2008:landfall",
+        startsMinute: 0,
+        endsMinute: MINUTES_PER_MONTH,
+        attributes: {},
+        effects: {
+          facilityOutputMultipliersById: { [String(facility.id)]: 0.6 },
+        },
+      },
+    ];
+    renderFacilities(constrained, null);
+    expect(screen.getByText("Derated to 60%")).toBeInTheDocument();
   });
 
   it("uses compact watt units in the accessible chart summary", () => {

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import {
   Avatar,
   Button,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -152,6 +153,20 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
   }
 
   const fuel = (facility as Partial<GeneratorOperatingType>).fuel;
+  const storyOutputMultiplier = game.worldEvents.active
+    .filter(
+      (event) =>
+        game.date.minute >= event.startsMinute &&
+        game.date.minute < event.endsMinute,
+    )
+    .reduce(
+      (multiplier, event) =>
+        multiplier *
+        (event.effects.facilityOutputMultipliersById?.[String(facility.id)] ||
+          (fuel && event.effects.facilityOutputMultipliersByFuel?.[fuel]) ||
+          1),
+      1,
+    );
   const accentColor = facilityColor(fuel);
   const outputFraction =
     facility.peakW > 0 ? Math.min(1, facility.currentW / facility.peakW) : 0;
@@ -357,7 +372,22 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                 </div>
               </div>
             </ListItemAvatar>
-            <ListItemText primary={facility.name} secondary={secondaryText} />
+            <ListItemText
+              primary={
+                <>
+                  {facility.name}
+                  {storyOutputMultiplier < 1 && (
+                    <Chip
+                      className="storyDerateBadge"
+                      color="warning"
+                      size="small"
+                      label={`Derated to ${Math.round(storyOutputMultiplier * 100)}%`}
+                    />
+                  )}
+                </>
+              }
+              secondary={secondaryText}
+            />
             {open && (
               // Inside the row, so without this every click in the confirmation dialog also
               // lands on the row behind it and toggles the selection

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -1,4 +1,6 @@
 import { LCWH } from "../helpers/Financials";
+import { buildStorySnapshot } from "../helpers/Story";
+import { getDateFromMinute, MINUTES_PER_MONTH } from "../helpers/DateTime";
 import { hasFuelPrices } from "./FuelPrices";
 import { getInflationIndex, hasEconomy } from "./Economy";
 import { DIFFICULTIES } from "../Constants";
@@ -15,6 +17,7 @@ import {
   getViableLocationCount,
   getViableLocationsRemaining,
 } from "./FacilitySites";
+import { resolveStoryAtDate } from "./WorldEvents";
 
 /**
  * What a dollar in the tables below is worth by the time the game reaches this month. Every cost
@@ -182,6 +185,40 @@ export function GENERATORS(
 ) {
   const magnitude = Math.log10(peakW) - 6; // 0 = 1MW, 4 = 10GW (+1 for each 10x)
   const year = state.date.year;
+  const storySnapshot = buildStorySnapshot(
+    state.monthlyHistory || [],
+    state.facilities || [],
+    state.date.minute,
+  );
+  const storyContext = {
+    seed: state.seed,
+    scenarioId: state.scenarioId,
+    difficulty: state.difficulty,
+    location: state.location,
+    snapshot: storySnapshot,
+    occurrences: state.worldEvents?.occurrences || [],
+  };
+  const currentStoryEffects = state.storyEffectsDisabled
+    ? {}
+    : resolveStoryAtDate({ ...storyContext, date: state.date }).effects;
+  const carbonFeeCache = new Map<number, number>();
+  const carbonFeeAtYear = (yearsFromQuote: number) => {
+    const monthOffset = Math.round(yearsFromQuote * 12);
+    const cached = carbonFeeCache.get(monthOffset);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const date = getDateFromMinute(
+      state.date.minute + monthOffset * MINUTES_PER_MONTH,
+      state.startingYear,
+    );
+    const fee = state.storyEffectsDisabled
+      ? state.feePerKgCO2e
+      : (resolveStoryAtDate({ ...storyContext, date }).effects
+          .carbonFeePerKgCO2e ?? state.feePerKgCO2e);
+    carbonFeeCache.set(monthOffset, fee);
+    return fee;
+  };
 
   const hydroLocations = getViableLocationCount(state.location, "Hydro");
   const hydroLocationsRemaining = getViableLocationsRemaining(
@@ -566,6 +603,8 @@ export function GENERATORS(
   const inflation = getCostInflation(state);
   generators = generators.filter((g: GeneratorShoppingType) => {
     g.buildCost *= difficulty.buildCost * inflation;
+    g.buildCost *=
+      currentStoryEffects.buildCostMultipliersByFuel?.[g.fuel] || 1;
     g.annualOperatingCost *= difficulty.expensesOM * inflation;
     if (g.variableOperatingCostPerMWh !== undefined) {
       g.variableOperatingCostPerMWh *= difficulty.expensesOM * inflation;
@@ -578,7 +617,14 @@ export function GENERATORS(
     // price data a levelized cost needs. Nothing there reads lcWh, and a cost per Wh with no
     // fuel prices behind it is genuinely unknown rather than zero
     g.lcWh = hasFuelPrices()
-      ? LCWH(g, state.date, state.feePerKgCO2e, state.seed, state.location)
+      ? LCWH(
+          g,
+          state.date,
+          currentStoryEffects.carbonFeePerKgCO2e ?? state.feePerKgCO2e,
+          state.seed,
+          state.location,
+          carbonFeeAtYear,
+        )
       : Infinity;
     return g.available;
   });

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -859,7 +859,9 @@ export const SCENARIOS = [
     },
     ownership: "Investor",
     startingYear: 1980,
-    cash: 198000000,
+    // The authored coal derate temporarily avoids loss-making generation. Keep the original
+    // CEO balance gate intact: a passive fleet still runs out of runway before year twenty.
+    cash: 160000000,
     feePerKgCO2e: 0,
     dollarsPerkWh: 0.025,
     durationMonths: 12 * 20,

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -3,6 +3,11 @@ import { getDateFromMinute, MINUTES_PER_MONTH } from "../helpers/DateTime";
 import { StorySnapshotType } from "../Types";
 import {
   combineStoryEffects,
+  CARBON_FEE_BALANCE,
+  END_OF_ERA_BALANCE,
+  HURRICANE_BALANCE,
+  PARADISE_BALANCE,
+  RENEWABLES_BALANCE,
   resolveStoryAtDate,
   resolveStoryScheduleMonth,
   SHALE_BOOM_BALANCE,
@@ -10,6 +15,7 @@ import {
   StoryArcDefinitionType,
   storyPhaseKey,
   upcomingStoryPhases,
+  validateStoryDifficultyMonotonicity,
 } from "./WorldEvents";
 import { DifficultyType } from "../Types";
 
@@ -261,13 +267,169 @@ describe("The Shale Boom pilot arc", () => {
       "story:103:shale-boom:regional-glut",
       "story:103:shale-boom:freeze-warning",
       "story:103:shale-boom:freeze",
+      "story:103:shale-boom:freeze-recovery",
       "story:103:shale-boom:normalization",
     ]);
     expect(resolveStoryAtDate(shaleContext(47)).effects).toEqual({});
   });
 
-  it("authors only the scored Shale scenario in this pilot", () => {
-    expect(STORY_ARC_DEFINITIONS.map((arc) => arc.scenarioId)).toEqual([103]);
+  it("authors every scored scenario and no custom game", () => {
+    expect(
+      [...new Set(STORY_ARC_DEFINITIONS.map((arc) => arc.scenarioId))].sort(),
+    ).toEqual([100, 101, 102, 103, 104, 105]);
     expect(resolveStoryAtDate(context(48, 999)).occurrences).toEqual([]);
+  });
+});
+
+describe("remaining scored story arcs", () => {
+  it("checks in exact Manager reference values and monotonic scaling", () => {
+    expect(CARBON_FEE_BALANCE.Manager).toBe(100);
+    expect(PARADISE_BALANCE.Manager).toEqual({
+      visitorDemand: 1.06,
+      oilShock: 1.45,
+    });
+    expect(RENEWABLES_BALANCE.Manager).toEqual({
+      solarBuildCost: 0.75,
+      windBuildCost: 0.9,
+      demandLoad: 1.08,
+    });
+    expect(HURRICANE_BALANCE.Manager).toEqual({
+      severity: "Major",
+      targetCapacityShare: 0.3,
+      outputMultiplier: 0.6,
+      durationMonths: 4,
+      oilMultiplier: 1.4,
+    });
+    expect(END_OF_ERA_BALANCE.Manager).toEqual({
+      oldCoalOutput: 0.85,
+      coalOM: 1.2,
+    });
+    expect(validateStoryDifficultyMonotonicity()).toEqual([]);
+  });
+
+  it("applies each fixed Manager effect at its exact boundary", () => {
+    expect(resolveStoryAtDate(context(48, 100)).effects).toMatchObject({
+      carbonFeePerKgCO2e: 0.1,
+    });
+    expect(resolveStoryAtDate(context(28, 105)).effects).toMatchObject({
+      demandMultiplier: 1.06,
+    });
+    expect(resolveStoryAtDate(context(84, 101)).effects).toMatchObject({
+      buildCostMultipliersByFuel: { Sun: 0.75, Wind: 0.9 },
+    });
+    expect(resolveStoryAtDate(context(180, 102)).effects).toMatchObject({
+      operatingCostMultipliersByFuel: { Coal: 1.2 },
+    });
+  });
+
+  it("selects hurricane capacity stably rather than depending on fleet order", () => {
+    const snapshot: StorySnapshotType = {
+      ...EMPTY_SNAPSHOT,
+      facilities: [
+        {
+          id: 10,
+          name: "Oil A",
+          fuel: "Oil",
+          ageYears: 10,
+          peakW: 100,
+          operational: true,
+        },
+        {
+          id: 11,
+          name: "Gas B",
+          fuel: "Natural Gas",
+          ageYears: 10,
+          peakW: 300,
+          operational: true,
+        },
+        {
+          id: 12,
+          name: "Storage",
+          ageYears: 1,
+          peakW: 1000,
+          operational: true,
+        },
+      ],
+    };
+    const landfallMonth = resolveStoryScheduleMonth(
+      STORY_ARC_DEFINITIONS.find((arc) => arc.scenarioId === 104)!.phases[1]
+        .schedule,
+      77,
+      storyPhaseKey(104, "hurricane-2008", "landfall"),
+    );
+    const resolve = (facilities: StorySnapshotType["facilities"]) =>
+      resolveStoryAtDate({
+        ...context(landfallMonth, 104, 77),
+        snapshot: { ...snapshot, facilities },
+      }).occurrences.find((event) => event.definitionId.endsWith("landfall"));
+    const first = resolve(snapshot.facilities)!;
+    const reordered = resolve([...snapshot.facilities].reverse())!;
+    expect(first.attributes.selectedFacilityIds).toEqual(
+      reordered.attributes.selectedFacilityIds,
+    );
+    expect(first.attributes.selectedCapacityShare).toBeGreaterThanOrEqual(0.3);
+    expect(first.effects.facilityOutputMultipliersById).toBeDefined();
+    expect(first.effects.facilityOutputMultipliersById?.["12"]).toBeUndefined();
+  });
+
+  it("reports exact hurricane restoration-window totals", () => {
+    const hurricane = STORY_ARC_DEFINITIONS.find(
+      (arc) => arc.scenarioId === 104,
+    )!;
+    const landfallMonth = resolveStoryScheduleMonth(
+      hurricane.phases[1].schedule,
+      77,
+      storyPhaseKey(104, "hurricane-2008", "landfall"),
+    );
+    const restoration = resolveStoryAtDate({
+      ...context(landfallMonth + 4, 104, 77),
+      periodSnapshots: {
+        4: {
+          deliveredWhByFuel: { Oil: 50 },
+          demandWh: 100,
+          unservedWh: 2,
+          netIncome: -1,
+          peakDemandW: 10,
+        },
+      },
+      occurrences: [
+        {
+          key: "story:104:hurricane-2008:landfall",
+          definitionId: "hurricane-2008:landfall",
+          startsMinute: landfallMonth * MINUTES_PER_MONTH,
+          endsMinute: (landfallMonth + 4) * MINUTES_PER_MONTH,
+          attributes: { selectedFacilityNames: ["Oil A"] },
+          effects: {},
+        },
+      ],
+    }).occurrences.find((event) => event.definitionId.endsWith("restoration"))!;
+    expect(restoration.attributes).toMatchObject({
+      demandWh: 100,
+      unservedWh: 2,
+      reliability: 0.98,
+    });
+    expect(restoration.message).toMatch(/98% of demand was served/);
+  });
+
+  it("branches checkpoints from persisted simulation facts", () => {
+    const strongSnapshot: StorySnapshotType = {
+      ...EMPTY_SNAPSHOT,
+      deliveredWhByFuel12m: { "Natural Gas": 30 },
+      demandWh12m: 100,
+      unservedWh12m: 0,
+      netIncome12m: 1,
+      peakDemandW12m: 100,
+      firmPeakW: 80,
+      storagePeakW: 20,
+    };
+    const normalization = resolveStoryAtDate({
+      ...context(122, 103),
+      snapshot: strongSnapshot,
+    }).occurrences[0];
+    expect(normalization.message).toMatch(/reliable/i);
+    expect(normalization.attributes).toMatchObject({
+      gasShare: 0.3,
+      reliability: 1,
+    });
   });
 });

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -5,7 +5,10 @@ import {
   DifficultyType,
   GameEventImportanceType,
   GameEventKindType,
+  FuelNameType,
   LocationType,
+  StoryAttributeValueType,
+  StoryPeriodSnapshotType,
   StorySnapshotType,
   StoryActionTargetType,
   WorldEventEffectsType,
@@ -20,6 +23,10 @@ export interface StoryContextType {
   date: DateType;
   location: LocationType;
   snapshot: StorySnapshotType;
+  /** Exact completed-month summaries used by short recovery phases. */
+  periodSnapshots?: Partial<Record<number, StoryPeriodSnapshotType>>;
+  /** Previously persisted live resolutions, including expired onsets. */
+  occurrences?: ActiveWorldEventType[];
 }
 
 export type StoryScheduleType =
@@ -39,15 +46,19 @@ export interface StoryPhaseDescriptionType {
   kind: GameEventKindType;
   importance?: GameEventImportanceType;
   actionTarget?: StoryActionTargetType;
-  attributes?: Record<string, string | number>;
+  attributes?: Record<string, StoryAttributeValueType>;
   effects?: WorldEventEffectsType;
+  turningPointPriority?: number;
 }
 
 export interface StoryPhaseDefinitionType {
   id: string;
   schedule: StoryScheduleType;
   /** Zero (the default) logs a point-in-time phase without applying lasting effects. */
-  durationMonths?: number;
+  durationMonths?: number | ((context: StoryContextType) => number);
+  /** Allows linked seeded phases (for example landfall/restoration) to share one addressed draw. */
+  scheduleAddress?: string;
+  scheduleOffsetMonths?: number | ((context: StoryContextType) => number);
   describe: (
     context: StoryContextType,
     random: StoryRandomType,
@@ -66,6 +77,41 @@ export interface ResolvedStoryType {
   /** Scheduled phases whose effect window contains the requested date. */
   active: Array<ActiveWorldEventType & StoryPhaseDescriptionType>;
   effects: WorldEventEffectsType;
+}
+
+const DIFFICULTY_ORDER: DifficultyType[] = [
+  "Intern",
+  "Employee",
+  "Manager",
+  "VP",
+  "CEO",
+];
+
+function share(part: number, whole: number): number {
+  return whole > 0 ? Math.max(0, Math.min(1, part / whole)) : 0;
+}
+
+function reliabilityOf(demandWh: number, unservedWh: number): number {
+  return demandWh > 0 ? 1 - share(unservedWh, demandWh) : 1;
+}
+
+function percent(value: number): string {
+  return `${(value * 100).toFixed(value >= 0.1 ? 0 : 1)}%`;
+}
+
+function compactMultiplier(value: number): string {
+  return value.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function deliveredFrom(
+  snapshot: StorySnapshotType | StoryPeriodSnapshotType,
+  fuels: FuelNameType[],
+): number {
+  const delivered =
+    "deliveredWhByFuel12m" in snapshot
+      ? snapshot.deliveredWhByFuel12m
+      : snapshot.deliveredWhByFuel;
+  return fuels.reduce((total, fuel) => total + (delivered[fuel] || 0), 0);
 }
 
 export interface ShaleBoomBalanceType {
@@ -200,12 +246,360 @@ const SHALE_BOOM_ARC: StoryArcDefinitionType = {
     {
       id: "normalization",
       schedule: { atMonth: 122 },
-      describe: () => ({
-        title: "Gas market normalization",
-        message:
-          "Regional natural gas prices return to normal after the shale glut.",
+      describe: ({ snapshot }) => {
+        const gasShare = share(
+          snapshot.deliveredWhByFuel12m["Natural Gas"] || 0,
+          snapshot.demandWh12m,
+        );
+        const reliability = reliabilityOf(
+          snapshot.demandWh12m,
+          snapshot.unservedWh12m,
+        );
+        const resilient = reliability >= 0.999 && gasShare < 0.5;
+        return {
+          title: "Gas market normalization",
+          message: resilient
+            ? "Regional gas prices normalize with the grid reliable and less than half dependent on gas."
+            : "Regional gas prices normalize, exposing how strongly the grid still depends on gas.",
+          details: `Prior 12 months: ${percent(gasShare)} delivered gas share and ${percent(reliability)} reliability.`,
+          concept: "fuel",
+          kind: "WORLD_EVENT",
+          importance: "ROUTINE",
+          actionTarget: FUEL_PRICE_TARGET,
+          attributes: { gasShare, reliability },
+          turningPointPriority: 80,
+        };
+      },
+    },
+    {
+      id: "freeze-recovery",
+      schedule: { atMonth: 99 },
+      describe: ({ difficulty }) => ({
+        title: "Winter gas squeeze ends",
+        message: `Gas output is fully restored and prices return to the continuing ${Math.round((1 - SHALE_BOOM_BALANCE[difficulty].boomGasMultiplier) * 100)}% shale discount.`,
+        concept: "supply",
+        kind: "WORLD_EVENT",
+        importance: "ROUTINE",
+        actionTarget: FUEL_PRICE_TARGET,
+      }),
+    },
+  ],
+};
+
+export const CARBON_FEE_BALANCE: Record<DifficultyType, number> = {
+  Intern: 80,
+  Employee: 90,
+  Manager: 100,
+  VP: 110,
+  CEO: 120,
+};
+
+export interface ParadiseBalanceType {
+  visitorDemand: number;
+  oilShock: number;
+}
+
+export const PARADISE_BALANCE: Record<DifficultyType, ParadiseBalanceType> = {
+  Intern: { visitorDemand: 1.04, oilShock: 1.3 },
+  Employee: { visitorDemand: 1.05, oilShock: 1.375 },
+  Manager: { visitorDemand: 1.06, oilShock: 1.45 },
+  VP: { visitorDemand: 1.07, oilShock: 1.525 },
+  CEO: { visitorDemand: 1.08, oilShock: 1.6 },
+};
+
+export interface RenewablesBalanceType {
+  solarBuildCost: number;
+  windBuildCost: number;
+  demandLoad: number;
+}
+
+export const RENEWABLES_BALANCE: Record<DifficultyType, RenewablesBalanceType> =
+  {
+    Intern: { solarBuildCost: 0.7, windBuildCost: 0.86, demandLoad: 1.05 },
+    Employee: {
+      solarBuildCost: 0.725,
+      windBuildCost: 0.88,
+      demandLoad: 1.065,
+    },
+    Manager: { solarBuildCost: 0.75, windBuildCost: 0.9, demandLoad: 1.08 },
+    VP: { solarBuildCost: 0.775, windBuildCost: 0.92, demandLoad: 1.095 },
+    CEO: { solarBuildCost: 0.8, windBuildCost: 0.94, demandLoad: 1.11 },
+  };
+
+export interface HurricaneBalanceType {
+  severity: string;
+  targetCapacityShare: number;
+  outputMultiplier: number;
+  durationMonths: number;
+  oilMultiplier: number;
+}
+
+export const HURRICANE_BALANCE: Record<DifficultyType, HurricaneBalanceType> = {
+  Intern: {
+    severity: "Limited",
+    targetCapacityShare: 0.15,
+    outputMultiplier: 0.8,
+    durationMonths: 2,
+    oilMultiplier: 1.15,
+  },
+  Employee: {
+    severity: "Moderate",
+    targetCapacityShare: 0.2,
+    outputMultiplier: 0.7,
+    durationMonths: 3,
+    oilMultiplier: 1.25,
+  },
+  Manager: {
+    severity: "Major",
+    targetCapacityShare: 0.3,
+    outputMultiplier: 0.6,
+    durationMonths: 4,
+    oilMultiplier: 1.4,
+  },
+  VP: {
+    severity: "Severe",
+    targetCapacityShare: 0.4,
+    outputMultiplier: 0.5,
+    durationMonths: 5,
+    oilMultiplier: 1.5,
+  },
+  CEO: {
+    severity: "Extreme",
+    targetCapacityShare: 0.5,
+    outputMultiplier: 0.4,
+    durationMonths: 6,
+    oilMultiplier: 1.6,
+  },
+};
+
+export interface EndOfEraBalanceType {
+  oldCoalOutput: number;
+  coalOM: number;
+}
+
+export const END_OF_ERA_BALANCE: Record<DifficultyType, EndOfEraBalanceType> = {
+  Intern: { oldCoalOutput: 0.9, coalOM: 1.1 },
+  Employee: { oldCoalOutput: 0.875, coalOM: 1.15 },
+  Manager: { oldCoalOutput: 0.85, coalOM: 1.2 },
+  VP: { oldCoalOutput: 0.825, coalOM: 1.25 },
+  CEO: { oldCoalOutput: 0.8, coalOM: 1.3 },
+};
+
+const FLEET_TARGET: StoryActionTargetType = {
+  card: "FACILITIES",
+  view: "FLEET",
+};
+const GENERATOR_TARGET: StoryActionTargetType = {
+  card: "FACILITIES",
+  view: "BUILD_GENERATORS",
+};
+const SUPPLY_DEMAND_TARGET: StoryActionTargetType = {
+  card: "INSIGHTS",
+  layer: "SUPPLY_DEMAND",
+};
+
+const CARBON_FEE_ARC: StoryArcDefinitionType = {
+  id: "carbon-fee-ratchet",
+  scenarioId: 100,
+  phases: [
+    {
+      id: "published-ratchet",
+      schedule: { atMonth: 12 },
+      describe: ({ difficulty }) => {
+        const feePerTon = CARBON_FEE_BALANCE[difficulty];
+        return {
+          title: "Carbon fee ratchet published",
+          message: `The carbon fee rises to $${feePerTon}/t in Jan 2024.`,
+          details: `At representative heat rates, that adds about $${Math.round(feePerTon)}/MWh for coal and $${Math.round(feePerTon * 0.5)}/MWh for gas.`,
+          concept: "goal",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: GENERATOR_TARGET,
+          attributes: { feePerTon },
+        };
+      },
+    },
+    {
+      id: "ratchet-onset",
+      schedule: { atMonth: 48 },
+      durationMonths: 96,
+      describe: ({ difficulty }) => {
+        const feePerTon = CARBON_FEE_BALANCE[difficulty];
+        return {
+          title: "Carbon fee ratchet begins",
+          message: `The carbon fee is now $${feePerTon}/t CO2e through the end of the mission.`,
+          details:
+            "Dispatch, accounting, forecasts, fuel crossovers, generator quotes, and lifetime cost now use the higher fee.",
+          concept: "goal",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: GENERATOR_TARGET,
+          attributes: { feePerTon },
+          effects: { carbonFeePerKgCO2e: feePerTon / 1000 },
+          turningPointPriority: 90,
+        };
+      },
+    },
+    {
+      id: "transition-audit",
+      schedule: { atMonth: 84 },
+      describe: ({ snapshot }) => {
+        const combustion = deliveredFrom(snapshot, [
+          "Coal",
+          "Natural Gas",
+          "Oil",
+          "Biomass",
+        ]);
+        const combustionShare = share(combustion, snapshot.demandWh12m);
+        const unservedShare = share(
+          snapshot.unservedWh12m,
+          snapshot.demandWh12m,
+        );
+        const onTrack =
+          unservedShare <= 0.001 &&
+          combustionShare < 0.5 &&
+          snapshot.netIncome12m > 0;
+        return {
+          title: "Carbon transition audit",
+          message: onTrack
+            ? "The audit finds a reliable, profitable grid with carbon-priced combustion below half of delivered power."
+            : "The audit finds the transition still exposed on reliability, combustion, or income.",
+          details: `${percent(combustionShare)} carbon-priced combustion share · ${percent(1 - unservedShare)} reliability · ${snapshot.netIncome12m >= 0 ? "positive" : "negative"} net income.`,
+          concept: "goal",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: SUPPLY_DEMAND_TARGET,
+          attributes: {
+            combustionShare,
+            reliability: 1 - unservedShare,
+            netIncome: snapshot.netIncome12m,
+          },
+          turningPointPriority: 100,
+        };
+      },
+    },
+  ],
+};
+
+const PARADISE_ARC: StoryArcDefinitionType = {
+  id: "island-energy",
+  scenarioId: 105,
+  phases: [
+    {
+      id: "visitor-warning",
+      schedule: { atMonth: 21 },
+      describe: ({ difficulty }) => ({
+        title: "Visitor peak forecast",
+        message: `Visitor demand is expected to lift electricity use ${Math.round((PARADISE_BALANCE[difficulty].visitorDemand - 1) * 100)}% from May 2006 through Oct 2007.`,
+        details: "Usage rises, but customer count does not.",
+        concept: "customers",
+        kind: "WORLD_EVENT",
+        importance: "NOTABLE",
+        actionTarget: SUPPLY_DEMAND_TARGET,
+      }),
+    },
+    {
+      id: "visitor-peak",
+      schedule: { atMonth: 28 },
+      durationMonths: 18,
+      describe: ({ difficulty }) => {
+        const demandMultiplier = PARADISE_BALANCE[difficulty].visitorDemand;
+        return {
+          title: "Visitor peak",
+          message: `Electricity usage rises ${Math.round((demandMultiplier - 1) * 100)}% through Oct 2007; customer count is unchanged.`,
+          concept: "customers",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: SUPPLY_DEMAND_TARGET,
+          attributes: { demandMultiplier },
+          effects: { demandMultiplier },
+        };
+      },
+    },
+    {
+      id: "cargo-warning",
+      schedule: { atMonth: 101 },
+      describe: ({ difficulty }) => ({
+        title: "Fuel cargo delay warning",
+        message: `A Sep–Nov 2013 cargo disruption could raise oil prices ${Math.round((PARADISE_BALANCE[difficulty].oilShock - 1) * 100)}%.`,
         details:
-          "Review how much of the grid now depends on gas before the next market cycle.",
+          "Prepare local generation or reserves before the shipment window.",
+        concept: "danger",
+        kind: "WORLD_EVENT",
+        importance: "NOTABLE",
+        actionTarget: FLEET_TARGET,
+      }),
+    },
+    {
+      id: "visitor-recovery",
+      schedule: { atMonth: 46 },
+      describe: () => ({
+        title: "Visitor peak ends",
+        message: "Seasonal visitor electricity usage returns to normal.",
+        concept: "customers",
+        kind: "WORLD_EVENT",
+        importance: "ROUTINE",
+        actionTarget: SUPPLY_DEMAND_TARGET,
+      }),
+    },
+    {
+      id: "oil-shock",
+      schedule: { atMonth: 116 },
+      durationMonths: 3,
+      describe: ({ difficulty }) => {
+        const oilMultiplier = PARADISE_BALANCE[difficulty].oilShock;
+        return {
+          title: "Fuel cargo delayed",
+          message: `Oil prices rise ${Math.round((oilMultiplier - 1) * 100)}% through Nov 2013.`,
+          details: `${compactMultiplier(oilMultiplier)}× oil price multiplier.`,
+          concept: "danger",
+          kind: "WORLD_EVENT",
+          importance: "CRITICAL",
+          actionTarget: FLEET_TARGET,
+          attributes: { oilMultiplier },
+          effects: { fuelPriceMultipliers: { Oil: oilMultiplier } },
+          turningPointPriority: 95,
+        };
+      },
+    },
+    {
+      id: "local-energy-review",
+      schedule: { atMonth: 120 },
+      describe: ({ snapshot }) => {
+        const shipped = deliveredFrom(snapshot, [
+          "Coal",
+          "Natural Gas",
+          "Oil",
+          "Uranium",
+          "Biomass",
+        ]);
+        const shippedShare = share(shipped, snapshot.demandWh12m);
+        const reliability = reliabilityOf(
+          snapshot.demandWh12m,
+          snapshot.unservedWh12m,
+        );
+        return {
+          title: "Local-energy review",
+          message:
+            reliability >= 0.999 && shippedShare < 0.5
+              ? "The island stayed reliable while local resources supplied most delivered power."
+              : "The review finds the island still exposed to shipped fuels or reliability risk.",
+          details: `${percent(shippedShare)} shipped-fuel share · ${percent(reliability)} reliability. The game conservatively counts Coal, Natural Gas, Oil, Uranium, and Biomass as shipped because feedstock origin is not modeled.`,
+          concept: "goal",
+          kind: "WORLD_EVENT",
+          importance: "ROUTINE",
+          actionTarget: SUPPLY_DEMAND_TARGET,
+          attributes: { shippedShare, reliability },
+          turningPointPriority: 85,
+        };
+      },
+    },
+    {
+      id: "cargo-restored",
+      schedule: { atMonth: 119 },
+      describe: () => ({
+        title: "Fuel cargo restored",
+        message: "Oil deliveries and prices return to normal after the delay.",
         concept: "fuel",
         kind: "WORLD_EVENT",
         importance: "ROUTINE",
@@ -215,7 +609,513 @@ const SHALE_BOOM_ARC: StoryArcDefinitionType = {
   ],
 };
 
-export const STORY_ARC_DEFINITIONS: StoryArcDefinitionType[] = [SHALE_BOOM_ARC];
+const RENEWABLES_ARC: StoryArcDefinitionType = {
+  id: "renewables-scale",
+  scenarioId: 101,
+  phases: [
+    {
+      id: "manufacturing-warning",
+      schedule: { atMonth: 72 },
+      describe: ({ difficulty }) => {
+        const balance = RENEWABLES_BALANCE[difficulty];
+        return {
+          title: "Renewable manufacturing scale",
+          message: `New Solar and Wind quotes fall in Jan 2009 to ${percent(balance.solarBuildCost)} and ${percent(balance.windBuildCost)} of normal cost.`,
+          details:
+            "Already-committed projects keep their signed construction cost.",
+          concept: "build",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: GENERATOR_TARGET,
+        };
+      },
+    },
+    {
+      id: "procurement-step",
+      schedule: { atMonth: 84 },
+      durationMonths: 60,
+      describe: ({ difficulty }) => {
+        const balance = RENEWABLES_BALANCE[difficulty];
+        return {
+          title: "Renewable procurement step",
+          message: `New Solar costs ${Math.round((1 - balance.solarBuildCost) * 100)}% less and new Wind costs ${Math.round((1 - balance.windBuildCost) * 100)}% less through mission end.`,
+          details:
+            "The discount applies once to new quotes after year, inflation, and difficulty pricing; commitments already underway do not change.",
+          concept: "build",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: GENERATOR_TARGET,
+          attributes: {
+            solarBuildCost: balance.solarBuildCost,
+            windBuildCost: balance.windBuildCost,
+          },
+          effects: {
+            buildCostMultipliersByFuel: {
+              Sun: balance.solarBuildCost,
+              Wind: balance.windBuildCost,
+            },
+          },
+          turningPointPriority: 80,
+        };
+      },
+    },
+    {
+      id: "clean-tech-load-warning",
+      schedule: { atMonth: 114 },
+      describe: ({ difficulty }) => ({
+        title: "Clean-tech load warning",
+        message: `A new clean-tech industry raises usage ${Math.round((RENEWABLES_BALANCE[difficulty].demandLoad - 1) * 100)}% from Jan 2012 through Dec 2013.`,
+        concept: "customers",
+        kind: "WORLD_EVENT",
+        importance: "NOTABLE",
+        actionTarget: SUPPLY_DEMAND_TARGET,
+      }),
+    },
+    {
+      id: "clean-tech-load",
+      schedule: { atMonth: 120 },
+      durationMonths: 24,
+      describe: ({ difficulty }) => {
+        const demandMultiplier = RENEWABLES_BALANCE[difficulty].demandLoad;
+        return {
+          title: "Clean-tech load arrives",
+          message: `Electricity usage rises ${Math.round((demandMultiplier - 1) * 100)}% through Dec 2013.`,
+          concept: "customers",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: SUPPLY_DEMAND_TARGET,
+          attributes: { demandMultiplier },
+          effects: { demandMultiplier },
+        };
+      },
+    },
+    {
+      id: "integration-review",
+      schedule: { atMonth: 132 },
+      describe: ({ snapshot }) => {
+        const variable = deliveredFrom(snapshot, [
+          "Sun",
+          "Wind",
+          "Offshore Wind",
+          "Airborne Wind",
+        ]);
+        const variableShare = share(variable, snapshot.demandWh12m);
+        const reliability = reliabilityOf(
+          snapshot.demandWh12m,
+          snapshot.unservedWh12m,
+        );
+        const coverage = share(
+          snapshot.firmPeakW + snapshot.storagePeakW,
+          snapshot.peakDemandW12m,
+        );
+        return {
+          title: "Renewable integration review",
+          message:
+            reliability >= 0.999 && coverage >= 0.75
+              ? "Variable renewables grew while firm and storage coverage kept the grid reliable."
+              : "The review flags a gap between variable-renewable growth and dependable peak coverage.",
+          details: `${percent(variableShare)} variable-renewable delivered share · ${percent(reliability)} reliability · ${percent(coverage)} firm/storage peak coverage.`,
+          concept: "goal",
+          kind: "WORLD_EVENT",
+          importance: "ROUTINE",
+          actionTarget: SUPPLY_DEMAND_TARGET,
+          attributes: { variableShare, reliability, coverage },
+          turningPointPriority: 90,
+        };
+      },
+    },
+  ],
+};
+
+const HURRICANE_ARC: StoryArcDefinitionType = {
+  id: "hurricane-2008",
+  scenarioId: 104,
+  phases: [
+    {
+      id: "outlook",
+      schedule: { atMonth: 96 },
+      describe: ({ difficulty }) => {
+        const balance = HURRICANE_BALANCE[difficulty];
+        return {
+          title: "2008 hurricane outlook",
+          message: `A ${balance.severity.toLowerCase()} landfall may hit between Jun and Nov 2008, derating enough generators to reach ${percent(balance.targetCapacityShare)} of operating capacity for ${balance.durationMonths} months.`,
+          details: `Affected output falls to ${percent(balance.outputMultiplier)} and oil rises ${Math.round((balance.oilMultiplier - 1) * 100)}%. Diversify the fleet and prepare storage.`,
+          concept: "danger",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: FLEET_TARGET,
+        };
+      },
+    },
+    {
+      id: "landfall",
+      schedule: {
+        seededMonthRange: { firstMonth: 101, lastMonth: 106 },
+        randomKey: "landfall-month",
+      },
+      scheduleAddress: "landfall",
+      durationMonths: ({ difficulty }) =>
+        HURRICANE_BALANCE[difficulty].durationMonths,
+      describe: (context, random) => {
+        const balance = HURRICANE_BALANCE[context.difficulty];
+        const candidates = context.snapshot.facilities
+          .filter((facility) => facility.operational && !!facility.fuel)
+          .map((facility) => ({
+            ...facility,
+            score: random(`facility|${facility.id}`),
+          }))
+          .sort((a, b) => a.score - b.score || a.id - b.id);
+        const totalPeakW = candidates.reduce(
+          (total, facility) => total + facility.peakW,
+          0,
+        );
+        const targetPeakW = totalPeakW * balance.targetCapacityShare;
+        const selected: typeof candidates = [];
+        let selectedPeakW = 0;
+        for (const candidate of candidates) {
+          if (selectedPeakW >= targetPeakW) {
+            break;
+          }
+          selected.push(candidate);
+          selectedPeakW += candidate.peakW;
+        }
+        const facilityOutputMultipliersById = Object.fromEntries(
+          selected.map((facility) => [
+            String(facility.id),
+            balance.outputMultiplier,
+          ]),
+        );
+        const selectedNames = selected.map((facility) => facility.name);
+        return {
+          title: `${balance.severity} hurricane landfall`,
+          message:
+            selectedNames.length > 0
+              ? `${selectedNames.join(", ")} ${selectedNames.length === 1 ? "is" : "are"} derated to ${percent(balance.outputMultiplier)} output for ${balance.durationMonths} months.`
+              : `No generator is operating at landfall; the ${Math.round((balance.oilMultiplier - 1) * 100)}% oil surcharge still applies.`,
+          details: `Selected ${percent(share(selectedPeakW, totalPeakW))} of operating generator capacity; oil prices are ${compactMultiplier(balance.oilMultiplier)}×. Storage remains available as prepared backup.`,
+          concept: "danger",
+          kind: "WORLD_EVENT",
+          importance: "CRITICAL",
+          actionTarget: FLEET_TARGET,
+          attributes: {
+            severity: balance.severity,
+            targetCapacityShare: balance.targetCapacityShare,
+            selectedCapacityShare: share(selectedPeakW, totalPeakW),
+            selectedFacilityIds: selected.map((facility) => facility.id),
+            selectedFacilityNames: selectedNames,
+            outputMultiplier: balance.outputMultiplier,
+            durationMonths: balance.durationMonths,
+            oilMultiplier: balance.oilMultiplier,
+          },
+          effects: {
+            fuelPriceMultipliers: { Oil: balance.oilMultiplier },
+            facilityOutputMultipliersById,
+          },
+          turningPointPriority: 100,
+        };
+      },
+    },
+    {
+      id: "restoration",
+      schedule: {
+        seededMonthRange: { firstMonth: 101, lastMonth: 106 },
+        randomKey: "landfall-month",
+      },
+      scheduleAddress: "landfall",
+      scheduleOffsetMonths: ({ difficulty }) =>
+        HURRICANE_BALANCE[difficulty].durationMonths,
+      describe: (context) => {
+        const balance = HURRICANE_BALANCE[context.difficulty];
+        const period = context.periodSnapshots?.[balance.durationMonths];
+        const demandWh = period?.demandWh || context.snapshot.demandWh12m;
+        const unservedWh = period?.unservedWh || context.snapshot.unservedWh12m;
+        const reliability = reliabilityOf(demandWh, unservedWh);
+        const onset = context.occurrences?.find(
+          (event) => event.key === "story:104:hurricane-2008:landfall",
+        );
+        const selectedNames = (onset?.attributes.selectedFacilityNames ||
+          []) as string[];
+        return {
+          title: "Storm restoration complete",
+          message: `${selectedNames.length ? `${selectedNames.join(", ")} restored. ` : "Generator output restored. "}${percent(reliability)} of demand was served during the disruption.`,
+          details: `${unservedWh > 0 ? `${unservedWh.toExponential(2)} Wh unserved` : "No unserved energy"} across the exact ${balance.durationMonths}-month event window; oil prices return to normal.`,
+          concept: "supply",
+          kind: "WORLD_EVENT",
+          importance: unservedWh > demandWh * 0.001 ? "NOTABLE" : "ROUTINE",
+          actionTarget: SUPPLY_DEMAND_TARGET,
+          attributes: { demandWh, unservedWh, reliability },
+          turningPointPriority: 90,
+        };
+      },
+    },
+  ],
+};
+
+const END_OF_ERA_ARC: StoryArcDefinitionType = {
+  id: "coal-transition",
+  scenarioId: 102,
+  phases: [
+    {
+      id: "aging-warning",
+      schedule: { atMonth: 48 },
+      describe: ({ snapshot, difficulty }) => {
+        const selected = snapshot.facilities.filter(
+          (facility) => facility.fuel === "Coal" && facility.ageYears + 2 >= 30,
+        );
+        return {
+          title: "Aging coal review",
+          message: `${selected.length} coal ${selected.length === 1 ? "unit is" : "units are"} projected to be at least 30 years old by Jan 1986.`,
+          details: `Those units will fall to ${percent(END_OF_ERA_BALANCE[difficulty].oldCoalOutput)} output through Dec 1987. Sold units disappear naturally; newly purchased coal is not classified as old coal.`,
+          concept: "generator",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: FLEET_TARGET,
+          attributes: {
+            selectedFacilityIds: selected.map((facility) => facility.id),
+            selectedFacilityNames: selected.map((facility) => facility.name),
+          },
+        };
+      },
+    },
+    {
+      id: "aging-derate",
+      schedule: { atMonth: 72 },
+      durationMonths: 24,
+      describe: ({ snapshot, difficulty }) => {
+        const outputMultiplier = END_OF_ERA_BALANCE[difficulty].oldCoalOutput;
+        const selected = snapshot.facilities.filter(
+          (facility) =>
+            facility.fuel === "Coal" &&
+            facility.operational &&
+            facility.ageYears >= 30,
+        );
+        return {
+          title: "Old-coal derate",
+          message: `${selected.length} aging coal ${selected.length === 1 ? "unit is" : "units are"} limited to ${percent(outputMultiplier)} output through Dec 1987.`,
+          concept: "generator",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: FLEET_TARGET,
+          attributes: {
+            selectedFacilityIds: selected.map((facility) => facility.id),
+            outputMultiplier,
+          },
+          effects: {
+            facilityOutputMultipliersById: Object.fromEntries(
+              selected.map((facility) => [
+                String(facility.id),
+                outputMultiplier,
+              ]),
+            ),
+          },
+        };
+      },
+    },
+    {
+      id: "compliance-warning",
+      schedule: { atMonth: 130 },
+      describe: ({ difficulty }) => ({
+        title: "1995 coal compliance deadline",
+        message: `All coal O&M rises ${Math.round((END_OF_ERA_BALANCE[difficulty].coalOM - 1) * 100)}% in Jan 1995.`,
+        details:
+          "The policy covers fixed O&M, variable O&M, and start maintenance for existing and new coal.",
+        concept: "danger",
+        kind: "WORLD_EVENT",
+        importance: "NOTABLE",
+        actionTarget: GENERATOR_TARGET,
+      }),
+    },
+    {
+      id: "aging-restoration",
+      schedule: { atMonth: 96 },
+      describe: () => ({
+        title: "Aging review closes",
+        message:
+          "The temporary old-coal derate ends; nameplate output is restored.",
+        concept: "supply",
+        kind: "WORLD_EVENT",
+        importance: "ROUTINE",
+        actionTarget: FLEET_TARGET,
+      }),
+    },
+    {
+      id: "compliance",
+      schedule: { atMonth: 180 },
+      durationMonths: 60,
+      describe: ({ difficulty }) => {
+        const coalOM = END_OF_ERA_BALANCE[difficulty].coalOM;
+        return {
+          title: "Coal compliance deadline",
+          message: `Coal fixed, variable, and start O&M are now ${Math.round((coalOM - 1) * 100)}% higher through mission end.`,
+          concept: "danger",
+          kind: "WORLD_EVENT",
+          importance: "CRITICAL",
+          actionTarget: GENERATOR_TARGET,
+          attributes: { coalOM },
+          effects: { operatingCostMultipliersByFuel: { Coal: coalOM } },
+          turningPointPriority: 100,
+        };
+      },
+    },
+    {
+      id: "successor-review",
+      schedule: { atMonth: 216 },
+      describe: ({ snapshot }) => {
+        const coalShare = share(
+          snapshot.deliveredWhByFuel12m.Coal || 0,
+          snapshot.demandWh12m,
+        );
+        const reliability = reliabilityOf(
+          snapshot.demandWh12m,
+          snapshot.unservedWh12m,
+        );
+        const legacyCoalW = snapshot.facilities
+          .filter(
+            (facility) =>
+              facility.fuel === "Coal" &&
+              facility.operational &&
+              facility.ageYears >= 30,
+          )
+          .reduce((total, facility) => total + facility.peakW, 0);
+        const allCoalW = snapshot.facilities
+          .filter(
+            (facility) => facility.fuel === "Coal" && facility.operational,
+          )
+          .reduce((total, facility) => total + facility.peakW, 0);
+        const nonCoalFirmW = Math.max(0, snapshot.firmPeakW - allCoalW);
+        return {
+          title: "Successor fleet review",
+          message:
+            reliability >= 0.999 && snapshot.netIncome12m > 0 && coalShare < 0.5
+              ? "A reliable, profitable successor fleet now supplies most power beyond coal."
+              : "The successor review finds the business still exposed to coal, reliability, or profit risk.",
+          details: `${percent(coalShare)} delivered coal share · ${percent(reliability)} reliability · ${snapshot.netIncome12m >= 0 ? "positive" : "negative"} net income · ${(legacyCoalW / 1e6).toFixed(0)} MW legacy coal · ${(nonCoalFirmW / 1e6).toFixed(0)} MW non-coal firm capacity.`,
+          concept: "goal",
+          kind: "WORLD_EVENT",
+          importance: "ROUTINE",
+          actionTarget: FLEET_TARGET,
+          attributes: {
+            coalShare,
+            reliability,
+            netIncome: snapshot.netIncome12m,
+            legacyCoalW,
+            nonCoalFirmW,
+          },
+          turningPointPriority: 95,
+        };
+      },
+    },
+  ],
+};
+
+export const STORY_ARC_DEFINITIONS: StoryArcDefinitionType[] = [
+  CARBON_FEE_ARC,
+  RENEWABLES_ARC,
+  END_OF_ERA_ARC,
+  SHALE_BOOM_ARC,
+  HURRICANE_ARC,
+  PARADISE_ARC,
+];
+
+/** Content-level difficulty scaling is centralized and mechanically checkable. */
+export function validateStoryDifficultyMonotonicity(): string[] {
+  const problems: string[] = [];
+  const ascending = (name: string, values: number[]) => {
+    if (values.some((value, index) => index > 0 && value < values[index - 1])) {
+      problems.push(`${name} must not decrease from Intern to CEO`);
+    }
+  };
+  const descending = (name: string, values: number[]) => {
+    if (values.some((value, index) => index > 0 && value > values[index - 1])) {
+      problems.push(`${name} must not increase from Intern to CEO`);
+    }
+  };
+  ascending(
+    "Carbon fee",
+    DIFFICULTY_ORDER.map((difficulty) => CARBON_FEE_BALANCE[difficulty]),
+  );
+  ascending(
+    "Shale boom price",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => SHALE_BOOM_BALANCE[difficulty].boomGasMultiplier,
+    ),
+  );
+  ascending(
+    "Shale freeze surcharge",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => SHALE_BOOM_BALANCE[difficulty].freezeSurcharge,
+    ),
+  );
+  descending(
+    "Shale freeze output",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => SHALE_BOOM_BALANCE[difficulty].freezeGasOutput,
+    ),
+  );
+  ascending(
+    "Paradise visitor demand",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => PARADISE_BALANCE[difficulty].visitorDemand,
+    ),
+  );
+  ascending(
+    "Paradise oil shock",
+    DIFFICULTY_ORDER.map((difficulty) => PARADISE_BALANCE[difficulty].oilShock),
+  );
+  ascending(
+    "Renewables solar cost",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => RENEWABLES_BALANCE[difficulty].solarBuildCost,
+    ),
+  );
+  ascending(
+    "Renewables wind cost",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => RENEWABLES_BALANCE[difficulty].windBuildCost,
+    ),
+  );
+  ascending(
+    "Renewables demand",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => RENEWABLES_BALANCE[difficulty].demandLoad,
+    ),
+  );
+  ascending(
+    "Hurricane affected capacity",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => HURRICANE_BALANCE[difficulty].targetCapacityShare,
+    ),
+  );
+  descending(
+    "Hurricane output",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => HURRICANE_BALANCE[difficulty].outputMultiplier,
+    ),
+  );
+  ascending(
+    "Hurricane duration",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => HURRICANE_BALANCE[difficulty].durationMonths,
+    ),
+  );
+  ascending(
+    "Hurricane oil",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => HURRICANE_BALANCE[difficulty].oilMultiplier,
+    ),
+  );
+  descending(
+    "Old coal output",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => END_OF_ERA_BALANCE[difficulty].oldCoalOutput,
+    ),
+  );
+  ascending(
+    "Coal O&M",
+    DIFFICULTY_ORDER.map((difficulty) => END_OF_ERA_BALANCE[difficulty].coalOM),
+  );
+  return problems;
+}
 
 /** Stable 32-bit address for a string, independent of definition and facility array order. */
 export function storyHash(value: string): number {
@@ -325,10 +1225,10 @@ export function resolveStoryPhase(
   context: StoryContextType,
 ): ActiveWorldEventType & StoryPhaseDescriptionType {
   const key = storyPhaseKey(arc.scenarioId, arc.id, phase.id);
-  const scheduledMonth = resolveStoryScheduleMonth(
-    phase.schedule,
-    context.seed,
-    key,
+  const { scheduledMonth, durationMonths } = resolvePhaseTiming(
+    arc,
+    phase,
+    context,
   );
   const random = (attribute: string) =>
     randomAt(
@@ -342,7 +1242,7 @@ export function resolveStoryPhase(
     key,
     definitionId: `${arc.id}:${phase.id}`,
     startsMinute,
-    endsMinute: startsMinute + (phase.durationMonths || 0) * MINUTES_PER_MONTH,
+    endsMinute: startsMinute + durationMonths * MINUTES_PER_MONTH,
     ...description,
     attributes: {
       scheduledMonth,
@@ -350,6 +1250,29 @@ export function resolveStoryPhase(
     },
     effects: description.effects || {},
   };
+}
+
+function resolvePhaseTiming(
+  arc: StoryArcDefinitionType,
+  phase: StoryPhaseDefinitionType,
+  context: StoryContextType,
+) {
+  const key = storyPhaseKey(arc.scenarioId, arc.id, phase.id);
+  const scheduleKey = phase.scheduleAddress
+    ? storyPhaseKey(arc.scenarioId, arc.id, phase.scheduleAddress)
+    : key;
+  const offset =
+    typeof phase.scheduleOffsetMonths === "function"
+      ? phase.scheduleOffsetMonths(context)
+      : phase.scheduleOffsetMonths || 0;
+  const scheduledMonth =
+    resolveStoryScheduleMonth(phase.schedule, context.seed, scheduleKey) +
+    offset;
+  const durationMonths =
+    typeof phase.durationMonths === "function"
+      ? phase.durationMonths(context)
+      : phase.durationMonths || 0;
+  return { scheduledMonth, durationMonths };
 }
 
 /**
@@ -375,15 +1298,24 @@ export function resolveStoryAtDate(
       ),
     )
     .forEach(({ arc, phase }) => {
+      const { scheduledMonth, durationMonths } = resolvePhaseTiming(
+        arc,
+        phase,
+        context,
+      );
+      const occursNow = context.date.monthsElapsed === scheduledMonth;
+      const activeNow =
+        durationMonths > 0 &&
+        context.date.monthsElapsed >= scheduledMonth &&
+        context.date.monthsElapsed < scheduledMonth + durationMonths;
+      if (!occursNow && !activeNow) {
+        return;
+      }
       const resolved = resolveStoryPhase(arc, phase, context);
-      const scheduledMonth = resolved.attributes.scheduledMonth as number;
-      if (context.date.monthsElapsed === scheduledMonth) {
+      if (occursNow) {
         occurrences.push(resolved);
       }
-      if (
-        context.date.minute >= resolved.startsMinute &&
-        context.date.minute < resolved.endsMinute
-      ) {
+      if (activeNow) {
         active.push(resolved);
       }
     });

--- a/src/helpers/Debrief.test.tsx
+++ b/src/helpers/Debrief.test.tsx
@@ -52,3 +52,37 @@ it("captures a plain then-versus-now story and the latest meaningful beats", () 
     "Jan 2028",
   ]);
 });
+
+it("selects authored turning points intentionally before recent routine events", () => {
+  const scenario = SCENARIOS.find((candidate) => candidate.id === 103)!;
+  const events = [
+    {
+      id: 5,
+      kind: "CONSTRUCTION",
+      label: "Jan 2025",
+      message: "A recent build",
+    },
+    {
+      id: 4,
+      kind: "WORLD_EVENT",
+      label: "Mar 2016",
+      message: "Normalization review",
+      importance: "ROUTINE",
+      turningPointPriority: 80,
+    },
+    {
+      id: 3,
+      kind: "WORLD_EVENT",
+      label: "Jan 2014",
+      message: "Winter gas squeeze",
+      importance: "CRITICAL",
+      turningPointPriority: 100,
+    },
+  ] as GameEventType[];
+  const debrief = buildVictoryDebrief(scenario, summary, [], events);
+  expect(debrief.highlights.map((event) => event.message)).toEqual([
+    "Winter gas squeeze",
+    "Normalization review",
+    "A recent build",
+  ]);
+});

--- a/src/helpers/Debrief.tsx
+++ b/src/helpers/Debrief.tsx
@@ -35,7 +35,7 @@ export function fleetCapacity(
 
 function debriefHighlights(events: GameEventType[]) {
   const seen = new Set<string>();
-  return events
+  const candidates = events
     .filter(
       (event) =>
         event.importance ||
@@ -50,14 +50,27 @@ function debriefHighlights(events: GameEventType[]) {
       seen.add(event.message);
       return true;
     })
+    .sort((a, b) => {
+      const priority =
+        (b.turningPointPriority || 0) - (a.turningPointPriority || 0);
+      if (priority !== 0) {
+        return priority;
+      }
+      const importance = { ROUTINE: 0, NOTABLE: 1, CRITICAL: 2 };
+      const importanceDelta =
+        importance[b.importance || "ROUTINE"] -
+        importance[a.importance || "ROUTINE"];
+      return importanceDelta !== 0 ? importanceDelta : b.id - a.id;
+    })
     .slice(0, 3)
-    .reverse()
-    .map(({ kind, label, message, importance }) => ({
-      kind,
-      label,
-      message,
-      importance,
-    }));
+    // The chosen events are intentionally ranked, but the debrief reads as a timeline.
+    .sort((a, b) => a.id - b.id);
+  return candidates.map(({ kind, label, message, importance }) => ({
+    kind,
+    label,
+    message,
+    importance,
+  }));
 }
 
 export function buildVictoryDebrief(

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -213,6 +213,22 @@ describe("LCWH", () => {
     );
   });
 
+  it("integrates a known future carbon fee over the applicable operating years", () => {
+    const gas = {
+      ...generator,
+      fuel: "Natural Gas",
+      btuPerWh: 0.0035,
+      yearsToBuild: 2,
+    } as GeneratorShoppingType;
+    const noFee = LCWH(gas, date, 0, SEED);
+    const futureFee = LCWH(gas, date, 0, SEED, undefined, (yearsFromQuote) =>
+      yearsFromQuote >= 4 ? 0.1 : 0,
+    );
+    const fullFee = LCWH(gas, date, 0.1, SEED);
+    expect(futureFee).toBeGreaterThan(noFee);
+    expect(futureFee).toBeLessThan(fullFee);
+  });
+
   /**
    * An intermittent generator sampled across a window with no sun in it comes back with a zero
    * capacity factor, and dividing by that used to reach the build screen as "$INFINITY/MWh".

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -141,12 +141,27 @@ export function LCWH(
   feePerKgCO2e: number,
   seed: number,
   location?: LocationType,
+  feePerKgCO2eAtYear?: (yearsFromQuote: number) => number,
 ) {
   const fuel = FUELS[g.fuel] || {};
   const fuelCostPerWh =
     ((getFuelPricesPerMBTU(date, seed, location)[g.fuel] || 0) * g.btuPerWh) /
     1000000;
-  const carbonCostPerWh = (feePerKgCO2e * fuel.kgCO2ePerBtu || 0) * g.btuPerWh;
+  let lifetimeFee = feePerKgCO2e;
+  if (feePerKgCO2eAtYear) {
+    let weightedFee = 0;
+    let weight = 0;
+    const retention = Math.max(0, 1 - (g.annualOutputDegradation || 0));
+    for (let year = 0; year < Math.ceil(g.lifespanYears); year++) {
+      const fraction = Math.min(1, g.lifespanYears - year);
+      const yearWeight = Math.pow(retention, year) * fraction;
+      weightedFee +=
+        feePerKgCO2eAtYear(g.yearsToBuild + year + fraction / 2) * yearWeight;
+      weight += yearWeight;
+    }
+    lifetimeFee = weight > 0 ? weightedFee / weight : feePerKgCO2e;
+  }
+  const carbonCostPerWh = (lifetimeFee * fuel.kgCO2ePerBtu || 0) * g.btuPerWh;
   // Zero when the capacity factor estimate is zero -- an intermittent generator sampled across
   // a window with no sun or no wind in it. The cost per Wh of a plant expected to produce nothing
   // is genuinely unbounded, so this returns Infinity rather than inventing a number; the money

--- a/src/helpers/Story.tsx
+++ b/src/helpers/Story.tsx
@@ -2,6 +2,7 @@ import {
   FacilityOperatingType,
   FuelNameType,
   MonthlyHistoryType,
+  StoryPeriodSnapshotType,
   StorySnapshotType,
 } from "../Types";
 import { summarizeHistory } from "./DateTime";
@@ -13,6 +14,25 @@ const VARIABLE_FUELS = new Set<FuelNameType>([
   "Offshore Wind",
   "Airborne Wind",
 ]);
+
+export function buildStoryPeriodSnapshot(
+  monthlyHistory: MonthlyHistoryType[],
+  months: number,
+): StoryPeriodSnapshotType {
+  const summary = summarizeHistory(monthlyHistory.slice(0, months));
+  const expenses =
+    summary.expensesFuel +
+    summary.expensesOM +
+    summary.expensesCarbonFee +
+    summary.expensesInterest;
+  return {
+    deliveredWhByFuel: { ...summary.deliveredWhByFuel },
+    demandWh: summary.demandWh,
+    unservedWh: Math.max(0, summary.demandWh - summary.supplyWh),
+    netIncome: summary.revenue - expenses,
+    peakDemandW: summary.peakDemandW,
+  };
+}
 
 /**
  * Derives the story-facing state from authoritative simulation history and the current fleet.

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -38,7 +38,7 @@ import { computeScoreBreakdown, totalScore } from "../helpers/Scoring";
 import { formatLargeMass } from "../helpers/Units";
 import { buildConsequenceMessage } from "../helpers/BuildConsequences";
 import { buildVictoryDebrief } from "../helpers/Debrief";
-import { buildStorySnapshot } from "../helpers/Story";
+import { buildStoryPeriodSnapshot, buildStorySnapshot } from "../helpers/Story";
 import {
   getAirborneWindOutputFactor,
   getAirborneWindReferenceKph,
@@ -129,6 +129,7 @@ import {
   FuelProductionType,
   ReplayActionType,
   VictoryType,
+  WorldEventEffectsType,
 } from "../Types";
 
 interface BuildFacilityAction {
@@ -302,6 +303,7 @@ function generatorCostPerMWh(
   generator: GeneratorOperatingType,
   prices: FuelPricesType,
   feePerKgCO2e: number,
+  operatingCostMultiplier = 1,
 ): number | undefined {
   if (
     generator.yearsToBuildLeft > 0 ||
@@ -323,7 +325,10 @@ function generatorCostPerMWh(
     (FUELS[generator.fuel]?.kgCO2ePerBtu || 0) *
     feePerKgCO2e;
   return (
-    estimatedAnnualOperatingCost(generator) / annualMWh + fuelCost + carbonCost
+    (estimatedAnnualOperatingCost(generator) * operatingCostMultiplier) /
+      annualMWh +
+    fuelCost +
+    carbonCost
   );
 }
 
@@ -332,6 +337,10 @@ function currentFuelCosts(
 ): Partial<Record<FuelNameType, number>> {
   const costs: Partial<Record<FuelNameType, number>> = {};
   const prices = getEffectiveFuelPrices(state.date, state);
+  const operatingCostMultipliers = storyEffectsAt(
+    state.date,
+    state,
+  ).operatingCostMultipliersByFuel;
   state.facilities.forEach((facility: FacilityOperatingType) => {
     const generator = facility as Partial<GeneratorOperatingType>;
     if (!generator.fuel) {
@@ -341,6 +350,7 @@ function currentFuelCosts(
       facility as GeneratorOperatingType,
       prices,
       effectiveCarbonFee(state.date, state),
+      operatingCostMultipliers?.[generator.fuel] || 1,
     );
     if (cost === undefined) {
       return;
@@ -418,6 +428,7 @@ function updateWorldEvents(state: GameType): Set<FuelNameType> {
     (event) => event.endsMinute > state.date.minute,
   );
   if (
+    state.storyEffectsDisabled ||
     !STORY_ARC_DEFINITIONS.some((arc) => arc.scenarioId === state.scenarioId)
   ) {
     return storyPriceFuels;
@@ -433,6 +444,13 @@ function updateWorldEvents(state: GameType): Set<FuelNameType> {
       state.facilities,
       state.date.minute,
     ),
+    periodSnapshots: Object.fromEntries(
+      [2, 3, 4, 5, 6].map((months) => [
+        months,
+        buildStoryPeriodSnapshot(state.monthlyHistory, months),
+      ]),
+    ),
+    occurrences: state.worldEvents.occurrences,
   });
   resolved.occurrences.forEach((occurrence) => {
     if (state.worldEvents.checkedKeys.includes(occurrence.key)) {
@@ -440,6 +458,7 @@ function updateWorldEvents(state: GameType): Set<FuelNameType> {
     }
     state.worldEvents.checkedKeys.push(occurrence.key);
     state.worldEvents.active.push(occurrence);
+    state.worldEvents.occurrences.push(occurrence);
     Object.keys(occurrence.effects.fuelPriceMultipliers || {}).forEach((fuel) =>
       storyPriceFuels.add(fuel as FuelNameType),
     );
@@ -450,6 +469,7 @@ function updateWorldEvents(state: GameType): Set<FuelNameType> {
       details: occurrence.details,
       concept: occurrence.concept,
       storyPhaseKey: occurrence.key,
+      turningPointPriority: occurrence.turningPointPriority,
       reportedKey: occurrence.key,
       pause: occurrence.importance === "CRITICAL",
     });
@@ -460,6 +480,12 @@ function updateWorldEvents(state: GameType): Set<FuelNameType> {
       state.worldEvents.checkedKeys.length - MAX_WORLD_EVENT_CHECKS,
     );
   }
+  if (state.worldEvents.occurrences.length > MAX_WORLD_EVENT_CHECKS) {
+    state.worldEvents.occurrences.splice(
+      0,
+      state.worldEvents.occurrences.length - MAX_WORLD_EVENT_CHECKS,
+    );
+  }
   return storyPriceFuels;
 }
 
@@ -467,15 +493,102 @@ function updateWorldEvents(state: GameType): Set<FuelNameType> {
  * Scheduled effects for any simulated date. Persisted live occurrences win over a newly resolved
  * copy, which is what preserves facility IDs and other onset-time attributes after they are drawn.
  */
+const storyEffectsCache = new WeakMap<
+  GameType,
+  {
+    month: number;
+    scenarioId: number;
+    difficulty: GameType["difficulty"];
+    disabled: boolean;
+    activeKey: string;
+    effects: WorldEventEffectsType;
+  }
+>();
+const scheduledStoryEffectsCache = new Map<string, WorldEventEffectsType>();
+
+function scheduledStoryCacheKey(date: DateType, state: GameType): string {
+  const fleetSensitive =
+    state.scenarioId === 104 ||
+    (state.scenarioId === 102 &&
+      date.monthsElapsed >= 72 &&
+      date.monthsElapsed < 96);
+  const fleetKey = fleetSensitive
+    ? state.facilities
+        .map((facility) =>
+          [
+            facility.id,
+            facility.fuel,
+            facility.peakW,
+            facility.yearsToBuildLeft <= 0,
+            facility.paused,
+            facility.minuteOperational,
+          ].join(":"),
+        )
+        .sort()
+        .join(";")
+    : "";
+  return [
+    state.scenarioId,
+    state.difficulty,
+    state.seed,
+    date.monthsElapsed,
+    fleetKey,
+  ].join("|");
+}
+
 function storyEffectsAt(date: DateType, state: GameType) {
+  const activeKey = state.worldEvents.active
+    .map((event) => event.key)
+    .join("|");
+  const cached = storyEffectsCache.get(state);
+  if (
+    cached?.month === date.monthsElapsed &&
+    cached.scenarioId === state.scenarioId &&
+    cached.difficulty === state.difficulty &&
+    cached.disabled === !!state.storyEffectsDisabled &&
+    cached.activeKey === activeKey
+  ) {
+    return cached.effects;
+  }
   const persisted = state.worldEvents.active.filter(
     (event) =>
       date.minute >= event.startsMinute && date.minute < event.endsMinute,
   );
   if (
+    state.storyEffectsDisabled ||
     !STORY_ARC_DEFINITIONS.some((arc) => arc.scenarioId === state.scenarioId)
   ) {
-    return combineStoryEffects(persisted);
+    const effects = combineStoryEffects(persisted);
+    storyEffectsCache.set(state, {
+      month: date.monthsElapsed,
+      scenarioId: state.scenarioId,
+      difficulty: state.difficulty,
+      disabled: !!state.storyEffectsDisabled,
+      activeKey,
+      effects,
+    });
+    return effects;
+  }
+  // Forecast passes create shallow state copies, so the WeakMap above cannot share their work.
+  // With no persisted live onset to distinguish, the scheduled result is a pure month lookup;
+  // only the two facility-selecting arcs add a stable fleet signature.
+  const scheduledCacheKey =
+    state.worldEvents.active.length === 0
+      ? scheduledStoryCacheKey(date, state)
+      : undefined;
+  const scheduledCached = scheduledCacheKey
+    ? scheduledStoryEffectsCache.get(scheduledCacheKey)
+    : undefined;
+  if (scheduledCached) {
+    storyEffectsCache.set(state, {
+      month: date.monthsElapsed,
+      scenarioId: state.scenarioId,
+      difficulty: state.difficulty,
+      disabled: false,
+      activeKey,
+      effects: scheduledCached,
+    });
+    return scheduledCached;
   }
   const persistedKeys = new Set(persisted.map((event) => event.key));
   const scheduled = resolveStoryAtDate({
@@ -487,10 +600,26 @@ function storyEffectsAt(date: DateType, state: GameType) {
     snapshot: buildStorySnapshot(
       state.monthlyHistory,
       state.facilities,
-      state.date.minute,
+      date.minute,
     ),
+    occurrences: state.worldEvents.occurrences,
   }).active.filter((event) => !persistedKeys.has(event.key));
-  return combineStoryEffects([...persisted, ...scheduled]);
+  const effects = combineStoryEffects([...persisted, ...scheduled]);
+  if (scheduledCacheKey) {
+    if (scheduledStoryEffectsCache.size > 10000) {
+      scheduledStoryEffectsCache.clear();
+    }
+    scheduledStoryEffectsCache.set(scheduledCacheKey, effects);
+  }
+  storyEffectsCache.set(state, {
+    month: date.monthsElapsed,
+    scenarioId: state.scenarioId,
+    difficulty: state.difficulty,
+    disabled: !!state.storyEffectsDisabled,
+    activeKey,
+    effects,
+  });
+  return effects;
 }
 
 function effectiveCarbonFee(date: DateType, state: GameType): number {
@@ -539,7 +668,7 @@ const initialGame: GameType = {
   eventLog: [] as GameEventType[],
   reportedEventKeys: [],
   eventLogReadThroughId: 0,
-  worldEvents: { active: [], checkedKeys: [] },
+  worldEvents: { active: [], occurrences: [], checkedKeys: [] },
 };
 
 // Restarts the self-rescheduling tick() loop when leaving PAUSED, unless it's already running.
@@ -612,7 +741,7 @@ export const gameSlice = createSlice({
       state.eventLog = [] as GameEventType[];
       state.reportedEventKeys = [];
       state.eventLogReadThroughId = 0;
-      state.worldEvents = { active: [], checkedKeys: [] };
+      state.worldEvents = { active: [], occurrences: [], checkedKeys: [] };
       state.fuelCostSnapshot = undefined;
       state.timeline = [] as TickPresentFutureType[];
       // A game being watched is not a game being recorded; anything else starts an empty log,
@@ -1593,8 +1722,15 @@ function minimumStableOperatingCost(
 ): number {
   const minimumW = generator.peakW * (generator.minimumStableOutput || 0);
   const generatedWh = (minimumW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+  const tickDate = getDateFromMinute(tick.minute, state.startingYear);
+  const operatingCostMultiplier =
+    storyEffectsAt(tickDate, state).operatingCostMultipliersByFuel?.[
+      generator.fuel
+    ] || 1;
   const variableOM =
-    (generatedWh / 1000000) * (generator.variableOperatingCostPerMWh || 0);
+    (generatedWh / 1000000) *
+    (generator.variableOperatingCostPerMWh || 0) *
+    operatingCostMultiplier;
   const fuel = FUELS[generator.fuel];
   if (!fuel) {
     return variableOM;
@@ -1604,12 +1740,7 @@ function minimumStableOperatingCost(
     GAME_TO_REAL_YEARS;
   const fuelCost = (fuelBtu * (tick[generator.fuel] ?? 0)) / 1000000;
   const carbonCost =
-    fuelBtu *
-    fuel.kgCO2ePerBtu *
-    effectiveCarbonFee(
-      getDateFromMinute(tick.minute, state.startingYear),
-      state,
-    );
+    fuelBtu * fuel.kgCO2ePerBtu * effectiveCarbonFee(tickDate, state);
   return variableOM + fuelCost + carbonCost;
 }
 
@@ -1835,7 +1966,11 @@ function updateSupplyFacilitiesFinances(
                     forecast: state.timeline,
                     fromIndex: forecastIndexAt(state, now.minute),
                     startCost:
-                      (generator.costPerStart || 0) * GAME_TO_REAL_YEARS,
+                      (generator.costPerStart || 0) *
+                      GAME_TO_REAL_YEARS *
+                      (tickStoryEffects.operatingCostMultipliersByFuel?.[
+                        generator.fuel
+                      ] || 1),
                     minimumOperatingCost: (futureTick) =>
                       minimumStableOperatingCost(state, generator, futureTick),
                   });
@@ -1969,6 +2104,11 @@ function updateSupplyFacilitiesFinances(
         // represents the same daily start repeated throughout that month.
         facilityOM += (g.costPerStart || 0) * GAME_TO_REAL_YEARS;
       }
+      const operatingFuel = (g as Partial<GeneratorOperatingType>).fuel;
+      facilityOM *=
+        (operatingFuel &&
+          tickStoryEffects.operatingCostMultipliersByFuel?.[operatingFuel]) ||
+        1;
       facilityExpenses += facilityOM;
       expensesOM += facilityOM;
       if (g.fuel && FUELS[g.fuel]) {

--- a/src/reducers/StoryEffects.test.tsx
+++ b/src/reducers/StoryEffects.test.tsx
@@ -1,4 +1,6 @@
+import cloneDeep from "lodash.clonedeep";
 import { TICKS_PER_DAY } from "../Constants";
+import { GENERATORS } from "../data/Facilities";
 import { getDateFromMinute, MINUTES_PER_MONTH } from "../helpers/DateTime";
 import { generateNewTimeline, tickState } from "./Game";
 import { createGame } from "../testing/Simulator";
@@ -46,6 +48,64 @@ describe("story effects in dispatch", () => {
         ...restored.map((tick) => tick.supplyByFuel["Natural Gas"] || 0),
       ),
     ).toBeGreaterThan(gas.peakW * 0.7);
+  });
+
+  it("applies the renewable discount once to new quotes without repricing commitments", () => {
+    const game = createGame({ scenarioId: 101, difficulty: "Manager" });
+    game.date = getDateFromMinute(84 * MINUTES_PER_MONTH, game.startingYear);
+    const quote = (state: typeof game) =>
+      GENERATORS(state, 100_000_000, [20], [500]).find(
+        (generator) => generator.fuel === "Sun",
+      )!;
+    const baseline = quote({ ...game, storyEffectsDisabled: true });
+    const discounted = quote(game);
+    expect(discounted.buildCost / baseline.buildCost).toBeCloseTo(0.75, 10);
+
+    const committed = cloneDeep(discounted);
+    game.date = getDateFromMinute(100 * MINUTES_PER_MONTH, game.startingYear);
+    expect(committed.buildCost).toBe(discounted.buildCost);
+  });
+
+  it("applies the full coal O&M multiplier to live and forecast costs", () => {
+    const game = createGame({ scenarioId: 102, difficulty: "Manager" });
+    game.date = getDateFromMinute(180 * MINUTES_PER_MONTH, game.startingYear);
+    game.facilities = [game.facilities[0]];
+    const baselineGame = cloneDeep(game);
+    baselineGame.storyEffectsDisabled = true;
+    const story = generateNewTimeline(
+      game,
+      1_000_000_000,
+      2_000_000,
+      TICKS_PER_DAY,
+    );
+    const baseline = generateNewTimeline(
+      baselineGame,
+      1_000_000_000,
+      2_000_000,
+      TICKS_PER_DAY,
+    );
+    const storyOM = story.reduce((total, tick) => total + tick.expensesOM, 0);
+    const baselineOM = baseline.reduce(
+      (total, tick) => total + tick.expensesOM,
+      0,
+    );
+    expect(storyOM / baselineOM).toBeCloseTo(1.2, 6);
+  });
+
+  it("keeps Paradise customer count unchanged while visitor usage rises", () => {
+    const game = createGame({ scenarioId: 105, difficulty: "Manager" });
+    game.date = getDateFromMinute(28 * MINUTES_PER_MONTH, game.startingYear);
+    const baselineGame = cloneDeep(game);
+    baselineGame.storyEffectsDisabled = true;
+    const story = generateNewTimeline(game, 1_000_000_000, 1_000_000, 1)[0];
+    const baseline = generateNewTimeline(
+      baselineGame,
+      1_000_000_000,
+      1_000_000,
+      1,
+    )[0];
+    expect(story.customers).toBe(baseline.customers);
+    expect(story.demandW / baseline.demandW).toBeCloseTo(1.06, 6);
   });
 
   it("pauses exactly once at freeze onset and logs the authored price change once", () => {

--- a/src/testing/BalancePlaybooks.ts
+++ b/src/testing/BalancePlaybooks.ts
@@ -1,0 +1,60 @@
+import { SimOptionsType } from "./Simulator";
+
+/**
+ * Reproducible, UI-legal playthroughs used by both the CEO economics gates and the seeded story
+ * matrix. They deliberately contain only actions the headless simulator records as player input.
+ */
+export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
+  100: {
+    // The announced carbon-fee step makes the old $0.055/kWh gas-heavy play insolvent.
+    dollarsPerkWh: 0.08,
+    initialBuild: {
+      name: "Natural Gas",
+      peakW: 150000000,
+      financed: true,
+    },
+    sellFacilityId: 1,
+    sellAtMonth: 37,
+  },
+  101: {
+    dollarsPerkWh: 0.1,
+    initialBuild: {
+      name: "Natural Gas",
+      peakW: 300000000,
+      financed: true,
+    },
+    sellFacilityId: 1,
+    sellAtMonth: 39,
+  },
+  102: {
+    dollarsPerkWh: 0.15,
+    initialBuild: {
+      name: "Natural Gas",
+      peakW: 300000000,
+      financed: true,
+    },
+    sellFacilityId: 1,
+    sellAtMonth: 39,
+  },
+  103: {
+    // This control must remain viable without the shale discount as well as with it.
+    dollarsPerkWh: 0.08,
+    initialBuild: {
+      name: "Natural Gas",
+      peakW: 600000000,
+      financed: true,
+    },
+    sellFacilityId: 1,
+    sellAtMonth: 39,
+  },
+  104: { dollarsPerkWh: 0.08 },
+  105: {
+    // Oil's output-dependent O&M makes the old $0.08/kWh play run out of cash in 2007.
+    dollarsPerkWh: 0.085,
+    initialBuild: {
+      name: "Natural Gas",
+      peakW: 300000000,
+      financed: true,
+    },
+  },
+};

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -29,6 +29,30 @@ profit, emissions), the number of recorded player actions, totals for the run, t
 finished with, and any invariant violations. Outcomes match the real game: completed, bankrupt,
 or fired after three consecutive months below 90% supplied.
 `npm run sim -- --help` lists the flags; `--list` shows the scenario ids.
+Pass `--without-stories` to run the same playthrough as an authored-effects control.
+
+Story balance uses the checked-in seeds 1–20 across all six scored scenarios and five
+difficulties, running the same UI-legal playbooks as the CEO economics tests with authored effects
+disabled and enabled:
+
+```sh
+npm run sim -- --matrix
+```
+
+Each cell records outcome month, unserved share, ending cash, generation mix, phase keys,
+onset-selected facility IDs, and resolved effects (`--full` prints the records). A failure-rate
+gate is only calculated when at least 12 baseline seeds complete; otherwise the cell reports
+`INSUFFICIENT COVERAGE` instead of a misleading percentage. The story run may fail no more than
+25% of those otherwise-successful seeds.
+
+The forecast performance gate is independently reproducible:
+
+```sh
+npm run sim -- --benchmark-stories
+```
+
+It compares median warmed 20-year Shale forecasts with scheduled story resolution disabled and
+enabled, and fails above a 15% regression.
 
 `--year` and `--location` play an authored scenario somewhere or somewhen else, which is the
 only way to exercise a start past the recorded weather from the command line:

--- a/src/testing/SimCli.tsx
+++ b/src/testing/SimCli.tsx
@@ -9,7 +9,28 @@ import { CUSTOM_SCENARIO_ID, SCENARIOS } from "../data/Scenarios";
 import { DifficultyType, ScenarioType } from "../Types";
 import { formatReport } from "./Report";
 import { getSimLocation, simLocationIds } from "./SimData";
-import { runSimulation, SimOptionsType, StrategyType } from "./Simulator";
+import { TICKS_PER_YEAR } from "../Constants";
+import { getTimeFromTimeline } from "../helpers/DateTime";
+import { generateNewTimeline } from "../reducers/Game";
+import {
+  createGame,
+  runSimulation,
+  SimOptionsType,
+  StrategyType,
+} from "./Simulator";
+import { STANDARD_BALANCE_PLAYS } from "./BalancePlaybooks";
+
+export const STANDARD_BALANCE_SEEDS = Array.from(
+  { length: 20 },
+  (_, index) => index + 1,
+);
+const MATRIX_DIFFICULTIES: DifficultyType[] = [
+  "Intern",
+  "Employee",
+  "Manager",
+  "VP",
+  "CEO",
+];
 
 jest.setTimeout(600000);
 
@@ -69,6 +90,7 @@ function baseOptions(): Omit<SimOptionsType, "scenarioId"> {
       : undefined,
     sellFacilityId: envNumber("SIM_SELL_ID"),
     sellAtMonth: envNumber("SIM_SELL_MONTH"),
+    storyEffectsEnabled: process.env.SIM_WITHOUT_STORIES !== "1",
   };
 }
 
@@ -126,6 +148,150 @@ function runSweep() {
   write("");
 }
 
+function matrixRecord(result: ReturnType<typeof runSimulation>) {
+  const demandWh = result.months.reduce(
+    (total, month) => total + month.demandWh,
+    0,
+  );
+  const supplyWh = result.months.reduce(
+    (total, month) => total + month.supplyWh,
+    0,
+  );
+  const generationMix = result.months.reduce<Record<string, number>>(
+    (totals, month) => {
+      Object.entries(month.deliveredWhByFuel).forEach(([fuel, wh]) => {
+        totals[fuel] = (totals[fuel] || 0) + (wh || 0);
+      });
+      return totals;
+    },
+    {},
+  );
+  return {
+    seed: result.options.seed,
+    outcome: result.outcome,
+    outcomeMonth:
+      result.bankruptAtMonth ?? result.firedAtMonth ?? result.months.length,
+    unservedShare:
+      demandWh > 0 ? Math.max(0, (demandWh - supplyWh) / demandWh) : 0,
+    endingCash: result.finalCash,
+    generationMix,
+    phaseKeys: result.storyOccurrences.map((event) => event.key),
+    selectedIds: result.storyOccurrences.flatMap((event) =>
+      Array.isArray(event.attributes.selectedFacilityIds)
+        ? (event.attributes.selectedFacilityIds as number[])
+        : [],
+    ),
+    resolvedEffects: result.storyOccurrences.map((event) => event.effects),
+  };
+}
+
+function runMatrix() {
+  const scenarios = SCENARIOS.filter((scenario: ScenarioType) =>
+    [100, 101, 102, 103, 104, 105].includes(scenario.id),
+  );
+  let failedGates = 0;
+  write("");
+  write(
+    "  SCENARIO                  DIFFICULTY BASELINE  STORY FAILURES  GATE",
+  );
+  write(
+    "  ------------------------- ---------- --------- --------------- --------------------",
+  );
+  scenarios.forEach((scenario) => {
+    MATRIX_DIFFICULTIES.forEach((difficulty) => {
+      const records = STANDARD_BALANCE_SEEDS.map((seed) => {
+        const common = {
+          ...STANDARD_BALANCE_PLAYS[scenario.id],
+          scenarioId: scenario.id,
+          difficulty,
+          seed,
+        };
+        return {
+          baseline: matrixRecord(
+            runSimulation({ ...common, storyEffectsEnabled: false }),
+          ),
+          story: matrixRecord(
+            runSimulation({ ...common, storyEffectsEnabled: true }),
+          ),
+        };
+      });
+      const otherwiseSuccessful = records.filter(
+        ({ baseline }) => baseline.outcome === "completed",
+      );
+      const storyFailures = otherwiseSuccessful.filter(
+        ({ story }) => story.outcome !== "completed",
+      ).length;
+      const enoughCoverage = otherwiseSuccessful.length >= 12;
+      const failureRate = enoughCoverage
+        ? storyFailures / otherwiseSuccessful.length
+        : null;
+      const passed = failureRate !== null && failureRate <= 0.25;
+      if (!passed) {
+        failedGates++;
+      }
+      write(
+        "  " +
+          scenario.name.slice(0, 25).padEnd(26) +
+          difficulty.padEnd(11) +
+          String(otherwiseSuccessful.length).padEnd(10) +
+          String(storyFailures).padEnd(16) +
+          (!enoughCoverage
+            ? "INSUFFICIENT COVERAGE"
+            : `${(100 * (failureRate || 0)).toFixed(1)}% ${passed ? "ok" : "FAILED"}`),
+      );
+      if (process.env.SIM_FULL === "1") {
+        write(JSON.stringify({ scenarioId: scenario.id, difficulty, records }));
+      }
+    });
+  });
+  write("");
+  write(
+    failedGates === 0
+      ? "  Story balance matrix passed every coverage and failure-rate gate."
+      : `  ${failedGates} story balance matrix gates need attention.`,
+  );
+  write("");
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function benchmarkForecast(storyEffectsDisabled: boolean): number {
+  const samples: number[] = [];
+  for (let sample = 0; sample < 5; sample++) {
+    const state = createGame({
+      scenarioId: 103,
+      difficulty: "Manager",
+      seed: 7,
+    });
+    state.storyEffectsDisabled = storyEffectsDisabled;
+    const now = getTimeFromTimeline(state.date.minute, state.timeline)!;
+    const started = performance.now();
+    generateNewTimeline(state, now.cash, now.customers, TICKS_PER_YEAR * 20);
+    const elapsed = performance.now() - started;
+    if (sample > 0) {
+      samples.push(elapsed);
+    }
+  }
+  return median(samples);
+}
+
+function runStoryBenchmark() {
+  const baselineMs = benchmarkForecast(true);
+  const storyMs = benchmarkForecast(false);
+  const regression = storyMs / baselineMs - 1;
+  write("");
+  write(`  20-year forecast without stories  ${baselineMs.toFixed(1)} ms`);
+  write(`  20-year forecast with stories     ${storyMs.toFixed(1)} ms`);
+  write(
+    `  Story resolution regression       ${(regression * 100).toFixed(1)}%`,
+  );
+  write("");
+  expect(regression).toBeLessThanOrEqual(0.15);
+}
+
 function runSingle() {
   const scenarioId = envNumber("SIM_SCENARIO") ?? 101;
   const base = SCENARIOS.find((s: ScenarioType) => s.id === scenarioId);
@@ -144,7 +310,11 @@ function runSingle() {
 }
 
 it("simulation", () => {
-  if (process.env.SIM_ALL === "1") {
+  if (process.env.SIM_STORY_BENCHMARK === "1") {
+    runStoryBenchmark();
+  } else if (process.env.SIM_MATRIX === "1") {
+    runMatrix();
+  } else if (process.env.SIM_ALL === "1") {
     runSweep();
   } else {
     runSingle();

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -1,6 +1,7 @@
 import { CUSTOM_SCENARIO_ID, SCENARIOS } from "../data/Scenarios";
 import { DifficultyType, GameType, ScenarioType } from "../Types";
 import { createGame, runSimulation, SimResultType } from "./Simulator";
+import { STANDARD_BALANCE_PLAYS } from "./BalancePlaybooks";
 import { loadSimData } from "./SimData";
 import { LOCATIONS, TICKS_PER_MONTH } from "../Constants";
 import { getTimeFromTimeline } from "../helpers/DateTime";
@@ -288,53 +289,9 @@ describe("airborne wind dispatch", () => {
 });
 
 describe("simulation economics", () => {
-  // Reproducible, UI-legal playthroughs found by the CEO playtest agents. Investor scenarios use
-  // facility actions only; the one rate change belongs to the Public scenario and is checked below.
-  const CEO_WINNING_PLAYS = {
-    100: {
-      initialBuild: {
-        name: "Natural Gas",
-        peakW: 150000000,
-        financed: true,
-      },
-      sellFacilityId: 1,
-      sellAtMonth: 37,
-    },
-    101: { sellFacilityId: 1 },
-    102: {
-      dollarsPerkWh: 0.034,
-      initialBuild: {
-        name: "Natural Gas",
-        peakW: 200000000,
-        financed: true,
-      },
-      sellFacilityId: 1,
-      sellAtMonth: 39,
-    },
-    103: {
-      dollarsPerkWh: 0.039,
-      initialBuild: {
-        name: "Natural Gas",
-        peakW: 400000000,
-        financed: true,
-      },
-      sellFacilityId: 1,
-      sellAtMonth: 39,
-    },
-    104: { dollarsPerkWh: 0.08 },
-    105: {
-      // Oil's output-dependent O&M makes the old $0.08/kWh play run out of cash in 2007.
-      dollarsPerkWh: 0.085,
-      initialBuild: {
-        name: "Natural Gas",
-        peakW: 300000000,
-        financed: true,
-      },
-    },
-  } as const;
   const CEO_ACTION_COUNTS = {
-    100: 2,
-    101: 1,
+    100: 3,
+    101: 3,
     102: 3,
     103: 3,
     104: 1,
@@ -352,8 +309,7 @@ describe("simulation economics", () => {
         expect(passive.actionCount).toBe(0);
         expect(passive.outcome).not.toBe("completed");
 
-        const play =
-          CEO_WINNING_PLAYS[scenario.id as keyof typeof CEO_WINNING_PLAYS];
+        const play = STANDARD_BALANCE_PLAYS[scenario.id];
         const active = runSimulation({
           scenarioId: scenario.id,
           difficulty: "CEO",

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -20,6 +20,7 @@ import { getStartingCustomers } from "../data/LocationProfiles";
 import { getTimeFromTimeline } from "../helpers/DateTime";
 import { getScenarioLocation } from "../helpers/Locations";
 import {
+  ActiveWorldEventType,
   DifficultyType,
   FacilityOperatingType,
   GameType,
@@ -75,6 +76,7 @@ export interface SimOptionsType {
   initialBuild?: InitialBuildType;
   sellFacilityId?: number;
   sellAtMonth?: number;
+  storyEffectsEnabled?: boolean;
 }
 
 export interface ResolvedSimOptionsType {
@@ -87,6 +89,7 @@ export interface ResolvedSimOptionsType {
   initialBuild: InitialBuildType | null;
   sellFacilityId: number | null;
   sellAtMonth: number;
+  storyEffectsEnabled: boolean;
 }
 
 export interface BuildRecordType {
@@ -115,6 +118,7 @@ export interface SimResultType {
   violations: ViolationType[];
   violationCountByRule: { [rule: string]: number };
   violationCount: number;
+  storyOccurrences: ActiveWorldEventType[];
 }
 
 const DEFAULT_SEED = 12345;
@@ -174,6 +178,9 @@ function setUpGame(
   // the rate on the Finances screen would
   if (options.dollarsPerkWh !== null) {
     state = gameReducer(state, delta({ dollarsPerkWh: options.dollarsPerkWh }));
+  }
+  if (!options.storyEffectsEnabled) {
+    state = gameReducer(state, delta({ storyEffectsDisabled: true }));
   }
   if (options.initialBuild) {
     const build = GENERATORS(
@@ -304,6 +311,7 @@ function resolveOptions(
     initialBuild: options.initialBuild || null,
     sellFacilityId: options.sellFacilityId ?? null,
     sellAtMonth: options.sellAtMonth || 0,
+    storyEffectsEnabled: options.storyEffectsEnabled !== false,
   };
 }
 
@@ -453,5 +461,6 @@ export function runSimulation(options: SimOptionsType): SimResultType {
     violations: collector.getViolations(),
     violationCountByRule: collector.getCountByRule(),
     violationCount: collector.getTotalCount(),
+    storyOccurrences: state.worldEvents.occurrences,
   };
 }


### PR DESCRIPTION
## Summary

- Completes the remaining staged scope from issue #250 after the shared foundation and Shale pilot.
- Adds authored warning, onset, recovery, and review phases for all six scored scenarios, with exact difficulty scaling, deterministic facility selection, state-aware copy, and prioritized debrief turning points.
- Persists story occurrences and snapshots through save and replay, applies the new demand, fuel, carbon, output, O&M, and quote effects, and exposes facility derates in the UI.
- Adds reusable legal balance playbooks, a 1,200-run control matrix, an authored-effects control flag, and a 20-year forecast performance gate.

## Validation

- npm run check — 88 suites and 753 tests passed
- npm run build — production build succeeded
- npm run sim -- --matrix — all 30 cells had 20/20 baseline coverage and 0% story-induced failures
- npm run sim -- --benchmark-stories — passed the 15% regression gate; final run was 13% faster with stories enabled
- Desktop and 390px browser QA — Event navigation and accessible names, one-time critical pause, exact recovery metrics, and facility derate badges verified

Completes the remaining staged work from #250.