### PR TITLE
Eliminate skipped responsive tests

### DIFF
--- a/e2e/responsive-320.spec.ts
+++ b/e2e/responsive-320.spec.ts
@@ -2,8 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test("custom setup and settings stay usable on a 320px phone", async ({
   page,
-}, testInfo) => {
-  test.skip(testInfo.project.name !== "mobile-320px");
+}) => {
   await page.addInitScript(() => {
     window.localStorage.clear();
     window.localStorage.setItem(
@@ -44,8 +43,7 @@ test("custom setup and settings stay usable on a 320px phone", async ({
 
 test("main-menu resources do not sit behind the footer at low height", async ({
   page,
-}, testInfo) => {
-  test.skip(testInfo.project.name !== "mobile-320px");
+}) => {
   await page.setViewportSize({ width: 360, height: 320 });
   await page.goto("/");
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,10 +16,12 @@ export default defineConfig({
   projects: [
     {
       name: "desktop-chromium",
+      testIgnore: /responsive-320\.spec\.ts/,
       use: { browserName: "chromium", viewport: { width: 1280, height: 800 } },
     },
     {
       name: "mobile-390px",
+      testIgnore: /responsive-320\.spec\.ts/,
       use: {
         browserName: "chromium",
         hasTouch: true,

--- a/src/testing/SimData.tsx
+++ b/src/testing/SimData.tsx
@@ -41,26 +41,6 @@ export function simLocationIds(): string[] {
   return Object.keys({ ...LOCATIONS, ...downloadedLocations() });
 }
 
-/** Whether the separately generated weather assets needed for a headless run are present. */
-export function hasSimWeather(
-  locationOrId: LocationIdType | LocationType,
-): boolean {
-  const id = typeof locationOrId === "string" ? locationOrId : locationOrId.id;
-  if (!isValidLocationId(id)) {
-    return false;
-  }
-  const location =
-    typeof locationOrId === "string" ? getSimLocation(id) : locationOrId;
-  return [
-    id,
-    ...(location?.watershedId && location.watershedId !== id
-      ? [location.watershedId]
-      : []),
-  ].every((weatherId) =>
-    fs.existsSync(path.join(WEATHER_DIR, `${weatherId}.bin`)),
-  );
-}
-
 /**
  * Loads the weather, fuel price and economic data the simulation needs, resetting whatever a previous
  * run left behind. Both modules loop or throw when asked for data they don't have, so this


### PR DESCRIPTION
Scopes the 320px responsive spec to the mobile-320px Playwright project, removing four runtime-skipped executions while preserving the two intended checks. Also removes the obsolete weather-asset skip helper now that representative downloaded-location coverage is in place; this intentionally does not add exhaustive per-location weather tests. Verification: npm run check (87 suites, 788 tests); npm run sim -- --all (all invariants pass); Playwright ran all 5 scheduled browser tests successfully with 0 skipped.