### PR TITLE
Polish Carbon Fee and Data Center scenario icons

### DIFF
--- a/public/images/ai data center boom.svg
+++ b/public/images/ai data center boom.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1fe76de8cb7ab139166b3a50e76660feb6e6264236cd6b3f078adc171810a78
-size 1216
+oid sha256:6f2882a0b8c346c3d24d07dabee8e6babf0faab315d178dd46394f9185a47fd9
+size 1032

--- a/public/images/ai data center boom.svg
+++ b/public/images/ai data center boom.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f2882a0b8c346c3d24d07dabee8e6babf0faab315d178dd46394f9185a47fd9
+oid sha256:3e29a7e76c39d7d900d02804f5ec0cfe57dee020a94b38fbdee09e903c9f1c14
 size 1032

--- a/public/images/carbon fee.svg
+++ b/public/images/carbon fee.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ebcc23f801c0850180f35e37c6cd9c9b2d5ceee50d561c8ff6f8d7dd417997d
-size 1108
+oid sha256:08eab9ee560ccc1c8b868faf4b51ee1752be5b536c886df7e6fc80bfb919e88e
+size 913

--- a/public/images/carbon fee.svg
+++ b/public/images/carbon fee.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:08eab9ee560ccc1c8b868faf4b51ee1752be5b536c886df7e6fc80bfb919e88e
-size 913
+oid sha256:09cd0411593cfa7c68a97bc9f2e14eb48e87e945a0a2d996ef5b680f71db90da
+size 1013

--- a/public/images/hurricane season.svg
+++ b/public/images/hurricane season.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7326b752808d179aada59592135fb9e0c075661c7b98e2f6d27b24da3a243d42
+oid sha256:b2f7289fde8987211ffa68a68059bdd46356cd2edeb739faf5828d44994f57f9
 size 810

--- a/public/images/paradise.svg
+++ b/public/images/paradise.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8eeafdcddbbf47ed36c62eccfa4d36cb36005d840204b6687d4fecdd01c7f85
+oid sha256:a15db35355cdcd355a71f409c8750d8e7373686b0e511b22da970056760f3dff
 size 1011

--- a/public/images/rise of renewables.svg
+++ b/public/images/rise of renewables.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:803e22c3b78fc4e0bae39e78fa0fa96d8f4e3857728bbf4265c499671baa6fbb
-size 1084
+oid sha256:64167907f9f0dff98d59d35e7543d52fdfb335e4b4295f49f3765b4a4579f492
+size 1085

--- a/public/images/texas deep freeze.svg
+++ b/public/images/texas deep freeze.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b997ffd5084754876f536d11d4704598c180ce8ea1283e4b6376a101dc4a945
+oid sha256:7e24e3228e5eb7b8ea5d80df4de8b343db408c20cbfddb61ba585dfc3d831982
 size 1940

--- a/public/images/the end of an era.svg
+++ b/public/images/the end of an era.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c99894da689dde8765ac3826b09fa6506e24719fe1b33cd4ee38ceaac295be67
+oid sha256:a2c487c6eb69fd92060e2cd767fa084e244e9c8df6a7b5513ca08747b91a5afe
 size 678

--- a/public/images/the shale boom.svg
+++ b/public/images/the shale boom.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:493961a05cd35f7f80b09ebafd48e67eec829ec36ba22be44d1230315706881c
+oid sha256:3bd665ba17f3df5c8e1f6bf36a390edab6d7927c3ec79e46b2a7672da455c35f
 size 667

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -60,6 +60,9 @@ describe("NewGame", () => {
     expect(
       screen.getByRole("img", { name: "Carbon Fee icon" }),
     ).toHaveAttribute("src", "/images/carbon fee.svg");
+    expect(
+      screen.getByRole("img", { name: "Data Center Boom icon" }),
+    ).toHaveAttribute("src", "/images/ai data center boom.svg");
   });
 
   it("highlights the first incomplete tutorial without replacing its subtitle", () => {

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -861,7 +861,7 @@ export const SCENARIOS = [
   {
     id: 106, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
     name: "Data Center Boom",
-    icon: "natural gas",
+    icon: "ai data center boom",
     locationId: "Manassas",
     location: {
       id: "Manassas",


### PR DESCRIPTION
## Summary
- use the selected Center Seam carbon-coin artwork for Carbon Fee
- switch Data Center Boom from the generic natural-gas icon to its dedicated simplified server-and-growth badge
- retain the existing icons for every other scenario
- cover the Data Center Boom icon mapping in the scenario-list test

## Testing
- 11 targeted New Game and scenario-details tests pass
- Prettier checks pass
- rendered both production SVGs in Chromium for visual verification