### PR TITLE
Balance Austin freeze and polish mobile UI

### DIFF
--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -43,7 +43,7 @@ export const DIFFICULTIES = {
     buildTime: 1,
     blackoutPenalty: 10,
     description:
-      "Full challenge: standard costs, building times, and outage consequences.",
+      "Full challenge: fully realistic costs, building times, and outage consequences.",
   },
 } as { [index: string]: DifficultyMultipliersType };
 

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -28,9 +28,9 @@ import {
  * reducers/ImportOrder.test.tsx guards against.
  */
 
-// v4 includes calibrated demand and authored absolute-load schedules in scenario reconstruction.
+// v5 includes the difficulty-scaled Winter Storm Uri demand surge and reliability objective.
 // Older actions cannot reproduce the same monthly facts and are rejected rather than migrated.
-export const REPLAY_VERSION = 4;
+export const REPLAY_VERSION = 5;
 
 export function replayVersionError(raw: unknown): string | undefined {
   if (typeof raw !== "object" || raw === null) {

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -610,6 +610,13 @@ export interface ScenarioType {
   loadAdditions?: ScenarioLoadAdditionType[];
   /** Optional mission gate evaluated at the authored end date. */
   minimumCustomerRetention?: number;
+  /** Optional requirement to serve a specific month without falling below a reliability target. */
+  reliabilityObjective?: {
+    year: number;
+    month: number;
+    minimumDemandServed: number;
+    label: string;
+  };
   dollarsPerkWh: number;
   durationMonths: number;
   endTitle?: string;

--- a/src/app.scss
+++ b/src/app.scss
@@ -1439,12 +1439,12 @@ html[data-theme="dark"] .uplot {
 
 .victoryDebriefStats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 7px;
 
   & > div {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: auto minmax(0, 1fr);
     align-items: center;
     gap: 2px 6px;
     padding: 7px;
@@ -1455,6 +1455,12 @@ html[data-theme="dark"] .uplot {
 
   .conceptIcon {
     grid-row: 1 / span 2;
+  }
+
+  strong {
+    min-width: 0;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
   }
 }
 
@@ -1478,8 +1484,33 @@ html[data-theme="dark"] .uplot {
 }
 
 @media (max-width: 520px) {
+  .victoryDebrief {
+    padding: 10px;
+  }
+
   .victoryFleetComparison {
     grid-template-columns: 1fr;
+  }
+
+  .victoryDebriefStats {
+    grid-template-columns: 1fr;
+
+    & > div {
+      min-height: 48px;
+      padding: 8px 10px;
+    }
+  }
+
+  .victoryDialogActions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+
+    & > .MuiButton-root {
+      width: 100%;
+      min-height: 40px;
+      margin: 0;
+    }
   }
 }
 

--- a/src/components/base/ScenarioDetailsDialog.tsx
+++ b/src/components/base/ScenarioDetailsDialog.tsx
@@ -73,6 +73,7 @@ export default function ScenarioDetailsDialog(props: Props): React.JSX.Element {
           ownership={scenario.ownership}
           dollarsPerkWh={scenario.dollarsPerkWh}
           minimumCustomerRetention={scenario.minimumCustomerRetention}
+          reliabilityObjective={scenario.reliabilityObjective}
         />
         {breakdown && (
           <>

--- a/src/components/base/VictoryConditions.tsx
+++ b/src/components/base/VictoryConditions.tsx
@@ -7,6 +7,7 @@ export interface Props {
   ownership: ScenarioType["ownership"];
   dollarsPerkWh: number;
   minimumCustomerRetention?: number;
+  reliabilityObjective?: ScenarioType["reliabilityObjective"];
 }
 
 /**
@@ -16,7 +17,12 @@ export interface Props {
  * Scoring algorithm should also be updated in helpers/Scoring.tsx and in the Manual.
  */
 export default function VictoryConditions(props: Props): React.JSX.Element {
-  const { ownership, dollarsPerkWh, minimumCustomerRetention } = props;
+  const {
+    ownership,
+    dollarsPerkWh,
+    minimumCustomerRetention,
+    reliabilityObjective,
+  } = props;
   const units = useUnits();
   const perEmissions = formatLargeMassApprox(KG_PER_MEGATONNE, units);
   if (ownership === "Investor") {
@@ -32,6 +38,13 @@ export default function VictoryConditions(props: Props): React.JSX.Element {
   }
   return (
     <div>
+      {reliabilityObjective !== undefined && (
+        <p>
+          Required: serve at least{" "}
+          {Math.round(reliabilityObjective.minimumDemandServed * 100)}% of
+          demand during the {reliabilityObjective.label}
+        </p>
+      )}
       {minimumCustomerRetention !== undefined && (
         <p>
           Required: retain at least {Math.round(minimumCustomerRetention * 100)}

--- a/src/components/base/VictoryDialog.tsx
+++ b/src/components/base/VictoryDialog.tsx
@@ -425,6 +425,7 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
         )}
       </DialogContent>
       <DialogActions
+        className="victoryDialogActions"
         sx={{
           px: { xs: 2, sm: 3 },
           pb: 2,

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -782,6 +782,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
             ownership={scenario.ownership}
             dollarsPerkWh={scenario.dollarsPerkWh}
             minimumCustomerRetention={scenario.minimumCustomerRetention}
+            reliabilityObjective={scenario.reliabilityObjective}
           />
         </DialogContent>
         <DialogActions>

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -255,6 +255,14 @@ describe("Insights layers", () => {
     expect(levers.textContent).not.toMatch(/market [^·]*\/kWh/);
   });
 
+  it("keeps the customer growth rate visible for public utilities", () => {
+    renderInsights(107);
+
+    const levers = screen.getByRole("region", { name: "Planning levers" });
+    expect(levers).toHaveTextContent(/customer growth \+1.5%\/yr/i);
+    expect(levers).not.toHaveTextContent(/market/i);
+  });
+
   it("offers one rolling 12-month range instead of separate calendar years", async () => {
     localStorage.setItem("insightsRange", "current");
     renderInsights();

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -22,6 +22,7 @@ import LayersIcon from "@mui/icons-material/Layers";
 import TuneIcon from "@mui/icons-material/Tune";
 import {
   GAME_TO_REAL_YEARS,
+  ORGANIC_GROWTH_MAX_ANNUAL,
   TICK_MINUTES,
   TICKS_PER_YEAR,
 } from "../../Constants";
@@ -758,6 +759,16 @@ export default class Insights extends React.Component<Props, State> {
               · market {formatMoneyConcise(marketRate)} · projected customers{" "}
               <strong>
                 {formatCustomerChange(customerChange, now.customers)}
+              </strong>{" "}
+              next month
+            </>
+          )}
+          {scenario.ownership === "Public" && (
+            <>
+              {" "}
+              · customer growth{" "}
+              <strong>
+                +{(ORGANIC_GROWTH_MAX_ANNUAL * 100).toFixed(1)}%/yr
               </strong>
             </>
           )}

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -501,6 +501,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                 ownership={scenario.ownership}
                 dollarsPerkWh={scenario.dollarsPerkWh}
                 minimumCustomerRetention={scenario.minimumCustomerRetention}
+                reliabilityObjective={scenario.reliabilityObjective}
               />
             </DialogContent>
             <DialogActions>

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -165,6 +165,12 @@ describe("authored starting fleets", () => {
       startingCustomers: 472_701,
       ownership: "Public",
       dollarsPerkWh: 0.09,
+      reliabilityObjective: {
+        year: 2021,
+        month: 2,
+        minimumDemandServed: 1,
+        label: "February 2021 freeze",
+      },
     });
     expect(austin.location).toMatchObject({
       id: "Austin",

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -921,7 +921,8 @@ export const SCENARIOS = [
     briefing: {
       tone: "storm",
       fantasy: "Keep Austin powered through a brutal winter storm.",
-      objective: "Strengthen the grid before the February 2021 freeze.",
+      objective:
+        "Strengthen the grid and keep every customer supplied during the February 2021 freeze.",
       threat: "Extreme cold will cut supplies just as demand surges.",
     },
     ownership: "Public",
@@ -934,6 +935,12 @@ export const SCENARIOS = [
     dollarsPerkWh: 0.09,
     cash: 335000000,
     feePerKgCO2e: 0,
+    reliabilityObjective: {
+      year: 2021,
+      month: 2,
+      minimumDemandServed: 1,
+      label: "February 2021 freeze",
+    },
     // Aggregate Austin Energy resource/PPA portfolio, not a plant ownership table. The solar
     // residual balances the published 1,287 MW renewable total; it is not a separately audited
     // solar nameplate.

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -14,6 +14,7 @@ import {
   STORY_ARC_DEFINITIONS,
   StoryArcDefinitionType,
   storyPhaseKey,
+  TEXAS_DEEP_FREEZE_DEMAND,
   upcomingStoryPhases,
   validateStoryDifficultyMonotonicity,
 } from "./WorldEvents";
@@ -282,6 +283,16 @@ describe("The Shale Boom pilot arc", () => {
 });
 
 describe("Texas Deep Freeze", () => {
+  it("uses the observed-to-unconstrained ERCOT demand range by difficulty", () => {
+    expect(TEXAS_DEEP_FREEZE_DEMAND).toEqual({
+      Intern: 1.2,
+      Employee: 1.23,
+      Manager: 1.27,
+      VP: 1.3,
+      CEO: 1.33,
+    });
+  });
+
   it("starts only in February 2021 and expires completely in March", () => {
     const january = resolveStoryAtDate(context(48, 107));
     const february = resolveStoryAtDate(context(49, 107));
@@ -294,7 +305,7 @@ describe("Texas Deep Freeze", () => {
     });
     expect(february.effects).toEqual({
       temperatureOffsetC: -20,
-      demandMultiplier: 1,
+      demandMultiplier: 1.27,
       fuelPriceMultipliers: { "Natural Gas": 2.8 },
       facilityOutputMultipliersByFuel: {
         "Natural Gas": 0.62,
@@ -311,10 +322,11 @@ describe("Texas Deep Freeze", () => {
     expect(resolveStoryAtDate(context(49, 999)).effects).toEqual({});
   });
 
-  it("uses exactly one explicit wind availability adjustment", () => {
+  it("raises cold-weather demand and uses exactly one wind adjustment", () => {
     const uri = resolveStoryAtDate(context(49, 107)).occurrences[0];
     expect(uri.effects.facilityOutputMultipliersByFuel?.Wind).toBe(0.44);
-    expect(uri.effects.demandMultiplier).toBeUndefined();
+    expect(uri.effects.demandMultiplier).toBe(1.27);
+    expect(uri.details).toMatch(/demand is 27% above normal/i);
     expect(uri.details).toMatch(/plants can produce less/i);
   });
 

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -1051,11 +1051,22 @@ const END_OF_ERA_ARC: StoryArcDefinitionType = {
   ],
 };
 
+export const TEXAS_DEEP_FREEZE_DEMAND: Record<DifficultyType, number> = {
+  // The joint FERC/NERC report measured actual ERCOT peak load 20% above the normal-weather
+  // forecast and estimated unconstrained demand 33% above it. Difficulty spans that observed
+  // range while leaving the researched Austin portfolio and plant availability anchors intact.
+  Intern: 1.2,
+  Employee: 1.23,
+  Manager: 1.27,
+  VP: 1.3,
+  CEO: 1.33,
+};
+
 /**
- * Austin-scale simulation of ERCOT-wide Winter Storm Uri conditions. The availability ratios are
- * system abstractions from FERC/NERC actual-versus-expected output, not outage claims about named
- * Austin Energy plants. Wind uses this one explicit availability adjustment; no icing derate is
- * applied elsewhere, and solar follows only the event weather.
+ * Austin-scale simulation of ERCOT-wide Winter Storm Uri conditions. The demand and availability
+ * ratios are system abstractions from FERC/NERC actual-versus-forecast output, not outage claims
+ * about named Austin Energy plants. Wind uses this one explicit availability adjustment; no icing
+ * derate is applied elsewhere, and solar follows only the event weather.
  */
 const TEXAS_DEEP_FREEZE_ARC: StoryArcDefinitionType = {
   id: "texas-deep-freeze",
@@ -1066,30 +1077,33 @@ const TEXAS_DEEP_FREEZE_ARC: StoryArcDefinitionType = {
       // January 2017 is month zero, so February 2021 is month 49.
       schedule: { atMonth: 49 },
       durationMonths: 1,
-      describe: () => ({
-        title: "The deep freeze",
-        message:
-          "Record cold is straining power supplies across Texas just as demand surges.",
-        details:
-          "This month, gas, coal, nuclear, and wind plants can produce less while gas costs spike.",
-        concept: "blackout",
-        kind: "WORLD_EVENT",
-        importance: "CRITICAL",
-        actionTarget: { card: "FACILITIES", view: "FLEET" },
-        effects: {
-          // Calibrated against the fixed scenario seed so the representative February day reaches
-          // approximately 6°F (-14.4°C) for several game hours.
-          temperatureOffsetC: -20,
-          fuelPriceMultipliers: { "Natural Gas": 2.8 },
-          facilityOutputMultipliersByFuel: {
-            "Natural Gas": 0.62,
-            Coal: 0.73,
-            Uranium: 0.77,
-            Wind: 0.44,
+      describe: ({ difficulty }) => {
+        const demandMultiplier = TEXAS_DEEP_FREEZE_DEMAND[difficulty];
+        return {
+          title: "The deep freeze",
+          message:
+            "Record cold is straining power supplies across Texas just as demand surges.",
+          details: `Demand is ${Math.round((demandMultiplier - 1) * 100)}% above normal this month while gas, coal, nuclear, and wind plants can produce less and gas costs spike.`,
+          concept: "blackout",
+          kind: "WORLD_EVENT",
+          importance: "CRITICAL",
+          actionTarget: { card: "FACILITIES", view: "FLEET" },
+          effects: {
+            // Calibrated against the fixed scenario seed so the representative February day
+            // reaches approximately 6°F (-14.4°C) for several game hours.
+            temperatureOffsetC: -20,
+            demandMultiplier,
+            fuelPriceMultipliers: { "Natural Gas": 2.8 },
+            facilityOutputMultipliersByFuel: {
+              "Natural Gas": 0.62,
+              Coal: 0.73,
+              Uranium: 0.77,
+              Wind: 0.44,
+            },
           },
-        },
-        turningPointPriority: 110,
-      }),
+          turningPointPriority: 110,
+        };
+      },
     },
     {
       id: "thaw",
@@ -1196,6 +1210,10 @@ export function validateStoryDifficultyMonotonicity(): string[] {
     DIFFICULTY_ORDER.map(
       (difficulty) => RENEWABLES_BALANCE[difficulty].demandLoad,
     ),
+  );
+  ascending(
+    "Texas deep freeze demand",
+    DIFFICULTY_ORDER.map((difficulty) => TEXAS_DEEP_FREEZE_DEMAND[difficulty]),
   );
   ascending(
     "Hurricane affected capacity",

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1582,18 +1582,33 @@ export function scenarioObjectiveFailure(
   scenario: ScenarioType,
   history: MonthlyHistoryType[],
 ): string | undefined {
+  const reliabilityObjective = scenario.reliabilityObjective;
+  if (reliabilityObjective) {
+    const target = history.find(
+      (month) =>
+        month.year === reliabilityObjective.year &&
+        month.month === reliabilityObjective.month,
+    );
+    if (target) {
+      const demandServed =
+        target.demandWh > 0 ? target.supplyWh / target.demandWh : 1;
+      if (demandServed < reliabilityObjective.minimumDemandServed) {
+        return `You served ${(demandServed * 100).toFixed(2)}% of demand during the ${reliabilityObjective.label}; this mission requires ${Math.round(reliabilityObjective.minimumDemandServed * 100)}%.`;
+      }
+    }
+  }
+
   if (
-    scenario.minimumCustomerRetention === undefined ||
-    scenario.startingCustomers === undefined ||
-    history.length === 0
+    scenario.minimumCustomerRetention !== undefined &&
+    scenario.startingCustomers !== undefined &&
+    history.length > 0
   ) {
-    return undefined;
+    const retained = history[0].customers / scenario.startingCustomers;
+    if (retained < scenario.minimumCustomerRetention) {
+      return `Customer attrition left you with only ${Math.round(retained * 100)}% of the community you started with; this mission requires retaining at least ${Math.round(scenario.minimumCustomerRetention * 100)}%.`;
+    }
   }
-  const retained = history[0].customers / scenario.startingCustomers;
-  if (retained >= scenario.minimumCustomerRetention) {
-    return undefined;
-  }
-  return `Customer attrition left you with only ${Math.round(retained * 100)}% of the community you started with; this mission requires retaining at least ${Math.round(scenario.minimumCustomerRetention * 100)}%.`;
+  return undefined;
 }
 
 // Simplified customer forecast, assumes no blackouts since supply calculation depends on demand

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -420,11 +420,33 @@ describe("researched public-utility scenarios", () => {
   );
 
   it.each(difficulties)(
-    "keeps Texas Deep Freeze mathematically survivable on %s",
+    "rejects an unattended Texas Deep Freeze run on %s",
     (difficulty) => {
       const result = runSimulation({ scenarioId: 107, difficulty });
       expectNoViolations(result);
+      expect(result.outcome).toBe("fired");
+      const uri = result.months.find(
+        (month) => month.year === 2021 && month.month === 2,
+      )!;
+      expect(uri.supplyWh).toBeLessThan(uri.demandWh);
+    },
+  );
+
+  it.each(difficulties)(
+    "keeps Texas Deep Freeze winnable with planned firm capacity on %s",
+    (difficulty) => {
+      const result = runSimulation({
+        scenarioId: 107,
+        difficulty,
+        initialBuild: {
+          name: "Natural Gas",
+          peakW: 1_000_000_000,
+          financed: true,
+        },
+      });
+      expectNoViolations(result);
       expect(result.outcome).toBe("completed");
+      expect(result.actionCount).toBeGreaterThan(0);
     },
   );
 
@@ -455,19 +477,24 @@ describe("researched public-utility scenarios", () => {
   });
 
   it("supports materially different Manager strategies for Texas Deep Freeze", () => {
-    const existingPortfolio = runSimulation({
+    const gasPlan = runSimulation({
       scenarioId: 107,
       difficulty: "Manager",
+      initialBuild: {
+        name: "Natural Gas",
+        peakW: 1_000_000_000,
+        financed: true,
+      },
     });
-    const extraWind = runSimulation({
+    const oilPlan = runSimulation({
       scenarioId: 107,
       difficulty: "Manager",
-      initialBuild: { name: "Wind", peakW: 250_000_000, financed: true },
+      initialBuild: { name: "Oil", peakW: 500_000_000, financed: true },
     });
-    expect(existingPortfolio.outcome).toBe("completed");
-    expect(extraWind.outcome).toBe("completed");
-    expect(existingPortfolio.builds).toHaveLength(0);
-    expect(extraWind.builds).toHaveLength(1);
+    expect(gasPlan.outcome).toBe("completed");
+    expect(oilPlan.outcome).toBe("completed");
+    expect(gasPlan.builds[0].name).toBe("Natural Gas");
+    expect(oilPlan.builds[0].name).toBe("Oil");
   });
 });
 


### PR DESCRIPTION
## Summary

- Show customer growth in mobile/public Levers and describe Expert as fully realistic.
- Rebalance Austin Deep Freeze with a difficulty-scaled cold-weather demand surge and an explicit 100% February 2021 reliability objective.
- Polish the end-of-scenario highlights and action layout for narrow mobile screens.
- Bump the replay version because the authored scenario balance changes replay outcomes.

## Balance verification

- Unattended Austin runs now fail on every difficulty.
- A planned 1 GW gas build can win on every difficulty.
- Manager remains viable with either 500 MW oil or 1 GW gas.

## Testing

- npm run check
- npm run build
- Responsive Playwright cases: 5 applicable cases passed and 4 skipped; the Windows runner required manual cleanup after its web-server shutdown hung.