### PR TITLE
Polish scenario details and generator tutorial capstone

### DIFF
--- a/e2e/tutorial-capstone.spec.ts
+++ b/e2e/tutorial-capstone.spec.ts
@@ -5,7 +5,7 @@ test("guided objective reaches a retryable capstone and succeeds", async ({
 }, testInfo) => {
   await page.addInitScript(() => window.localStorage.clear());
   await page.goto("/");
-  await page.getByRole("button", { name: "Play", exact: true }).click();
+  await page.getByRole("button", { name: "Start playing" }).click();
 
   await expect(
     page.getByRole("heading", { name: "Mission objective" }),

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -523,10 +523,12 @@ export interface TutorialStepType {
   // toggle): advance when an action with one of these types is dispatched. Either gate
   // field alone makes the step gated; both may be combined (OR)
   advanceOnAction?: string | string[];
-  // An independent application check. Entering one restarts the authored scenario at this step,
-  // giving it a deterministic, retryable state instead of inheriting whatever the guided portion
-  // changed. Success advances normally; failure pauses for consequence-specific feedback.
+  // An independent application check. By default, entering one restarts the authored scenario at
+  // this step, giving it a deterministic, retryable state instead of inheriting whatever the
+  // guided portion changed. A capstone that explicitly builds on the guided work can preserve it.
+  // Success advances normally; failure pauses for consequence-specific feedback.
   capstone?: {
+    preserveProgress?: boolean;
     // Optional authored checkpoint overrides. The normal tutorial and its capstone can therefore
     // teach with different starting economics while still rebuilding the whole Game slice through
     // initGame on entry/retry. Anything omitted inherits the mission's scenario-level value.
@@ -576,7 +578,6 @@ export interface ScenarioBriefingType {
   tone: ScenarioBriefingToneType;
   fantasy: string;
   objective: string;
-  constraint: string;
   threat: string;
 }
 

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -169,7 +169,7 @@ describe("onTutorialStep", () => {
     });
   });
 
-  it("starts an unguided capstone from its authored scenario state", () => {
+  it("carries the guided generator purchase into its capstone", () => {
     const capstone = generators.findIndex((candidate) => candidate.capstone);
     expect(capstone).toBeGreaterThan(0);
 
@@ -180,12 +180,26 @@ describe("onTutorialStep", () => {
       currentCard: "FACILITIES",
     });
 
+    expect(dispatched.map((action) => action.type)).toEqual(["game/delta"]);
+    expect(dispatched[0].payload).toEqual({ tutorialStep: capstone });
+  });
+
+  it("still rebuilds capstones that require an authored checkpoint", () => {
+    const storage = walkthrough("Mission 3: Storage");
+    const capstone = storage.findIndex((candidate) => candidate.capstone);
+
+    const dispatched = step({
+      steps: storage,
+      fromStep: capstone - 1,
+      toStep: capstone,
+      currentCard: "FACILITIES",
+    });
+
     expect(dispatched.map((action) => action.type)).toEqual([
       "game/quit",
       "game/start",
       "game/delta",
     ]);
-    expect(dispatched[1].payload).toBe(1);
     expect(dispatched[2].payload).toEqual({ tutorialStep: capstone });
   });
 });

--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -121,7 +121,9 @@ describe("the customer forecast", () => {
         name: "The rate you charge for electricity generation",
       }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/market \$/)).toBeInTheDocument();
+    const rateSummary = screen.getByText(/market \$/);
+    expect(rateSummary).toBeInTheDocument();
+    expect(rateSummary.textContent).not.toMatch(/market [^—]*\/kWh/);
     cleanup();
   });
 });

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -937,7 +937,7 @@ export default class Finances extends React.Component<Props, State> {
               /kWh
               {scenario.ownership === "Investor" && (
                 <>
-                  &nbsp;&mdash;&nbsp;market {formatMoneyConcise(marketRate)}/kWh
+                  &nbsp;&mdash;&nbsp;market {formatMoneyConcise(marketRate)}
                   &nbsp;&mdash;&nbsp;
                   {numbro(now.customers).format({ average: true })} customers,
                   projected&nbsp;

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -247,6 +247,14 @@ describe("Insights layers", () => {
     );
   });
 
+  it("shows the market benchmark without repeating the rate unit", () => {
+    renderInsights();
+
+    const levers = screen.getByRole("region", { name: "Planning levers" });
+    expect(levers).toHaveTextContent(/Rate .*\/kWh/);
+    expect(levers.textContent).not.toMatch(/market [^·]*\/kWh/);
+  });
+
   it("offers one rolling 12-month range instead of separate calendar years", async () => {
     localStorage.setItem("insightsRange", "current");
     renderInsights();

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -753,8 +753,7 @@ export default class Insights extends React.Component<Props, State> {
           {scenario.ownership === "Investor" && (
             <>
               {" "}
-              · market {formatMoneyConcise(marketRate)}/kWh · projected
-              customers{" "}
+              · market {formatMoneyConcise(marketRate)} · projected customers{" "}
               <strong>
                 {formatCustomerChange(customerChange, now.customers)}
               </strong>

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -42,8 +42,9 @@ describe("NewGame", () => {
       (a, b) =>
         b.startingYear - a.startingYear ||
         b.startingYear +
-          b.durationMonths / 12 -
-          (a.startingYear + a.durationMonths / 12),
+          Math.ceil(b.durationMonths / 12) -
+          1 -
+          (a.startingYear + Math.ceil(a.durationMonths / 12) - 1),
     );
     [...TUTORIALS, ...scenariosNewestFirst].forEach((scenario, index) =>
       expect(rows[index]).toHaveTextContent(
@@ -76,6 +77,20 @@ describe("NewGame", () => {
     expect(
       screen.getByRole("img", { name: "Data Center Boom icon" }),
     ).toHaveAttribute("src", "/images/ai data center boom.svg");
+    expect(
+      screen.getByRole("img", { name: "Austin Deep Freeze icon" }),
+    ).toHaveAttribute("src", "/images/texas deep freeze.svg");
+  });
+
+  it("shows the inclusive final calendar year for each scenario", () => {
+    render(<NewGame {...props()} />);
+
+    expect(screen.getByTestId("mission-row-107")).toHaveTextContent(
+      "Austin, TX · 2017–2023",
+    );
+    expect(screen.getByTestId("mission-row-106")).toHaveTextContent(
+      "Manassas, VA · 2020–2035",
+    );
   });
 
   it("highlights the first incomplete tutorial without replacing its subtitle", () => {

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -41,7 +41,7 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 function scenarioEndYear(scenario: ScenarioType): number {
-  return scenario.startingYear + scenario.durationMonths / 12;
+  return scenario.startingYear + Math.ceil(scenario.durationMonths / 12) - 1;
 }
 
 interface MissionListItemProps {

--- a/src/components/views/NewGameDetails.test.tsx
+++ b/src/components/views/NewGameDetails.test.tsx
@@ -83,7 +83,6 @@ describe("NewGameDetails leaderboard", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Your goal")).toBeInTheDocument();
-    expect(screen.getByText("The catch")).toBeInTheDocument();
     expect(screen.getByText("Watch out")).toBeInTheDocument();
     expect(screen.queryByText("Winning looks like")).not.toBeInTheDocument();
     expect(

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -359,7 +359,6 @@ export default class NewGameDetails extends React.Component<Props, State> {
     const briefing = scenario.briefing || {
       fantasy: scenario.summary || scenario.name,
       objective: "Keep the lights on and finish the term.",
-      constraint: `${scenario.ownership}-owned scoring rewards a balanced grid.`,
       threat: "Blackouts and insolvency can end the run early.",
     };
     const endYear =
@@ -427,9 +426,6 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   }
                 >
                   {briefing.objective}
-                </BriefingFact>
-                <BriefingFact concept="finances" label="The catch">
-                  {briefing.constraint}
                 </BriefingFact>
                 <BriefingFact concept="danger" label="Watch out">
                   {briefing.threat}

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -102,10 +102,10 @@ describe("authored scenario briefings", () => {
             tone: expect.any(String),
             fantasy: expect.any(String),
             objective: expect.any(String),
-            constraint: expect.any(String),
             threat: expect.any(String),
           }),
         );
+        expect(scenario.briefing).not.toHaveProperty("constraint");
       },
     );
   });
@@ -178,7 +178,6 @@ describe("authored starting fleets", () => {
         austin.summary,
         austin.briefing?.fantasy,
         austin.briefing?.objective,
-        austin.briefing?.constraint,
         austin.briefing?.threat,
       ].join(" "),
     ).not.toMatch(/ERCOT|PPA|portfolio/i);

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -8,16 +8,10 @@ const hasBlackout = (state: AppStateType) =>
   state.game.eventLog.some((event) => event.kind === "BLACKOUT");
 
 const generatorCapstoneSucceeded = (state: AppStateType) => {
-  const now = getTimeFromTimeline(state.game.date.minute, state.game.timeline);
-  return !!(
-    now &&
-    state.game.facilities.length >= 2 &&
-    state.game.facilities
-      .slice(1)
-      .some((facility) => facility.yearsToBuildLeft <= 0) &&
-    now.supplyW >= now.demandW &&
-    now.cash >= 0
-  );
+  const playerBuiltGeneratorTypes = state.game.facilities
+    .slice(1)
+    .flatMap((facility) => ("fuel" in facility ? [facility.name] : []));
+  return new Set(playerBuiltGeneratorTypes).size >= 2;
 };
 
 const latestMonthProfit = (state: AppStateType) => {
@@ -252,19 +246,18 @@ export const SCENARIOS = [
         card: "FACILITIES",
         content: (
           <TutorialPrompt
-            concepts={["forecast", "build", "supply"]}
-            text="Your turn: commission enough capacity to cover demand within nine months and stay solvent."
+            concepts={["build", "generator", "fuel"]}
+            text="Your turn: build one more generator of a different type."
           />
         ),
-        hint: "Compare the forecast peak with your current capacity, then choose any generator whose cost and construction time fit the deadline.",
+        hint: "Open the generator shop and choose a different fuel or technology from the generator you just bought.",
         capstone: {
+          preserveProgress: true,
           success: generatorCapstoneSucceeded,
-          failure: (s: AppStateType) =>
-            s.game.date.monthsElapsed >= 9 && !generatorCapstoneSucceeded(s),
           successMessage:
-            "Capstone complete - new capacity came online before the deadline and covered demand without exhausting cash.",
+            "Capstone complete - you built two different types of generator.",
           failureMessage:
-            "The added capacity was not online and covering demand by the nine-month deadline. Compare construction time, capacity and financing before trying again.",
+            "Build another generator with a different fuel or technology from your first purchase.",
         },
       },
     ],
@@ -722,7 +715,6 @@ export const SCENARIOS = [
       tone: "transition",
       fantasy: "Modernize an aging grid as pollution gets more expensive.",
       objective: "Replace dirty power while keeping the lights on.",
-      constraint: "Burning coal and gas now costs extra.",
       threat: "Old coal plants and tight finances leave little room for delay.",
     },
     ownership: "Investor",
@@ -746,8 +738,6 @@ export const SCENARIOS = [
       tone: "boom",
       fantasy: "Turn a cheap-gas boom into lasting success.",
       objective: "Grow with cheaper gas without relying on it alone.",
-      constraint:
-        "Most power comes from coal, and new plants are long-term bets.",
       threat: "Gas prices may rebound before new plants pay off.",
     },
     ownership: "Investor",
@@ -768,7 +758,6 @@ export const SCENARIOS = [
       tone: "island",
       fantasy: "Keep an island paradise bright without outside backup.",
       objective: "Use less costly oil while meeting changing demand.",
-      constraint: "Fuel and construction cost more on an island.",
       threat: "One weak link can leave the whole island in the dark.",
     },
     ownership: "Investor",
@@ -793,7 +782,6 @@ export const SCENARIOS = [
       tone: "innovation",
       fantasy: "Build the next generation of clean power.",
       objective: "Replace aging oil plants with cleaner options.",
-      constraint: "New technologies arrive at different times and prices.",
       threat: "Invest too early and overpay; wait too long and demand wins.",
     },
     ownership: "Investor",
@@ -817,7 +805,6 @@ export const SCENARIOS = [
       tone: "storm",
       fantasy: "Protect an island grid through years of fierce storms.",
       objective: "Build a grid that keeps essential power flowing.",
-      constraint: "Fuel is costly, and new plants take time to build.",
       threat: "A major storm can overwhelm a small backup margin.",
     },
     ownership: "Public",
@@ -842,7 +829,6 @@ export const SCENARIOS = [
       tone: "legacy",
       fantasy: "Decide what comes after a century of coal.",
       objective: "Build a new business before old coal plants hold you back.",
-      constraint: "Most of your money and experience are tied to coal.",
       threat: "Old plants, new rivals, and slow construction punish delay.",
     },
     ownership: "Investor",
@@ -879,7 +865,6 @@ export const SCENARIOS = [
       tone: "boom",
       fantasy: "Guide a small city grid through explosive growth.",
       objective: "Get enough reliable power ready before data centers arrive.",
-      constraint: "Today's grid is small, old, and short on cash.",
       threat: "New demand will overwhelm the grid if you build too late.",
     },
     ownership: "Public",
@@ -920,7 +905,7 @@ export const SCENARIOS = [
   {
     id: 107, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
     name: "Austin Deep Freeze",
-    icon: "wind",
+    icon: "texas deep freeze",
     locationId: "Austin",
     location: {
       id: "Austin",
@@ -937,8 +922,6 @@ export const SCENARIOS = [
       tone: "storm",
       fantasy: "Keep Austin powered through a brutal winter storm.",
       objective: "Strengthen the grid before the February 2021 freeze.",
-      constraint:
-        "You manage a citywide mix of power sources, not individual plants.",
       threat: "Extreme cold will cut supplies just as demand surges.",
     },
     ownership: "Public",

--- a/src/data/TutorialCapstones.test.tsx
+++ b/src/data/TutorialCapstones.test.tsx
@@ -1,11 +1,13 @@
 import { getStore } from "../StoreRegistry";
 import { AppStateType, GameType, ScenarioType } from "../Types";
 import gameReducer, {
+  buildFacility,
   delta,
   initGame,
   start,
   tickState,
 } from "../reducers/Game";
+import { GENERATORS } from "./Facilities";
 import { createGame } from "../testing/Simulator";
 import { TUTORIALS } from "./Scenarios";
 
@@ -40,6 +42,26 @@ describe("authored tutorial capstones", () => {
   afterEach(() => {
     jest.clearAllTimers();
     jest.useRealTimers();
+  });
+
+  it("completes Mission 2 after buying a second, different generator type", () => {
+    const objective = capstone(1);
+    let game = createGame({
+      scenarioId: 1,
+      initialBuild: { name: "Oil", peakW: 100000000, financed: true },
+    });
+
+    expect(objective.success(appState(game))).toBe(false);
+
+    const differentGenerator = GENERATORS(game, 100000000, [20], [500]).find(
+      (generator) => generator.available && generator.fuel === "Natural Gas",
+    )!;
+    game = gameReducer(
+      game,
+      buildFacility({ facility: differentGenerator, financed: true }),
+    );
+
+    expect(objective.success(appState(game))).toBe(true);
   });
 
   it("cycles storage through charge and discharge before Mission 3's deadline", () => {

--- a/src/reducers/Tutorial.tsx
+++ b/src/reducers/Tutorial.tsx
@@ -19,6 +19,7 @@ import { dialogOpen, snackbarOpen } from "./UI";
  * faster and safer than maintaining a second partial snapshot format: cash, clock, fleet, event
  * log and all derived forecasts are rebuilt together, and a scenario seed makes the rebuild
  * deterministic. LoadingContainer preserves the requested step instead of reopening step zero.
+ * Capstones that build directly on guided progress do not use this path on entry.
  */
 export function restartTutorialAtStep(
   dispatch: AppDispatch,
@@ -64,7 +65,11 @@ export function changeTutorialStep(
     }
   }
 
-  if (toStep > fromStep && entering?.capstone) {
+  if (
+    toStep > fromStep &&
+    entering?.capstone &&
+    !entering.capstone.preserveProgress
+  ) {
     restartTutorialAtStep(dispatch, scenarioId, toStep);
     return;
   }


### PR DESCRIPTION
## Summary

- use the dedicated Texas deep-freeze icon for Austin and show inclusive scenario end years
- remove the redundant briefing constraint and its UI label from scenario data, types, and tests
- remove the repeated `/kWh` unit from market benchmarks while retaining it on the rate
- preserve guided progress for the generator capstone and ask for a second, different generator type instead of forecasting-based capacity planning
- refresh the capstone browser test locator for the current main-menu action

## Testing

- `npm run check`
- `npm run build`
- `npm run test:e2e -- e2e/tutorial-capstone.spec.ts` (all three browser projects passed; the local Windows web-server teardown was manually stopped after results)
