### PR TITLE
Optimize simulation and facilities rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
 import { useEffect, useLayoutEffect, useState } from "react";
-import { Provider } from "react-redux";
 import type { User } from "firebase/auth";
 import CompositorContainer from "./components/CompositorContainer";
 import UnitsProvider from "./components/base/UnitsContext";
@@ -231,18 +230,16 @@ export default function App() {
 
   return (
     <StyledEngineProvider injectFirst>
-      <Provider store={store}>
-        <ThemedApp>
-          {/* Above the compositor, whose shouldComponentUpdate would otherwise swallow a
+      <ThemedApp>
+        {/* Above the compositor, whose shouldComponentUpdate would otherwise swallow a
               settings change that did not also change the card */}
-          <InstallPromptProvider>
-            <OfflineNotice />
-            <UnitsProvider>
-              <CompositorContainer store={store} />
-            </UnitsProvider>
-          </InstallPromptProvider>
-        </ThemedApp>
-      </Provider>
+        <InstallPromptProvider>
+          <OfflineNotice />
+          <UnitsProvider>
+            <CompositorContainer store={store} />
+          </UnitsProvider>
+        </InstallPromptProvider>
+      </ThemedApp>
     </StyledEngineProvider>
   );
 }

--- a/src/Store.tsx
+++ b/src/Store.tsx
@@ -18,6 +18,12 @@ export const store = configureStore({
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
+      // Timeline/history dominate the state by several orders of magnitude and are replaced only
+      // by reducer-owned simulation code. Walking every tick of both after every 1x/20x action
+      // made development builds spend more time validating forecasts than running them.
+      immutableCheck: {
+        ignoredPaths: ["game.timeline", "game.monthlyHistory"],
+      },
       // The shared dialog/snackbar layer predates this store and deliberately carries React
       // content and click callbacks. Those values never leave the live UI state, but Redux
       // Toolkit otherwise reports them on every simulation tick, burying actionable warnings
@@ -29,6 +35,9 @@ export const store = configureStore({
           "ui.dialog.action",
           "ui.dialog.secondaryAction",
           "ui.snackbar.action",
+          "game.timeline",
+          "game.monthlyHistory",
+          "game.replayLog",
         ],
       },
     }).concat(tutorialGateMiddleware),

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -311,10 +311,9 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     // The exponentially smoothed bill customers respond to, rather than the slider's latest value
     customerRate: number;
     supplyByFuel: FuelProductionType;
-    // The unconstrained dispatch request for each facility in the most recent forecast pass.
-    // Kept on forecast ticks so minimum-load generators can decide whether avoiding a future
-    // start is worth remaining online; it is intentionally not copied into monthly history.
-    dispatchTargetWByFacility: Record<number, number>;
+    // Legacy saves may contain the old enumerable commitment forecast. New forecasts keep this
+    // transient so it cannot inflate saves, chart copies, or Redux development scans.
+    dispatchTargetWByFacility?: Record<number, number>;
   };
 
 export type DerivedHistoryKeysType = Exclude<

--- a/src/app.scss
+++ b/src/app.scss
@@ -2177,10 +2177,12 @@ html[data-theme="dark"] .uplot {
     top: 0;
     bottom: 2px;
     left: 0;
+    right: 0;
+    transform-origin: left center;
     // Keep a hint of motion without leaving the utilization display several simulation frames
     // behind the generator it describes (NORMAL ticks every 60ms).
     transition:
-      width 50ms linear,
+      transform 50ms linear,
       background 50ms linear;
   }
 
@@ -2199,13 +2201,10 @@ html[data-theme="dark"] .uplot {
 
     .capacityProgressBar {
       width: 12px;
-      background-color: var(--capacity-bar);
+      height: 39px;
       position: absolute;
       bottom: 0;
       left: 42px;
-      transition:
-        height 0.6s ease-out,
-        background-color 0.6s linear;
 
       &:after {
         content: "";
@@ -2215,6 +2214,16 @@ html[data-theme="dark"] .uplot {
         left: 0;
         right: 0;
         bottom: 0;
+      }
+
+      .capacityProgressBarFill {
+        position: absolute;
+        inset: 0;
+        background-color: var(--capacity-bar);
+        transform-origin: bottom center;
+        transition:
+          transform 0.6s ease-out,
+          background-color 0.6s linear;
       }
     }
 

--- a/src/components/base/ChartSupplyDemand.tsx
+++ b/src/components/base/ChartSupplyDemand.tsx
@@ -296,4 +296,4 @@ const ChartSupplyDemand = (props: Props): React.JSX.Element => {
     />
   );
 };
-export default ChartSupplyDemand;
+export default React.memo(ChartSupplyDemand);

--- a/src/components/base/FacilityDetails.tsx
+++ b/src/components/base/FacilityDetails.tsx
@@ -130,7 +130,24 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
   const equivalentCycles = facilityEquivalentCycles(facility);
   const equivalentOperatingHours = facilityEquivalentOperatingHours(facility);
 
-  const trend = fuel ? fuelPriceTrend(fuel, date, seed, location) : [];
+  // Price history only changes at a month boundary. Selected-facility lifetime totals still
+  // refresh visually, but the twelve table lookups and sparkline input do not run every tick.
+  const trend = React.useMemo(
+    () =>
+      fuel
+        ? fuelPriceTrend(
+            fuel,
+            {
+              year: date.year,
+              monthNumber: date.monthNumber,
+              monthsElapsed: date.monthsElapsed,
+            } as DateType,
+            seed,
+            location,
+          )
+        : [],
+    [fuel, date.year, date.monthNumber, date.monthsElapsed, seed, location],
+  );
   const trendChange =
     trend.length > 1 && trend[0] > 0
       ? trend[trend.length - 1] / trend[0] - 1

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -112,11 +112,131 @@ const ACTIVITY_LABELS: { [k in FacilityActivityType]: string } = {
   DISCHARGING: "discharging",
 };
 
+function FacilityActions(props: {
+  facility: FacilityOperatingType;
+  listLength: number;
+  readOnly: boolean;
+  spotInList: number;
+  onPause: DispatchProps["onPause"];
+  onReprioritize: DispatchProps["onReprioritize"];
+  onTogglePause: DispatchProps["onTogglePause"];
+  onOpenSell: () => void;
+}) {
+  const {
+    facility,
+    listLength,
+    onOpenSell,
+    onPause,
+    onReprioritize,
+    onTogglePause,
+    readOnly,
+    spotInList,
+  } = props;
+  const underConstruction = facility.yearsToBuildLeft > 0;
+  return (
+    <span className="facilityActions">
+      {!readOnly && listLength > 1 && (
+        <>
+          <IconButton
+            onClick={(e) => {
+              e.stopPropagation();
+              onReprioritize(spotInList, -1);
+            }}
+            aria-label={`Move ${facility.name} earlier in the dispatch order`}
+            disabled={spotInList === 0}
+            edge="end"
+            color="primary"
+            size="small"
+          >
+            <KeyboardArrowUpIcon />
+          </IconButton>
+          <IconButton
+            onClick={(e) => {
+              e.stopPropagation();
+              onReprioritize(spotInList, 1);
+            }}
+            aria-label={`Move ${facility.name} later in the dispatch order`}
+            disabled={spotInList === listLength - 1}
+            edge="end"
+            color="primary"
+            size="small"
+          >
+            <KeyboardArrowDownIcon />
+          </IconButton>
+        </>
+      )}
+      {!readOnly && !underConstruction && !facility.paused && (
+        <IconButton
+          onClick={(e) => {
+            e.stopPropagation();
+            onPause(facility.id, facility.name);
+          }}
+          aria-label={`Pause ${facility.name}`}
+          edge="end"
+          color="primary"
+          size="small"
+        >
+          <ConceptIcon concept="pause" />
+        </IconButton>
+      )}
+      {!readOnly && facility.paused && (
+        <IconButton
+          onClick={(e) => {
+            e.stopPropagation();
+            onTogglePause(facility.id);
+          }}
+          aria-label={`Resume ${facility.name}`}
+          edge="end"
+          color="primary"
+          size="small"
+        >
+          <ConceptIcon concept="play" />
+        </IconButton>
+      )}
+      {!readOnly && (underConstruction || listLength > 1) && (
+        <IconButton
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpenSell();
+          }}
+          aria-label={`${underConstruction ? "Cancel construction of" : "Sell"} ${facility.name}`}
+          edge="end"
+          color="primary"
+          size="small"
+        >
+          {underConstruction ? <CancelIcon /> : <DeleteForeverIcon />}
+        </IconButton>
+      )}
+    </span>
+  );
+}
+
+const MemoizedFacilityActions = React.memo(
+  FacilityActions,
+  (previous, next) => {
+    const previousUnderConstruction = previous.facility.yearsToBuildLeft > 0;
+    const nextUnderConstruction = next.facility.yearsToBuildLeft > 0;
+    return (
+      previous.facility.id === next.facility.id &&
+      previous.facility.name === next.facility.name &&
+      previous.facility.paused === next.facility.paused &&
+      previousUnderConstruction === nextUnderConstruction &&
+      previous.listLength === next.listLength &&
+      previous.readOnly === next.readOnly &&
+      previous.spotInList === next.spotInList &&
+      previous.onPause === next.onPause &&
+      previous.onReprioritize === next.onReprioritize &&
+      previous.onTogglePause === next.onTogglePause &&
+      previous.onOpenSell === next.onOpenSell
+    );
+  },
+);
+
 function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
   const [open, setOpen] = React.useState(false);
-  const toggleDialog = () => {
-    setOpen(!open);
-  };
+  const toggleDialog = React.useCallback(() => {
+    setOpen((value) => !value);
+  }, []);
 
   const {
     facility,
@@ -230,101 +350,16 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                 : undefined
             }
             secondaryAction={
-              // Hidden until the row is hovered, focused or selected (desktop only - see
-              // app.scss), because a permanent cluster of buttons takes the width the numbers
-              // below want. Each one stops its click short of the row, which would otherwise
-              // read the same click as "select this facility" on the way past
-              <span className="facilityActions">
-                {!readOnly && props.listLength > 1 && (
-                  <>
-                    {/* Dispatch order is a core mechanic, and dragging was the only way to set
-                        it - undiscoverable with a mouse, and unusable once the list has
-                        scrolled. These move one place at a time, the way a drag does */}
-                    <IconButton
-                      onClick={(e: React.MouseEvent) => {
-                        e.stopPropagation();
-                        onReprioritize(spotInList, -1);
-                      }}
-                      aria-label={`Move ${facility.name} earlier in the dispatch order`}
-                      disabled={spotInList === 0}
-                      edge="end"
-                      color="primary"
-                      size="small"
-                    >
-                      <KeyboardArrowUpIcon />
-                    </IconButton>
-                    <IconButton
-                      onClick={(e: React.MouseEvent) => {
-                        e.stopPropagation();
-                        onReprioritize(spotInList, 1);
-                      }}
-                      aria-label={`Move ${facility.name} later in the dispatch order`}
-                      disabled={spotInList === props.listLength - 1}
-                      edge="end"
-                      color="primary"
-                      size="small"
-                    >
-                      <KeyboardArrowDownIcon />
-                    </IconButton>
-                  </>
-                )}
-                {!readOnly && !underConstruction && !facility.paused && (
-                  <IconButton
-                    onClick={(e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      onPause(facility.id, facility.name);
-                    }}
-                    aria-label={`Pause ${facility.name}`}
-                    edge="end"
-                    color="primary"
-                    size="small"
-                  >
-                    <ConceptIcon concept="pause" />
-                  </IconButton>
-                )}
-                {!readOnly && facility.paused && (
-                  <IconButton
-                    onClick={(e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      onTogglePause(facility.id);
-                    }}
-                    aria-label={`Resume ${facility.name}`}
-                    edge="end"
-                    color="primary"
-                    size="small"
-                  >
-                    <ConceptIcon concept="play" />
-                  </IconButton>
-                )}
-                {!readOnly && !underConstruction && props.listLength > 1 && (
-                  <IconButton
-                    onClick={(e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      toggleDialog();
-                    }}
-                    aria-label={`Sell ${facility.name}`}
-                    edge="end"
-                    color="primary"
-                    size="small"
-                  >
-                    <DeleteForeverIcon />
-                  </IconButton>
-                )}
-                {!readOnly && underConstruction && (
-                  <IconButton
-                    onClick={(e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      toggleDialog();
-                    }}
-                    aria-label={`Cancel construction of ${facility.name}`}
-                    edge="end"
-                    color="primary"
-                    size="small"
-                  >
-                    <CancelIcon />
-                  </IconButton>
-                )}
-              </span>
+              <MemoizedFacilityActions
+                facility={facility}
+                listLength={props.listLength}
+                readOnly={readOnly}
+                spotInList={spotInList}
+                onPause={onPause}
+                onReprioritize={onReprioritize}
+                onTogglePause={onTogglePause}
+                onOpenSell={toggleDialog}
+              />
             }
           >
             {!readOnly && (
@@ -339,7 +374,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
               <div
                 className="outputProgressBar"
                 style={{
-                  width: `${outputFraction * 100}%`,
+                  transform: `scaleX(${outputFraction})`,
                   background: withAlpha(accentColor, 0.18),
                 }}
               />
@@ -352,16 +387,18 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                   src={`/images/${facility.name.toLowerCase()}.svg`}
                 />
                 {facility.peakWh > 0 && !underConstruction && (
-                  <div
-                    className="capacityProgressBar"
-                    style={{
-                      height: `${(facility.currentWh / facility.peakWh) * 100}%`,
-                      backgroundColor:
-                        activity === "CHARGING"
-                          ? chartPalette().storage
-                          : undefined,
-                    }}
-                  />
+                  <div className="capacityProgressBar">
+                    <div
+                      className="capacityProgressBarFill"
+                      style={{
+                        transform: `scaleY(${facility.currentWh / facility.peakWh})`,
+                        backgroundColor:
+                          activity === "CHARGING"
+                            ? chartPalette().storage
+                            : undefined,
+                      }}
+                    />
+                  </div>
                 )}
                 <div
                   className="facilityActivity"
@@ -488,10 +525,8 @@ export default class Facilities extends React.Component<Props, {}> {
   private dragging = false;
   private speedBeforeDrag: GameType["speed"] = "PAUSED";
 
-  // In fast mode, skip frames so that CPU can focus on simulation. This used to be 1 frame in
-  // 8, when the supply/demand chart was on Victory and one pane render cost 18ms; on uPlot the
-  // same render is 3.6ms, so 1 in 2 refreshes the pane four times as often and still costs less
-  // per tick than the old setting did.
+  // Keep 1x presentation unchanged, but cap FAST's 100 simulation ticks/sec to 25 visual
+  // refreshes/sec. Intermediate simulation ticks still run; the pane simply presents the newest.
   public shouldComponentUpdate(nextProps: Props) {
     if (this.dragging) {
       return false;
@@ -507,7 +542,7 @@ export default class Facilities extends React.Component<Props, {}> {
     ) {
       return true;
     }
-    return this.throttle.due(nextProps.game.date.minute, 2);
+    return this.throttle.due(nextProps.game.date.minute, 4);
   }
 
   public componentDidUpdate() {

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -105,8 +105,19 @@ jest.mock("../base/ChartForecastWater", () => ({
 }));
 jest.mock("../base/ChartForecastWeather", () => ({
   __esModule: true,
-  default: ({ syncKey }: ChartMockProps) => (
-    <div role="img" data-chart="weather" data-sync-key={syncKey} />
+  default: ({ syncKey, timeline }: ChartMockProps) => (
+    <div
+      role="img"
+      data-chart="weather"
+      data-sync-key={syncKey}
+      data-points={timeline?.length}
+      data-step={
+        timeline && timeline.length > 1
+          ? (timeline[1] as { minute: number }).minute -
+            (timeline[0] as { minute: number }).minute
+          : undefined
+      }
+    />
   ),
 }));
 
@@ -248,6 +259,15 @@ describe("Insights layers", () => {
     expect(options.getByText("Next 12 months")).toBeVisible();
     expect(options.queryByText("Current year")).toBeNull();
     expect(options.queryByText("Next year")).toBeNull();
+  });
+
+  it("uses hourly points for the twenty-year forecast", () => {
+    localStorage.setItem("insightsRange", "next20");
+    localStorage.setItem("insightsLayers", JSON.stringify(["weather"]));
+    renderInsights();
+
+    expect(screen.getByRole("img")).toHaveAttribute("data-points", "5760");
+    expect(screen.getByRole("img")).toHaveAttribute("data-step", "60");
   });
 
   it("keeps tutorial targets visible without duplicating stored layers", () => {

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -567,9 +567,12 @@ export default class Insights extends React.Component<Props, State> {
     const years = rangeYears(this.state.range);
     const nextYearMinute =
       (game.date.year - game.startingYear + 1) * 12 * MINUTES_PER_MONTH;
+    const projectionStepMinutes =
+      this.state.range === "next20" ? 60 : TICK_MINUTES;
+    const tickScale = projectionStepMinutes / TICK_MINUTES;
     const ticks =
       years > 0
-        ? TICKS_PER_YEAR * years
+        ? (TICKS_PER_YEAR * years) / tickScale
         : Math.max(
             1,
             Math.ceil((nextYearMinute - game.date.minute) / TICK_MINUTES),
@@ -593,7 +596,13 @@ export default class Insights extends React.Component<Props, State> {
       return projection;
     }
 
-    const timeline = generateNewTimeline(game, now.cash, now.customers, ticks);
+    const timeline = generateNewTimeline(
+      game,
+      now.cash,
+      now.customers,
+      ticks,
+      projectionStepMinutes,
+    );
     let domainMin = Number.POSITIVE_INFINITY;
     let domainMax = 0;
     for (const tick of timeline) {
@@ -620,8 +629,10 @@ export default class Insights extends React.Component<Props, State> {
           current = { wh: 0, peakW: 0, start: tick.minute, end: tick.minute };
         }
         const amount = tick.demandW - tick.supplyW;
-        blackoutTotalWh += amount;
-        current.wh += amount;
+        const amountWh =
+          amount * (projectionStepMinutes / 60) * GAME_TO_REAL_YEARS;
+        blackoutTotalWh += amountWh;
+        current.wh += amountWh;
         current.peakW = Math.max(current.peakW, amount);
       } else if (isBlackout) {
         blackouts.push({ minute: tick.minute, value: domainMax });
@@ -640,7 +651,7 @@ export default class Insights extends React.Component<Props, State> {
 
     const sampleYears = Math.max(1, years);
     const sampled = timeline.filter(
-      (tick) => tick.minute % (240 * sampleYears) < TICK_MINUTES,
+      (tick) => tick.minute % (240 * sampleYears) < projectionStepMinutes,
     );
     if (sampled[0] !== timeline[0]) {
       sampled.unshift(timeline[0]);

--- a/src/helpers/Commitment.test.tsx
+++ b/src/helpers/Commitment.test.tsx
@@ -1,10 +1,14 @@
-import { shouldKeepGeneratorCommitted } from "./Commitment";
+import {
+  prepareGeneratorCommitment,
+  recordDispatchTarget,
+  shouldKeepGeneratorCommitted,
+} from "./Commitment";
 import { TickPresentFutureType } from "../Types";
 
 function tick(target: number | undefined): TickPresentFutureType {
-  return {
-    dispatchTargetWByFacility: target === undefined ? {} : { 7: target },
-  } as TickPresentFutureType;
+  return (
+    target === undefined ? {} : { dispatchTargetWByFacility: { 7: target } }
+  ) as TickPresentFutureType;
 }
 
 describe("generator commitment optimization", () => {
@@ -63,5 +67,31 @@ describe("generator commitment optimization", () => {
         minimumOperatingCost: () => 20,
       }),
     ).toBe(false);
+  });
+
+  it("precomputes the same decisions without serializing forecast targets", () => {
+    const forecast = [tick(undefined), tick(undefined), tick(undefined)];
+    forecast.forEach((item, index) =>
+      recordDispatchTarget(item, 7, index === 2 ? 1 : 0),
+    );
+    const minimumOperatingCost = jest.fn(() => 20);
+
+    prepareGeneratorCommitment({
+      facilityId: 7,
+      forecast,
+      minimumOperatingCost,
+    });
+
+    expect(
+      shouldKeepGeneratorCommitted({
+        facilityId: 7,
+        forecast,
+        fromIndex: 0,
+        startCost: 50,
+        minimumOperatingCost,
+      }),
+    ).toBe(true);
+    expect(minimumOperatingCost).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(forecast)).not.toContain("dispatchTarget");
   });
 });

--- a/src/helpers/Commitment.tsx
+++ b/src/helpers/Commitment.tsx
@@ -1,5 +1,117 @@
 import { TickPresentFutureType } from "../Types";
 
+interface ForecastMetadata {
+  dispatchTargets: Record<number, number>;
+  runningCostToNextDispatch: Record<number, number>;
+}
+
+// Forecast-only data must not be serialized into saves, copied into chart rows, or walked by
+// Redux Toolkit's development checks. A non-enumerable symbol keeps it beside the tick whose
+// index it describes while remaining invisible to JSON.stringify/Object.entries/object spread.
+const FORECAST_METADATA = Symbol("forecastMetadata");
+
+type ForecastTick = TickPresentFutureType & {
+  [FORECAST_METADATA]?: ForecastMetadata;
+};
+
+function metadata(
+  tick: TickPresentFutureType,
+  create = false,
+): ForecastMetadata | undefined {
+  const forecastTick = tick as ForecastTick;
+  if (!forecastTick[FORECAST_METADATA] && create) {
+    Object.defineProperty(forecastTick, FORECAST_METADATA, {
+      configurable: true,
+      enumerable: false,
+      value: {
+        dispatchTargets: {},
+        runningCostToNextDispatch: {},
+      },
+      writable: true,
+    });
+  }
+  return forecastTick[FORECAST_METADATA];
+}
+
+export function hasPreparedGeneratorCommitment(
+  tick: TickPresentFutureType | null | undefined,
+  facilityId: number,
+): boolean {
+  return (
+    tick != null &&
+    metadata(tick)?.runningCostToNextDispatch[facilityId] !== undefined
+  );
+}
+
+export function recordDispatchTarget(
+  tick: TickPresentFutureType,
+  facilityId: number,
+  targetW: number,
+) {
+  metadata(tick, true)!.dispatchTargets[facilityId] = targetW;
+}
+
+function dispatchTarget(
+  tick: TickPresentFutureType,
+  facilityId: number,
+): number | undefined {
+  return (
+    // Compatibility with timelines loaded from saves written before forecast metadata became
+    // transient. Prefer it when present so an old save (or focused simulation fixture) remains
+    // authoritative rather than being shadowed by metadata from an earlier forecast.
+    tick.dispatchTargetWByFacility?.[facilityId] ??
+    metadata(tick)?.dispatchTargets[facilityId]
+  );
+}
+
+/** Copies transient metadata when a forecast pass clones a tick with object spread. */
+export function copyCommitmentMetadata(
+  source: TickPresentFutureType,
+  destination: TickPresentFutureType,
+) {
+  const sourceMetadata = metadata(source);
+  if (!sourceMetadata) {
+    return;
+  }
+  Object.defineProperty(destination as ForecastTick, FORECAST_METADATA, {
+    configurable: true,
+    enumerable: false,
+    value: sourceMetadata,
+    writable: true,
+  });
+}
+
+interface PrepareCommitmentOptions {
+  facilityId: number;
+  forecast: TickPresentFutureType[];
+  minimumOperatingCost: (tick: TickPresentFutureType) => number;
+}
+
+/**
+ * Precomputes the minimum-load cost before the next requested dispatch in one backward pass.
+ * Every later commitment decision is then O(1), instead of scanning the same future ticks again.
+ */
+export function prepareGeneratorCommitment({
+  facilityId,
+  forecast,
+  minimumOperatingCost,
+}: PrepareCommitmentOptions) {
+  let runningCostToNextDispatch = Infinity;
+  for (let i = forecast.length - 1; i >= 0; i--) {
+    metadata(forecast[i], true)!.runningCostToNextDispatch[facilityId] =
+      runningCostToNextDispatch;
+    const targetW = dispatchTarget(forecast[i], facilityId);
+    if (targetW === undefined) {
+      continue;
+    }
+    if (targetW > 0) {
+      runningCostToNextDispatch = 0;
+    } else if (Number.isFinite(runningCostToNextDispatch)) {
+      runningCostToNextDispatch += minimumOperatingCost(forecast[i]);
+    }
+  }
+}
+
 interface KeepCommittedOptions {
   facilityId: number;
   forecast: TickPresentFutureType[];
@@ -26,13 +138,20 @@ export function shouldKeepGeneratorCommitted({
     return false;
   }
 
+  const preparedCost = forecast[fromIndex].dispatchTargetWByFacility
+    ? undefined
+    : metadata(forecast[fromIndex])?.runningCostToNextDispatch[facilityId];
+  if (preparedCost !== undefined) {
+    return preparedCost < startCost;
+  }
+
   let runningCost = 0;
   for (let i = fromIndex + 1; i < forecast.length; i++) {
-    const dispatchTarget = forecast[i].dispatchTargetWByFacility?.[facilityId];
-    if (dispatchTarget === undefined) {
+    const targetW = dispatchTarget(forecast[i], facilityId);
+    if (targetW === undefined) {
       continue;
     }
-    if (dispatchTarget > 0) {
+    if (targetW > 0) {
       return true;
     }
     runningCost += minimumOperatingCost(forecast[i]);

--- a/src/helpers/Customers.test.tsx
+++ b/src/helpers/Customers.test.tsx
@@ -85,6 +85,15 @@ describe("customer price competition", () => {
     expect(perceived).toBeCloseTo(0.0683, 3);
   });
 
+  it("preserves bill-memory decay when an hourly forecast advances four ticks", () => {
+    let quarterHourly = 0.1;
+    for (let i = 0; i < 4; i++) {
+      quarterHourly = updateCustomerRate(quarterHourly, 0.05);
+    }
+
+    expect(updateCustomerRate(0.1, 0.05, 4)).toBeCloseTo(quarterHourly, 12);
+  });
+
   it("projects the same gradual response used by the tick model", () => {
     const common = {
       customers: 1_000_000,

--- a/src/helpers/Customers.tsx
+++ b/src/helpers/Customers.tsx
@@ -38,14 +38,20 @@ export interface CustomerTickInputType {
   marketSize: number;
   ownership: "Investor" | "Public";
   organicGrowthRate?: number;
+  tickScale?: number;
 }
 
 export function updateCustomerRate(
   previousRate: number,
   currentRate: number,
+  tickScale = 1,
 ): number {
   const ticksOfMemory = CUSTOMER_RATE_MEMORY_MONTHS * TICKS_PER_MONTH;
-  return previousRate + (currentRate - previousRate) / ticksOfMemory;
+  if (tickScale === 1) {
+    return previousRate + (currentRate - previousRate) / ticksOfMemory;
+  }
+  const retained = Math.pow(1 - 1 / ticksOfMemory, tickScale);
+  return previousRate + (currentRate - previousRate) * (1 - retained);
 }
 
 /** Annual fraction of the relevant customer pool that switches to or from the company. */
@@ -79,15 +85,16 @@ export function nextCustomerCount({
   marketSize,
   ownership,
   organicGrowthRate = ORGANIC_GROWTH_MAX_ANNUAL,
+  tickScale = 1,
 }: CustomerTickInputType): number {
-  let change = (customers * organicGrowthRate) / TICKS_PER_YEAR;
+  let change = (customers * organicGrowthRate * tickScale) / TICKS_PER_YEAR;
   if (ownership === "Investor") {
     const switchingRate = customerSwitchingRate(customerRate, marketRate);
     const switchingBase =
       switchingRate >= 0
         ? Math.max(0, marketSize - customers)
         : Math.max(0, customers);
-    change += (switchingBase * switchingRate) / TICKS_PER_YEAR;
+    change += (switchingBase * switchingRate * tickScale) / TICKS_PER_YEAR;
   }
   const next = Math.max(0, Math.round(customers + change));
   return ownership === "Investor"

--- a/src/helpers/DateTime.test.tsx
+++ b/src/helpers/DateTime.test.tsx
@@ -208,6 +208,18 @@ describe("summarizeTimeline", () => {
       ),
     ).toBeCloseTo(summary.supplyWh);
   });
+
+  it("integrates hourly forecast points across their full duration", () => {
+    const hourly = ticks([100, 200]);
+    hourly[1].minute = 60;
+
+    const summary = summarizeTimeline(hourly, 2020);
+
+    expect(summary.demandWh).toBeCloseTo(
+      ((200 + 300) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS * 4,
+    );
+    expect(summary.revenue).toBe(20);
+  });
 });
 
 describe("summarizeHistory", () => {

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -109,13 +109,17 @@ function accumulateTick(
   summary: MonthlyHistoryType,
   t: TickPresentFutureType,
   startingYear: number,
+  tickScale: number,
 ) {
   const date = getMonthYearFromMinute(t.minute, startingYear);
   // Integrate instantaneous electricity (watts) to watt hours
   // Only electricity isn't multiplied by this during tick calculations (financials are)
   summary.supplyWh +=
-    (Math.min(t.demandW, t.supplyW) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
-  summary.demandWh += (t.demandW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+    (Math.min(t.demandW, t.supplyW) / TICKS_PER_HOUR) *
+    GAME_TO_REAL_YEARS *
+    tickScale;
+  summary.demandWh +=
+    (t.demandW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS * tickScale;
   // Dispatch can briefly oversupply while a minimum-load plant ramps. Attribute only the share
   // that demand accepted, so fuel totals describe delivered energy and never claim the curtailed
   // excess. Storage is deliberately absent because it is not a fuel.
@@ -124,7 +128,9 @@ function accumulateTick(
     if (watts !== undefined) {
       summary.deliveredWhByFuel[fuel] =
         (summary.deliveredWhByFuel[fuel] || 0) +
-        ((watts * deliveredShare) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+        ((watts * deliveredShare) / TICKS_PER_HOUR) *
+          GAME_TO_REAL_YEARS *
+          tickScale;
     }
   });
   summary.peakDemandW = Math.max(summary.peakDemandW, t.demandW);
@@ -156,13 +162,17 @@ export function summarizeTimeline(
   filter?: (t: TickPresentFutureType) => boolean,
 ): MonthlyHistoryType {
   const summary = emptyHistory();
+  const tickScale =
+    timeline.length > 1
+      ? Math.max(1, (timeline[1].minute - timeline[0].minute) / TICK_MINUTES)
+      : 1;
   // Ticks are ordered oldest first, so walk forwards: reduceHistories keeps the last value it
   // sees for the point-in-time fields, and the period should report the balances it ended on.
   // Note that summarizeHistory below walks the other way, because monthlyHistory is newest first.
   for (let i = 0; i < timeline.length; i++) {
     const t = timeline[i];
     if (!filter || filter(t)) {
-      accumulateTick(summary, t, startingYear);
+      accumulateTick(summary, t, startingYear, tickScale);
     }
   }
   return summary;
@@ -182,6 +192,10 @@ export function summarizeTimelineByMonth(
   startingYear: number,
 ): MonthlyHistoryType[] {
   const byMonth = new Map<number, MonthlyHistoryType>();
+  const tickScale =
+    timeline.length > 1
+      ? Math.max(1, (timeline[1].minute - timeline[0].minute) / TICK_MINUTES)
+      : 1;
   // Forwards, with each tick overwriting the ending values, for the same reason summarizeTimeline
   // does it -- so a month summarized here reads the same way as one recorded during play, and
   // each one reports the balances it ended on rather than the ones it opened with
@@ -195,7 +209,7 @@ export function summarizeTimelineByMonth(
       summary = emptyHistory();
       byMonth.set(month, summary);
     }
-    accumulateTick(summary, t, startingYear);
+    accumulateTick(summary, t, startingYear, tickScale);
   }
   return [...byMonth.keys()]
     .sort((a, b) => a - b)

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1603,12 +1603,14 @@ function getDemandW(
   game: GameType,
   prev: TickPresentFutureType,
   now: TickPresentFutureType,
+  tickScale = 1,
 ) {
   const scenario =
     getScenario(game.scenarioId, game.customScenario) || SCENARIOS[0];
   now.customerRate = updateCustomerRate(
     prev.customerRate || game.customerRate,
     game.dollarsPerkWh,
+    tickScale,
   );
   now.customers = nextCustomerCount({
     customers: prev.customers,
@@ -1621,6 +1623,7 @@ function getDemandW(
     ),
     marketSize: customerMarketSizeAt(game.customerMarketSize, now.minute),
     ownership: scenario.ownership,
+    tickScale,
   });
   const sun = getSunriseSunset(date, game.location);
 
@@ -1761,12 +1764,15 @@ function reforecastWeatherAndPrices(
   });
 }
 
-function reforecastDemand(state: GameType): TickPresentFutureType[] {
+function reforecastDemand(
+  state: GameType,
+  tickScale = 1,
+): TickPresentFutureType[] {
   let prev = state.timeline[0];
   return state.timeline.map((t: TickPresentFutureType) => {
     if (t.minute >= state.date.minute) {
       const date = getDateFromMinute(t.minute, state.startingYear);
-      t.demandW = getDemandW(date, state, prev, t);
+      t.demandW = getDemandW(date, state, prev, t, tickScale);
       prev = t;
       return t;
     }
@@ -1779,9 +1785,11 @@ function minimumStableOperatingCost(
   state: GameType,
   generator: GeneratorOperatingType,
   tick: TickPresentFutureType,
+  stepMinutes = TICK_MINUTES,
 ): number {
+  const ticksPerHour = 60 / stepMinutes;
   const minimumW = generator.peakW * (generator.minimumStableOutput || 0);
-  const generatedWh = (minimumW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+  const generatedWh = (minimumW / ticksPerHour) * GAME_TO_REAL_YEARS;
   const tickDate = getDateFromMinute(tick.minute, state.startingYear);
   const operatingCostMultiplier =
     storyEffectsAt(tickDate, state).operatingCostMultipliersByFuel?.[
@@ -1796,7 +1804,7 @@ function minimumStableOperatingCost(
     return variableOM;
   }
   const fuelBtu =
-    ((minimumW * (generator.btuPerWh || 0)) / TICKS_PER_HOUR) *
+    ((minimumW * (generator.btuPerWh || 0)) / ticksPerHour) *
     GAME_TO_REAL_YEARS;
   const fuelCost = (fuelBtu * (tick[generator.fuel] ?? 0)) / 1000000;
   const carbonCost =
@@ -1808,9 +1816,13 @@ function forecastIndexAt(state: GameType, minute: number): number {
   if (state.timeline.length === 0) {
     return 0;
   }
+  const stepMinutes =
+    state.timeline.length > 1
+      ? state.timeline[1].minute - state.timeline[0].minute
+      : TICK_MINUTES;
   return Math.max(
     0,
-    Math.round((minute - state.timeline[0].minute) / TICK_MINUTES),
+    Math.round((minute - state.timeline[0].minute) / stepMinutes),
   );
 }
 
@@ -1822,15 +1834,23 @@ function updateSupplyFacilitiesFinances(
   simulated?: boolean,
   preRoll?: boolean,
   optimizeCommitment = true,
+  stepMinutes = TICK_MINUTES,
 ) {
   const { facilities, date } = state;
+  const tickScale = stepMinutes / TICK_MINUTES;
+  const ticksPerHour = 60 / stepMinutes;
+  const ticksPerMonth = TICKS_PER_MONTH / tickScale;
+  const ticksPerYear = TICKS_PER_YEAR / tickScale;
   const tickDate = getDateFromMinute(now.minute, state.startingYear);
   const difficulty = DIFFICULTIES[state.difficulty];
 
   // Update facility construction status
   facilities.forEach((f: FacilityOperatingType) => {
     if (f.yearsToBuildLeft > 0) {
-      f.yearsToBuildLeft = Math.max(0, f.yearsToBuildLeft - YEARS_PER_TICK);
+      f.yearsToBuildLeft = Math.max(
+        0,
+        f.yearsToBuildLeft - YEARS_PER_TICK * tickScale,
+      );
       if (f.yearsToBuildLeft === 0) {
         f.minuteOperational = now.minute;
         if (!simulated) {
@@ -1868,7 +1888,7 @@ function updateSupplyFacilitiesFinances(
       indexOfLastUnchargedBattery = i;
       totalChargeNeeded += Math.min(
         g.peakW,
-        (g.peakWh - g.currentWh) * TICKS_PER_HOUR,
+        (g.peakWh - g.currentWh) * ticksPerHour,
       );
     }
   });
@@ -1911,7 +1931,7 @@ function updateSupplyFacilitiesFinances(
     if (hydro && g.yearsToBuildLeft === 0) {
       const capacityWh = g.reservoirCapacityWh || 0;
       const inflowWh =
-        ((g.hydroWhPerMm || 0) * now.hydroRunoffMm) / TICKS_PER_MONTH;
+        ((g.hydroWhPerMm || 0) * now.hydroRunoffMm) / ticksPerMonth;
       const beforeSpill = (g.reservoirWh ?? capacityWh / 2) + inflowWh;
       const spillWh = Math.max(0, beforeSpill - capacityWh);
       g.reservoirWh = Math.min(capacityWh, beforeSpill);
@@ -1923,7 +1943,7 @@ function updateSupplyFacilitiesFinances(
         g.reservoirWh,
         ((g.hydroMeanMonthlyInflowWh || 0) *
           mandatedReleaseFraction(tickDate.monthNumber)) /
-          TICKS_PER_MONTH,
+          ticksPerMonth,
       );
       const deadpoolWh = capacityWh * HYDRO_DEADPOOL_FRACTION;
       const turbineWaterWh = Math.max(0, g.reservoirWh - deadpoolWh);
@@ -1933,11 +1953,11 @@ function updateSupplyFacilitiesFinances(
         g.reservoirWh = Math.max(0, g.reservoirWh - bypassWh);
         mandatedW = Math.min(
           availablePeakW,
-          (turbineMandatedWh * TICKS_PER_HOUR) / GAME_TO_REAL_YEARS,
+          (turbineMandatedWh * ticksPerHour) / GAME_TO_REAL_YEARS,
         );
         dispatchPeakW = Math.min(
           availablePeakW,
-          (turbineWaterWh * TICKS_PER_HOUR) / GAME_TO_REAL_YEARS,
+          (turbineWaterWh * ticksPerHour) / GAME_TO_REAL_YEARS,
         );
         g.hydroLastMandatedReleaseWh = requiredReleaseWh;
         g.hydroLastBypassWh = bypassWh;
@@ -1954,7 +1974,7 @@ function updateSupplyFacilitiesFinances(
       // Storage leaks even while paused: pausing controls grid dispatch, not battery
       // self-discharge or water evaporating from a pumped-hydro upper reservoir.
       const lossWh =
-        g.currentWh * (1 - Math.pow(1 - g.hourlyLoss, 1 / TICKS_PER_HOUR));
+        g.currentWh * (1 - Math.pow(1 - g.hourlyLoss, 1 / ticksPerHour));
       g.currentWh = Math.max(0, g.currentWh - lossWh);
       storageLossWh += lossWh;
     }
@@ -1967,7 +1987,7 @@ function updateSupplyFacilitiesFinances(
       }
       g.currentW = Math.max(
         0,
-        g.currentW - (g.peakW * TICK_MINUTES) / g.spinMinutes,
+        g.currentW - (g.peakW * stepMinutes) / g.spinMinutes,
       ); // ramp down
       if (storage) {
         storedWh += g.currentWh;
@@ -2036,7 +2056,12 @@ function updateSupplyFacilitiesFinances(
                         generator.fuel
                       ] || 1),
                     minimumOperatingCost: (futureTick) =>
-                      minimumStableOperatingCost(state, generator, futureTick),
+                      minimumStableOperatingCost(
+                        state,
+                        generator,
+                        futureTick,
+                        stepMinutes,
+                      ),
                   });
                 generator.committed = keepOnline;
               }
@@ -2051,7 +2076,7 @@ function updateSupplyFacilitiesFinances(
                 : 0;
             }
 
-            const rampW = (g.peakW * TICK_MINUTES) / g.spinMinutes;
+            const rampW = (g.peakW * stepMinutes) / g.spinMinutes;
             g.currentW = Math.min(
               dispatchPeakW,
               committedTargetW > g.currentW
@@ -2063,8 +2088,7 @@ function updateSupplyFacilitiesFinances(
         supply += g.currentW;
         supplyByFuel[g.fuel] = (supplyByFuel[g.fuel] || 0) + g.currentW;
         if (hydro) {
-          const generatedWh =
-            (g.currentW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+          const generatedWh = (g.currentW / ticksPerHour) * GAME_TO_REAL_YEARS;
           g.reservoirWh = Math.max(0, (g.reservoirWh || 0) - generatedWh);
           hydroMandatedReleaseW += Math.min(g.currentW, mandatedW);
         }
@@ -2087,19 +2111,19 @@ function updateSupplyFacilitiesFinances(
         const targetW = Math.max(0, now.demandW - supply);
         if (g.currentWh > 0 && targetW > 0) {
           // If there's a need and we have charge, discharge
-          g.currentW = Math.min(g.peakW, targetW, g.currentWh * TICKS_PER_HOUR);
-          g.currentWh = Math.max(0, g.currentWh - g.currentW / TICKS_PER_HOUR);
+          g.currentW = Math.min(g.peakW, targetW, g.currentWh * ticksPerHour);
+          g.currentWh = Math.max(0, g.currentWh - g.currentW / ticksPerHour);
           supply += g.currentW;
         } else if (g.currentWh < g.peakWh && supply - charge > now.demandW) {
           // If there's spare capacity, charge
           g.currentW = -Math.min(
             g.peakW,
             supply - now.demandW - charge,
-            (g.peakWh - g.currentWh) * TICKS_PER_HOUR,
+            (g.peakWh - g.currentWh) * ticksPerHour,
           );
           g.currentWh = Math.min(
             g.peakWh,
-            g.currentWh - g.currentW / TICKS_PER_HOUR,
+            g.currentWh - g.currentW / ticksPerHour,
           );
           charge -= g.currentW / g.roundTripEfficiency;
         } else {
@@ -2125,9 +2149,9 @@ function updateSupplyFacilitiesFinances(
 
   // Update finances
   const supplyWh =
-    (Math.min(now.supplyW, now.demandW) / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+    (Math.min(now.supplyW, now.demandW) / ticksPerHour) * GAME_TO_REAL_YEARS;
   // Scale the representative simulated day to the real month it stands for.
-  const demandWh = (now.demandW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+  const demandWh = (now.demandW / ticksPerHour) * GAME_TO_REAL_YEARS;
   const revenue = (supplyWh / 1000) * state.dollarsPerkWh;
 
   // Facilities expenses
@@ -2152,13 +2176,13 @@ function updateSupplyFacilitiesFinances(
       // generation. A paused plant may still be ramping down internally, but it produces and
       // incurs no variable O&M while it is disconnected from dispatch.
       const deliveredW = g.paused ? 0 : Math.max(0, g.currentW);
-      const generatedWh = (deliveredW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+      const generatedWh = (deliveredW / ticksPerHour) * GAME_TO_REAL_YEARS;
       let facilityOM = 0;
       if (g.paused) {
         // paused facilities only pay half of their operating costs
-        facilityOM += g.annualOperatingCost / TICKS_PER_YEAR / 2;
+        facilityOM += g.annualOperatingCost / ticksPerYear / 2;
       } else {
-        facilityOM += g.annualOperatingCost / TICKS_PER_YEAR;
+        facilityOM += g.annualOperatingCost / ticksPerYear;
       }
       facilityOM +=
         (generatedWh / 1000000) * (g.variableOperatingCostPerMWh || 0);
@@ -2177,7 +2201,7 @@ function updateSupplyFacilitiesFinances(
       expensesOM += facilityOM;
       if (g.fuel && FUELS[g.fuel]) {
         const fuelBtu =
-          ((g.currentW * (g.btuPerWh || 0)) / TICKS_PER_HOUR) *
+          ((g.currentW * (g.btuPerWh || 0)) / ticksPerHour) *
           GAME_TO_REAL_YEARS; // Output-dependent #'s converted to real months, since we don't simulate every day
         // Hydro and geothermal carry a zero-emission FUELS entry so carbon accounting can name
         // them, but they do not buy a fuel and therefore have no entry in the price table. In
@@ -2202,10 +2226,10 @@ function updateSupplyFacilitiesFinances(
         // which reads as the lender owing the player money, counts towards net worth, and trips
         // the loan invariant on every tick from then on
         const paymentPrincipal = Math.min(
-          (g.loanMonthlyPayment - paymentInterest) / TICKS_PER_MONTH,
+          (g.loanMonthlyPayment - paymentInterest) / ticksPerMonth,
           g.loanAmountLeft,
         );
-        expensesInterest += paymentInterest / TICKS_PER_MONTH;
+        expensesInterest += paymentInterest / ticksPerMonth;
         principalRepayment += paymentPrincipal;
         g.loanAmountLeft -= paymentPrincipal;
         // The last payment of a loan is the only interesting one, and nothing else on screen
@@ -2213,7 +2237,7 @@ function updateSupplyFacilitiesFinances(
         if (!simulated && g.loanAmountLeft <= 0) {
           logGameEvent(state, "LOAN", `Loan paid off: ${g.name}`);
         }
-        facilityExpenses += paymentInterest / TICKS_PER_MONTH;
+        facilityExpenses += paymentInterest / ticksPerMonth;
       }
       // Only a real tick is a tick of this facility's life. The pre-roll frames after a month
       // rollover and every tick of every forecast come through here too, and neither happened
@@ -2223,8 +2247,7 @@ function updateSupplyFacilitiesFinances(
         // crediting them here would book revenue nobody was paid for. Its potential keeps
         // accruing though -- being switched off is exactly what a capacity factor is for
         g.lifetimeWh += generatedWh;
-        g.lifetimePotentialWh +=
-          (g.peakW / TICKS_PER_HOUR) * GAME_TO_REAL_YEARS;
+        g.lifetimePotentialWh += (g.peakW / ticksPerHour) * GAME_TO_REAL_YEARS;
         g.lifetimeRevenue += deliveredW * revenuePerSuppliedW;
         g.lifetimeExpenses += facilityExpenses;
         if (started) {
@@ -2233,7 +2256,7 @@ function updateSupplyFacilitiesFinances(
       }
     } else {
       facilityExpenses =
-        getPaymentInterest(g.loanAmountLeft, g.interestRate) / TICKS_PER_MONTH;
+        getPaymentInterest(g.loanAmountLeft, g.interestRate) / ticksPerMonth;
       expensesInterest += facilityExpenses;
       // A half-built plant is already costing interest, and a row that only started counting on
       // the day it switched on would hide the cheapest place to notice that
@@ -2270,6 +2293,7 @@ function updateSupplyFacilitiesFinances(
     marketSize: customerMarketSizeAt(state.customerMarketSize, now.minute),
     ownership: scenario.ownership,
     organicGrowthRate,
+    tickScale,
   });
   now.cash = Math.round(
     prev.cash +
@@ -2304,6 +2328,7 @@ function supplyForecastPass(
   state: GameType,
   simulated?: boolean,
   withoutMinimumStableOutput = false,
+  stepMinutes = TICK_MINUTES,
 ): TickPresentFutureType[] {
   // updateSupplyFacilitiesFinances ramps generators, charges batteries and pays down loans by
   // mutating the facilities in place, so forecasting has to run against a copy of them. A shallow
@@ -2334,6 +2359,7 @@ function supplyForecastPass(
         simulated,
         undefined,
         !withoutMinimumStableOutput,
+        stepMinutes,
       );
       // The current tick already happened. Reforecast its supply against the player's action,
       // but keep the transaction and customer balance that caused this reforecast. Otherwise
@@ -2356,12 +2382,13 @@ function supplyForecastPass(
 function reforecastSupply(
   state: GameType,
   simulated?: boolean,
+  stepMinutes = TICK_MINUTES,
 ): TickPresentFutureType[] {
   // First record the merit-order request each generator would receive without minimum-load
   // constraints. The optimized pass then scans those per-facility requests to compare the cost
   // of remaining online with the cost of the next start. Keeping this as two linear passes avoids
   // recursively re-simulating the fleet for every plant on every tick.
-  const baseline = supplyForecastPass(state, true, true);
+  const baseline = supplyForecastPass(state, true, true, stepMinutes);
   state.facilities.forEach((facility) => {
     const generator = facility as GeneratorOperatingType;
     if (!facility.peakWh && (generator.minimumStableOutput || 0) > 0) {
@@ -2369,11 +2396,16 @@ function reforecastSupply(
         facilityId: facility.id,
         forecast: baseline,
         minimumOperatingCost: (futureTick) =>
-          minimumStableOperatingCost(state, generator, futureTick),
+          minimumStableOperatingCost(state, generator, futureTick, stepMinutes),
       });
     }
   });
-  return supplyForecastPass({ ...state, timeline: baseline }, simulated);
+  return supplyForecastPass(
+    { ...state, timeline: baseline },
+    simulated,
+    false,
+    stepMinutes,
+  );
 }
 
 export function generateNewTimeline(
@@ -2381,7 +2413,9 @@ export function generateNewTimeline(
   cash: number,
   customers: number,
   ticks = TICKS_PER_DAY,
+  stepMinutes = TICK_MINUTES,
 ): TickPresentFutureType[] {
+  const tickScale = stepMinutes / TICK_MINUTES;
   // Everything below runs against a private copy, because reforecastSupply ramps generators and
   // pays down loans by mutating the facilities it is handed. Only the facilities need the deep
   // clone though: the timeline is overwritten on the very next line, and by the end of a long
@@ -2408,7 +2442,7 @@ export function generateNewTimeline(
       ?.customerRate || readOnlyState.customerRate;
   for (let i = 0; i < ticks; i++) {
     state.timeline[i] = {
-      minute: state.date.minute + i * TICK_MINUTES,
+      minute: state.date.minute + i * stepMinutes,
       supplyW: 0,
       demandW: 0,
       demandByType: {
@@ -2459,8 +2493,8 @@ export function generateNewTimeline(
   // advances at the month rollover, which is when this runs, so the forecast never shifts under a
   // player mid-month.
   state.timeline = reforecastWeatherAndPrices(state, cumulativeMegatons);
-  state.timeline = reforecastDemand(state);
-  state.timeline = reforecastSupply(state, true);
+  state.timeline = reforecastDemand(state, tickScale);
+  state.timeline = reforecastSupply(state, true, stepMinutes);
   return state.timeline;
 }
 

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -92,7 +92,13 @@ import {
   STORAGE,
   windAnnualOutputDegradation,
 } from "../data/Facilities";
-import { shouldKeepGeneratorCommitted } from "../helpers/Commitment";
+import {
+  copyCommitmentMetadata,
+  hasPreparedGeneratorCommitment,
+  prepareGeneratorCommitment,
+  recordDispatchTarget,
+  shouldKeepGeneratorCommitted,
+} from "../helpers/Commitment";
 import { getViableLocationsRemaining } from "../data/FacilitySites";
 import { logEvent } from "../Globals";
 import { getPlayedScenarioIds, recordScenarioPlayed } from "../LocalStorage";
@@ -151,6 +157,9 @@ interface NewGameAction {
 }
 
 let previousTickMs = 0;
+let accumulatedTickMs = 0;
+const MAX_PRESENTATION_FPS = 60;
+const MIN_PRESENTATION_INTERVAL_MS = 1000 / MAX_PRESENTATION_FPS;
 // Only for restoring speed after a blocking dialog (bankrupt/fired/win) closes -- NOT used to
 // decide whether the tick loop needs restarting, since state.speed can change without going
 // through setSpeed (e.g. dialogClose below), which would desync a "previous speed" comparison.
@@ -493,18 +502,7 @@ function updateWorldEvents(state: GameType): Set<FuelNameType> {
  * Scheduled effects for any simulated date. Persisted live occurrences win over a newly resolved
  * copy, which is what preserves facility IDs and other onset-time attributes after they are drawn.
  */
-const storyEffectsCache = new WeakMap<
-  GameType,
-  {
-    month: number;
-    scenarioId: number;
-    difficulty: GameType["difficulty"];
-    disabled: boolean;
-    activeKey: string;
-    effects: WorldEventEffectsType;
-  }
->();
-const scheduledStoryEffectsCache = new Map<string, WorldEventEffectsType>();
+const storyEffectsCache = new Map<string, WorldEventEffectsType>();
 
 function scheduledStoryCacheKey(date: DateType, state: GameType): string {
   const fleetSensitive =
@@ -540,15 +538,21 @@ function storyEffectsAt(date: DateType, state: GameType) {
   const activeKey = state.worldEvents.active
     .map((event) => event.key)
     .join("|");
-  const cached = storyEffectsCache.get(state);
-  if (
-    cached?.month === date.monthsElapsed &&
-    cached.scenarioId === state.scenarioId &&
-    cached.difficulty === state.difficulty &&
-    cached.disabled === !!state.storyEffectsDisabled &&
-    cached.activeKey === activeKey
-  ) {
-    return cached.effects;
+  const lastOccurrence = state.worldEvents.occurrences.at(-1);
+  // Immer produces a fresh draft identity on every reducer call and forecasts use shallow state
+  // copies, so an object-keyed WeakMap missed almost every lookup. These are the stable inputs
+  // that can change a month's resolved effects; using them lets live play and both forecast
+  // passes share one result without changing the authored story decision.
+  const cacheKey = [
+    scheduledStoryCacheKey(date, state),
+    state.storyEffectsDisabled ? 1 : 0,
+    activeKey,
+    state.worldEvents.occurrences.length,
+    lastOccurrence?.key || "",
+  ].join("|");
+  const cached = storyEffectsCache.get(cacheKey);
+  if (cached) {
+    return cached;
   }
   const persisted = state.worldEvents.active.filter(
     (event) =>
@@ -559,36 +563,8 @@ function storyEffectsAt(date: DateType, state: GameType) {
     !STORY_ARC_DEFINITIONS.some((arc) => arc.scenarioId === state.scenarioId)
   ) {
     const effects = combineStoryEffects(persisted);
-    storyEffectsCache.set(state, {
-      month: date.monthsElapsed,
-      scenarioId: state.scenarioId,
-      difficulty: state.difficulty,
-      disabled: !!state.storyEffectsDisabled,
-      activeKey,
-      effects,
-    });
+    storyEffectsCache.set(cacheKey, effects);
     return effects;
-  }
-  // Forecast passes create shallow state copies, so the WeakMap above cannot share their work.
-  // With no persisted live onset to distinguish, the scheduled result is a pure month lookup;
-  // only the two facility-selecting arcs add a stable fleet signature.
-  const scheduledCacheKey =
-    state.worldEvents.active.length === 0
-      ? scheduledStoryCacheKey(date, state)
-      : undefined;
-  const scheduledCached = scheduledCacheKey
-    ? scheduledStoryEffectsCache.get(scheduledCacheKey)
-    : undefined;
-  if (scheduledCached) {
-    storyEffectsCache.set(state, {
-      month: date.monthsElapsed,
-      scenarioId: state.scenarioId,
-      difficulty: state.difficulty,
-      disabled: false,
-      activeKey,
-      effects: scheduledCached,
-    });
-    return scheduledCached;
   }
   const persistedKeys = new Set(persisted.map((event) => event.key));
   const scheduled = resolveStoryAtDate({
@@ -605,20 +581,10 @@ function storyEffectsAt(date: DateType, state: GameType) {
     occurrences: state.worldEvents.occurrences,
   }).active.filter((event) => !persistedKeys.has(event.key));
   const effects = combineStoryEffects([...persisted, ...scheduled]);
-  if (scheduledCacheKey) {
-    if (scheduledStoryEffectsCache.size > 10000) {
-      scheduledStoryEffectsCache.clear();
-    }
-    scheduledStoryEffectsCache.set(scheduledCacheKey, effects);
+  if (storyEffectsCache.size > 10000) {
+    storyEffectsCache.clear();
   }
-  storyEffectsCache.set(state, {
-    month: date.monthsElapsed,
-    scenarioId: state.scenarioId,
-    difficulty: state.difficulty,
-    disabled: !!state.storyEffectsDisabled,
-    activeKey,
-    effects,
-  });
+  storyEffectsCache.set(cacheKey, effects);
   return effects;
 }
 
@@ -680,9 +646,10 @@ function ensureTicking(state: GameType) {
   if (state.speed !== "PAUSED" && !tickLoopRunning) {
     tickLoopRunning = true;
     previousTickMs = performance.now();
+    accumulatedTickMs = 0;
     setTimeout(
       () => getStore().dispatch(gameSlice.actions.tick()),
-      TICK_MS[state.speed],
+      Math.max(TICK_MS[state.speed], MIN_PRESENTATION_INTERVAL_MS),
     );
   }
 }
@@ -708,18 +675,27 @@ export const gameSlice = createSlice({
       }
       tickLoopRunning = true;
 
-      // update simulation if accumulated delta exceeds frame time
-      // calculate multiple simulation frames per render if on a slow device
-      let delta = performance.now() - previousTickMs;
-      while (delta > TICK_MS[state.speed]) {
+      // Accumulate wall time before doing any simulation work. The old loop reset its timestamp
+      // inside every iteration, losing both reducer time and the fractional remainder. That made
+      // the clock run slower precisely when a frame was expensive. FAST also dispatched at
+      // 100Hz; batching its 10ms simulation steps behind a 60Hz presentation ceiling preserves
+      // every deterministic tick while giving React at most one update per display frame.
+      const nowMs = performance.now();
+      accumulatedTickMs += Math.max(0, nowMs - previousTickMs);
+      previousTickMs = nowMs;
+      const simulationStepMs = TICK_MS[state.speed];
+      while (accumulatedTickMs >= simulationStepMs) {
         tickState(state);
-        delta -= TICK_MS[state.speed];
-        previousTickMs = performance.now();
+        accumulatedTickMs -= simulationStepMs;
+        if (!state.inGame || (state.speed as SpeedType) === "PAUSED") {
+          tickLoopRunning = false;
+          return;
+        }
       }
 
       setTimeout(
         () => getStore().dispatch(gameSlice.actions.tick()),
-        Math.max(1, TICK_MS[state.speed] - delta),
+        Math.max(simulationStepMs, MIN_PRESENTATION_INTERVAL_MS),
       );
     },
     delta: (state, action: PayloadAction<Partial<GameType>>) => {
@@ -949,6 +925,24 @@ export const gameSlice = createSlice({
       };
     });
     builder.addCase(loaded, (state) => {
+      // Forecast metadata is intentionally absent from JSON saves. Rebuild only that derived
+      // forecast after the data tables have loaded, so a resumed thermal plant makes the same
+      // commitment decision as an uninterrupted one.
+      const currentTick = getTimeFromTimeline(
+        state.date.minute,
+        state.timeline,
+      );
+      const needsCommitmentForecast = state.facilities.some((facility) => {
+        const generator = facility as GeneratorOperatingType;
+        return (
+          !facility.peakWh &&
+          (generator.minimumStableOutput || 0) > 0 &&
+          !hasPreparedGeneratorCommitment(currentTick, facility.id)
+        );
+      });
+      if (needsCommitmentForecast) {
+        state.timeline = reforecastSupply(state, true);
+      }
       // Start ticking in game
       setTimeout(() => {
         return getStore().dispatch(gameSlice.actions.tick());
@@ -1891,7 +1885,6 @@ function updateSupplyFacilitiesFinances(
   let hydroMandatedReleaseW = 0;
   const startedFacilityIds = new Set<number>();
   const tickStoryEffects = storyEffectsAt(tickDate, state);
-  now.dispatchTargetWByFacility = {};
   facilities.forEach((g: FacilityOperatingType, i: number) => {
     const previousW = g.currentW;
     const generator = g as GeneratorOperatingType;
@@ -1966,7 +1959,9 @@ function updateSupplyFacilitiesFinances(
       storageLossWh += lossWh;
     }
     if (g.paused) {
-      now.dispatchTargetWByFacility[g.id] = 0;
+      if (!optimizeCommitment) {
+        recordDispatchTarget(now, g.id, 0);
+      }
       if (hasMinimumStableOutput) {
         generator.committed = false;
       }
@@ -2019,7 +2014,9 @@ function updateSupplyFacilitiesFinances(
                 ? now.demandW + totalChargeNeeded - charge
                 : requiredTargetW,
             );
-            now.dispatchTargetWByFacility[g.id] = dispatchTargetW;
+            if (!optimizeCommitment) {
+              recordDispatchTarget(now, g.id, dispatchTargetW);
+            }
 
             let committedTargetW = dispatchTargetW;
             if (hasMinimumStableOutput) {
@@ -2326,11 +2323,14 @@ function supplyForecastPass(
   const currentCustomers = current?.customers;
   let prev = newState.timeline[0];
   return newState.timeline.map((t: TickPresentFutureType) => {
+    const sourceTick = t;
     if (t.minute >= state.date.minute) {
+      t = { ...t };
+      copyCommitmentMetadata(sourceTick, t);
       t = updateSupplyFacilitiesFinances(
         newState,
         prev,
-        { ...t },
+        t,
         simulated,
         undefined,
         !withoutMinimumStableOutput,
@@ -2362,6 +2362,17 @@ function reforecastSupply(
   // of remaining online with the cost of the next start. Keeping this as two linear passes avoids
   // recursively re-simulating the fleet for every plant on every tick.
   const baseline = supplyForecastPass(state, true, true);
+  state.facilities.forEach((facility) => {
+    const generator = facility as GeneratorOperatingType;
+    if (!facility.peakWh && (generator.minimumStableOutput || 0) > 0) {
+      prepareGeneratorCommitment({
+        facilityId: facility.id,
+        forecast: baseline,
+        minimumOperatingCost: (futureTick) =>
+          minimumStableOperatingCost(state, generator, futureTick),
+      });
+    }
+  });
   return supplyForecastPass({ ...state, timeline: baseline }, simulated);
 }
 
@@ -2438,7 +2449,6 @@ export function generateNewTimeline(
       hydroMandatedReleaseW: 0,
       storageLossWh: 0,
       supplyByFuel: {} as FuelProductionType,
-      dispatchTargetWByFacility: {},
       // Asserted because FuelPricesType carries a `[index: string]: number` index signature,
       // which a fresh object literal with a non-number field cannot satisfy. Same reason
       // reforecastWeatherAndPrices asserts its own tick literal.

--- a/src/reducers/GeneratorCommitment.test.tsx
+++ b/src/reducers/GeneratorCommitment.test.tsx
@@ -34,7 +34,7 @@ describe("minimum stable generator dispatch", () => {
   it("holds an online plant at its minimum when avoiding the next start is cheaper", () => {
     const { state, coal, nextIndex } = isolatedOnlineCoal();
     coal.costPerStart = 1000000000;
-    state.timeline[nextIndex + 2].dispatchTargetWByFacility[coal.id] = 1;
+    state.timeline[nextIndex + 2].dispatchTargetWByFacility![coal.id] = 1;
 
     tickState(state);
 
@@ -52,7 +52,7 @@ describe("minimum stable generator dispatch", () => {
     const { state, coal, nextIndex } = isolatedOnlineCoal();
     coal.costPerStart = 1;
     coal.variableOperatingCostPerMWh = 1000000000;
-    state.timeline[nextIndex + 3].dispatchTargetWByFacility[coal.id] = 1;
+    state.timeline[nextIndex + 3].dispatchTargetWByFacility![coal.id] = 1;
     const minimumW = coal.currentW;
 
     tickState(state);


### PR DESCRIPTION
## Summary
- fix the wall-clock accumulator so reducer/render cost and fractional elapsed time are no longer discarded
- batch 20x simulation ticks behind a 60 Hz dispatch ceiling and cap the Facilities pane at 25 visual refreshes/sec
- replace repeated forward commitment scans with a linear backward plan stored as transient, non-serialized forecast metadata
- reduce Facilities work with memoized static controls, memoized charts/monthly fuel trends, and transform-based output/storage meters
- run the Next 20 years Insights projection at hourly resolution (5,760 points instead of 23,040) while preserving 15-minute resolution for every shorter forecast and live play
- share story-effect results across Immer drafts, skip large derived paths in development middleware checks, and remove the redundant Redux Provider

## Game-impact boundary
- every deterministic live simulation tick still runs in order; only Redux/presentation frequency is capped
- hourly forecast steps scale storage, hydro, construction, loans, customer movement, commitment costs, blackout energy, and monthly summaries by their actual duration
- commitment decisions retain legacy-save fallback behavior and rebuild transient metadata after save resume
- no save or replay version bump is required because the new forecast metadata is intentionally excluded from JSON

## Verification
- npm run check (87 suites, 811 tests, 14 scenarios, all invariants)
- npm run build
- focused Insights test confirms 5,760 points at 60-minute intervals for Next 20 years
- focused Facilities, GameAppBar, commitment, generator commitment, date/time integration, customer scaling, facility lifetime, and save tests
- Playwright app startup/layout smoke: app loaded in all projects; the existing suite then timed out on stale selectors that request Play/Options while current master exposes Start playing/Settings