### PR TITLE
Fix QA findings in public utility scenarios

### DIFF
--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -13,6 +13,7 @@ import {
 } from "./SaveGame";
 import { createGame } from "./testing/Simulator";
 import { GameType } from "./Types";
+import { tickState } from "./reducers/Game";
 
 jest.setTimeout(60000);
 
@@ -125,6 +126,21 @@ describe("SaveGame", () => {
         },
       }),
     ).toBeNull();
+  });
+
+  it("repairs the impossible extra opening-history row from older v4 sessions", () => {
+    const advanced = createGame(OPTIONS);
+    while (advanced.date.monthsElapsed < 1) {
+      tickState(advanced);
+    }
+    expect(advanced.monthlyHistory).toHaveLength(1);
+    const legacy = serializeSave({
+      ...advanced,
+      monthlyHistory: [...advanced.monthlyHistory, advanced.monthlyHistory[0]],
+    });
+    expect(parseSave(legacy)!.game.monthlyHistory).toEqual(
+      advanced.monthlyHistory,
+    );
   });
 
   it("rejects a current-version save without current runtime state", () => {

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -1,4 +1,5 @@
 import packageJson from "../package.json";
+import { MINUTES_PER_MONTH } from "./helpers/DateTime";
 import { isValidLocation } from "./helpers/Locations";
 import {
   getStorageJson,
@@ -208,6 +209,12 @@ export function parseSave(raw: unknown): SaveGameType | null {
     !Array.isArray(worldEvents.checkedKeys)
   ) {
     return null;
+  }
+  // Older v4 sessions could record the opening forecast as an extra completed month. History is
+  // newest-first, so any impossible excess is the oldest tail and can be repaired losslessly.
+  const completedMonths = Math.floor(game.date.minute / MINUTES_PER_MONTH);
+  if (game.monthlyHistory.length > completedMonths) {
+    game.monthlyHistory = game.monthlyHistory.slice(0, completedMonths);
   }
   return save as SaveGameType;
 }

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -608,6 +608,8 @@ export interface ScenarioType {
   // Absolute loads owned by this scenario. A Data centers schedule replaces the generic regional
   // data-center curve instead of stacking on top of it.
   loadAdditions?: ScenarioLoadAdditionType[];
+  /** Optional mission gate evaluated at the authored end date. */
+  minimumCustomerRetention?: number;
   dollarsPerkWh: number;
   durationMonths: number;
   endTitle?: string;

--- a/src/components/base/ChartForecastDemandByType.test.tsx
+++ b/src/components/base/ChartForecastDemandByType.test.tsx
@@ -84,3 +84,33 @@ it("orders the legend and tooltip by demand at the start of the plotted range", 
       .map((line) => line.split(":")[0]),
   ).toEqual(ordered);
 });
+
+it("shows an authored load label without changing its demand category", () => {
+  const breakdown = {
+    Residential: 200,
+    Commercial: 100,
+    Industrial: 50,
+    Transportation: 25,
+    "Data centers": 100,
+  };
+  expect(
+    formatDemandTypeTooltip(0, breakdown, 2020, ["Data centers"], {
+      "Data centers": "New data centers",
+    }),
+  ).toContain("New data centers: 100W");
+
+  render(
+    <ChartForecastDemandByType
+      timeline={[tick(0, breakdown)]}
+      domain={{ x: [0, 1440] }}
+      startingYear={2020}
+      multiyear={false}
+      typeLabels={{ "Data centers": "New data centers" }}
+    />,
+  );
+  expect(
+    screen.getByRole("img", {
+      name: /new data centers/i,
+    }),
+  ).toBeInTheDocument();
+});

--- a/src/components/base/ChartForecastDemandByType.tsx
+++ b/src/components/base/ChartForecastDemandByType.tsx
@@ -28,6 +28,8 @@ export interface Props {
   domain: { x: [number, number] };
   /** Shared with the DOM legend so both surfaces always present the same ranking. */
   displayTypes?: readonly DemandTypeNameType[];
+  /** Player-facing authored labels while the underlying demand category remains stable. */
+  typeLabels?: Partial<Record<DemandTypeNameType, string>>;
   startingYear: number;
   multiyear: boolean;
   showXLabels?: boolean;
@@ -42,6 +44,7 @@ interface State {
   maxY: number;
   startingYear: number;
   multiyear: boolean;
+  typeLabels: Partial<Record<DemandTypeNameType, string>>;
 }
 
 function buildOptions(showXLabels: boolean) {
@@ -131,10 +134,13 @@ export function formatDemandTypeTooltip(
   breakdown: DemandByTypeType,
   startingYear: number,
   displayTypes: readonly DemandTypeNameType[],
+  typeLabels: Partial<Record<DemandTypeNameType, string>> = {},
 ): string {
   return [
     formatMinuteAsTooltipHeader(minute, startingYear),
-    ...displayTypes.map((type) => `${type}: ${formatWatts(breakdown[type])}`),
+    ...displayTypes.map(
+      (type) => `${typeLabels[type] || type}: ${formatWatts(breakdown[type])}`,
+    ),
   ].join("\n");
 }
 
@@ -144,6 +150,7 @@ function tooltip(idx: number, state: State): string {
     state.byType[idx],
     state.startingYear,
     state.displayTypes,
+    state.typeLabels,
   );
 }
 
@@ -161,6 +168,7 @@ export default class ChartForecastDemandByType extends React.PureComponent<
       multiyear,
       showXLabels,
       syncKey,
+      typeLabels = {},
     } = this.props;
     const minutes: number[] = [];
     const byType: DemandByTypeType[] = [];
@@ -193,6 +201,7 @@ export default class ChartForecastDemandByType extends React.PureComponent<
       maxY,
       startingYear,
       multiyear,
+      typeLabels,
     };
 
     return (
@@ -204,7 +213,7 @@ export default class ChartForecastDemandByType extends React.PureComponent<
           state={state}
           data={[minutes, ...stacked]}
           summaryData={[minutes, ...unstacked]}
-          seriesLabels={[...DEMAND_TYPES]}
+          seriesLabels={DEMAND_TYPES.map((type) => typeLabels[type] || type)}
           buildOptions={buildOptions(showXLabels !== false)}
           structureKey={String(showXLabels !== false)}
           syncKey={syncKey}

--- a/src/components/base/ScenarioDetailsDialog.tsx
+++ b/src/components/base/ScenarioDetailsDialog.tsx
@@ -72,6 +72,7 @@ export default function ScenarioDetailsDialog(props: Props): React.JSX.Element {
         <VictoryConditions
           ownership={scenario.ownership}
           dollarsPerkWh={scenario.dollarsPerkWh}
+          minimumCustomerRetention={scenario.minimumCustomerRetention}
         />
         {breakdown && (
           <>

--- a/src/components/base/VictoryConditions.tsx
+++ b/src/components/base/VictoryConditions.tsx
@@ -6,6 +6,7 @@ import { useUnits } from "./UnitsContext";
 export interface Props {
   ownership: ScenarioType["ownership"];
   dollarsPerkWh: number;
+  minimumCustomerRetention?: number;
 }
 
 /**
@@ -15,7 +16,7 @@ export interface Props {
  * Scoring algorithm should also be updated in helpers/Scoring.tsx and in the Manual.
  */
 export default function VictoryConditions(props: Props): React.JSX.Element {
-  const { ownership, dollarsPerkWh } = props;
+  const { ownership, dollarsPerkWh, minimumCustomerRetention } = props;
   const units = useUnits();
   const perEmissions = formatLargeMassApprox(KG_PER_MEGATONNE, units);
   if (ownership === "Investor") {
@@ -31,6 +32,12 @@ export default function VictoryConditions(props: Props): React.JSX.Element {
   }
   return (
     <div>
+      {minimumCustomerRetention !== undefined && (
+        <p>
+          Required: retain at least {Math.round(minimumCustomerRetention * 100)}
+          % of starting customers
+        </p>
+      )}
       <p>
         +/-80 pts per lifetime average $0.01/kWh charged above/below $
         {dollarsPerkWh}/kWh

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -781,6 +781,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
           <VictoryConditions
             ownership={scenario.ownership}
             dollarsPerkWh={scenario.dollarsPerkWh}
+            minimumCustomerRetention={scenario.minimumCustomerRetention}
           />
         </DialogContent>
         <DialogActions>

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -932,11 +932,17 @@ export default class Insights extends React.Component<Props, State> {
             projection.sampled,
             projection.domain.x[0],
           );
+          const demandTypeLabels = Object.fromEntries(
+            game.loadAdditions.map((addition) => [
+              addition.demandType,
+              addition.label,
+            ]),
+          );
           body = (
             <>
               <ChartLegend
                 items={demandTypes.map((type) => ({
-                  name: type,
+                  name: demandTypeLabels[type] || type,
                   color: demandTypeColors()[type],
                 }))}
               />
@@ -945,6 +951,7 @@ export default class Insights extends React.Component<Props, State> {
                 timeline={projection.sampled}
                 domain={{ x: projection.domain.x }}
                 displayTypes={demandTypes}
+                typeLabels={demandTypeLabels}
                 startingYear={game.startingYear}
                 multiyear={multiyear}
                 syncKey={SYNC_KEY}

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -507,6 +507,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
               <VictoryConditions
                 ownership={scenario.ownership}
                 dollarsPerkWh={scenario.dollarsPerkWh}
+                minimumCustomerRetention={scenario.minimumCustomerRetention}
               />
             </DialogContent>
             <DialogActions>

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -136,6 +136,7 @@ describe("authored starting fleets", () => {
       startingCustomers: 16_500,
       ownership: "Public",
       dollarsPerkWh: 0.1,
+      minimumCustomerRetention: 0.9,
     });
     expect(manassas.location).toMatchObject({
       id: "Manassas",
@@ -171,6 +172,8 @@ describe("authored starting fleets", () => {
       admin: "TX",
       timeZone: "America/Chicago",
     });
+    expect(austin.briefing?.objective).toMatch(/preserve.*resilience/i);
+    expect(austin.briefing?.objective).not.toMatch(/build/i);
     expect(
       austin.facilities.reduce(
         (total, facility) => total + (facility.peakW || 0),

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -898,6 +898,9 @@ export const SCENARIOS = [
     // Calibrates the customer-driven model to a 45-52 MW municipal average without inventing
     // hundreds of thousands of accounts. The authored data-center schedule is separate below.
     startingDemandScale: 7.5,
+    // Surviving by shedding a third of the municipal customer base is not a successful response
+    // to the boom. This is shown with the victory conditions before play and checked at the end.
+    minimumCustomerRetention: 0.9,
     dollarsPerkWh: 0.1,
     cash: 25000000,
     feePerKgCO2e: 0,
@@ -944,9 +947,10 @@ export const SCENARIOS = [
       "Four years before Winter Storm Uri, harden an Austin-scale public grid for record cold and cascading ERCOT shortages.",
     briefing: {
       tone: "storm",
-      fantasy: "Prepare an Austin-scale public grid for a known winter crisis.",
+      fantasy:
+        "Steward an Austin-scale public grid through a known winter crisis.",
       objective:
-        "Build portfolio resilience before Winter Storm Uri arrives in February 2021.",
+        "Preserve the existing portfolio's resilience through Winter Storm Uri in February 2021.",
       constraint:
         "The opening fleet represents aggregate Austin resources and PPAs, not plant ownership.",
       threat:
@@ -958,7 +962,7 @@ export const SCENARIOS = [
     durationMonths: 7 * 12,
     startingCustomers: 472701,
     // Reconciles the customer model to Austin Energy's FY2017 13.010 TWh / 2.654 GW system.
-    startingDemandScale: 7.6,
+    startingDemandScale: 7.61,
     dollarsPerkWh: 0.09,
     cash: 335000000,
     feePerKgCO2e: 0,

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -319,6 +319,37 @@ describe("Texas Deep Freeze", () => {
       /Solar follows weather without an extra derate/,
     );
   });
+
+  it("keeps the future thaw neutral, then reports the recorded outcome", () => {
+    const thawUpcoming = upcomingStoryPhases(context(0, 107)).find((phase) =>
+      phase.key.endsWith(":thaw"),
+    )!;
+    expect(thawUpcoming.message).toMatch(/outcome will depend/i);
+    expect(thawUpcoming.message).not.toMatch(/carried|recovery/i);
+
+    const period = {
+      deliveredWhByFuel: {},
+      demandWh: 1,
+      netIncome: 0,
+      peakDemandW: 1,
+    };
+    const success = resolveStoryAtDate({
+      ...context(50, 107),
+      periodSnapshots: { 1: { ...period, unservedWh: 0 } },
+    }).occurrences[0];
+    const deficit = resolveStoryAtDate({
+      ...context(50, 107),
+      periodSnapshots: { 1: { ...period, unservedWh: 1 } },
+    }).occurrences[0];
+    expect(success.message).toMatch(/without unserved energy/i);
+    expect(deficit.message).toMatch(/recovery/i);
+  });
+
+  it("does not claim local load shed before the simulation records a deficit", () => {
+    const uri = resolveStoryAtDate(context(49, 107)).occurrences[0];
+    expect(uri.message).toMatch(/emergency operations across Texas/i);
+    expect(uri.message).not.toMatch(/forced local load shed/i);
+  });
 });
 
 describe("remaining scored story arcs", () => {

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -1088,7 +1088,7 @@ const TEXAS_DEEP_FREEZE_ARC: StoryArcDefinitionType = {
       describe: () => ({
         title: "Winter Storm Uri",
         message:
-          "Record cold and ERCOT-wide shortages have forced local load shed. Austin Energy reported that its own diverse generation performed well; these grid-wide availability ratios are an Austin-scale simulation, not failures assigned to specific local plants.",
+          "Record cold and ERCOT-wide shortages have forced emergency operations across Texas. Austin Energy reported that its own diverse generation performed well; these grid-wide availability ratios are an Austin-scale simulation, not failures assigned to specific local plants.",
         details:
           "For February, normal modeled output is available at 62% for natural gas, 73% for coal, 77% for uranium and 44% for wind. Texas natural-gas fuel cost is 2.8×. Solar follows weather without an extra derate.",
         concept: "blackout",
@@ -1119,9 +1119,11 @@ const TEXAS_DEEP_FREEZE_ARC: StoryArcDefinitionType = {
         return {
           title: "The thaw",
           message:
-            unservedWh > 0
-              ? "The freeze has ended and normal availability and gas pricing are restored. Your grid now begins a long recovery from ERCOT-wide load shed."
-              : "The freeze has ended and normal availability and gas pricing are restored. Your preparations carried the local grid through ERCOT-wide shortages without unserved energy.",
+            event === undefined
+              ? "After the February emergency, normal availability and gas pricing will return. The outcome will depend on how the local portfolio performs through the freeze."
+              : unservedWh > 0
+                ? "The freeze has ended and normal availability and gas pricing are restored. Your grid now begins a long recovery from ERCOT-wide load shed."
+                : "The freeze has ended and normal availability and gas pricing are restored. Your preparations carried the local grid through ERCOT-wide shortages without unserved energy.",
           details:
             "Historically, ERCOT estimated 76,819 MW of unconstrained peak demand, served a 69,871 MW actual peak and shed roughly 20,000 MW at the worst point; about 200,000-220,000 Austin customers lost power.",
           concept: "weather",

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -162,7 +162,6 @@ let speedBeforeManual: SpeedType | undefined;
 // Tracks whether the self-rescheduling tick() loop is currently alive, so that any transition
 // out of PAUSED (manual speed click, tutorial script, dialog closing) reliably restarts it.
 let tickLoopRunning = false;
-let previousMonth = "";
 // Edge-detects the blackout toast, so a sustained blackout announces itself once rather than
 // four times an hour of game time
 let previouslyInBlackout = false;
@@ -734,9 +733,6 @@ export const gameSlice = createSlice({
     },
     initGame: (state, action: PayloadAction<NewGameAction>) => {
       const a = action.payload;
-      // Without this a second game in the same session inherits the first one's month and skips
-      // its first rollover, which also makes an otherwise identical seed produce a different run
-      previousMonth = "";
       previouslyInBlackout = false;
       blackoutUnservedWh = 0;
       previousFuelPrices = undefined;
@@ -906,10 +902,7 @@ export const gameSlice = createSlice({
     });
     builder.addCase(resume, (_state, action) => {
       const restored = cloneDeep(action.payload);
-      // The tick loop's module-level locals have to line up with the state being restored.
-      // Unlike initGame, this one keeps the month: clearing it would make the first tick record a
-      // second history entry for a month that's already in the log.
-      previousMonth = restored.date.month;
+      // The tick loop's remaining module-level locals have to line up with restored state.
       const now = getTimeFromTimeline(restored.date.minute, restored.timeline);
       previouslyInBlackout = now ? now.supplyW < now.demandW : false;
       blackoutStartMinute = restored.date.minute;
@@ -1303,9 +1296,11 @@ export function tickState(state: GameType) {
       }, 0);
     }
 
-    if (previousMonth !== state.date.month) {
-      previousMonth = state.date.month;
-      const history = state.monthlyHistory;
+    const history = state.monthlyHistory;
+    // One row per completed month is both the rollover signal and the persisted checkpoint. It
+    // avoids module-level calendar state leaking between concurrent simulations or a second game,
+    // and unlike an empty sentinel it cannot count the opening forecast as completed history.
+    if (history.length < state.date.monthsElapsed) {
       const { cash, customers } = now;
       state.customerRate = now.customerRate;
 
@@ -1438,12 +1433,31 @@ export function tickState(state: GameType) {
       };
 
       const chronicBlackouts = hasChronicBlackouts(history);
+      const objectiveFailure =
+        state.date.monthsElapsed === (scenario.durationMonths || 12 * 20)
+          ? scenarioObjectiveFailure(scenario, history)
+          : undefined;
       const failure =
         now.cash < 0
-          ? ({ outcome: "bankrupt", title: "Bankrupt!" } as const)
+          ? ({
+              outcome: "bankrupt",
+              title: "Bankrupt!",
+              reason: undefined,
+            } as const)
           : chronicBlackouts
-            ? ({ outcome: "fired", title: "Fired!" } as const)
-            : undefined;
+            ? ({
+                outcome: "fired",
+                title: "Fired!",
+                reason:
+                  "You've allowed chronic blackouts for 3 months, causing the utility board to remove you from office.",
+              } as const)
+            : objectiveFailure
+              ? ({
+                  outcome: "fired",
+                  title: "Mission objective missed",
+                  reason: objectiveFailure,
+                } as const)
+              : undefined;
 
       if (failure) {
         const summary = summarizeHistory(history);
@@ -1452,7 +1466,7 @@ export function tickState(state: GameType) {
           `${
             failure.outcome === "bankrupt"
               ? "You've run out of money."
-              : "You've allowed chronic blackouts for 3 months, causing shareholders to remove you from office."
+              : failure.reason
           }
                 You survived for ${yearsSurvived} years,
                 earned ${formatMoneyConcise(summary.revenue)} in revenue
@@ -1562,6 +1576,25 @@ export function hasChronicBlackouts(history: MonthlyHistoryType[]): boolean {
     history.length >= 3 &&
     history.slice(0, 3).every((month) => month.supplyWh < month.demandWh * 0.9)
   );
+}
+
+/** A scenario-specific end gate, kept pure so headless QA and the live game agree exactly. */
+export function scenarioObjectiveFailure(
+  scenario: ScenarioType,
+  history: MonthlyHistoryType[],
+): string | undefined {
+  if (
+    scenario.minimumCustomerRetention === undefined ||
+    scenario.startingCustomers === undefined ||
+    history.length === 0
+  ) {
+    return undefined;
+  }
+  const retained = history[0].customers / scenario.startingCustomers;
+  if (retained >= scenario.minimumCustomerRetention) {
+    return undefined;
+  }
+  return `Customer attrition left you with only ${Math.round(retained * 100)}% of the community you started with; this mission requires retaining at least ${Math.round(scenario.minimumCustomerRetention * 100)}%.`;
 }
 
 // Simplified customer forecast, assumes no blackouts since supply calculation depends on demand

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -209,6 +209,9 @@ describe("ending a scenario from inside the reducer", () => {
       (s: ScenarioType) => s.id === 100,
     ) as ScenarioType;
     const state = createGame({ scenarioId: scenario.id });
+    while (state.date.monthsElapsed < 3) {
+      tickState(state);
+    }
     const blackoutMonth: MonthlyHistoryType = {
       year: scenario.startingYear,
       month: 0,
@@ -244,7 +247,7 @@ describe("ending a scenario from inside the reducer", () => {
       facility.currentW = 0;
     });
 
-    playOutOnTheStore(state, 1);
+    playOutOnTheStore(state, 4);
     jest.runOnlyPendingTimers();
 
     const victory = getStore().getState().ui.victory;

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -186,6 +186,7 @@ describe("researched public-utility scenarios", () => {
 
   it("calibrates Manassas against its authored weather", () => {
     const result = runSimulation({ scenarioId: 106, months: 12 });
+    expect(result.months).toHaveLength(12);
     const firstYear = result.months.slice(-12);
     const annualDemandWh = firstYear.reduce(
       (total, month) => total + month.demandWh,
@@ -216,6 +217,43 @@ describe("researched public-utility scenarios", () => {
     expect(replayed.startingDemandScale).toBe(7.5);
     expect(replayed.loadAdditions).toEqual(manassas.loadAdditions);
     expect(replayed.timeline).toEqual(state.timeline);
+  });
+
+  it("records only completed Manassas months across new game, save and replay", () => {
+    const fresh = createGame({ scenarioId: 106 });
+    expect(fresh.monthlyHistory).toEqual([]);
+    runMonths(fresh, 1);
+    expect(fresh.monthlyHistory).toHaveLength(1);
+    expect(fresh.monthlyHistory[0]).toMatchObject({ year: 2020, month: 1 });
+
+    const uninterrupted = createGame({ scenarioId: 106 });
+    runMonths(uninterrupted, 73);
+    const boundary = createGame({ scenarioId: 106 });
+    runMonths(boundary, 71); // December 2025, immediately before the authored load arrives
+    const restored = parseSave(
+      JSON.parse(JSON.stringify(serializeSave(boundary))),
+    )!.game;
+    runMonths(restored, 2);
+    expect(restored.monthlyHistory).toEqual(uninterrupted.monthlyHistory);
+
+    const replayed = createGameFromReplay(serializeReplay(boundary)!);
+    runMonths(replayed, 73);
+    expect(replayed.monthlyHistory).toEqual(uninterrupted.monthlyHistory);
+
+    const full = runSimulation({
+      scenarioId: 106,
+      initialBuild: {
+        name: "Natural Gas",
+        peakW: 50_000_000,
+        financed: true,
+      },
+    });
+    expect(full.months).toHaveLength(192);
+    expect(full.months[0]).toMatchObject({ year: 2020, month: 1 });
+    expect(full.months[191]).toMatchObject({ year: 2035, month: 12 });
+    expect(
+      new Set(full.months.map((month) => `${month.year}-${month.month}`)).size,
+    ).toBe(192);
   });
 
   it("defaults demand calibration to one and applies it to the whole forecast", () => {
@@ -353,15 +391,31 @@ describe("researched public-utility scenarios", () => {
     "CEO",
   ];
   it.each(difficulties)(
-    "keeps Data Center Boom survivable on %s with a responsive build strategy",
+    "completes Data Center Boom on %s with capacity planned before the arrival",
     (difficulty) => {
       const result = runSimulation({
         scenarioId: 106,
         difficulty,
-        strategy: "keepUp",
+        initialBuild: {
+          name: "Natural Gas",
+          peakW: 50_000_000,
+          financed: true,
+        },
       });
       expectNoViolations(result);
       expect(result.outcome).toBe("completed");
+    },
+  );
+
+  it.each(difficulties)(
+    "rejects passive customer attrition as a Data Center Boom win on %s",
+    (difficulty) => {
+      const result = runSimulation({ scenarioId: 106, difficulty });
+      expectNoViolations(result);
+      expect(result.outcome).toBe("fired");
+      expect(result.months[result.months.length - 1].customers).toBeLessThan(
+        manassas.startingCustomers! * manassas.minimumCustomerRetention!,
+      );
     },
   );
 
@@ -375,24 +429,28 @@ describe("researched public-utility scenarios", () => {
   );
 
   it("supports materially different Manager strategies for Data Center Boom", () => {
-    const responsiveSolar = runSimulation({
-      scenarioId: 106,
-      difficulty: "Manager",
-      strategy: "keepUp",
-    });
-    const plannedGas = runSimulation({
+    const leanPlan = runSimulation({
       scenarioId: 106,
       difficulty: "Manager",
       initialBuild: {
         name: "Natural Gas",
-        peakW: 100_000_000,
+        peakW: 40_000_000,
         financed: true,
       },
     });
-    expect(responsiveSolar.outcome).toBe("completed");
-    expect(plannedGas.outcome).toBe("completed");
-    expect(responsiveSolar.builds.map((build) => build.name)).not.toEqual(
-      plannedGas.builds.map((build) => build.name),
+    const reservePlan = runSimulation({
+      scenarioId: 106,
+      difficulty: "Manager",
+      initialBuild: {
+        name: "Natural Gas",
+        peakW: 50_000_000,
+        financed: true,
+      },
+    });
+    expect(leanPlan.outcome).toBe("completed");
+    expect(reservePlan.outcome).toBe("completed");
+    expect(leanPlan.builds[0].buildCost).not.toBe(
+      reservePlan.builds[0].buildCost,
     );
   });
 

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -8,6 +8,7 @@ import gameReducer, {
   delta,
   initGame,
   hasChronicBlackouts,
+  scenarioObjectiveFailure,
   start,
   startReplay,
   sellFacility,
@@ -433,6 +434,15 @@ export function runSimulation(options: SimOptionsType): SimResultType {
     }
     // The timeline was just regenerated and pre-rolled, so tick continuity restarts next tick
     prevTick = null;
+  }
+
+  if (
+    firedAtMonth === null &&
+    bankruptAtMonth === null &&
+    state.date.monthsElapsed >= scenario.durationMonths &&
+    scenarioObjectiveFailure(scenario, state.monthlyHistory)
+  ) {
+    firedAtMonth = state.date.monthsElapsed;
   }
 
   return {


### PR DESCRIPTION
## Summary

Two independent QA passes covered the merged Data Center Boom and Texas Deep Freeze scenarios. This follow-up fixes their confirmed findings:

- record exactly one history row per completed month (192 rows for 2020–2035), eliminate module-level rollover leakage between games/simulations, and repair the impossible extra opening row in existing v4 saves
- require Data Center Boom to retain at least 90% of its starting customers, expose that gate in Victory Conditions, and reject passive customer attrition as a win
- keep planned Manassas capacity viable on every difficulty and keep the Austin calibration inside its researched tolerance after correcting monthly accounting
- show the authored “New data centers” label in the demand forecast
- keep the future Austin thaw description neutral until February results exist, and remove the unconditional local-load-shed claim from Uri onset
- describe Austin as stewardship of an already resilient aggregate portfolio, consistent with the historical premise and passive portfolio result

## QA evidence

- Data Center Boom passive play: rejected on Intern, Employee, Manager, VP, and CEO for seeds 12345 and 98765
- Data Center Boom planned 50 MW natural-gas build: completes on all five difficulties
- New-game history starts empty; the first rollover records January 2020; a full run records 192 unique months through December 2035
- December 2025 save/resume and replay match an uninterrupted run through the January 2026 load arrival
- Uri multipliers, temperature offset, gas-price multiplier, save/replay seam, and March expiry remained correct in the independent Austin QA

## Verification

- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false --runInBand — 87 suites, 798 tests passed
- npm run build

Follow-up to #268 and #270.