### PR TITLE
Balance story arcs across difficulty extremes

### DIFF
--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -289,6 +289,7 @@ describe("remaining scored story arcs", () => {
       oilShock: 1.45,
     });
     expect(RENEWABLES_BALANCE.Manager).toEqual({
+      bridgeGasBuildCost: 1,
       solarBuildCost: 0.75,
       windBuildCost: 0.9,
       demandLoad: 1.08,
@@ -303,6 +304,7 @@ describe("remaining scored story arcs", () => {
     expect(END_OF_ERA_BALANCE.Manager).toEqual({
       oldCoalOutput: 0.85,
       coalOM: 1.2,
+      complianceCoalOutput: 0.75,
     });
     expect(validateStoryDifficultyMonotonicity()).toEqual([]);
   });
@@ -319,6 +321,7 @@ describe("remaining scored story arcs", () => {
     });
     expect(resolveStoryAtDate(context(180, 102)).effects).toMatchObject({
       operatingCostMultipliersByFuel: { Coal: 1.2 },
+      facilityOutputMultipliersByFuel: { Coal: 0.75 },
     });
   });
 

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -287,7 +287,7 @@ const SHALE_BOOM_ARC: StoryArcDefinitionType = {
 };
 
 export const CARBON_FEE_BALANCE: Record<DifficultyType, number> = {
-  Intern: 80,
+  Intern: 60,
   Employee: 90,
   Manager: 100,
   VP: 110,
@@ -308,6 +308,7 @@ export const PARADISE_BALANCE: Record<DifficultyType, ParadiseBalanceType> = {
 };
 
 export interface RenewablesBalanceType {
+  bridgeGasBuildCost: number;
   solarBuildCost: number;
   windBuildCost: number;
   demandLoad: number;
@@ -315,15 +316,36 @@ export interface RenewablesBalanceType {
 
 export const RENEWABLES_BALANCE: Record<DifficultyType, RenewablesBalanceType> =
   {
-    Intern: { solarBuildCost: 0.7, windBuildCost: 0.86, demandLoad: 1.05 },
+    Intern: {
+      bridgeGasBuildCost: 0.3,
+      solarBuildCost: 0.7,
+      windBuildCost: 0.86,
+      demandLoad: 1.05,
+    },
     Employee: {
+      bridgeGasBuildCost: 0.65,
       solarBuildCost: 0.725,
       windBuildCost: 0.88,
       demandLoad: 1.065,
     },
-    Manager: { solarBuildCost: 0.75, windBuildCost: 0.9, demandLoad: 1.08 },
-    VP: { solarBuildCost: 0.775, windBuildCost: 0.92, demandLoad: 1.095 },
-    CEO: { solarBuildCost: 0.8, windBuildCost: 0.94, demandLoad: 1.11 },
+    Manager: {
+      bridgeGasBuildCost: 1,
+      solarBuildCost: 0.75,
+      windBuildCost: 0.9,
+      demandLoad: 1.08,
+    },
+    VP: {
+      bridgeGasBuildCost: 1,
+      solarBuildCost: 0.775,
+      windBuildCost: 0.92,
+      demandLoad: 1.095,
+    },
+    CEO: {
+      bridgeGasBuildCost: 1,
+      solarBuildCost: 0.8,
+      windBuildCost: 0.94,
+      demandLoad: 1.11,
+    },
   };
 
 export interface HurricaneBalanceType {
@@ -365,8 +387,8 @@ export const HURRICANE_BALANCE: Record<DifficultyType, HurricaneBalanceType> = {
   },
   CEO: {
     severity: "Extreme",
-    targetCapacityShare: 0.5,
-    outputMultiplier: 0.4,
+    targetCapacityShare: 0.6,
+    outputMultiplier: 0.1,
     durationMonths: 6,
     oilMultiplier: 1.6,
   },
@@ -375,14 +397,23 @@ export const HURRICANE_BALANCE: Record<DifficultyType, HurricaneBalanceType> = {
 export interface EndOfEraBalanceType {
   oldCoalOutput: number;
   coalOM: number;
+  complianceCoalOutput: number;
 }
 
 export const END_OF_ERA_BALANCE: Record<DifficultyType, EndOfEraBalanceType> = {
-  Intern: { oldCoalOutput: 0.9, coalOM: 1.1 },
-  Employee: { oldCoalOutput: 0.875, coalOM: 1.15 },
-  Manager: { oldCoalOutput: 0.85, coalOM: 1.2 },
-  VP: { oldCoalOutput: 0.825, coalOM: 1.25 },
-  CEO: { oldCoalOutput: 0.8, coalOM: 1.3 },
+  Intern: { oldCoalOutput: 0.9, coalOM: 1.1, complianceCoalOutput: 1 },
+  Employee: {
+    oldCoalOutput: 0.875,
+    coalOM: 1.15,
+    complianceCoalOutput: 0.9,
+  },
+  Manager: {
+    oldCoalOutput: 0.85,
+    coalOM: 1.2,
+    complianceCoalOutput: 0.75,
+  },
+  VP: { oldCoalOutput: 0.825, coalOM: 1.25, complianceCoalOutput: 0.5 },
+  CEO: { oldCoalOutput: 0.8, coalOM: 1.3, complianceCoalOutput: 0.001 },
 };
 
 const FLEET_TARGET: StoryActionTargetType = {
@@ -613,6 +644,32 @@ const RENEWABLES_ARC: StoryArcDefinitionType = {
   id: "renewables-scale",
   scenarioId: 101,
   phases: [
+    {
+      id: "bridge-contracts",
+      schedule: { atMonth: 0 },
+      durationMonths: 144,
+      describe: ({ difficulty }) => {
+        const balance = RENEWABLES_BALANCE[difficulty];
+        return {
+          title: "Transition bridge contracts",
+          message: `New gas quotes cost ${percent(balance.bridgeGasBuildCost)} of normal through mission end.`,
+          details:
+            "The bridge contract applies only to new gas commitments and does not reprice projects already underway.",
+          concept: "build",
+          kind: "WORLD_EVENT",
+          importance: "NOTABLE",
+          actionTarget: GENERATOR_TARGET,
+          attributes: {
+            bridgeGasBuildCost: balance.bridgeGasBuildCost,
+          },
+          effects: {
+            buildCostMultipliersByFuel: {
+              "Natural Gas": balance.bridgeGasBuildCost,
+            },
+          },
+        };
+      },
+    },
     {
       id: "manufacturing-warning",
       schedule: { atMonth: 72 },
@@ -943,16 +1000,21 @@ const END_OF_ERA_ARC: StoryArcDefinitionType = {
       schedule: { atMonth: 180 },
       durationMonths: 60,
       describe: ({ difficulty }) => {
-        const coalOM = END_OF_ERA_BALANCE[difficulty].coalOM;
+        const { coalOM, complianceCoalOutput } = END_OF_ERA_BALANCE[difficulty];
         return {
           title: "Coal compliance deadline",
-          message: `Coal fixed, variable, and start O&M are now ${Math.round((coalOM - 1) * 100)}% higher through mission end.`,
+          message: `Coal fixed, variable, and start O&M are now ${Math.round((coalOM - 1) * 100)}% higher and coal output is limited to ${percent(complianceCoalOutput)} through mission end.`,
           concept: "danger",
           kind: "WORLD_EVENT",
           importance: "CRITICAL",
           actionTarget: GENERATOR_TARGET,
-          attributes: { coalOM },
-          effects: { operatingCostMultipliersByFuel: { Coal: coalOM } },
+          attributes: { coalOM, complianceCoalOutput },
+          effects: {
+            operatingCostMultipliersByFuel: { Coal: coalOM },
+            facilityOutputMultipliersByFuel: {
+              Coal: complianceCoalOutput,
+            },
+          },
           turningPointPriority: 100,
         };
       },
@@ -1063,6 +1125,12 @@ export function validateStoryDifficultyMonotonicity(): string[] {
     DIFFICULTY_ORDER.map((difficulty) => PARADISE_BALANCE[difficulty].oilShock),
   );
   ascending(
+    "Renewables bridge gas cost",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => RENEWABLES_BALANCE[difficulty].bridgeGasBuildCost,
+    ),
+  );
+  ascending(
     "Renewables solar cost",
     DIFFICULTY_ORDER.map(
       (difficulty) => RENEWABLES_BALANCE[difficulty].solarBuildCost,
@@ -1113,6 +1181,12 @@ export function validateStoryDifficultyMonotonicity(): string[] {
   ascending(
     "Coal O&M",
     DIFFICULTY_ORDER.map((difficulty) => END_OF_ERA_BALANCE[difficulty].coalOM),
+  );
+  descending(
+    "Compliance coal output",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => END_OF_ERA_BALANCE[difficulty].complianceCoalOutput,
+    ),
   );
   return problems;
 }

--- a/src/testing/BalancePlaybooks.ts
+++ b/src/testing/BalancePlaybooks.ts
@@ -47,7 +47,16 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
     sellFacilityId: 1,
     sellAtMonth: 39,
   },
-  104: { dollarsPerkWh: 0.08 },
+  104: {
+    dollarsPerkWh: 0.08,
+    initialBuild: {
+      name: "Natural Gas",
+      peakW: 300000000,
+      financed: true,
+    },
+    sellFacilityId: 1,
+    sellAtMonth: 110,
+  },
   105: {
     // Oil's output-dependent O&M makes the old $0.08/kWh play run out of cash in 2007.
     dollarsPerkWh: 0.085,
@@ -56,5 +65,35 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
       peakW: 300000000,
       financed: true,
     },
+    sellFacilityId: 1,
+    sellAtMonth: 39,
+  },
+};
+
+/**
+ * The single commitment that teaches each Intern scenario's intended first lesson. These use no
+ * tariff change, sale, or reactive strategy: passive play must fail, while this one build wins.
+ */
+export const INTERN_ONE_BUILD_PLAYS: Record<
+  number,
+  Pick<SimOptionsType, "initialBuild">
+> = {
+  100: {
+    initialBuild: { name: "Geothermal", peakW: 500000000, financed: true },
+  },
+  101: {
+    initialBuild: { name: "Natural Gas", peakW: 390000000, financed: true },
+  },
+  102: {
+    initialBuild: { name: "Natural Gas", peakW: 350000000, financed: true },
+  },
+  103: {
+    initialBuild: { name: "Natural Gas", peakW: 600000000, financed: true },
+  },
+  104: {
+    initialBuild: { name: "Natural Gas", peakW: 300000000, financed: true },
+  },
+  105: {
+    initialBuild: { name: "Natural Gas", peakW: 525000000, financed: true },
   },
 };

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -1,7 +1,10 @@
 import { CUSTOM_SCENARIO_ID, SCENARIOS } from "../data/Scenarios";
 import { DifficultyType, GameType, ScenarioType } from "../Types";
 import { createGame, runSimulation, SimResultType } from "./Simulator";
-import { STANDARD_BALANCE_PLAYS } from "./BalancePlaybooks";
+import {
+  INTERN_ONE_BUILD_PLAYS,
+  STANDARD_BALANCE_PLAYS,
+} from "./BalancePlaybooks";
 import { loadSimData } from "./SimData";
 import { LOCATIONS, TICKS_PER_MONTH } from "../Constants";
 import { getTimeFromTimeline } from "../helpers/DateTime";
@@ -289,18 +292,33 @@ describe("airborne wind dispatch", () => {
 });
 
 describe("simulation economics", () => {
-  const CEO_ACTION_COUNTS = {
-    100: 3,
-    101: 3,
-    102: 3,
-    103: 3,
-    104: 1,
-    105: 2,
-  } as Record<number, number>;
+  SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
+    (scenario) => {
+      it(`fails passively but needs only one build on Intern in "${scenario.name}"`, () => {
+        const passive = runSimulation({
+          scenarioId: scenario.id,
+          difficulty: "Intern",
+        });
+        expectNoViolations(passive);
+        expect(passive.actionCount).toBe(0);
+        expect(passive.outcome).not.toBe("completed");
+
+        const active = runSimulation({
+          scenarioId: scenario.id,
+          difficulty: "Intern",
+          ...INTERN_ONE_BUILD_PLAYS[scenario.id],
+        });
+        expectNoViolations(active);
+        expect(active.actionCount).toBe(1);
+        expect(active.builds).toHaveLength(1);
+        expect(active.outcome).toBe("completed");
+      });
+    },
+  );
 
   SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
     (scenario) => {
-      it(`requires player input to win "${scenario.name}" on CEO`, () => {
+      it(`rejects passive play and accepts a multi-action plan in "${scenario.name}" on CEO`, () => {
         const passive = runSimulation({
           scenarioId: scenario.id,
           difficulty: "CEO",
@@ -316,11 +334,35 @@ describe("simulation economics", () => {
           ...play,
         });
         expectNoViolations(active);
-        expect(active.actionCount).toBe(CEO_ACTION_COUNTS[scenario.id]);
+        expect(active.actionCount).toBeGreaterThanOrEqual(3);
         expect(active.outcome).toBe("completed");
       });
     },
   );
+
+  it("makes a replacement build necessary at the End of an Era compliance deadline", () => {
+    const shortcut = runSimulation({
+      scenarioId: 102,
+      difficulty: "CEO",
+      dollarsPerkWh: 0.15,
+      sellFacilityId: 1,
+      sellAtMonth: 39,
+    });
+    expectNoViolations(shortcut);
+    expect(shortcut.actionCount).toBe(2);
+    expect(shortcut.outcome).not.toBe("completed");
+  });
+
+  it("makes storm hardening necessary on Hurricane Season CEO", () => {
+    const shortcut = runSimulation({
+      scenarioId: 104,
+      difficulty: "CEO",
+      dollarsPerkWh: 0.08,
+    });
+    expectNoViolations(shortcut);
+    expect(shortcut.actionCount).toBe(1);
+    expect(shortcut.outcome).not.toBe("completed");
+  });
 
   it("bills every customer it supplies at the going rate", () => {
     const result = runSimulation({


### PR DESCRIPTION
## Summary
- add an explicit one-build Intern playbook for all six authored scenarios and verify passive failure versus one-action success
- tune only scenario-local story weights for Carbon Fee, Rise of Renewables, Hurricane Season, and The End of an Era
- require multi-action CEO playbooks for every arc and close the coal-holdout and rate-only hurricane shortcuts

## Validation
- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false --runTestsByPath src/data/WorldEvents.test.tsx src/testing/Simulation.test.tsx
- npm run sim -- --matrix (all 30 cells passed; 1,200 playthroughs)
- npm run sim -- --benchmark-stories (13.5% regression, below 15% gate)
- full Jest run: 86/87 suites passed; Manual.test.tsx timed out under parallel load, then passed all 15 tests in isolation