### PR TITLE
Polish mission difficulty and score views

### DIFF
--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -568,7 +568,6 @@ export interface ScenarioBriefingType {
   objective: string;
   constraint: string;
   threat: string;
-  target: string;
 }
 
 export interface ScenarioType {

--- a/src/app.scss
+++ b/src/app.scss
@@ -1080,8 +1080,7 @@ html[data-theme="dark"] .uplot {
   margin-top: 4px;
 }
 
-.scenarioBriefingFact,
-.scenarioTarget {
+.scenarioBriefingFact {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: start;
@@ -1098,15 +1097,31 @@ html[data-theme="dark"] .uplot {
   }
 }
 
-.scenarioTarget {
-  border-color: var(--border-selected);
-  background: var(--bg-selected);
-}
-
 .scenarioStartControls {
+  display: grid;
+  grid-template-columns: minmax(360px, 1fr) minmax(180px, 0.65fr) auto;
+  align-items: center;
+  gap: 12px;
   margin-top: 4px;
   padding-top: 12px;
   border-top: 1px solid var(--border-subtle);
+}
+
+.difficultyPicker {
+  min-width: 0;
+
+  .MuiToggleButtonGroup-root {
+    display: flex;
+    width: 100%;
+  }
+
+  .MuiToggleButton-root {
+    min-width: 0;
+    flex: 1;
+    padding: 5px 6px;
+    font-size: 0.72rem;
+    line-height: 1.25;
+  }
 }
 
 .leaderboard {
@@ -1128,6 +1143,14 @@ html[data-theme="dark"] .uplot {
   .scenarioDossierIcon {
     width: 180px;
     margin: 0 auto 16px;
+  }
+
+  .scenarioStartControls {
+    grid-template-columns: 1fr;
+  }
+
+  .difficultyPicker .MuiToggleButton-root {
+    padding-inline: 2px;
   }
 }
 

--- a/src/components/views/NewGameDetails.test.tsx
+++ b/src/components/views/NewGameDetails.test.tsx
@@ -66,7 +66,7 @@ describe("NewGameDetails leaderboard", () => {
     await screen.findByText("Play the scenario to set a high score");
   });
 
-  it("leads with the scenario fantasy, stakes, and target", async () => {
+  it("leads with the scenario fantasy, objective, and stakes", async () => {
     render(<NewGameDetails {...props()} />);
 
     expect(
@@ -80,7 +80,10 @@ describe("NewGameDetails leaderboard", () => {
     expect(screen.getByText("Objective")).toBeInTheDocument();
     expect(screen.getByText("Constraint")).toBeInTheDocument();
     expect(screen.getByText("Threat")).toBeInTheDocument();
-    expect(screen.getByText("Winning looks like")).toBeInTheDocument();
+    expect(screen.queryByText("Winning looks like")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Victory conditions" }),
+    ).toBeVisible();
     expect(screen.getByRole("button", { name: "Start mission" })).toBeVisible();
     await screen.findByText("Play the scenario to set a high score");
   });
@@ -109,6 +112,20 @@ describe("NewGameDetails leaderboard", () => {
     );
   });
 
+  it("offers every difficulty as a one-tap choice", async () => {
+    const onDelta = jest.fn();
+    render(<NewGameDetails {...props({ onDelta })} />);
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Easy (Employee)" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.click(screen.getByRole("button", { name: "Expert (CEO)" }));
+
+    expect(onDelta).toHaveBeenCalledWith({ difficulty: "CEO" });
+  });
+
   it("puts the player's best score in the score column", async () => {
     mockGetDocs.mockResolvedValueOnce({ docs: [] }).mockResolvedValueOnce({
       docs: [{ data: () => ({ score: 432, uid: "player" }) }],
@@ -124,23 +141,61 @@ describe("NewGameDetails leaderboard", () => {
     expect(cells[1]).not.toHaveTextContent("432");
   });
 
-  it("keeps the leaderboard secondary until the player asks for all rows", async () => {
-    mockGetDocs.mockResolvedValue({
-      docs: Array.from({ length: 5 }, (_, index) => ({
-        data: () => ({
-          score: 500 - index,
-          displayName: `Player ${index + 1}`,
-        }),
-      })),
-    });
+  it("shows all difficulties and their labels only on the expanded board", async () => {
+    mockGetDocs
+      .mockResolvedValueOnce({
+        docs: Array.from({ length: 5 }, (_, index) => ({
+          data: () => ({
+            score: 500 - index,
+            displayName: `Player ${index + 1}`,
+            difficulty: "Employee",
+          }),
+        })),
+      })
+      .mockResolvedValueOnce({
+        docs: [
+          {
+            data: () => ({
+              score: 900,
+              displayName: "Expert Player",
+              difficulty: "CEO",
+            }),
+          },
+          {
+            data: () => ({
+              score: 800,
+              displayName: "Beginner Player",
+              difficulty: "Intern",
+            }),
+          },
+        ],
+      });
     render(<NewGameDetails {...props()} />);
 
     await screen.findByText("Player 3");
     expect(screen.queryByText("Player 4")).toBeNull();
+    expect(
+      screen.queryByRole("columnheader", { name: "Difficulty" }),
+    ).toBeNull();
     await userEvent.click(
-      screen.getByRole("button", { name: "View all 5 scores" }),
+      screen.getByRole("button", { name: "View all scores" }),
     );
-    expect(screen.getByText("Player 4")).toBeInTheDocument();
-    expect(screen.getByText("Player 5")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", {
+        name: "Global High Scores — All Difficulties",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Difficulty" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", { name: /Expert Player 900 Expert/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", { name: /Beginner Player 800 Beginner/ }),
+    ).toBeInTheDocument();
+    expect(
+      mockWhere.mock.calls.filter(([field]) => field === "difficulty"),
+    ).toHaveLength(1);
   });
 });

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -10,25 +10,21 @@ import {
   limit,
 } from "firebase/firestore";
 import {
-  Box,
   Button,
   IconButton,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
   Table,
   TableBody,
   TableCell,
   TableHead,
   TableRow,
   Toolbar,
-  Tooltip,
   Typography,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
-  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
 } from "@mui/material";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import CloseIcon from "@mui/icons-material/Close";
@@ -66,6 +62,10 @@ function formatScore(score: number): string {
   return numbro(score).format({ thousandSeparated: true, mantissa: 0 });
 }
 
+function formatDifficulty(difficulty: string): string {
+  return DIFFICULTY_LABELS[difficulty] || difficulty;
+}
+
 export interface StateProps {
   game: GameType;
   uid?: string;
@@ -81,9 +81,11 @@ export interface DispatchProps {
 
 interface State {
   scores?: ScoreType[];
+  allScores?: ScoreType[];
   myTopScore?: ScoreType;
   // Tells "nobody has played this yet" apart from "the board couldn't be read"
   boardFailed?: boolean;
+  allScoresFailed?: boolean;
   scenario: ScenarioType | null;
   location: LocationType | null;
   victoryDialogOpen?: boolean;
@@ -98,6 +100,7 @@ function BriefingFact(props: {
   concept: ConceptNameType;
   label: string;
   children: React.ReactNode;
+  action?: React.ReactNode;
 }): React.JSX.Element {
   return (
     <div className="scenarioBriefingFact">
@@ -108,6 +111,7 @@ function BriefingFact(props: {
         </Typography>
         <Typography variant="body2">{props.children}</Typography>
       </div>
+      {props.action}
     </div>
   );
 }
@@ -162,6 +166,42 @@ export default class NewGameDetails extends React.Component<Props, State> {
       if (requestId === this.boardRequestId) {
         this.setState({ scores: [], boardFailed: true });
       }
+    }
+  }
+
+  /** Loads the scenario-wide board only when the player asks to compare every difficulty. */
+  private async loadAllScores() {
+    const scenario = this.state.scenario;
+    if (!scenario) {
+      return;
+    }
+    this.setState({ allScores: undefined, allScoresFailed: false });
+    try {
+      const querySnapshot = await getDocs(
+        query(
+          collection(getDb(), "scores"),
+          where("scenarioId", "==", scenario.id),
+          orderBy("score", "desc"),
+          limit(50),
+        ),
+      );
+      this.setState({
+        allScores: querySnapshot.docs.map((doc) => doc.data() as ScoreType),
+      });
+    } catch (err) {
+      console.warn("Couldn't load all high scores: ", err);
+      this.setState({ allScores: [], allScoresFailed: true });
+    }
+  }
+
+  private toggleLeaderboard() {
+    const leaderboardExpanded = !this.state.leaderboardExpanded;
+    this.setState({ leaderboardExpanded });
+    if (
+      leaderboardExpanded &&
+      (!this.state.allScores || this.state.allScoresFailed)
+    ) {
+      void this.loadAllScores();
     }
   }
 
@@ -289,6 +329,8 @@ export default class NewGameDetails extends React.Component<Props, State> {
       location,
       victoryDialogOpen,
       boardFailed,
+      allScores,
+      allScoresFailed,
       leaderboardExpanded,
     } = this.state;
 
@@ -319,12 +361,14 @@ export default class NewGameDetails extends React.Component<Props, State> {
       objective: "Keep the lights on and finish the term.",
       constraint: `${scenario.ownership}-owned scoring rewards a balanced grid.`,
       threat: "Blackouts and insolvency can end the run early.",
-      target: "A reliable grid and a healthy company.",
     };
     const endYear =
       scenario.startingYear + Math.floor(scenario.durationMonths / 12);
-    const visibleScores =
-      scores && !leaderboardExpanded ? scores.slice(0, 3) : scores;
+    const visibleScores = leaderboardExpanded ? allScores : scores?.slice(0, 3);
+    const scoreColumnCount = leaderboardExpanded ? 5 : 4;
+    const visibleBoardFailed = leaderboardExpanded
+      ? allScoresFailed
+      : boardFailed;
 
     return (
       <div id="listCard" className="flexContainer">
@@ -371,7 +415,20 @@ export default class NewGameDetails extends React.Component<Props, State> {
                 {scenario.summary}
               </Typography>
               <div className="scenarioBriefingFacts">
-                <BriefingFact concept="goal" label="Objective">
+                <BriefingFact
+                  concept="goal"
+                  label="Objective"
+                  action={
+                    <IconButton
+                      onClick={toggleVictoryDialog}
+                      aria-label="Victory conditions"
+                      color="primary"
+                      size="small"
+                    >
+                      <InfoIcon />
+                    </IconButton>
+                  }
+                >
                   {briefing.objective}
                 </BriefingFact>
                 <BriefingFact concept="finances" label="Constraint">
@@ -381,53 +438,34 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   {briefing.threat}
                 </BriefingFact>
               </div>
-              <Box className="scenarioTarget">
-                <ConceptIcon concept="supply" fontSize="small" />
-                <div>
-                  <Typography variant="overline" component="div">
-                    Winning looks like
-                  </Typography>
-                  <Typography variant="body2">{briefing.target}</Typography>
-                </div>
-                <IconButton
-                  onClick={toggleVictoryDialog}
-                  aria-label="Victory conditions"
-                  color="primary"
-                  size="small"
-                >
-                  <InfoIcon />
-                </IconButton>
-              </Box>
-              <Stack
-                className="scenarioStartControls"
-                direction={{ xs: "column", sm: "row" }}
-                spacing={1.5}
-                sx={{ alignItems: { xs: "stretch", sm: "center" } }}
-              >
-                <div>
+              <div className="scenarioStartControls">
+                <div className="difficultyPicker">
                   <Typography variant="caption" component="div">
                     Difficulty
                   </Typography>
-                  <Select
+                  <ToggleButtonGroup
+                    exclusive
                     value={game.difficulty}
                     size="small"
-                    onChange={(e: SelectChangeEvent<DifficultyType>) =>
-                      onDelta({ difficulty: e.target.value as DifficultyType })
-                    }
+                    color="primary"
+                    aria-label="Difficulty"
+                    onChange={(_event, difficulty: DifficultyType | null) => {
+                      if (difficulty) {
+                        onDelta({ difficulty });
+                      }
+                    }}
                   >
                     {Object.keys(DIFFICULTIES).map((d: string) => (
-                      <MenuItem value={d} key={d}>
-                        <Tooltip
-                          title={DIFFICULTIES[d].description}
-                          placement="right"
-                        >
-                          <span>
-                            {DIFFICULTY_LABELS[d]} ({d})
-                          </span>
-                        </Tooltip>
-                      </MenuItem>
+                      <ToggleButton
+                        value={d}
+                        key={d}
+                        title={DIFFICULTIES[d].description}
+                        aria-label={`${DIFFICULTY_LABELS[d]} (${d})`}
+                      >
+                        {DIFFICULTY_LABELS[d]}
+                      </ToggleButton>
                     ))}
-                  </Select>
+                  </ToggleButtonGroup>
                 </div>
                 <Typography
                   variant="body2"
@@ -446,7 +484,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                 >
                   Start mission
                 </Button>
-              </Stack>
+              </div>
             </div>
           </section>
 
@@ -488,9 +526,11 @@ export default class NewGameDetails extends React.Component<Props, State> {
             <Table id="HighScores">
               <TableHead>
                 <TableRow>
-                  <TableCell colSpan={4}>
+                  <TableCell colSpan={scoreColumnCount}>
                     <Typography variant="h6">
-                      Global High Scores — {DIFFICULTY_LABELS[game.difficulty]}
+                      {leaderboardExpanded
+                        ? "Global High Scores — All Difficulties"
+                        : `Global High Scores — ${DIFFICULTY_LABELS[game.difficulty]}`}
                     </Typography>
                   </TableCell>
                 </TableRow>
@@ -498,6 +538,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   <TableCell className="rank">#</TableCell>
                   <TableCell>Name</TableCell>
                   <TableCell>Score</TableCell>
+                  {leaderboardExpanded && <TableCell>Difficulty</TableCell>}
                   <TableCell className="replay">Replay</TableCell>
                 </TableRow>
               </TableHead>
@@ -509,23 +550,28 @@ export default class NewGameDetails extends React.Component<Props, State> {
                     <TableCell className="rank" />
                     <TableCell>Your best</TableCell>
                     <TableCell>{formatScore(myTopScore.score)}</TableCell>
+                    {leaderboardExpanded && (
+                      <TableCell>
+                        {formatDifficulty(myTopScore.difficulty)}
+                      </TableCell>
+                    )}
                     {this.renderReplayCell(myTopScore)}
                   </TableRow>
                 )}
-                {!scores && (
+                {!visibleScores && (
                   <TableRow>
-                    <TableCell colSpan={4}>
+                    <TableCell colSpan={scoreColumnCount}>
                       <Typography variant="body2" color="textSecondary">
                         Loading...
                       </Typography>
                     </TableCell>
                   </TableRow>
                 )}
-                {scores && scores.length === 0 && (
+                {visibleScores && visibleScores.length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={4}>
+                    <TableCell colSpan={scoreColumnCount}>
                       <Typography variant="body2" color="textSecondary">
-                        {boardFailed
+                        {visibleBoardFailed
                           ? "Couldn't load the high scores right now."
                           : "Play the scenario to set a high score"}
                       </Typography>
@@ -550,23 +596,21 @@ export default class NewGameDetails extends React.Component<Props, State> {
                           {score.displayName || "Anonymous"}
                         </TableCell>
                         <TableCell>{formatScore(score.score)}</TableCell>
+                        {leaderboardExpanded && (
+                          <TableCell>
+                            {formatDifficulty(score.difficulty)}
+                          </TableCell>
+                        )}
                         {this.renderReplayCell(score)}
                       </TableRow>
                     );
                   })}
               </TableBody>
             </Table>
-            {scores && scores.length > 3 && (
+            {scores !== undefined && (
               <div className="leaderboardToggle">
-                <Button
-                  size="small"
-                  onClick={() =>
-                    this.setState({ leaderboardExpanded: !leaderboardExpanded })
-                  }
-                >
-                  {leaderboardExpanded
-                    ? "Show top 3"
-                    : `View all ${scores.length} scores`}
+                <Button size="small" onClick={() => this.toggleLeaderboard()}>
+                  {leaderboardExpanded ? "Show top 3" : "View all scores"}
                 </Button>
               </div>
             )}

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -94,7 +94,7 @@ describe("tutorial mission metadata", () => {
 });
 
 describe("authored scenario briefings", () => {
-  it("gives every scored scenario a reusable story, stakes, and target", () => {
+  it("gives every scored scenario a reusable story and stakes", () => {
     SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
       (scenario) => {
         expect(scenario.briefing).toEqual(
@@ -104,7 +104,6 @@ describe("authored scenario briefings", () => {
             objective: expect.any(String),
             constraint: expect.any(String),
             threat: expect.any(String),
-            target: expect.any(String),
           }),
         );
       },

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -724,7 +724,6 @@ export const SCENARIOS = [
       objective: "Modernize the fleet without sacrificing reliability.",
       constraint: "A $50/t CO2 fee makes every dirty MWh more expensive.",
       threat: "Aging coal assets and thin margins leave little room for delay.",
-      target: "A reliable, lower-carbon grid that still creates value.",
     },
     ownership: "Investor",
     startingYear: 2020,
@@ -751,7 +750,6 @@ export const SCENARIOS = [
       constraint:
         "Coal dominates the starting fleet and new plants last decades.",
       threat: "Fuel prices can turn before a rushed buildout pays for itself.",
-      target: "A flexible fleet that can survive the boom's next turn.",
     },
     ownership: "Investor",
     startingYear: 2006,
@@ -774,7 +772,6 @@ export const SCENARIOS = [
       constraint:
         "Every fuel shipment and every build dollar matters more offshore.",
       threat: "One weak link can leave the whole island in the dark.",
-      target: "A diverse island grid powered by local resources.",
     },
     ownership: "Investor",
     startingYear: 2004,
@@ -802,7 +799,6 @@ export const SCENARIOS = [
         "Promising options arrive at different times and price points.",
       threat:
         "Move too early and overpay; move too late and fall behind demand.",
-      target: "A modern fleet ready for the next energy era.",
     },
     ownership: "Investor",
     startingYear: 2002,
@@ -827,7 +823,6 @@ export const SCENARIOS = [
       objective: "Build enough resilience to keep essential power flowing.",
       constraint: "Remote fuel is costly and replacement capacity takes time.",
       threat: "Extreme weather can turn a narrow reserve into a crisis.",
-      target: "A resilient, diversified grid that can weather the next storm.",
     },
     ownership: "Public",
     startingYear: 2000,
@@ -855,7 +850,6 @@ export const SCENARIOS = [
       constraint: "Most of your capital and operating knowledge sits in coal.",
       threat:
         "Old plants, new competitors and long build times punish hesitation.",
-      target: "A profitable successor to the coal empire you inherited.",
     },
     ownership: "Investor",
     startingYear: 1980,


### PR DESCRIPTION
Replaces the mobile difficulty dropdown with a compact five-choice segmented control. Removes the redundant Winning looks like UI, briefing schema field, authored scenario data, and related assertions while keeping victory conditions accessible from Objective. Keeps the initial leaderboard focused on the selected difficulty, then loads the scenario-wide board and shows a Difficulty column when View all scores is selected. Verification: npm run check (87 suites, 761 tests), plus live responsive checks at 320px and 360px.