### PR TITLE
Simplify the first-time game experience

### DIFF
--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -13,7 +13,7 @@ export const DIFFICULTIES = {
     buildTime: 0.2,
     blackoutPenalty: 2,
     description:
-      "Easiest: 40% cheaper facilities, 40% lower operating costs, 80% faster construction, and blackouts cost you the least growth.",
+      "Most forgiving: much lower costs, very fast building, and gentler outage consequences.",
   },
   Employee: {
     buildCost: 0.7,
@@ -21,23 +21,21 @@ export const DIFFICULTIES = {
     buildTime: 0.3,
     blackoutPenalty: 4,
     description:
-      "Easy: 30% cheaper facilities, 30% lower operating costs, 70% faster construction, and lighter blackout penalties.",
+      "Forgiving: lower costs, faster building, and gentler outage consequences.",
   },
   Manager: {
     buildCost: 0.8,
     expensesOM: 0.8,
     buildTime: 0.5,
     blackoutPenalty: 6,
-    description:
-      "Medium: 20% cheaper facilities, 20% lower operating costs, 50% faster construction, and moderate blackout penalties.",
+    description: "Balanced: some help with costs, building time, and outages.",
   },
   VP: {
     buildCost: 0.9,
     expensesOM: 0.9,
     buildTime: 0.7,
     blackoutPenalty: 8,
-    description:
-      "Hard: 10% cheaper facilities, 10% lower operating costs, 30% faster construction, and heavier blackout penalties.",
+    description: "Demanding: a little help with costs and building time.",
   },
   CEO: {
     buildCost: 1,
@@ -45,7 +43,7 @@ export const DIFFICULTIES = {
     buildTime: 1,
     blackoutPenalty: 10,
     description:
-      "Hardest: full-price facilities, full-price operations, full construction time, and the harshest blackout penalties.",
+      "Full challenge: standard costs, building times, and outage consequences.",
   },
 } as { [index: string]: DifficultyMultipliersType };
 

--- a/src/app.scss
+++ b/src/app.scss
@@ -1055,16 +1055,16 @@ html[data-theme="dark"] .uplot {
   display: flex;
   flex-direction: column;
   max-width: 900px;
-  margin: 24px auto;
+  margin: 16px auto 12px;
   padding: 0 20px;
 }
 
 .scenarioDossierIcon {
   display: block;
-  width: 132px;
+  width: 96px;
   aspect-ratio: 1;
   align-self: center;
-  margin-bottom: 14px;
+  margin-bottom: 10px;
 }
 
 .scenarioDossierCopy {
@@ -1076,8 +1076,10 @@ html[data-theme="dark"] .uplot {
 
 .scenarioBriefingFacts {
   display: grid;
-  gap: 8px;
+  gap: 0;
   margin-top: 4px;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
   text-align: left;
 }
 
@@ -1086,10 +1088,12 @@ html[data-theme="dark"] .uplot {
   grid-template-columns: auto 1fr auto;
   align-items: start;
   gap: 10px;
-  padding: 9px 11px;
-  border: 1px solid var(--border-tile);
-  border-radius: 8px;
-  background: var(--bg-raised);
+  padding: 10px 2px;
+  border-top: 1px solid var(--border-subtle);
+
+  &:first-child {
+    border-top: 0;
+  }
 
   .MuiTypography-overline {
     font-weight: 800;
@@ -1105,7 +1109,6 @@ html[data-theme="dark"] .uplot {
   gap: 12px;
   margin-top: 4px;
   padding-top: 12px;
-  border-top: 1px solid var(--border-subtle);
 }
 
 .difficultyPicker {
@@ -1146,8 +1149,8 @@ html[data-theme="dark"] .uplot {
   }
 
   .scenarioDossierIcon {
-    width: 120px;
-    margin-bottom: 12px;
+    width: 88px;
+    margin-bottom: 8px;
   }
 
   .scenarioStartControls {
@@ -1540,17 +1543,29 @@ html[data-theme="dark"] .uplot {
       margin: auto;
 
       .gameSubtitle {
-        margin: 0 auto 18px;
+        max-width: 380px;
+        margin: 0 auto 20px;
         color: $font_color_faded;
+        font-size: 1.05rem;
+        line-height: 1.5;
       }
 
       .mainActions {
         align-items: center;
-        margin-bottom: 6px;
+        margin-bottom: 10px;
+
+        .MuiButton-root {
+          width: min(100%, 260px);
+        }
+      }
+
+      .resourceActions {
+        max-width: 440px;
+        margin: 0 auto;
       }
 
       .discoveryActions {
-        margin-top: 6px;
+        margin-top: 2px;
       }
 
       button {
@@ -1733,6 +1748,41 @@ html[data-theme="dark"] .uplot {
     padding-top: size(base) !important;
     padding-bottom: 20px; /* for devices with with bottom bars */
     height: 100%;
+  }
+
+  .missionList {
+    background: $bg_primary;
+    padding-top: 0 !important;
+
+    .MuiListSubheader-root {
+      padding: 18px 16px 8px;
+      line-height: 1.35;
+
+      &:first-child {
+        padding-top: 12px;
+      }
+    }
+  }
+
+  .missionItem {
+    margin: 0 12px 8px;
+    border: 1px solid var(--border-tile);
+    border-radius: 10px;
+    box-shadow: none;
+
+    .MuiCardHeader-root {
+      padding: 10px 12px;
+    }
+
+    .MuiCardHeader-title {
+      font-weight: 700;
+    }
+
+    .missionMeta {
+      display: block;
+      margin-top: 2px;
+      color: $font_color_faded;
+    }
   }
 
   .facility {

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -18,11 +18,11 @@ function props(overrides: Partial<Props> = {}): Props {
 }
 
 describe("MainMenu", () => {
-  it("shows a single, compact game subtitle", () => {
+  it("explains the game without specialist language", () => {
     render(<MainMenu {...props()} />);
 
     expect(
-      screen.getByText(/Build power plants, keep the lights on/i),
+      screen.getByText(/Keep the lights on. Build a cleaner energy future/i),
     ).toHaveClass("gameSubtitle", "MuiTypography-body1");
     expect(screen.queryByText(/no energy or gaming experience/i)).toBeNull();
   });
@@ -32,18 +32,18 @@ describe("MainMenu", () => {
     const user = userEvent.setup();
     render(<MainMenu {...props({ onStart })} />);
 
-    await user.click(screen.getByRole("button", { name: "Play" }));
+    await user.click(screen.getByRole("button", { name: "Start playing" }));
     expect(onStart).toHaveBeenCalled();
     expect(screen.queryByText("Continue")).not.toBeInTheDocument();
   });
 
   it("only advertises account-free play before sign-in", () => {
     const { rerender } = render(<MainMenu {...props({ uid: undefined })} />);
-    expect(screen.getByText("Free · no account needed")).toBeInTheDocument();
+    expect(screen.getByText("Free · no sign-up needed")).toBeInTheDocument();
 
     rerender(<MainMenu {...props({ uid: "player" })} />);
     expect(
-      screen.queryByText("Free · no account needed"),
+      screen.queryByText("Free · no sign-up needed"),
     ).not.toBeInTheDocument();
   });
 
@@ -51,10 +51,10 @@ describe("MainMenu", () => {
     render(<MainMenu {...props({ hasSavedGame: true })} />);
 
     expect(
-      screen.getByRole("button", { name: "Continue your game" }),
+      screen.getByRole("button", { name: "Continue" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Choose a mission" }),
+      screen.getByRole("button", { name: "Start another game" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("navigation", { name: "Game resources" }),
@@ -64,7 +64,7 @@ describe("MainMenu", () => {
     );
   });
 
-  it("puts every non-footer action on its own line with cohesive spacing", () => {
+  it("groups secondary actions into compact rows", () => {
     render(
       <MainMenu
         {...props({
@@ -84,8 +84,8 @@ describe("MainMenu", () => {
     });
 
     expect(primary).toHaveStyle({ flexDirection: "column" });
-    expect(resources).toHaveStyle({ flexDirection: "column", gap: "6px" });
-    expect(discovery).toHaveStyle({ flexDirection: "column", gap: "6px" });
+    expect(resources).toHaveStyle({ flexDirection: "row", gap: "6px" });
+    expect(discovery).toHaveStyle({ flexDirection: "row", gap: "6px" });
   });
 
   it("keeps sharing as a compact footer icon", () => {

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -29,7 +29,9 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 const MainMenu = (props: Props): React.JSX.Element => {
-  const startLabel = props.hasSavedGame ? "Choose a mission" : "Play";
+  const startLabel = props.hasSavedGame
+    ? "Start another game"
+    : "Start playing";
   const [shareStatus, setShareStatus] = React.useState("");
 
   const onShare = async () => {
@@ -55,8 +57,7 @@ const MainMenu = (props: Props): React.JSX.Element => {
       </Typography>
       <Box id="centeredMenu" sx={{ px: 3 }}>
         <Typography className="gameSubtitle" variant="body1" component="p">
-          Build power plants, keep the lights on, and clean up the grid — learn
-          as you play.
+          Keep the lights on. Build a cleaner energy future.
         </Typography>
         <Stack
           component="section"
@@ -73,7 +74,7 @@ const MainMenu = (props: Props): React.JSX.Element => {
               color="primary"
               onClick={props.onContinue}
             >
-              Continue your game
+              Continue
             </Button>
           )}
           <Button
@@ -86,22 +87,24 @@ const MainMenu = (props: Props): React.JSX.Element => {
             {startLabel}
           </Button>
           {!props.hasSavedGame && !props.uid && (
-            <Typography variant="caption">Free · no account needed</Typography>
+            <Typography variant="caption">Free · no sign-up needed</Typography>
           )}
         </Stack>
         <Stack
           component="nav"
           aria-label="Game resources"
           className="resourceActions"
-          direction="column"
+          direction="row"
           spacing={0.75}
           useFlexGap
           sx={{
             alignItems: "center",
+            justifyContent: "center",
+            flexWrap: "wrap",
           }}
         >
           <Button variant="text" color="primary" onClick={props.onManual}>
-            Manual
+            How to play
           </Button>
           <Button
             data-settings-trigger
@@ -109,11 +112,11 @@ const MainMenu = (props: Props): React.JSX.Element => {
             color="primary"
             onClick={props.onSettings}
           >
-            Options
+            Settings
           </Button>
           {!props.uid && (
             <Button variant="text" color="primary" onClick={login}>
-              Sign in with Google
+              Sign in
             </Button>
           )}
         </Stack>
@@ -121,10 +124,14 @@ const MainMenu = (props: Props): React.JSX.Element => {
           component="section"
           aria-label="Discovery actions"
           className="discoveryActions"
-          direction="column"
+          direction="row"
           spacing={0.75}
           useFlexGap
-          sx={{ alignItems: "center" }}
+          sx={{
+            alignItems: "center",
+            justifyContent: "center",
+            flexWrap: "wrap",
+          }}
         >
           <InstallAppButton />
           {props.audioEnabled === undefined && (
@@ -133,7 +140,7 @@ const MainMenu = (props: Props): React.JSX.Element => {
               startIcon={<VolumeUpIcon />}
               onClick={() => props.onAudioChange(true)}
             >
-              Play with sound
+              Turn on sound
             </Button>
           )}
         </Stack>

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -40,18 +40,20 @@ describe("NewGame", () => {
       (scenario) => !scenario.tutorialSteps,
     ).sort((a, b) => b.startingYear - a.startingYear);
     [...TUTORIALS, ...scenariosNewestFirst].forEach((scenario, index) =>
-      expect(rows[index]).toHaveTextContent(scenario.name),
+      expect(rows[index]).toHaveTextContent(
+        scenario.name.replace(/^Mission \d+:\s*/, ""),
+      ),
     );
     const scenarioYears = scenariosNewestFirst.map(
       (scenario) => scenario.startingYear,
     );
     expect(scenarioYears).toEqual([...scenarioYears].sort((a, b) => b - a));
     expect(rows[rows.length - 1]).toHaveTextContent("Custom Game");
-    expect(screen.getByText("Training")).toBeInTheDocument();
-    expect(screen.getByText("Scenarios")).toBeInTheDocument();
-    expect(screen.getByText("Sandbox")).toBeInTheDocument();
+    expect(screen.getByText("New here?")).toBeInTheDocument();
+    expect(screen.getByText("Challenges")).toBeInTheDocument();
+    expect(screen.getByText("Make it your own")).toBeInTheDocument();
     expect(
-      screen.getByRole("list", { name: "Available missions" }),
+      screen.getByRole("list", { name: "Available games" }),
     ).toContainElement(rows[0]);
   });
 
@@ -71,10 +73,12 @@ describe("NewGame", () => {
     expect(next).toHaveTextContent(TUTORIALS[1].summary as string);
     expect(next).not.toHaveTextContent("Start here");
     expect(next).not.toHaveTextContent("Recommended next");
-    expect(next).toHaveTextContent(TUTORIALS[1].name);
+    expect(next).toHaveTextContent(
+      TUTORIALS[1].name.replace(/^Mission \d+:\s*/, ""),
+    );
     expect(next).toHaveClass("tutorialNext");
     expect(within(next).getByRole("button")).toHaveAccessibleName(
-      `Play ${TUTORIALS[1].name}`,
+      `Start ${TUTORIALS[1].name.replace(/^Mission \d+:\s*/, "")}`,
     );
   });
 

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -49,11 +49,16 @@ interface MissionListItemProps {
   onSelect: () => void;
 }
 
+function displayName(s: ScenarioType): string {
+  return s.name.replace(/^Mission \d+:\s*/, "");
+}
+
 // One row for everything: tutorial missions, scenarios, and the custom game all share the
 // list now - the only differences are the action control and what the subheader shows
 function MissionListItem(props: MissionListItemProps): React.JSX.Element {
   const { s, completed, next, onSelect } = props;
   const isTutorial = !!s.tutorialSteps;
+  const name = displayName(s);
   const location = getScenarioLocation(s) || { name: "UNKNOWN" };
   const summary =
     isTutorial || s.id === CUSTOM_SCENARIO_ID ? (
@@ -62,24 +67,24 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
       <span>
         {s.summary}
         <br />
-        <i>
-          {location.name}, {s.startingYear}-
+        <span className="missionMeta">
+          {location.name} · {s.startingYear}–
           {s.startingYear + s.durationMonths / 12}
-        </i>
+        </span>
       </span>
     );
   return (
     <Card
       data-testid={`mission-row-${s.id}`}
-      className={`build-list-item${next ? " tutorialNext" : ""}`}
+      className={`build-list-item missionItem${next ? " tutorialNext" : ""}`}
     >
       <CardActionArea
         onClick={onSelect}
         autoFocus={next}
         aria-label={
           isTutorial
-            ? `${completed ? "Replay" : "Play"} ${s.name}`
-            : `View ${s.name} details`
+            ? `${completed ? "Review" : "Start"} ${name}`
+            : `View ${name} details`
         }
       >
         <CardHeader
@@ -101,16 +106,16 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
             >
               <Avatar
                 src={`/images/${s.icon.toLowerCase()}.svg`}
-                alt={`${s.name} icon`}
+                alt={`${name} icon`}
               />
             </Badge>
           }
-          title={<span>{s.name}</span>}
+          title={<span>{name}</span>}
           subheader={<span>{summary}</span>}
           action={
             isTutorial ? (
               <Chip
-                label={completed ? "Replay" : "Play"}
+                label={completed ? "Review" : "Start"}
                 variant={completed ? "outlined" : "filled"}
                 color="primary"
               />
@@ -145,7 +150,7 @@ export default function NewGame(props: Props): React.JSX.Element {
             <ArrowBackIosIcon />
           </IconButton>
           <Typography component="h1" variant="h6">
-            Missions
+            Choose a game
           </Typography>
           {/* Otherwise the Manual is only reachable from the title screen and the in-game
               overflow menu, so players who stop partway through never find out it exists.
@@ -154,7 +159,7 @@ export default function NewGame(props: Props): React.JSX.Element {
           <IconButton
             sx={{ marginLeft: "auto" }}
             onClick={props.onManual}
-            aria-label="manual"
+            aria-label="How to play"
             color="primary"
             size="large"
           >
@@ -164,8 +169,8 @@ export default function NewGame(props: Props): React.JSX.Element {
       </div>
       <List
         dense
-        className="scrollable cardList"
-        aria-label="Available missions"
+        className="scrollable cardList missionList"
+        aria-label="Available games"
       >
         <ListSubheader
           disableSticky
@@ -180,10 +185,10 @@ export default function NewGame(props: Props): React.JSX.Element {
             variant="subtitle2"
             sx={{ fontWeight: 700 }}
           >
-            Training
+            New here?
           </Typography>
           <Typography variant="caption" component="p">
-            Six short missions teach the game step by step.
+            Learn the basics in six short lessons.
           </Typography>
         </ListSubheader>
         {TUTORIALS.map((s) => (
@@ -208,7 +213,10 @@ export default function NewGame(props: Props): React.JSX.Element {
             variant="subtitle2"
             sx={{ fontWeight: 700 }}
           >
-            Scenarios
+            Challenges
+          </Typography>
+          <Typography variant="caption" component="p">
+            Put your skills to work in a real place and time.
           </Typography>
         </ListSubheader>
         {scenarios.map((s) => (
@@ -233,7 +241,10 @@ export default function NewGame(props: Props): React.JSX.Element {
             variant="subtitle2"
             sx={{ fontWeight: 700 }}
           >
-            Sandbox
+            Make it your own
+          </Typography>
+          <Typography variant="caption" component="p">
+            Choose the city, time period and rules.
           </Typography>
         </ListSubheader>
         <MissionListItem

--- a/src/components/views/NewGameDetails.test.tsx
+++ b/src/components/views/NewGameDetails.test.tsx
@@ -63,7 +63,7 @@ describe("NewGameDetails leaderboard", () => {
     expect(mockPrefetchScenarioData).toHaveBeenCalledWith(
       expect.objectContaining({ id: "SF" }),
     );
-    await screen.findByText("Play the scenario to set a high score");
+    await screen.findByText("Finish this game to join the leaderboard");
   });
 
   it("leads with the scenario fantasy, objective, and stakes", async () => {
@@ -74,31 +74,34 @@ describe("NewGameDetails leaderboard", () => {
     ).toHaveAttribute("src", "/images/carbon fee.svg");
     expect(
       screen.getByRole("heading", {
-        name: "Carbon Fee — Modernize an aging grid as pollution gets more expensive.",
+        name: "Carbon Fee",
       }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Objective")).toBeInTheDocument();
-    expect(screen.getByText("Constraint")).toBeInTheDocument();
-    expect(screen.getByText("Threat")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Modernize an aging grid as pollution gets more expensive.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Your goal")).toBeInTheDocument();
+    expect(screen.getByText("The catch")).toBeInTheDocument();
+    expect(screen.getByText("Watch out")).toBeInTheDocument();
     expect(screen.queryByText("Winning looks like")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Victory conditions" }),
+      screen.getByRole("button", { name: "What counts as a win" }),
     ).toBeVisible();
-    expect(screen.getByRole("button", { name: "Start mission" })).toBeVisible();
-    expect(screen.getByText(/Easy: 30% cheaper facilities/)).toBeVisible();
-    await screen.findByText("Play the scenario to set a high score");
+    expect(screen.getByRole("button", { name: "Start game" })).toBeVisible();
+    expect(screen.getByText(/Forgiving: lower costs/)).toBeVisible();
+    await screen.findByText("Finish this game to join the leaderboard");
   });
 
   it("is always visible and follows the selected difficulty", async () => {
     const { rerender } = render(<NewGameDetails {...props()} />);
 
     expect(
-      screen.getByRole("heading", { name: "Global High Scores — Easy" }),
+      screen.getByRole("heading", { name: "Leaderboard — Easy" }),
     ).toBeInTheDocument();
     expect(screen.queryByText("See global leaderboard")).toBeNull();
-    expect(
-      screen.queryByRole("columnheader", { name: "Difficulty" }),
-    ).toBeNull();
+    expect(screen.queryByRole("columnheader", { name: "Level" })).toBeNull();
     await waitFor(() =>
       expect(mockWhere).toHaveBeenCalledWith("difficulty", "==", "Employee"),
     );
@@ -106,7 +109,7 @@ describe("NewGameDetails leaderboard", () => {
     rerender(<NewGameDetails {...props({ game: game("CEO") })} />);
 
     expect(
-      screen.getByRole("heading", { name: "Global High Scores — Expert" }),
+      screen.getByRole("heading", { name: "Leaderboard — Expert" }),
     ).toBeInTheDocument();
     await waitFor(() =>
       expect(mockWhere).toHaveBeenCalledWith("difficulty", "==", "CEO"),
@@ -118,11 +121,12 @@ describe("NewGameDetails leaderboard", () => {
     render(<NewGameDetails {...props({ onDelta })} />);
 
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Easy (Employee)" }),
-    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Easy" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
 
-    await userEvent.click(screen.getByRole("button", { name: "Expert (CEO)" }));
+    await userEvent.click(screen.getByRole("button", { name: "Expert" }));
 
     expect(onDelta).toHaveBeenCalledWith({ difficulty: "CEO" });
   });
@@ -175,19 +179,17 @@ describe("NewGameDetails leaderboard", () => {
 
     await screen.findByText("Player 3");
     expect(screen.queryByText("Player 4")).toBeNull();
-    expect(
-      screen.queryByRole("columnheader", { name: "Difficulty" }),
-    ).toBeNull();
+    expect(screen.queryByRole("columnheader", { name: "Level" })).toBeNull();
     await userEvent.click(
       screen.getByRole("button", { name: "View all scores" }),
     );
     expect(
       await screen.findByRole("heading", {
-        name: "Global High Scores — All Difficulties",
+        name: "Leaderboard — All levels",
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("columnheader", { name: "Difficulty" }),
+      screen.getByRole("columnheader", { name: "Level" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("row", { name: /Expert Player 900 Expert/ }),

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -384,7 +384,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
               <ArrowBackIosIcon />
             </IconButton>
             <Typography component="div" variant="h6">
-              Scenario
+              Game details
             </Typography>
           </Toolbar>
         </div>
@@ -406,19 +406,19 @@ export default class NewGameDetails extends React.Component<Props, State> {
                 component="h1"
                 sx={{ fontWeight: 800, lineHeight: 1.2 }}
               >
-                {scenario.name} — {briefing.fantasy}
+                {scenario.name}
               </Typography>
               <Typography variant="body1" color="textSecondary">
-                {scenario.summary}
+                {briefing.fantasy}
               </Typography>
               <div className="scenarioBriefingFacts">
                 <BriefingFact
                   concept="goal"
-                  label="Objective"
+                  label="Your goal"
                   action={
                     <IconButton
                       onClick={toggleVictoryDialog}
-                      aria-label="Victory conditions"
+                      aria-label="What counts as a win"
                       color="primary"
                       size="small"
                     >
@@ -428,24 +428,24 @@ export default class NewGameDetails extends React.Component<Props, State> {
                 >
                   {briefing.objective}
                 </BriefingFact>
-                <BriefingFact concept="finances" label="Constraint">
+                <BriefingFact concept="finances" label="The catch">
                   {briefing.constraint}
                 </BriefingFact>
-                <BriefingFact concept="danger" label="Threat">
+                <BriefingFact concept="danger" label="Watch out">
                   {briefing.threat}
                 </BriefingFact>
               </div>
               <div className="scenarioStartControls">
                 <div className="difficultyPicker">
                   <Typography variant="caption" component="div">
-                    Difficulty
+                    Challenge level
                   </Typography>
                   <ToggleButtonGroup
                     exclusive
                     value={game.difficulty}
                     size="small"
                     color="primary"
-                    aria-label="Difficulty"
+                    aria-label="Challenge level"
                     onChange={(_event, difficulty: DifficultyType | null) => {
                       if (difficulty) {
                         onDelta({ difficulty });
@@ -457,7 +457,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                         value={d}
                         key={d}
                         title={DIFFICULTIES[d].description}
-                        aria-label={`${DIFFICULTY_LABELS[d]} (${d})`}
+                        aria-label={DIFFICULTY_LABELS[d]}
                       >
                         {DIFFICULTY_LABELS[d]}
                       </ToggleButton>
@@ -479,7 +479,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   autoFocus
                   startIcon={<PlayCircleIcon />}
                 >
-                  Start mission
+                  Start game
                 </Button>
               </div>
             </div>
@@ -490,7 +490,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
             onClose={toggleVictoryDialog}
           >
             <DialogTitle>
-              Victory Conditions: {scenario.ownership}-Owned
+              What counts as a win
               <IconButton
                 aria-label="close"
                 onClick={toggleVictoryDialog}
@@ -527,8 +527,8 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   <TableCell colSpan={scoreColumnCount}>
                     <Typography variant="h6">
                       {leaderboardExpanded
-                        ? "Global High Scores — All Difficulties"
-                        : `Global High Scores — ${DIFFICULTY_LABELS[game.difficulty]}`}
+                        ? "Leaderboard — All levels"
+                        : `Leaderboard — ${DIFFICULTY_LABELS[game.difficulty]}`}
                     </Typography>
                   </TableCell>
                 </TableRow>
@@ -536,7 +536,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   <TableCell className="rank">#</TableCell>
                   <TableCell>Name</TableCell>
                   <TableCell>Score</TableCell>
-                  {leaderboardExpanded && <TableCell>Difficulty</TableCell>}
+                  {leaderboardExpanded && <TableCell>Level</TableCell>}
                   <TableCell className="replay">Replay</TableCell>
                 </TableRow>
               </TableHead>
@@ -571,7 +571,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                       <Typography variant="body2" color="textSecondary">
                         {visibleBoardFailed
                           ? "Couldn't load the high scores right now."
-                          : "Play the scenario to set a high score"}
+                          : "Finish this game to join the leaderboard"}
                       </Typography>
                     </TableCell>
                   </TableRow>


### PR DESCRIPTION
## Summary

- give the home screen one clear primary path and group secondary actions
- replace internal game vocabulary with shorter, plain-language labels
- simplify the game picker and briefing with quieter cards and less repeated copy
- explain challenge levels without percentage-heavy implementation details

## Verification

- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --watchAll=false --runInBand (87 suites, 799 tests)
- npm run build
- reviewed home, game picker, and briefing at mobile and desktop sizes with no browser console errors