### PR TITLE
Replace purchased power proxy with natural gas

### DIFF
--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -156,7 +156,6 @@ describe("authored starting fleets", () => {
       expect.objectContaining({
         fuel: "Natural Gas",
         peakW: 75_000_000,
-        label: "Purchased Power Proxy",
       }),
     ]);
 

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -901,8 +901,6 @@ export const SCENARIOS = [
         fuel: "Natural Gas",
         peakW: 75000000,
         initialAgeYears: 0,
-        // This is purchased power in gameplay terms, not a fictional city-owned gas plant.
-        label: "Purchased Power Proxy",
       },
     ],
     loadAdditions: [

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -204,7 +204,7 @@ describe("researched public-utility scenarios", () => {
     expect(
       state.facilities.find((facility) => facility.fuel === "Natural Gas")
         ?.name,
-    ).toBe("Purchased Power Proxy");
+    ).toBe("Natural Gas");
     expect(
       state.timeline.every((tick) => tick.demandByType["Data centers"] === 0),
     ).toBe(true);


### PR DESCRIPTION
## Summary
- remove the custom Purchased Power Proxy label from the Data Center Boom starting fleet
- represent the facility with the existing Natural Gas generator type
- update scenario and simulation coverage for the Natural Gas name

## Testing
- npm test -- --watchAll=false --runInBand src/data/Scenarios.test.tsx src/testing/Simulation.test.tsx
- npm run typecheck
- npm run lint -- --no-cache src/data/Scenarios.tsx src/data/Scenarios.test.tsx src/testing/Simulation.test.tsx
- npx prettier --check src/data/Scenarios.tsx src/data/Scenarios.test.tsx src/testing/Simulation.test.tsx