### PR TITLE
Polish facility construction headers

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -476,6 +476,95 @@ $topbar_height: 56px;
   padding-right: max(16px, env(safe-area-inset-right)) !important;
 }
 
+.constructionHeader {
+  flex: 0 0 auto;
+  background: var(--bg-primary);
+}
+
+.constructionTitle {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 12px;
+
+  .iconLabel {
+    min-width: 0;
+    white-space: nowrap;
+  }
+}
+
+.constructionCash {
+  flex: 0 0 auto;
+  font-size: 0.875rem;
+  white-space: nowrap;
+}
+
+.constructionControls {
+  display: grid;
+  grid-template-columns: max-content minmax(80px, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 50px;
+  padding: 0 max(8px, env(safe-area-inset-right)) 0
+    max(8px, env(safe-area-inset-left));
+  border-bottom: $border_accent;
+}
+
+.constructionCapacity {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.constructionCapacitySlider.MuiSlider-root {
+  width: 100% !important;
+  min-width: 80px;
+}
+
+.constructionSortButton {
+  margin-right: -8px !important;
+}
+
+.constructionSortSelect {
+  min-width: 156px !important;
+
+  .MuiSelect-select {
+    padding: 8px 32px 8px 12px !important;
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .constructionControls {
+    gap: 16px;
+    padding-left: max(16px, env(safe-area-inset-left));
+    padding-right: max(16px, env(safe-area-inset-right));
+  }
+}
+
+@media screen and (max-width: 359px) {
+  .constructionTitle {
+    gap: 6px;
+    font-size: 1.05rem !important;
+  }
+
+  .constructionCash {
+    font-size: 0.75rem;
+  }
+
+  .constructionControls {
+    gap: 4px;
+    padding-left: max(4px, env(safe-area-inset-left));
+    padding-right: max(4px, env(safe-area-inset-right));
+  }
+
+  .constructionCapacity {
+    flex-direction: column;
+    gap: 0;
+    line-height: 1.05;
+  }
+}
+
 // Four direct speed choices still fit beside the live status at phone width. The currency and
 // date already name their concepts in text, so their duplicate glyphs are omitted in the
 // component and the remaining chrome tightens just enough for a 320px viewport.

--- a/src/components/base/ConstructionBuildHeader.tsx
+++ b/src/components/base/ConstructionBuildHeader.tsx
@@ -1,0 +1,157 @@
+import * as React from "react";
+import {
+  FormControl,
+  IconButton,
+  Menu,
+  MenuItem,
+  Select,
+  Slider,
+  Toolbar,
+  Typography,
+  useMediaQuery,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import SortIcon from "@mui/icons-material/Sort";
+import { ConceptNameType } from "../../Types";
+import { formatMoneyStable } from "../../helpers/Format";
+import ConceptIcon from "./ConceptIcon";
+
+interface Props {
+  concept: ConceptNameType;
+  title: string;
+  cash: number;
+  capacity: string;
+  sliderValue: number;
+  sliderMin: number;
+  sliderMax: number;
+  sort: string;
+  sortOptions: ReadonlyArray<readonly [string, string]>;
+  onClose: () => void;
+  onSliderChange: (value: number) => void;
+  onSortChange: (value: string) => void;
+}
+
+/**
+ * Shared chrome for the generator and storage catalogs.
+ *
+ * The first row follows the same hierarchy as GameAppBar: current context on the left and the
+ * one global action on the right. The decision controls get their own shorter row so the title,
+ * cash, capacity and sort order do not compete for one wrapped toolbar.
+ */
+export default function ConstructionBuildHeader(
+  props: Props,
+): React.JSX.Element {
+  const [sortAnchorEl, setSortAnchorEl] = React.useState<HTMLElement | null>(
+    null,
+  );
+  // At 600px the label, useful slider track and 150px select all fit without truncation. Below
+  // that, preserving the slider's usable width is worth the compact icon-only sort control.
+  const showSortSelect = useMediaQuery("(min-width:600px)");
+  const currentSortLabel =
+    props.sortOptions.find(([value]) => value === props.sort)?.[1] ||
+    props.sort;
+
+  const updateSort = (value: string) => {
+    props.onSortChange(value);
+    setSortAnchorEl(null);
+  };
+
+  return (
+    <header className="constructionHeader">
+      <Toolbar className="constructionTitleBar">
+        <Typography variant="h6" className="constructionTitle">
+          <span className="iconLabel">
+            <ConceptIcon concept={props.concept} fontSize="small" />
+            {props.title}
+          </span>
+          <span
+            className="weak constructionCash"
+            aria-label={`Available cash ${formatMoneyStable(props.cash)}`}
+          >
+            {formatMoneyStable(props.cash)} cash
+          </span>
+        </Typography>
+        <IconButton
+          id="close-button"
+          color="primary"
+          onClick={props.onClose}
+          aria-label="close"
+          size="large"
+        >
+          <CloseIcon />
+        </IconButton>
+      </Toolbar>
+      <div className="constructionControls">
+        <Typography
+          id="construction-capacity"
+          className="constructionCapacity"
+          variant="body2"
+        >
+          <span className="weak">Capacity</span>
+          <Typography color="primary" component="strong">
+            {props.capacity}
+          </Typography>
+        </Typography>
+        <Slider
+          className="constructionCapacitySlider"
+          value={props.sliderValue}
+          aria-labelledby="construction-capacity"
+          valueLabelDisplay="off"
+          min={props.sliderMin}
+          step={1}
+          max={props.sliderMax}
+          onChange={(_event: Event, newValue: number | number[]) =>
+            props.onSliderChange(
+              Array.isArray(newValue) ? newValue[0] : newValue,
+            )
+          }
+        />
+        {showSortSelect ? (
+          <FormControl className="constructionSortSelect" size="small">
+            <Select
+              value={props.sort}
+              onChange={(event) => updateSort(event.target.value)}
+              renderValue={() => `Sort: ${currentSortLabel}`}
+              inputProps={{ "aria-label": "Sort facilities" }}
+            >
+              {props.sortOptions.map(([value, label]) => (
+                <MenuItem value={value} key={value}>
+                  {label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        ) : (
+          <>
+            <IconButton
+              className="constructionSortButton"
+              color="primary"
+              onClick={(event) => setSortAnchorEl(event.currentTarget)}
+              aria-label={`Sort facilities: ${currentSortLabel}`}
+              size="large"
+            >
+              <SortIcon />
+            </IconButton>
+            <Menu
+              id="sort-menu"
+              anchorEl={sortAnchorEl}
+              keepMounted
+              open={Boolean(sortAnchorEl)}
+              onClose={() => setSortAnchorEl(null)}
+            >
+              {props.sortOptions.map(([value, label]) => (
+                <MenuItem onClick={() => updateSort(value)} key={value}>
+                  {props.sort === value ? (
+                    <strong>{label}</strong>
+                  ) : (
+                    <span className="weak">{label}</span>
+                  )}
+                </MenuItem>
+              ))}
+            </Menu>
+          </>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/views/BuildGenerators.test.tsx
+++ b/src/components/views/BuildGenerators.test.tsx
@@ -183,7 +183,6 @@ it("pins up to three current-grid choices into a comparison tray", () => {
       game={game}
       onBack={jest.fn()}
       onBuildGenerator={jest.fn()}
-      onSpeedChange={jest.fn()}
     />,
   );
 

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -13,34 +13,24 @@ import {
   DialogTitle,
   IconButton,
   List,
-  Menu,
-  MenuItem,
-  Slider,
   Stack,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableRow,
-  Toolbar,
   Typography,
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
 import CloseIcon from "@mui/icons-material/Close";
-import PauseIcon from "@mui/icons-material/Pause";
-import SortIcon from "@mui/icons-material/Sort";
 import { getTimeFromTimeline } from "../../helpers/DateTime";
 import {
   estimatedAnnualOperatingCost,
   estimatedAnnualVariableOperatingCost,
   getMonthlyPayment,
 } from "../../helpers/Financials";
-import {
-  formatMoneyConcise,
-  formatMoneyStable,
-  formatWatts,
-} from "../../helpers/Format";
+import { formatMoneyConcise, formatWatts } from "../../helpers/Format";
 import { getFuelPricesPerMBTU } from "../../data/FuelPrices";
 import {
   DOWNPAYMENT_PERCENT,
@@ -56,7 +46,6 @@ import {
   GeneratorShoppingType,
   FuelNameType,
   LocationType,
-  SpeedType,
 } from "../../Types";
 import { generateNewTimeline } from "../../reducers/Game";
 import { MANUAL_ENTRY } from "../../data/Manual";
@@ -69,6 +58,7 @@ import {
   getBuildAvailability,
   ViableLocationsRow,
 } from "../base/BuildAvailability";
+import ConstructionBuildHeader from "../base/ConstructionBuildHeader";
 
 interface GeneratorBuildItemProps {
   cash: number;
@@ -756,7 +746,6 @@ export interface DispatchProps {
     financed: boolean,
   ) => void;
   onBack: () => void;
-  onSpeedChange: (speed: SpeedType) => void;
 }
 
 export interface Props extends StateProps, DispatchProps {}
@@ -772,7 +761,6 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
     getTickFromW(mostRecentBuiltValue),
   );
   const [sort, setSort] = React.useState<GeneratorSortKey>("buildCost");
-  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
   const [comparedNames, setComparedNames] = React.useState<string[]>([]);
 
   if (!now) {
@@ -840,112 +828,22 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
     );
   };
 
-  const onSlider = (_event: Event, newValue: number | number[]) => {
-    if (Array.isArray(newValue)) {
-      newValue = newValue[0];
-    }
-    setSliderTick(newValue);
-  };
-
-  const onSort = (newValue: GeneratorSortKey) => {
-    setSort(newValue);
-    onSortClose();
-  };
-
-  const onSortOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const onSortClose = () => {
-    setAnchorEl(null);
-  };
-
   return (
     <div id="topbar" className="flexContainer">
-      <Toolbar className="bottomBorder">
-        <Typography variant="h6">
-          {formatMoneyStable(cash)}{" "}
-          <span className="weak gameStatusValue">
-            <ConceptIcon concept="generator" fontSize="small" />
-            Build Generator
-          </span>
-        </Typography>
-        {game.speed !== "PAUSED" && (
-          <IconButton
-            onClick={() => props.onSpeedChange("PAUSED")}
-            aria-label="pause"
-            color="primary"
-            size="large"
-          >
-            <PauseIcon />
-          </IconButton>
-        )}
-        <IconButton
-          id="close-button"
-          color="primary"
-          onClick={onBack}
-          aria-label="close"
-          size="large"
-        >
-          <CloseIcon />
-        </IconButton>
-        <div className="flex-newline"></div>
-        <div
-          id="yearProgressBar"
-          style={{
-            width: `${game.date.percentOfYear * 100}%`,
-          }}
-        />
-        <Typography
-          id="peak-output"
-          className="flex-newline"
-          variant="body2"
-          color="textSecondary"
-        >
-          Capacity:{" "}
-          <Typography color="primary" component="strong">
-            {valueLabelFormat(sliderTick)}
-          </Typography>{" "}
-          {filtered.length <= 1 && "(slide to change)"}
-        </Typography>
-        <Slider
-          value={sliderTick}
-          aria-labelledby="peak-output"
-          valueLabelDisplay="off"
-          min={0}
-          step={1}
-          max={34}
-          onChange={onSlider}
-        />
-        <IconButton
-          id="sort"
-          color="primary"
-          onClick={onSortOpen}
-          aria-label="sort"
-          size="large"
-        >
-          <SortIcon />
-        </IconButton>
-        <Menu
-          id="sort-menu"
-          anchorEl={anchorEl}
-          keepMounted
-          open={Boolean(anchorEl)}
-          onClose={onSortClose}
-        >
-          {sortOptions.map((option) => {
-            return (
-              <MenuItem onClick={() => onSort(option[0])} key={option[0]}>
-                {sort === option[0] ? (
-                  <strong>{option[1]}</strong>
-                ) : (
-                  <span className="weak">{option[1]}</span>
-                )}
-              </MenuItem>
-            );
-          })}
-        </Menu>
-      </Toolbar>
+      <ConstructionBuildHeader
+        concept="generator"
+        title="Build Generator"
+        cash={cash}
+        capacity={valueLabelFormat(sliderTick)}
+        sliderValue={sliderTick}
+        sliderMin={0}
+        sliderMax={34}
+        sort={sort}
+        sortOptions={sortOptions}
+        onClose={onBack}
+        onSliderChange={setSliderTick}
+        onSortChange={(value) => setSort(value as GeneratorSortKey)}
+      />
       <GeneratorComparison
         generators={comparedGenerators}
         onClear={() => setComparedNames([])}

--- a/src/components/views/BuildGeneratorsContainer.tsx
+++ b/src/components/views/BuildGeneratorsContainer.tsx
@@ -1,11 +1,11 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigate } from "../../reducers/Card";
-import { setSpeed, buildFacility } from "../../reducers/Game";
+import { buildFacility } from "../../reducers/Game";
 import { selectFacility, snackbarOpen } from "../../reducers/UI";
 import { getStore } from "../../StoreRegistry";
 import { buildConsequenceMessage } from "../../helpers/BuildConsequences";
-import { AppStateType, GeneratorShoppingType, SpeedType } from "../../Types";
+import { AppStateType, GeneratorShoppingType } from "../../Types";
 import BuildGenerators, { DispatchProps, StateProps } from "./BuildGenerators";
 
 const mapStateToProps = (state: AppStateType): StateProps => {
@@ -45,9 +45,6 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
           }),
         );
       }
-    },
-    onSpeedChange: (speed: SpeedType) => {
-      dispatch(setSpeed(speed));
     },
   };
 };

--- a/src/components/views/BuildStorage.test.tsx
+++ b/src/components/views/BuildStorage.test.tsx
@@ -27,7 +27,6 @@ it("shows remaining pumped-hydro locations in the expanded build view", () => {
       game={game()}
       onBuildStorage={jest.fn()}
       onBack={jest.fn()}
-      onSpeedChange={jest.fn()}
     />,
   );
 
@@ -48,16 +47,61 @@ it("keeps toolbar actions inside compact viewport gutters", () => {
       game={game()}
       onBuildStorage={jest.fn()}
       onBack={jest.fn()}
-      onSpeedChange={jest.fn()}
     />,
   );
 
   expect(screen.getByRole("button", { name: "close" })).not.toHaveClass(
     "MuiIconButton-edgeEnd",
   );
-  expect(screen.getByRole("button", { name: "sort" })).not.toHaveClass(
-    "MuiIconButton-edgeEnd",
+  expect(
+    screen.getByRole("button", { name: "Sort facilities: Build Cost" }),
+  ).not.toHaveClass("MuiIconButton-edgeEnd");
+});
+
+it("shows decision context without live-time controls", () => {
+  render(
+    <BuildStorage
+      game={game()}
+      onBuildStorage={jest.fn()}
+      onBack={jest.fn()}
+    />,
   );
+
+  expect(screen.getByText("Build Storage")).toBeInTheDocument();
+  expect(screen.getByLabelText(/Available cash/)).toHaveTextContent("cash");
+  expect(screen.getByText("Capacity")).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "pause" })).toBeNull();
+});
+
+it("shows the current sort text when the controls have enough width", () => {
+  const originalMatchMedia = window.matchMedia;
+  window.matchMedia = (query: string) =>
+    ({
+      matches: query === "(min-width:600px)",
+      media: query,
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+
+  try {
+    render(
+      <BuildStorage
+        game={game()}
+        onBuildStorage={jest.fn()}
+        onBack={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("combobox", { name: "Sort facilities" }),
+    ).toHaveTextContent("Sort: Build Cost");
+  } finally {
+    window.matchMedia = originalMatchMedia;
+  }
 });
 
 it("submits a storage purchase only once on a double-click", () => {
@@ -67,7 +111,6 @@ it("submits a storage purchase only once on a double-click", () => {
       game={game()}
       onBuildStorage={onBuildStorage}
       onBack={jest.fn()}
-      onSpeedChange={jest.fn()}
     />,
   );
 

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -11,27 +11,20 @@ import {
   DialogTitle,
   IconButton,
   List,
-  Menu,
-  MenuItem,
-  Slider,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableRow,
-  Toolbar,
   Typography,
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
 import CloseIcon from "@mui/icons-material/Close";
-import PauseIcon from "@mui/icons-material/Pause";
-import SortIcon from "@mui/icons-material/Sort";
 import { getTimeFromTimeline } from "../../helpers/DateTime";
 import { getMonthlyPayment } from "../../helpers/Financials";
 import {
   formatMoneyConcise,
-  formatMoneyStable,
   formatWattHours,
   formatWatts,
 } from "../../helpers/Format";
@@ -45,7 +38,8 @@ import {
   getBuildAvailability,
   ViableLocationsRow,
 } from "../base/BuildAvailability";
-import { GameType, SpeedType, StorageShoppingType } from "../../Types";
+import ConstructionBuildHeader from "../base/ConstructionBuildHeader";
+import { GameType, StorageShoppingType } from "../../Types";
 
 interface StorageBuildItemProps {
   cash: number;
@@ -341,7 +335,6 @@ export interface StateProps {
 export interface DispatchProps {
   onBuildStorage: (storage: StorageShoppingType, financed: boolean) => void;
   onBack: () => void;
-  onSpeedChange: (speed: SpeedType) => void;
 }
 
 export interface Props extends StateProps, DispatchProps {}
@@ -357,7 +350,6 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
     getTickFromW(mostRecentBuiltValue),
   );
   const [sort, setSort] = React.useState<StorageSortKey>("buildCost");
-  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
 
   if (!now) {
     return <span />;
@@ -368,111 +360,22 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
     (a, b) => a[sort] - b[sort],
   );
 
-  const handleSliderChange = (_event: Event, newValue: number | number[]) => {
-    if (Array.isArray(newValue)) {
-      newValue = newValue[0];
-    }
-    setSliderTick(newValue);
-  };
-
-  const onSort = (newValue: StorageSortKey) => {
-    setSort(newValue);
-    onSortClose();
-  };
-
-  const onSortOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const onSortClose = () => {
-    setAnchorEl(null);
-  };
-
   return (
     <div id="topbar" className="flexContainer">
-      <Toolbar className="bottomBorder">
-        <Typography variant="h6">
-          {formatMoneyStable(cash)}{" "}
-          <span className="weak gameStatusValue">
-            <ConceptIcon concept="storage" fontSize="small" />
-            Build Storage
-          </span>
-        </Typography>
-        {game.speed !== "PAUSED" && (
-          <IconButton
-            onClick={() => props.onSpeedChange("PAUSED")}
-            aria-label="pause"
-            color="primary"
-            size="large"
-          >
-            <PauseIcon />
-          </IconButton>
-        )}
-        <IconButton
-          id="close-button"
-          color="primary"
-          onClick={onBack}
-          aria-label="close"
-          size="large"
-        >
-          <CloseIcon />
-        </IconButton>
-        <div className="flex-newline"></div>
-        <div
-          id="yearProgressBar"
-          style={{
-            width: `${game.date.percentOfYear * 100}%`,
-          }}
-        />
-        <Typography
-          id="peak-output"
-          className="flex-newline"
-          variant="body2"
-          color="textSecondary"
-        >
-          Capacity:{" "}
-          <Typography color="primary" component="strong">
-            {valueLabelFormat(sliderTick)}h
-          </Typography>{" "}
-          {filtered.length <= 0 && "(slide to change)"}
-        </Typography>
-        <Slider
-          value={sliderTick}
-          aria-labelledby="peak-output"
-          valueLabelDisplay="off"
-          min={4}
-          step={1}
-          max={37}
-          onChange={handleSliderChange}
-        />
-        <IconButton
-          color="primary"
-          onClick={onSortOpen}
-          aria-label="sort"
-          size="large"
-        >
-          <SortIcon />
-        </IconButton>
-        <Menu
-          id="sort-menu"
-          anchorEl={anchorEl}
-          keepMounted
-          open={Boolean(anchorEl)}
-          onClose={onSortClose}
-        >
-          {sortOptions.map((option) => {
-            return (
-              <MenuItem onClick={() => onSort(option[0])} key={option[0]}>
-                {sort === option[0] ? (
-                  <strong>{option[1]}</strong>
-                ) : (
-                  <span className="weak">{option[1]}</span>
-                )}
-              </MenuItem>
-            );
-          })}
-        </Menu>
-      </Toolbar>
+      <ConstructionBuildHeader
+        concept="storage"
+        title="Build Storage"
+        cash={cash}
+        capacity={`${valueLabelFormat(sliderTick)}h`}
+        sliderValue={sliderTick}
+        sliderMin={4}
+        sliderMax={37}
+        sort={sort}
+        sortOptions={sortOptions}
+        onClose={onBack}
+        onSliderChange={setSliderTick}
+        onSortChange={(value) => setSort(value as StorageSortKey)}
+      />
       <List dense className="scrollable cardList">
         {storage.map((g: StorageShoppingType, i: number) => (
           <StorageBuildItem

--- a/src/components/views/BuildStorageContainer.tsx
+++ b/src/components/views/BuildStorageContainer.tsx
@@ -1,12 +1,11 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { navigate } from "../../reducers/Card";
-import { setSpeed } from "../../reducers/Game";
 import { buildFacility } from "../../reducers/Game";
 import { selectFacility, snackbarOpen } from "../../reducers/UI";
 import { getStore } from "../../StoreRegistry";
 import { buildConsequenceMessage } from "../../helpers/BuildConsequences";
-import { AppStateType, SpeedType, StorageShoppingType } from "../../Types";
+import { AppStateType, StorageShoppingType } from "../../Types";
 import BuildStorage, { DispatchProps, StateProps } from "./BuildStorage";
 
 const mapStateToProps = (state: AppStateType): StateProps => {
@@ -42,9 +41,6 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
           }),
         );
       }
-    },
-    onSpeedChange: (speed: SpeedType) => {
-      dispatch(setSpeed(speed));
     },
   };
 };

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -54,7 +54,7 @@ describe("MainMenu", () => {
       screen.getByRole("button", { name: "Continue" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Start another game" }),
+      screen.getByRole("button", { name: "Start a new game" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("navigation", { name: "Game resources" }),

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -29,9 +29,7 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 const MainMenu = (props: Props): React.JSX.Element => {
-  const startLabel = props.hasSavedGame
-    ? "Start another game"
-    : "Start playing";
+  const startLabel = props.hasSavedGame ? "Start a new game" : "Start playing";
   const [shareStatus, setShareStatus] = React.useState("");
 
   const onShare = async () => {

--- a/src/helpers/BuildConsequences.test.tsx
+++ b/src/helpers/BuildConsequences.test.tsx
@@ -1,5 +1,8 @@
-import { GeneratorShoppingType } from "../Types";
-import { buildConsequenceMessage } from "./BuildConsequences";
+import { GeneratorShoppingType, StorageShoppingType } from "../Types";
+import {
+  buildConsequenceMessage,
+  buildStartedMessage,
+} from "./BuildConsequences";
 
 const generator = {
   name: "Natural Gas",
@@ -15,5 +18,28 @@ it("connects the commitment to construction and expected supply", () => {
   );
   expect(buildConsequenceMessage(generator, true)).toContain(
     "$30M down payment",
+  );
+});
+
+it("keeps construction event titles focused on what was started", () => {
+  expect(buildStartedMessage(generator)).toBe(
+    "Started construction on 200MW Natural Gas",
+  );
+  const storage: StorageShoppingType = {
+    name: "Battery",
+    description: "Fast storage",
+    available: true,
+    buildCost: 100000000,
+    annualOperatingCost: 1000000,
+    peakW: 200000000,
+    peakWh: 800000000,
+    maxPeakWh: 1000000000,
+    lifespanYears: 20,
+    yearsToBuild: 1,
+    roundTripEfficiency: 0.85,
+    hourlyLoss: 0.001,
+  };
+  expect(buildStartedMessage(storage)).toBe(
+    "Started construction on 4h 200MW Battery",
   );
 });

--- a/src/helpers/BuildConsequences.tsx
+++ b/src/helpers/BuildConsequences.tsx
@@ -19,3 +19,12 @@ export function buildConsequenceMessage(
     financed ? "down payment" : "committed"
   } → ${facility.name} online in ${months} mo → +${contribution}`;
 }
+
+/** A short event-feed title for the commitment itself; the snackbar carries the full forecast. */
+export function buildStartedMessage(facility: FacilityShoppingType): string {
+  if (facility.peakWh) {
+    const duration = Math.round((facility.peakWh / facility.peakW) * 10) / 10;
+    return `Started construction on ${duration}h ${formatWatts(facility.peakW)} ${facility.name}`;
+  }
+  return `Started construction on ${formatWatts(facility.peakW)} ${facility.name}`;
+}

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -36,7 +36,7 @@ import {
 import { arrayMove, newSeed } from "../helpers/Math";
 import { computeScoreBreakdown, totalScore } from "../helpers/Scoring";
 import { formatLargeMass } from "../helpers/Units";
-import { buildConsequenceMessage } from "../helpers/BuildConsequences";
+import { buildStartedMessage } from "../helpers/BuildConsequences";
 import { buildVictoryDebrief } from "../helpers/Debrief";
 import { buildStoryPeriodSnapshot, buildStorySnapshot } from "../helpers/Story";
 import {
@@ -155,10 +155,11 @@ let previousTickMs = 0;
 // decide whether the tick loop needs restarting, since state.speed can change without going
 // through setSpeed (e.g. dialogClose below), which would desync a "previous speed" comparison.
 let speedBeforeDialog = "PAUSED" as SpeedType;
-// Same idea for the manual, which is a full-screen card over a game that would otherwise keep
-// ticking -- looking up "Blackouts" mid-crisis used to cause blackouts. Undefined whenever the
-// manual isn't what paused us, so leaving any other card doesn't resume a deliberate pause.
-let speedBeforeManual: SpeedType | undefined;
+// Same idea for full-screen decision cards over a game that would otherwise keep ticking.
+// Undefined whenever a card isn't what paused us, so leaving one never resumes a deliberate
+// pause. Construction catalogs belong here too: the quote should not change while it is read.
+let speedBeforeBlockingCard: SpeedType | undefined;
+const BLOCKING_CARDS = new Set(["MANUAL", "BUILD_GENERATORS", "BUILD_STORAGE"]);
 // Tracks whether the self-rescheduling tick() loop is currently alive, so that any transition
 // out of PAUSED (manual speed click, tutorial script, dialog closing) reliably restarts it.
 let tickLoopRunning = false;
@@ -686,13 +687,13 @@ function ensureTicking(state: GameType) {
   }
 }
 
-// Puts the clock back the way the player left it before the manual paused it
-function restoreSpeedAfterManual(state: GameType) {
-  if (speedBeforeManual === undefined) {
+// Puts the clock back the way the player left it before a full-screen card paused it
+function restoreSpeedAfterBlockingCard(state: GameType) {
+  if (speedBeforeBlockingCard === undefined) {
     return;
   }
-  state.speed = speedBeforeManual;
-  speedBeforeManual = undefined;
+  state.speed = speedBeforeBlockingCard;
+  speedBeforeBlockingCard = undefined;
   ensureTicking(state);
 }
 
@@ -884,6 +885,14 @@ export const gameSlice = createSlice({
       recordReplayAction(state, "reprioritizeFacility", action.payload);
     },
     setSpeed: (state, action: PayloadAction<SpeedType>) => {
+      // Global keyboard shortcuts still fire over full-screen cards. Keep their quotes and
+      // instructions frozen until the player actually closes the card.
+      if (
+        speedBeforeBlockingCard !== undefined &&
+        action.payload !== "PAUSED"
+      ) {
+        return;
+      }
       state.speed = action.payload;
       ensureTicking(state);
     },
@@ -909,6 +918,7 @@ export const gameSlice = createSlice({
       blackoutUnservedWh = 0;
       previousFuelPrices = undefined;
       speedBeforeDialog = "PAUSED";
+      speedBeforeBlockingCard = undefined;
       // Never resume mid-tick; loaded() flips inGame once the CSVs are back
       restored.speed = "PAUSED";
       restored.inGame = false;
@@ -925,7 +935,7 @@ export const gameSlice = createSlice({
      */
     builder.addCase(startReplay, (_state, action) => {
       const replay = action.payload;
-      speedBeforeManual = undefined;
+      speedBeforeBlockingCard = undefined;
       speedBeforeDialog = "PAUSED";
       return {
         ...cloneDeep(initialGame),
@@ -946,23 +956,23 @@ export const gameSlice = createSlice({
       state.inGame = true;
     });
     builder.addCase(quit, () => {
-      speedBeforeManual = undefined;
+      speedBeforeBlockingCard = undefined;
       return cloneDeep(initialGame);
     });
-    // Opening the manual pauses the game, and closing it puts the speed back. Without this the
-    // sim runs on while the player reads, which punishes them for looking something up
+    // Opening a reading or construction card pauses the game, and closing it puts the speed back.
+    // The sim should not punish the player for reading, or mutate a quote during a decision.
     builder.addCase(navigate, (state, action) => {
       const payload = action.payload;
       const name = typeof payload === "string" ? payload : payload?.name;
-      if (name !== "MANUAL") {
+      if (!name || !BLOCKING_CARDS.has(name)) {
         // Navigating anywhere else (rather than backing out) still counts as leaving it
-        restoreSpeedAfterManual(state);
-      } else if (state.inGame && speedBeforeManual === undefined) {
-        speedBeforeManual = state.speed;
+        restoreSpeedAfterBlockingCard(state);
+      } else if (state.inGame && speedBeforeBlockingCard === undefined) {
+        speedBeforeBlockingCard = state.speed;
         state.speed = "PAUSED";
       }
     });
-    builder.addCase(navigateBack, restoreSpeedAfterManual);
+    builder.addCase(navigateBack, restoreSpeedAfterBlockingCard);
     builder.addCase(dialogOpen, (state) => {
       speedBeforeDialog = state.speed;
       state.speed = "PAUSED";
@@ -1043,15 +1053,10 @@ function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
   if (viableLocationsRemaining !== undefined && viableLocationsRemaining <= 0) {
     return;
   }
-  logGameEvent(
-    state,
-    "BUILD",
-    buildConsequenceMessage(built, payload.financed),
-    {
-      importance: "NOTABLE",
-      actionTarget: { card: "FACILITIES", view: "FLEET" },
-    },
-  );
+  logGameEvent(state, "BUILD", buildStartedMessage(built), {
+    importance: "NOTABLE",
+    actionTarget: { card: "FACILITIES", view: "FLEET" },
+  });
   state = buildFacilityHelper(state, built, payload.financed);
   // Assigned rather than spread into a new object: this is an immer draft, so a fresh object
   // assigned to the parameter is discarded and the forecast would never reach state

--- a/src/reducers/ManualPause.test.tsx
+++ b/src/reducers/ManualPause.test.tsx
@@ -51,6 +51,23 @@ describe("the manual pausing the game", () => {
   });
 });
 
+describe("construction catalogs pausing the game", () => {
+  it.each(["BUILD_GENERATORS", "BUILD_STORAGE"] as const)(
+    "pauses %s and restores the prior speed when it closes",
+    (card) => {
+      const paused = gameReducer(running("FAST"), navigate(card));
+      expect(paused.speed).toBe("PAUSED");
+      expect(gameReducer(paused, navigateBack()).speed).toBe("FAST");
+    },
+  );
+
+  it("stays paused if a global speed shortcut fires while the catalog is open", () => {
+    const paused = gameReducer(running("NORMAL"), navigate("BUILD_STORAGE"));
+    expect(gameReducer(paused, setSpeed("FAST")).speed).toBe("PAUSED");
+    expect(gameReducer(paused, navigate("FACILITIES")).speed).toBe("NORMAL");
+  });
+});
+
 describe("deep linking into a manual entry", () => {
   it("carries the entry through navigation", () => {
     const state = cardReducer(


### PR DESCRIPTION
Updates the homepage game-start copy and gives the generator and storage construction screens a shared, main-bar-aligned header. Construction catalogs now pause and restore game speed automatically, omit live time progress, and show the current sort label in a dropdown at 600px and wider while retaining the compact icon below that breakpoint. Construction event entries are shortened to the requested capacity/type wording. Verified with typecheck, lint, formatting, production build, 807 tests, and visual QA at 320px, 390px, and 900px.