### PR TITLE
Sort scenarios by start and end year

### DIFF
--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -31,14 +31,20 @@ function recordPlayed(...scenarioIds: number[]) {
 describe("NewGame", () => {
   beforeEach(() => localStorage.clear());
 
-  it("shows training in its authored order and scenarios newest first", () => {
+  it("shows training in its authored order and scenarios by latest timeframe", () => {
     render(<NewGame {...props()} />);
 
     const rows = screen.getAllByTestId(/^mission-row-/);
     expect(rows).toHaveLength(SCENARIOS.length + 1);
     const scenariosNewestFirst = SCENARIOS.filter(
       (scenario) => !scenario.tutorialSteps,
-    ).sort((a, b) => b.startingYear - a.startingYear);
+    ).sort(
+      (a, b) =>
+        b.startingYear - a.startingYear ||
+        b.startingYear +
+          b.durationMonths / 12 -
+          (a.startingYear + a.durationMonths / 12),
+    );
     [...TUTORIALS, ...scenariosNewestFirst].forEach((scenario, index) =>
       expect(rows[index]).toHaveTextContent(scenario.name),
     );
@@ -46,6 +52,11 @@ describe("NewGame", () => {
       (scenario) => scenario.startingYear,
     );
     expect(scenarioYears).toEqual([...scenarioYears].sort((a, b) => b - a));
+    expect(
+      scenariosNewestFirst
+        .filter((scenario) => scenario.startingYear === 2020)
+        .map((scenario) => scenario.name),
+    ).toEqual(["Data Center Boom", "Carbon Fee"]);
     expect(rows[rows.length - 1]).toHaveTextContent("Custom Game");
     expect(screen.getByText("Training")).toBeInTheDocument();
     expect(screen.getByText("Scenarios")).toBeInTheDocument();

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -40,6 +40,10 @@ export interface DispatchProps {
 
 export interface Props extends StateProps, DispatchProps {}
 
+function scenarioEndYear(scenario: ScenarioType): number {
+  return scenario.startingYear + scenario.durationMonths / 12;
+}
+
 interface MissionListItemProps {
   s: ScenarioType;
   completed: boolean;
@@ -63,8 +67,7 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
         {s.summary}
         <br />
         <i>
-          {location.name}, {s.startingYear}-
-          {s.startingYear + s.durationMonths / 12}
+          {location.name}, {s.startingYear}-{scenarioEndYear(s)}
         </i>
       </span>
     );
@@ -128,7 +131,9 @@ export default function NewGame(props: Props): React.JSX.Element {
   const ids = getPlayedScenarioIds();
   const nextTutorial = TUTORIALS.find((s) => ids.indexOf(s.id) === -1);
   const scenarios = SCENARIOS.filter((s) => !s.tutorialSteps).sort(
-    (a, b) => b.startingYear - a.startingYear,
+    (a, b) =>
+      b.startingYear - a.startingYear ||
+      scenarioEndYear(b) - scenarioEndYear(a),
   );
 
   return (


### PR DESCRIPTION
Sorts the scenario list by start year descending, then by end year descending for equal starts. Reuses the displayed end-year calculation and adds a regression test covering the tied 2020 scenarios. Tests: focused NewGame suite, TypeScript typecheck, ESLint, and Prettier.