### PR TITLE
Use hourly ten-year forecasts and test ten-facility performance

### DIFF
--- a/e2e/responsive-320.spec.ts
+++ b/e2e/responsive-320.spec.ts
@@ -14,7 +14,9 @@ test("custom setup and settings stay usable on a 320px phone", async ({
     );
   });
   await page.goto("/");
-  await page.getByRole("button", { name: "Play", exact: true }).click();
+  await page
+    .getByRole("button", { name: "Start playing", exact: true })
+    .click();
   await page.getByRole("button", { name: "View Custom Game details" }).click();
 
   await expect(
@@ -30,7 +32,7 @@ test("custom setup and settings stay usable on a 320px phone", async ({
   expect(setupOverflow).toBeLessThanOrEqual(1);
 
   await page.goto("/");
-  await page.getByRole("button", { name: "Options" }).click();
+  await page.getByRole("button", { name: "Settings" }).click();
   await expect(
     page.getByRole("heading", { name: "Keyboard shortcuts" }),
   ).toBeVisible();

--- a/e2e/tutorial-capstone.spec.ts
+++ b/e2e/tutorial-capstone.spec.ts
@@ -5,7 +5,9 @@ test("guided objective reaches a retryable capstone and succeeds", async ({
 }, testInfo) => {
   await page.addInitScript(() => window.localStorage.clear());
   await page.goto("/");
-  await page.getByRole("button", { name: "Play", exact: true }).click();
+  await page
+    .getByRole("button", { name: "Start playing", exact: true })
+    .click();
 
   await expect(
     page.getByRole("heading", { name: "Mission objective" }),

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -159,11 +159,25 @@ describe("the fleet list", () => {
         attributes: {},
         effects: {
           facilityOutputMultipliersById: { [String(facility.id)]: 0.6 },
+          facilityOutputMultipliersByFuel: { [facility.fuel!]: 0.5 },
         },
       },
     ];
     renderFacilities(constrained, null);
-    expect(screen.getByText("Derated to 60%")).toBeInTheDocument();
+    expect(screen.getByText("Derated to 30%")).toBeInTheDocument();
+  });
+
+  it("renders the reasonable worst-case fleet size", () => {
+    const tenFacilities = createGame({ scenarioId: 103 });
+    const template = tenFacilities.facilities[0];
+    tenFacilities.facilities = Array.from({ length: 10 }, (_, index) => ({
+      ...template,
+      id: index + 1,
+    }));
+
+    renderFacilities(tenFacilities, null);
+
+    expect(rows()).toHaveLength(10);
   });
 
   it("uses compact watt units in the accessible chart summary", () => {

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -38,6 +38,7 @@ import {
   FacilityOperatingType,
   GameType,
   GeneratorOperatingType,
+  WorldEventEffectsType,
 } from "../../Types";
 import { facilityCashBack } from "../../helpers/Financials";
 import {
@@ -51,6 +52,7 @@ import ChartSupplyDemand from "../base/ChartSupplyDemand";
 import FacilityDetails from "../base/FacilityDetails";
 import GameCard from "../base/GameCard";
 import ConceptIcon from "../base/ConceptIcon";
+import { combineStoryEffects } from "../../data/WorldEvents";
 
 interface FacilityListItemProps {
   facility: FacilityOperatingType;
@@ -58,6 +60,7 @@ interface FacilityListItemProps {
   listLength: number;
   game: GameType;
   selected: boolean;
+  storyOutputMultiplier: number;
   onSelect: (id: FacilityOperatingType["id"] | null) => void;
   // A replay is a recording of somebody else's decisions; letting the viewer make their own
   // would desync the run from the actions still queued up against it
@@ -66,6 +69,17 @@ interface FacilityListItemProps {
   onPause: DispatchProps["onPause"];
   onSell: DispatchProps["onSell"];
   onReprioritize: DispatchProps["onReprioritize"];
+}
+
+function storyOutputMultiplierForFacility(
+  facility: FacilityOperatingType,
+  effects: WorldEventEffectsType,
+): number {
+  const fuel = (facility as Partial<GeneratorOperatingType>).fuel;
+  return (
+    (effects.facilityOutputMultipliersById?.[String(facility.id)] || 1) *
+    (fuel ? effects.facilityOutputMultipliersByFuel?.[fuel] || 1 : 1)
+  );
 }
 
 const getDraggableStyle = (
@@ -248,6 +262,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
     readOnly,
     selected,
     spotInList,
+    storyOutputMultiplier,
   } = props;
   const underConstruction = facility.yearsToBuildLeft > 0;
   const isStorage = facility.peakWh > 0;
@@ -273,20 +288,6 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
   }
 
   const fuel = (facility as Partial<GeneratorOperatingType>).fuel;
-  const storyOutputMultiplier = game.worldEvents.active
-    .filter(
-      (event) =>
-        game.date.minute >= event.startsMinute &&
-        game.date.minute < event.endsMinute,
-    )
-    .reduce(
-      (multiplier, event) =>
-        multiplier *
-        (event.effects.facilityOutputMultipliersById?.[String(facility.id)] ||
-          (fuel && event.effects.facilityOutputMultipliersByFuel?.[fuel]) ||
-          1),
-      1,
-    );
   const accentColor = facilityColor(fuel);
   const outputFraction =
     facility.peakW > 0 ? Math.min(1, facility.currentW / facility.peakW) : 0;
@@ -578,6 +579,13 @@ export default class Facilities extends React.Component<Props, {}> {
     } = this.props;
     const facilitiesCount = game.facilities.length;
     const readOnly = !!game.replayPlayback;
+    const storyEffects = combineStoryEffects(
+      game.worldEvents.active.filter(
+        (event) =>
+          game.date.minute >= event.startsMinute &&
+          game.date.minute < event.endsMinute,
+      ),
+    );
 
     return (
       <GameCard className="facilities" id="facilitiesPane">
@@ -639,6 +647,10 @@ export default class Facilities extends React.Component<Props, {}> {
                         onReprioritize={onReprioritize}
                         onSelect={onSelect}
                         selected={selectedFacilityId === g.id}
+                        storyOutputMultiplier={storyOutputMultiplierForFacility(
+                          g,
+                          storyEffects,
+                        )}
                         spotInList={i}
                         listLength={facilitiesCount}
                         readOnly={readOnly}

--- a/src/components/views/Forecasts.tsx
+++ b/src/components/views/Forecasts.tsx
@@ -107,11 +107,14 @@ export default class Forecasts extends React.Component<Props, State> {
     }
 
     // Generate the forecast
+    const projectionStepMinutes = years >= 10 ? 60 : TICK_MINUTES;
+    const tickScale = projectionStepMinutes / TICK_MINUTES;
     const forecastedTimeline = generateNewTimeline(
       game,
       now.cash,
       now.customers,
-      TICKS_PER_YEAR * years,
+      (TICKS_PER_YEAR * years) / tickScale,
+      projectionStepMinutes,
     );
 
     let hasStorage = false;

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -261,12 +261,18 @@ describe("Insights layers", () => {
     expect(options.queryByText("Next year")).toBeNull();
   });
 
-  it("uses hourly points for the twenty-year forecast", () => {
-    localStorage.setItem("insightsRange", "next20");
+  it.each([
+    ["next10", "2880"],
+    ["next20", "5760"],
+  ])("uses hourly points for the %s forecast", (range, expectedPoints) => {
+    localStorage.setItem("insightsRange", range);
     localStorage.setItem("insightsLayers", JSON.stringify(["weather"]));
     renderInsights();
 
-    expect(screen.getByRole("img")).toHaveAttribute("data-points", "5760");
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "data-points",
+      expectedPoints,
+    );
     expect(screen.getByRole("img")).toHaveAttribute("data-step", "60");
   });
 

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -568,7 +568,9 @@ export default class Insights extends React.Component<Props, State> {
     const nextYearMinute =
       (game.date.year - game.startingYear + 1) * 12 * MINUTES_PER_MONTH;
     const projectionStepMinutes =
-      this.state.range === "next20" ? 60 : TICK_MINUTES;
+      this.state.range === "next10" || this.state.range === "next20"
+        ? 60
+        : TICK_MINUTES;
     const tickScale = projectionStepMinutes / TICK_MINUTES;
     const ticks =
       years > 0

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -51,8 +51,9 @@ The forecast performance gate is independently reproducible:
 npm run sim -- --benchmark-stories
 ```
 
-It compares median warmed 20-year Shale forecasts with scheduled story resolution disabled and
-enabled, and fails above a 15% regression.
+It compares median warmed 20-year hourly Shale forecasts with scheduled story resolution disabled
+and enabled across a ten-facility fleet, a reasonable worst case for normal play. It fails above a
+15% regression.
 
 `--year` and `--location` play an authored scenario somewhere or somewhen else, which is the
 only way to exercise a start past the recorded weather from the command line:

--- a/src/testing/SimCli.tsx
+++ b/src/testing/SimCli.tsx
@@ -6,10 +6,10 @@
  * stack trace after every call.
  */
 import { CUSTOM_SCENARIO_ID, SCENARIOS } from "../data/Scenarios";
-import { DifficultyType, ScenarioType } from "../Types";
+import { DifficultyType, GeneratorOperatingType, ScenarioType } from "../Types";
 import { formatReport } from "./Report";
 import { getSimLocation, simLocationIds } from "./SimData";
-import { TICKS_PER_YEAR } from "../Constants";
+import { TICK_MINUTES, TICKS_PER_YEAR } from "../Constants";
 import { getTimeFromTimeline } from "../helpers/DateTime";
 import { generateNewTimeline } from "../reducers/Game";
 import {
@@ -258,6 +258,10 @@ function median(values: number[]): number {
   return sorted[Math.floor(sorted.length / 2)];
 }
 
+const BENCHMARK_FACILITY_COUNT = 10;
+const BENCHMARK_FORECAST_YEARS = 20;
+const BENCHMARK_STEP_MINUTES = 60;
+
 function benchmarkForecast(storyEffectsDisabled: boolean): number {
   const samples: number[] = [];
   for (let sample = 0; sample < 5; sample++) {
@@ -267,9 +271,26 @@ function benchmarkForecast(storyEffectsDisabled: boolean): number {
       seed: 7,
     });
     state.storyEffectsDisabled = storyEffectsDisabled;
+    const template = state.facilities[0] as GeneratorOperatingType;
+    state.facilities = Array.from(
+      { length: BENCHMARK_FACILITY_COUNT },
+      (_, index) => ({
+        ...template,
+        id: index + 1,
+        peakW: template.peakW / BENCHMARK_FACILITY_COUNT,
+        currentW: template.currentW / BENCHMARK_FACILITY_COUNT,
+      }),
+    );
     const now = getTimeFromTimeline(state.date.minute, state.timeline)!;
     const started = performance.now();
-    generateNewTimeline(state, now.cash, now.customers, TICKS_PER_YEAR * 20);
+    generateNewTimeline(
+      state,
+      now.cash,
+      now.customers,
+      (TICKS_PER_YEAR * BENCHMARK_FORECAST_YEARS * TICK_MINUTES) /
+        BENCHMARK_STEP_MINUTES,
+      BENCHMARK_STEP_MINUTES,
+    );
     const elapsed = performance.now() - started;
     if (sample > 0) {
       samples.push(elapsed);
@@ -283,8 +304,12 @@ function runStoryBenchmark() {
   const storyMs = benchmarkForecast(false);
   const regression = storyMs / baselineMs - 1;
   write("");
-  write(`  20-year forecast without stories  ${baselineMs.toFixed(1)} ms`);
-  write(`  20-year forecast with stories     ${storyMs.toFixed(1)} ms`);
+  write(
+    `  ${BENCHMARK_FACILITY_COUNT}-facility, 20-year hourly forecast without stories  ${baselineMs.toFixed(1)} ms`,
+  );
+  write(
+    `  ${BENCHMARK_FACILITY_COUNT}-facility, 20-year hourly forecast with stories     ${storyMs.toFixed(1)} ms`,
+  );
   write(
     `  Story resolution regression       ${(regression * 100).toFixed(1)}%`,
   );


### PR DESCRIPTION
## Summary
- switch both current and legacy 10-year forecasts to hourly simulation steps
- update the reproducible forecast benchmark to exercise a ten-facility, 20-year hourly worst case
- resolve active story effects once per Facilities render and make displayed fuel/facility derates match simulation multiplication
- cover hourly 10/20-year ranges and ten-row fleet rendering
- update Playwright locators for the current Start playing and Settings menu labels

## Performance
- ten-facility benchmark: 227.3 ms without stories, 234.9 ms with stories
- story-resolution overhead: 3.4% against the existing 15% gate

## Validation
- npm run check
- npm run build
- npm run sim -- --benchmark-stories
- npm run test:e2e (all five applicable desktop/mobile tests pass; four project-specific skips)
- focused Facilities and Insights tests