### PR TITLE
Rewrite grid copy for high school learners

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -81,15 +81,14 @@
         <span class="panel__number" aria-hidden="true">01</span>
         <h2>A tycoon game with a purpose</h2>
         <p>
-          Think RollerCoaster Tycoon, but for electricity. Electrify uses the
-          time-honored tradition of simulation games to teach the challenges and
-          opportunities in the modern electricity market, including renewables
-          and energy storage.
+          Electrify is a strategy game about running an electric utility. It
+          teaches how electricity supply must match demand while players manage
+          power plants, storage, costs, reliability, and greenhouse gas
+          emissions.
         </p>
         <p>
-          The game is built on hundreds of hours of research into power markets
-          and generation technologies. Its numbers are grounded in real electric
-          companies and power plants, with sources and references available in
+          The game's numbers draw on research about power markets and generation
+          technologies. Sources and references are available in
           <a href="https://github.com/toddmedema/electrify"
             >the Electrify source code</a
           >. Electrify is 100% free and open source.
@@ -117,7 +116,7 @@
           <li>
             <a
               href="https://medium.com/@toddmedema/how-to-invest-in-the-environment-d280f6c5f41"
-              >Rethink your investment portfolio</a
+              >Rethink where your savings and investments go</a
             >
           </li>
         </ul>

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
     />
     <meta
       name="twitter:description"
-      content="It's like the RollerCoaster Tycoon of renewable energy"
+      content="Build power plants, keep supply equal to demand, manage costs, and reduce grid emissions in a learn-as-you-play strategy game."
     />
     <meta name="twitter:creator" content="@ToddMedema" />
     <meta
@@ -94,8 +94,8 @@
     <noscript id="noscript">
       <p>
         <b
-          >JavaScript is currently disabled. You must enabled JavaScript to use
-          the app and play Electrify</b
+          >JavaScript is currently disabled. You must enable JavaScript to use
+          the app and play Electrify.</b
         >
       </p>
       <p>

--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -13,7 +13,7 @@ export const DIFFICULTIES = {
     buildTime: 0.2,
     blackoutPenalty: 2,
     description:
-      "Most forgiving: much lower costs, very fast building, and gentler outage consequences.",
+      "Most forgiving: much lower game costs, very fast building, and smaller gameplay penalties from outages.",
   },
   Employee: {
     buildCost: 0.7,
@@ -21,21 +21,22 @@ export const DIFFICULTIES = {
     buildTime: 0.3,
     blackoutPenalty: 4,
     description:
-      "Forgiving: lower costs, faster building, and gentler outage consequences.",
+      "Forgiving: lower game costs, faster building, and smaller gameplay penalties from outages.",
   },
   Manager: {
     buildCost: 0.8,
     expensesOM: 0.8,
     buildTime: 0.5,
     blackoutPenalty: 6,
-    description: "Balanced: some help with costs, building time, and outages.",
+    description:
+      "Balanced: some help with game costs, building time, and outage penalties.",
   },
   VP: {
     buildCost: 0.9,
     expensesOM: 0.9,
     buildTime: 0.7,
     blackoutPenalty: 8,
-    description: "Demanding: a little help with costs and building time.",
+    description: "Demanding: a little help with game costs and building time.",
   },
   CEO: {
     buildCost: 1,
@@ -43,9 +44,17 @@ export const DIFFICULTIES = {
     buildTime: 1,
     blackoutPenalty: 10,
     description:
-      "Full challenge: fully realistic costs, building times, and outage consequences.",
+      "Full challenge: unadjusted game costs, building times, and outage penalties.",
   },
 } as { [index: string]: DifficultyMultipliersType };
+
+export const DIFFICULTY_LABELS: Record<string, string> = {
+  Intern: "Beginner",
+  Employee: "Easy",
+  Manager: "Medium",
+  VP: "Hard",
+  CEO: "Expert",
+};
 
 export const LOCATIONS = {
   PIT: {

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -28,9 +28,9 @@ import {
  * reducers/ImportOrder.test.tsx guards against.
  */
 
-// v5 includes the difficulty-scaled Winter Storm Uri demand surge and reliability objective.
+// v6 rounds every scenario's starting facility capacity to two significant digits.
 // Older actions cannot reproduce the same monthly facts and are rejected rather than migrated.
-export const REPLAY_VERSION = 5;
+export const REPLAY_VERSION = 6;
 
 export function replayVersionError(raw: unknown): string | undefined {
   if (typeof raw !== "object" || raw === null) {

--- a/src/app.scss
+++ b/src/app.scss
@@ -2085,18 +2085,33 @@ html[data-theme="dark"] .uplot {
     list-style: none;
   }
 
-  .upcomingEvents,
-  .eventLogHistoryTitle {
+  .eventLogSection {
     padding-top: size(small);
-
-    > .MuiTypography-root {
-      padding: 0 size(base) size(tiny);
-    }
   }
 
-  .eventLogHistoryTitle {
-    padding-right: size(base);
-    padding-left: size(base);
+  .eventLogSectionHeader {
+    display: grid;
+    gap: 1px;
+    padding: 0 size(base) size(small);
+  }
+
+  // Forecasts are grouped on a sunken surface and deliberately stay neutral: a future critical
+  // event should not look like a red, active emergency before it has happened.
+  .upcomingEvents {
+    border-bottom: 1px solid var(--border-strong);
+    background: var(--bg-sunken);
+
+    .eventLogItem {
+      border-style: dashed;
+      border-left: 4px solid $interactive_blue;
+      background: var(--bg-primary);
+
+      &.importance-NOTABLE,
+      &.importance-CRITICAL {
+        border-left-color: $interactive_blue;
+        background: var(--bg-primary);
+      }
+    }
   }
 
   .eventLogItem {

--- a/src/components/base/BuildAvailability.tsx
+++ b/src/components/base/BuildAvailability.tsx
@@ -24,7 +24,7 @@ export function getBuildAvailability(
   if (!siteBuildable) {
     return {
       buildable: false,
-      secondaryText: "No viable locations remaining.",
+      secondaryText: "No suitable project sites remain at this location.",
     };
   }
   if (!sizeBuildable) {
@@ -32,9 +32,9 @@ export function getBuildAvailability(
       buildable: false,
       secondaryText: (
         <div>
-          Too large for current tech.
+          This project size is not available with technology in this year.
           <br />
-          Max size: <strong>{maxSizeLabel}</strong>
+          Maximum available size: <strong>{maxSizeLabel}</strong>
         </div>
       ),
     };
@@ -52,7 +52,7 @@ export function ViableLocationsRow(props: {
   return (
     <TableRow>
       <TableCell>
-        Number of viable locations remaining
+        Suitable project sites remaining
         <Typography variant="body2" color="textSecondary">
           Each project uses one suitable site
         </Typography>

--- a/src/components/base/ChartForecastDemandByType.test.tsx
+++ b/src/components/base/ChartForecastDemandByType.test.tsx
@@ -39,7 +39,7 @@ it("makes every demand category readable without the canvas", () => {
   );
 
   const chart = screen.getByRole("img", {
-    name: /electricity demand by load type/i,
+    name: /electricity demand by customer or use type/i,
   });
   expect(chart).toHaveAccessibleName(/Residential:/);
   expect(chart).toHaveAccessibleName(/Commercial:/);

--- a/src/components/base/ChartForecastDemandByType.tsx
+++ b/src/components/base/ChartForecastDemandByType.tsx
@@ -207,7 +207,7 @@ export default class ChartForecastDemandByType extends React.PureComponent<
     return (
       <div id="chartForecastDemandByType">
         <UPlotChart<State>
-          ariaLabel="Chart of forecasted electricity demand by load type"
+          ariaLabel="Chart of predicted electricity demand by customer or use type"
           formatSummaryValue={formatWatts}
           height={height}
           state={state}

--- a/src/components/base/ChartForecastFuelPrices.tsx
+++ b/src/components/base/ChartForecastFuelPrices.tsx
@@ -83,7 +83,7 @@ function buildOptions(showXLabels: boolean) {
       }),
       yAxis(scale, {
         grid: true,
-        label: "Per MMBTU",
+        label: "Price per MMBtu",
         // The label sits outside the axis, so it comes out of the shared gutter too
         size: FORECAST_AXIS_LEFT - AXIS_LABEL_SIZE,
         values: (_u, splits) => splits.map((t) => formatMoneyConcise(t)),
@@ -147,7 +147,7 @@ export default class ChartForecastFuelPrices extends React.PureComponent<
     return (
       <div id="chartForecastFuelPrices">
         <UPlotChart<State>
-          ariaLabel="Chart of forecasted fuel prices"
+          ariaLabel="Chart of predicted fuel prices"
           formatSummaryValue={formatMoneyStable}
           height={height}
           state={{ prices, minutes, domain, startingYear, multiyear }}

--- a/src/components/base/ChartForecastRenewableCapacityFactor.test.tsx
+++ b/src/components/base/ChartForecastRenewableCapacityFactor.test.tsx
@@ -67,7 +67,7 @@ describe("ChartForecastRenewableCapacityFactor", () => {
 
     expect(
       screen.getByRole("img", {
-        name: /renewable capacity factors.*Wind capacity factor \(%\)/,
+        name: /predicted monthly renewable output.*Wind capacity factor \(%\)/,
       }),
     ).toBeInTheDocument();
   });

--- a/src/components/base/ChartForecastRenewableCapacityFactor.tsx
+++ b/src/components/base/ChartForecastRenewableCapacityFactor.tsx
@@ -243,7 +243,7 @@ export default class ChartForecastRenewableCapacityFactor extends React.PureComp
         />
         <UPlotChart<State>
           id="chartForecastRenewableCapacityFactor"
-          ariaLabel="Chart of forecasted monthly renewable capacity factors"
+          ariaLabel="Chart of predicted monthly renewable output"
           height={height}
           state={{
             data,

--- a/src/components/base/ChartForecastStorage.tsx
+++ b/src/components/base/ChartForecastStorage.tsx
@@ -114,7 +114,7 @@ export default class chartForecastStorage extends React.PureComponent<
     return (
       <UPlotChart<State>
         id="chartForecastStorage"
-        ariaLabel="Chart of forecasted stored power"
+        ariaLabel="Chart of predicted stored energy"
         formatSummaryValue={formatWattHours}
         height={height}
         state={{ timeline, domain, startingYear, multiyear }}

--- a/src/components/base/ChartForecastSupplyByFuel.tsx
+++ b/src/components/base/ChartForecastSupplyByFuel.tsx
@@ -227,7 +227,7 @@ export default class ChartForecastSupplyByFuel extends React.PureComponent<
     return (
       <div id="chartForecastSupplyByFuel">
         <UPlotChart<State>
-          ariaLabel="Chart of forecasted electricity supply by fuel type"
+          ariaLabel="Chart of predicted electricity supply by fuel type"
           formatSummaryValue={formatWatts}
           height={height}
           state={state}

--- a/src/components/base/ChartForecastSupplyDemand.tsx
+++ b/src/components/base/ChartForecastSupplyDemand.tsx
@@ -142,7 +142,7 @@ export default class chartForecastSupplyDemand extends React.PureComponent<
     return (
       <UPlotChart<State>
         id="chartForecastSupplyDemand"
-        ariaLabel="Chart of forecasted electricity supply and demand"
+        ariaLabel="Chart of predicted electricity supply and demand"
         formatSummaryValue={formatWatts}
         height={height}
         state={state}

--- a/src/components/base/ChartForecastWeather.test.tsx
+++ b/src/components/base/ChartForecastWeather.test.tsx
@@ -23,7 +23,7 @@ describe("ChartForecastWeather", () => {
     );
     expect(
       screen.getByRole("img", {
-        name: /Chart of forecasted temperature.*Temperature: latest 16/,
+        name: /Chart of predicted temperature.*Temperature: latest 16/,
       }),
     ).toBeInTheDocument();
   });

--- a/src/components/base/ChartForecastWeather.tsx
+++ b/src/components/base/ChartForecastWeather.tsx
@@ -131,7 +131,7 @@ export default class ChartForecastWeather extends React.PureComponent<
     return (
       <UPlotChart<State>
         id="chartForecastWeather"
-        ariaLabel="Chart of forecasted temperature"
+        ariaLabel="Chart of predicted temperature"
         height={height}
         state={{ data, domain, startingYear, multiyear, units }}
         data={[minutes, temperature]}

--- a/src/components/base/FacilityDetails.tsx
+++ b/src/components/base/FacilityDetails.tsx
@@ -164,13 +164,15 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
         ) : (
           <>
             <Stat
-              label="Age / design life"
+              label="Age / expected life"
               value={`${ageYears.toFixed(1)} / ${facility.lifespanYears} yr${ageYears >= facility.lifespanYears ? " · beyond" : ""}`}
             />
             <Stat
               // Capacity factor is the generator's word for it; a battery isn't producing
               // anything, it's being used or it isn't
-              label={isStorage ? "Utilization" : "Capacity factor"}
+              label={
+                isStorage ? "Time in use" : "Average output (capacity factor)"
+              }
               value={
                 lifetime.capacityFactor === undefined
                   ? "—"
@@ -180,7 +182,7 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
           </>
         )}
         <Stat
-          label="Cost"
+          label="Lifetime cost per MWh"
           value={
             lifetime.costPerMWh === undefined
               ? "—"
@@ -188,7 +190,7 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
           }
         />
         <Stat
-          label="Earned"
+          label="Revenue per MWh"
           value={
             lifetime.revenuePerMWh === undefined
               ? "—"
@@ -212,13 +214,13 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
         )}
         {facility.name === "Battery" && equivalentCycles !== undefined && (
           <Stat
-            label="Equivalent cycles"
+            label="Full-charge cycles (equivalent)"
             value={`${Math.round(equivalentCycles).toLocaleString()} / 7,300`}
           />
         )}
         {!isStorage && equivalentOperatingHours !== undefined && (
           <Stat
-            label="Equivalent operating hours"
+            label="Full-output hours (equivalent)"
             value={Math.round(equivalentOperatingHours).toLocaleString()}
           />
         )}
@@ -230,26 +232,26 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
         )}
         {variableOperatingCostPerMWh !== undefined && (
           <Stat
-            label="Fixed O&M"
+            label="Fixed operations & maintenance"
             value={`${formatMoneyConcise(facility.annualOperatingCost)}/yr`}
           />
         )}
         {variableOperatingCostPerMWh !== undefined && (
           <Stat
-            label="Variable O&M"
+            label="Variable operations & maintenance"
             value={`$${variableOperatingCostPerMWh.toFixed(2)}/MWh generated`}
           />
         )}
         {facility.tracksStarts && (
           <Stat
-            label="Equivalent starts"
+            label="Full start cycles (equivalent)"
             value={Math.round(facility.lifetimeStarts || 0).toLocaleString()}
           />
         )}
         {facility.tracksStarts && fuel === "Natural Gas" && (
           <Stat
-            label="Service intervals"
-            value="HGP 900 · major 1,800 starts"
+            label="Gas-turbine service"
+            value="Hot-gas-path: 900 starts · major: 1,800 starts"
           />
         )}
         {facility.costPerStart !== undefined && (
@@ -260,8 +262,8 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
         )}
         {facility.tracksStarts && (
           <Stat
-            label="Start accounting"
-            value="Each simulated day represents its month"
+            label="How starts are scaled"
+            value="One displayed operating day represents a full month of starts and costs"
           />
         )}
         {isHydro && (
@@ -275,36 +277,39 @@ export default function FacilityDetails(props: Props): React.JSX.Element {
         )}
         {isHydro && (
           <Stat
-            label="Last inflow"
+            label="Water added last month"
             value={formatWattHours(facility.hydroLastInflowWh || 0)}
           />
         )}
         {isHydro && (
           <Stat
-            label="Last spill"
+            label="Overflow lost last month"
             value={formatWattHours(facility.hydroLastSpillWh || 0)}
           />
         )}
         {isStorage && (
           <Stat
-            label="Round trip"
+            label="Round-trip efficiency"
             value={percent(
               (facility as StorageOperatingType).roundTripEfficiency,
             )}
           />
         )}
         {!isStorage && (
-          <Stat label="Nameplate" value={formatWatts(facility.peakW)} />
+          <Stat
+            label="Rated maximum output"
+            value={formatWatts(facility.peakW)}
+          />
         )}
         {!isStorage && outputFactor < 1 && (
           <Stat
-            label="Effective max"
-            value={`${formatWatts(facility.peakW * outputFactor)} · ${percent(outputFactor)} health`}
+            label="Current maximum output"
+            value={`${formatWatts(facility.peakW * outputFactor)} · limited to ${percent(outputFactor)}`}
           />
         )}
         {facility.loanAmountLeft > 0 && (
           <Stat
-            label="Loan left"
+            label="Loan balance"
             value={formatMoneyConcise(facility.loanAmountLeft)}
           />
         )}

--- a/src/components/base/GameAppBar.test.tsx
+++ b/src/components/base/GameAppBar.test.tsx
@@ -51,7 +51,9 @@ describe("GameAppBar", () => {
 
     expect(reserveCapacityW(game, now) - before).toBe(plant.peakW);
     renderAppBar({ game: { ...game, inGame: true } });
-    expect(screen.getByText(/Grid OK · .*W reserve/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Grid stable · .*W spare capacity/),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/% reserve/)).not.toBeInTheDocument();
   });
 

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -269,7 +269,7 @@ export function GameAppBar(props: Props) {
   const reserveW = Math.max(0, reserveCapacityW(game, now));
   const gridHealth = inBlackout
     ? `Blackout · ${formatWatts(now.demandW - now.supplyW)} short`
-    : `Grid OK · ${formatWatts(reserveW)} reserve`;
+    : `Grid stable · ${formatWatts(reserveW)} spare capacity`;
 
   return (
     <div id="appbar">
@@ -299,7 +299,12 @@ export function GameAppBar(props: Props) {
         aria-label={`Current grid status: ${gridHealth}`}
       >
         <strong>{gridHealth}</strong>
-        {inBlackout && <span>Resume or build generation.</span>}
+        {inBlackout && (
+          <span>
+            Resume available resources, discharge storage, or plan more
+            capacity.
+          </span>
+        )}
       </div>
       <span className="srOnly" aria-live="polite">
         {inBlackout

--- a/src/components/base/VictoryConditions.tsx
+++ b/src/components/base/VictoryConditions.tsx
@@ -28,11 +28,11 @@ export default function VictoryConditions(props: Props): React.JSX.Element {
   if (ownership === "Investor") {
     return (
       <div>
-        <p>+40 pts per $1B of net worth at the end</p>
-        <p>+2 pts per 100k customers at the end</p>
-        <p>+1 pt per TWh of electricity supplied</p>
-        <p>-2 pts per {perEmissions} of greenhouse gas emissions</p>
-        <p>-8 pts per TWh of blackouts</p>
+        <p>Earn 40 points per $1 billion of net worth at the end.</p>
+        <p>Earn 2 points per 100,000 customers at the end.</p>
+        <p>Earn 1 point per terawatt-hour (TWh) of electricity supplied.</p>
+        <p>Lose 2 points per {perEmissions} of greenhouse gas emissions.</p>
+        <p>Lose 8 points per TWh of customer demand not served.</p>
       </div>
     );
   }
@@ -55,12 +55,16 @@ export default function VictoryConditions(props: Props): React.JSX.Element {
         </p>
       )}
       <p>
-        +/-80 pts per lifetime average $0.01/kWh charged above/below $
-        {dollarsPerkWh}/kWh
+        Earn 80 points for each $0.01/kWh your lifetime average rate is below
+        the ${dollarsPerkWh}/kWh target.
       </p>
-      <p>+10 pts per TWh of electricity supplied</p>
-      <p>-5 pts per {perEmissions} of greenhouse gas emissions</p>
-      <p>-10 pts per TWh of blackouts</p>
+      <p>
+        Lose 80 points for each $0.01/kWh your lifetime average rate is above
+        the target.
+      </p>
+      <p>Earn 10 points per terawatt-hour (TWh) of electricity supplied.</p>
+      <p>Lose 5 points per {perEmissions} of greenhouse gas emissions.</p>
+      <p>Lose 10 points per TWh of customer demand not served.</p>
     </div>
   );
 }

--- a/src/components/base/VictoryDialog.test.tsx
+++ b/src/components/base/VictoryDialog.test.tsx
@@ -102,7 +102,7 @@ describe("VictoryDialog", () => {
           kgco2e: 2000000000,
           scenarioMetrics: [
             {
-              label: "Uri energy unserved · Feb 2021",
+              label: "Demand not met during Winter Storm Uri · Feb 2021",
               value: "12GWh",
               concept: "blackout",
             },
@@ -127,7 +127,7 @@ describe("VictoryDialog", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("99.8%")).toBeInTheDocument();
     expect(
-      screen.getByText("Uri energy unserved · Feb 2021"),
+      screen.getByText("Demand not met during Winter Storm Uri · Feb 2021"),
     ).toBeInTheDocument();
     expect(screen.getByText("12GWh")).toBeInTheDocument();
     expect(

--- a/src/components/base/VictoryDialog.tsx
+++ b/src/components/base/VictoryDialog.tsx
@@ -186,7 +186,7 @@ function RunDebrief({
         {debrief.unservedWh > 0 && (
           <div>
             <ConceptIcon concept="blackout" fontSize="small" />
-            <Typography variant="caption">Energy unserved</Typography>
+            <Typography variant="caption">Customer demand not met</Typography>
             <strong>{formatWattHours(debrief.unservedWh)}</strong>
           </div>
         )}

--- a/src/components/views/BuildGenerators.test.tsx
+++ b/src/components/views/BuildGenerators.test.tsx
@@ -25,7 +25,7 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
     />,
   );
 
-  expect(screen.getByText("Est O&M")).toBeInTheDocument();
+  expect(screen.getByText("Est. operations & maintenance")).toBeInTheDocument();
   expect(screen.getByText("$13.4M/yr")).toBeInTheDocument();
   expect(screen.queryByText("Flexible power")).toBeNull();
   expect(screen.getByText(/typical output/)).toBeInTheDocument();
@@ -35,7 +35,7 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
 
   expect(
     screen.getByRole("row", {
-      name: /Base O&M.*45% expected output.*\$4\.93M/,
+      name: /Base operations & maintenance.*45% expected output.*\$4\.93M/,
     }),
   ).toBeInTheDocument();
   expect(
@@ -45,7 +45,7 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
   ).toBeInTheDocument();
   expect(
     screen.getByRole("row", {
-      name: /Estimated O&M.*Base O&M plus one start\/day.*\$13\.4M\/yr/,
+      name: /Estimated operations & maintenance.*Base operating cost plus one start per simulated day.*\$13\.4M\/yr/,
     }),
   ).toBeInTheDocument();
 
@@ -56,7 +56,7 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
   expect(impact).toHaveTextContent("What changes");
   expect(impact).toHaveTextContent("Cash purchase");
   expect(impact).toHaveTextContent("Online in");
-  expect(impact).toHaveTextContent("Typical supply");
+  expect(impact).toHaveTextContent("Estimated average output");
 });
 
 it("shows Coal's physical and representative-day start charges", () => {
@@ -110,23 +110,23 @@ it("shows Oil's fixed, variable, and expected-output O&M", () => {
     />,
   );
 
-  expect(screen.getByText("Est O&M")).toBeInTheDocument();
+  expect(screen.getByText("Est. operations & maintenance")).toBeInTheDocument();
   expect(screen.getByText("$7.59M/yr")).toBeInTheDocument();
   fireEvent.click(screen.getByRole("button", { name: "Show Oil details" }));
 
   expect(
     screen.getByRole("row", {
-      name: /Fixed O&M.*Standing annual expense.*\$3\.09M\/yr/,
+      name: /Fixed operations & maintenance.*Standing annual expense.*\$3\.09M\/yr/,
     }),
   ).toBeInTheDocument();
   expect(
     screen.getByRole("row", {
-      name: /Variable O&M.*Per generated MWh.*\$25\.71\/MWh generated/,
+      name: /Variable operations & maintenance.*Per generated MWh.*\$25\.71\/MWh generated/,
     }),
   ).toBeInTheDocument();
   expect(
     screen.getByRole("row", {
-      name: /Estimated O&M.*20% expected output.*\$7\.59M\/yr/,
+      name: /Estimated operations & maintenance.*20% expected output.*\$7\.59M\/yr/,
     }),
   ).toBeInTheDocument();
   expect(screen.queryByText("Non-fuel start cost")).toBeNull();

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -210,7 +210,7 @@ export function GeneratorBuildItem(
             <Chip
               size="small"
               color={gapCoverage >= 100 ? "success" : "default"}
-              label={`~${gapCoverage}% of peak forecast gap`}
+              label={`~${gapCoverage}% of largest forecast shortage`}
             />
           )}
           {(props.advantages || []).map((advantage) => (
@@ -236,17 +236,19 @@ export function GeneratorBuildItem(
           value={`${Math.round(generator.yearsToBuild * 12)} mo`}
         />
         <GeneratorMetric
-          label="Est O&M"
+          label="Est. operations & maintenance"
           value={`${formatMoneyConcise(estimatedAnnualOperatingCost(generator))}/yr`}
         />
         <GeneratorMetric
-          label="Energy cost"
+          label="Lifetime cost / MWh"
           value={`${fuelPrices[generator.fuel] ? "~" : ""}${formatMoneyConcise(generator.lcWh * 1000000)}/MWh`}
         />
         <GeneratorMetric
           label="Emissions"
           value={
-            kgCO2ePerMWh > 0 ? `${formatMass(kgCO2ePerMWh, units)}/MWh` : "None"
+            kgCO2ePerMWh > 0
+              ? `${formatMass(kgCO2ePerMWh, units)}/MWh`
+              : "No direct emissions modeled"
           }
         />
       </Box>
@@ -272,11 +274,12 @@ export function GeneratorBuildItem(
               {props.secondaryMetric !== "lcWh" && (
                 <TableRow>
                   <TableCell>
-                    Total energy cost
+                    Estimated lifetime cost per MWh
                     <ManualLink entry={MANUAL_ENTRY.TOTAL_COST_OF_ENERGY} />
                     <Typography variant="body2" color="textSecondary">
-                      Across life, based on{" "}
-                      {Math.round(generator.capacityFactor * 100)}% uptime
+                      Across its lifetime, assuming a{" "}
+                      {Math.round(generator.capacityFactor * 100)}% capacity
+                      factor
                       {generator.costPerStart !== undefined
                         ? " and one start/day"
                         : ""}
@@ -289,7 +292,7 @@ export function GeneratorBuildItem(
               )}
               <TableRow>
                 <TableCell>
-                  Average output
+                  Estimated average output
                   <ManualLink
                     entry={MANUAL_ENTRY.CAPACITY_FACTOR}
                     label="capacity factor"
@@ -321,7 +324,9 @@ export function GeneratorBuildItem(
               )}
               <TableRow>
                 <TableCell>
-                  {hasVariableOM ? "Fixed O&M" : "Base O&M"}
+                  {hasVariableOM
+                    ? "Fixed operations & maintenance"
+                    : "Base operations & maintenance"}
                   <Typography variant="body2" color="textSecondary">
                     {hasVariableOM
                       ? "Standing annual expense"
@@ -335,7 +340,7 @@ export function GeneratorBuildItem(
               {hasVariableOM && (
                 <TableRow>
                   <TableCell>
-                    Variable O&M
+                    Variable operations & maintenance
                     <Typography variant="body2" color="textSecondary">
                       Per generated MWh
                     </Typography>
@@ -378,11 +383,11 @@ export function GeneratorBuildItem(
               {(hasVariableOM || generator.costPerStart !== undefined) && (
                 <TableRow>
                   <TableCell>
-                    Estimated O&M
+                    Estimated operations & maintenance
                     <Typography variant="body2" color="textSecondary">
                       {hasVariableOM
                         ? `Fixed plus ${formatMoneyConcise(estimatedVariableOM)}/yr variable at ${Math.round(generator.capacityFactor * 100)}% expected output`
-                        : "Base O&M plus one start/day"}
+                        : "Base operating cost plus one start per simulated day"}
                     </Typography>
                   </TableCell>
                   <TableCell align="right">
@@ -447,19 +452,19 @@ export function GeneratorBuildItem(
               )}
               <TableRow>
                 <TableCell>
-                  Air pollution
+                  Direct greenhouse gas emissions
                   <ManualLink
                     entry={MANUAL_ENTRY.EMISSIONS}
                     label="CO2e emissions"
                   />
                   <Typography variant="body2" color="textSecondary">
-                    Greenhouse gas released per unit generated
+                    CO2e released at the plant for each MWh generated
                   </Typography>
                 </TableCell>
                 <TableCell align="right">
                   {kgCO2ePerMWh > 0
                     ? `${formatMass(kgCO2ePerMWh, units)}/MWh`
-                    : "None"}
+                    : "No direct emissions modeled"}
                 </TableCell>
               </TableRow>
             </TableBody>
@@ -496,12 +501,12 @@ export function GeneratorBuildItem(
               },
               {
                 concept: "supply",
-                label: "Typical supply",
+                label: "Estimated average output",
                 value: `+${formatWatts(typicalOutputW)}`,
                 detail:
                   gapCoverage === undefined
-                    ? `${formatWatts(generator.peakW)} nameplate capacity`
-                    : `About ${gapCoverage}% of the peak forecast gap`,
+                    ? `${formatWatts(generator.peakW)} maximum rated output; average output is not guaranteed during a shortage`
+                    : `About ${gapCoverage}% of the largest forecast shortage, based on average output`,
               },
               {
                 concept: kgCO2ePerMWh > 0 ? "danger" : "goal",
@@ -509,7 +514,7 @@ export function GeneratorBuildItem(
                 value:
                   kgCO2ePerMWh > 0
                     ? `${formatMass(kgCO2ePerMWh, units)}/MWh`
-                    : "None",
+                    : "No direct emissions modeled",
               },
             ]}
           />

--- a/src/components/views/BuildStorage.test.tsx
+++ b/src/components/views/BuildStorage.test.tsx
@@ -35,7 +35,7 @@ it("shows remaining pumped-hydro locations in the expanded build view", () => {
   );
 
   const row = screen.getByRole("row", {
-    name: /Number of viable locations remaining.*648/,
+    name: /Suitable project sites remaining.*648/,
   });
   expect(row).toHaveTextContent("648");
   expect(row).toHaveTextContent("Each project uses one suitable site");

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -215,13 +215,13 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
                 label: "Online in",
                 value: `${Math.round(storage.yearsToBuild * 12)} months`,
                 detail:
-                  "Grid flexibility does not change until construction finishes.",
+                  "Stored energy and discharge power do not increase until construction finishes.",
               },
               {
                 concept: "storage",
-                label: "Grid flexibility",
-                value: `+${formatWattHours(storage.peakWh)} storage`,
-                detail: `${formatWatts(storage.peakW)} maximum charge or discharge`,
+                label: "Energy capacity",
+                value: `+${formatWattHours(storage.peakWh)} stored energy`,
+                detail: `${formatWatts(storage.peakW)} maximum charge or discharge rate`,
               },
               {
                 concept: "supply",

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -29,7 +29,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import DeleteIcon from "@mui/icons-material/Delete";
 import InfoIcon from "@mui/icons-material/Info";
 import VictoryConditions from "../base/VictoryConditions";
-import { DIFFICULTIES } from "../../Constants";
+import { DIFFICULTIES, DIFFICULTY_LABELS } from "../../Constants";
 import { CityType, getCities, initCities } from "../../data/Cities";
 import { GENERATORS, STORAGE } from "../../data/Facilities";
 import { getViableLocationsRemaining } from "../../data/FacilitySites";
@@ -515,8 +515,12 @@ export default function CustomGame(props: Props): React.JSX.Element {
                     })
                   }
                 >
-                  <MenuItem value="Investor">Investor-Owned</MenuItem>
-                  <MenuItem value="Public">Public-Owned</MenuItem>
+                  <MenuItem value="Investor">
+                    For-profit utility (investor-owned)
+                  </MenuItem>
+                  <MenuItem value="Public">
+                    Community or government utility (publicly owned)
+                  </MenuItem>
                 </Select>
               </TableCell>
             </TableRow>
@@ -615,7 +619,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
                           title={DIFFICULTIES[d].description}
                           placement="right"
                         >
-                          <span>{d}</span>
+                          <span>{DIFFICULTY_LABELS[d as DifficultyType]}</span>
                         </Tooltip>
                       </MenuItem>
                     );
@@ -649,6 +653,10 @@ export default function CustomGame(props: Props): React.JSX.Element {
                 >
                   <CasinoIcon />
                 </IconButton>
+                <Typography variant="caption" color="textSecondary">
+                  Using the same seed repeats the same weather and fuel-price
+                  pattern.
+                </Typography>
               </TableCell>
             </TableRow>
           </TableBody>
@@ -660,8 +668,9 @@ export default function CustomGame(props: Props): React.JSX.Element {
         {unavailable.length > 0 && (
           <Typography variant="body2" color="error" sx={{ paddingLeft: 1 }}>
             {unavailable.map(facilityName).join(", ")} can't be built with this
-            location and year, or exceeds the number of viable sites. Remove{" "}
-            {unavailable.length === 1 ? "it" : "them"} or change the setup.
+            location and year, or exceeds the number of suitable build sites.
+            Remove {unavailable.length === 1 ? "it" : "them"} or change the
+            setup.
           </Typography>
         )}
 
@@ -799,9 +808,9 @@ export default function CustomGame(props: Props): React.JSX.Element {
       <Dialog open={feeDialogOpen} onClose={() => setFeeDialogOpen(false)}>
         <DialogTitle>Carbon fee</DialogTitle>
         <DialogContent>
-          A fee placed on pollution to cover its damage to society. Charged by
-          the amount of greenhouse gas emitted, measured in{" "}
-          {largeMassUnit(units)} of CO2 equivalent.
+          A carbon fee charges for greenhouse gas emissions. The game measures
+          them in {largeMassUnit(units)} of carbon dioxide equivalent (CO2e), a
+          common unit for comparing different greenhouse gases.
         </DialogContent>
         <DialogActions>
           <Button

--- a/src/components/views/EventLog.test.tsx
+++ b/src/components/views/EventLog.test.tsx
@@ -43,7 +43,9 @@ describe("EventLog", () => {
     );
 
     const row = screen.getByRole("button", { name: /winter gas squeeze/i });
-    expect(screen.getByText("Upcoming")).toBeVisible();
+    expect(screen.getByText("Upcoming events")).toBeVisible();
+    expect(screen.getByText(/have not happened yet/i)).toBeVisible();
+    expect(screen.getByText("Event history")).toBeVisible();
     expect(screen.getByText("Jan 2014")).toBeVisible();
     row.focus();
     row.dispatchEvent(
@@ -56,7 +58,7 @@ describe("EventLog", () => {
     expect(screen.queryByText("Critical")).not.toBeInTheDocument();
   });
 
-  it("drops the history label once the log has more than one event", () => {
+  it("keeps upcoming and past events in labeled sections", () => {
     render(
       <EventLog
         events={[
@@ -85,7 +87,8 @@ describe("EventLog", () => {
       />,
     );
 
-    expect(screen.getByText("Upcoming")).toBeVisible();
-    expect(screen.queryByText("History")).not.toBeInTheDocument();
+    expect(screen.getByText("Upcoming events")).toBeVisible();
+    expect(screen.getByText("Event history")).toBeVisible();
+    expect(screen.getByText(/recorded after they happen/i)).toBeVisible();
   });
 });

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -67,12 +67,17 @@ export default function EventLog(props: Props): React.JSX.Element {
       <div className="scrollable">
         {upcoming.length > 0 && (
           <section
-            className="upcomingEvents"
+            className="eventLogSection upcomingEvents"
             aria-labelledby="upcomingEventsTitle"
           >
-            <Typography id="upcomingEventsTitle" variant="subtitle2">
-              Upcoming
-            </Typography>
+            <header className="eventLogSectionHeader">
+              <Typography id="upcomingEventsTitle" variant="subtitle2">
+                Upcoming events
+              </Typography>
+              <Typography variant="caption" color="textSecondary">
+                Scheduled scenario events that have not happened yet
+              </Typography>
+            </header>
             <ul className="eventLogList">
               {upcoming.map((event) => (
                 <li
@@ -132,78 +137,86 @@ export default function EventLog(props: Props): React.JSX.Element {
             </ul>
           </section>
         )}
-        {upcoming.length > 0 && events.length < 2 && (
-          <Typography className="eventLogHistoryTitle" variant="subtitle2">
-            History
-          </Typography>
-        )}
-        {events.length === 0 && (
-          <Typography
-            className="eventLogEmpty"
-            variant="body2"
-            color="textSecondary"
-          >
-            Blackouts, finished construction, loans closing and fuel price
-            swings will show up here as they happen.
-          </Typography>
-        )}
-        <ul className="eventLogList">
-          {events.map((event: GameEventType) => (
-            <li
-              className={`eventLogItem kind-${event.kind} importance-${event.importance || "ROUTINE"}${event.actionTarget ? " actionable" : ""}`}
-              key={event.id}
-              onClick={() => onSelect(event.actionTarget)}
-              onKeyDown={(e: React.KeyboardEvent<HTMLLIElement>) => {
-                if (
-                  event.actionTarget &&
-                  (e.key === "Enter" || e.key === " ")
-                ) {
-                  e.preventDefault();
-                  onSelect(event.actionTarget);
-                }
-              }}
-              role={event.actionTarget ? "button" : undefined}
-              tabIndex={event.actionTarget ? 0 : undefined}
+        <section
+          className="eventLogSection eventHistory"
+          aria-labelledby="eventHistoryTitle"
+        >
+          <header className="eventLogSectionHeader">
+            <Typography id="eventHistoryTitle" variant="subtitle2">
+              Event history
+            </Typography>
+            <Typography variant="caption" color="textSecondary">
+              Events recorded after they happen
+            </Typography>
+          </header>
+          {events.length === 0 && (
+            <Typography
+              className="eventLogEmpty"
+              variant="body2"
+              color="textSecondary"
             >
-              <span className="eventLogIcon">
-                <ConceptIcon
-                  concept={event.concept || KIND_CONCEPTS[event.kind]}
-                  fontSize="small"
-                />
-              </span>
-              <span>
-                {event.title && <strong>{event.title}</strong>}
-                <span className="eventLogCopy">
-                  <Typography
-                    variant="body2"
-                    component="span"
-                    sx={{ display: "block" }}
-                  >
-                    {event.message}
-                  </Typography>
-                  {event.details && (
+              Blackouts, finished construction, loans closing and fuel price
+              swings will show up here as they happen.
+            </Typography>
+          )}
+          <ul className="eventLogList">
+            {events.map((event: GameEventType) => (
+              <li
+                className={`eventLogItem kind-${event.kind} importance-${event.importance || "ROUTINE"}${event.actionTarget ? " actionable" : ""}`}
+                key={event.id}
+                onClick={() => onSelect(event.actionTarget)}
+                onKeyDown={(e: React.KeyboardEvent<HTMLLIElement>) => {
+                  if (
+                    event.actionTarget &&
+                    (e.key === "Enter" || e.key === " ")
+                  ) {
+                    e.preventDefault();
+                    onSelect(event.actionTarget);
+                  }
+                }}
+                role={event.actionTarget ? "button" : undefined}
+                tabIndex={event.actionTarget ? 0 : undefined}
+              >
+                <span className="eventLogIcon">
+                  <ConceptIcon
+                    concept={event.concept || KIND_CONCEPTS[event.kind]}
+                    fontSize="small"
+                  />
+                </span>
+                <span>
+                  {event.title && <strong>{event.title}</strong>}
+                  <span className="eventLogCopy">
                     <Typography
-                      variant="caption"
-                      color="textSecondary"
+                      variant="body2"
                       component="span"
                       sx={{ display: "block" }}
                     >
-                      {event.details}
+                      {event.message}
                     </Typography>
-                  )}
+                    {event.details && (
+                      <Typography
+                        variant="caption"
+                        color="textSecondary"
+                        component="span"
+                        sx={{ display: "block" }}
+                      >
+                        {event.details}
+                      </Typography>
+                    )}
+                  </span>
                 </span>
-              </span>
-              <Typography
-                className="eventLogWhen"
-                variant="body2"
-                color="textSecondary"
-                component="span"
-              >
-                {event.label}
-              </Typography>
-            </li>
-          ))}
-        </ul>
+                <Typography
+                  className="eventLogWhen"
+                  variant="body2"
+                  color="textSecondary"
+                  component="span"
+                >
+                  {event.label}
+                </Typography>
+              </li>
+            ))}
+          </ul>
+        </section>
       </div>
     </GameCard>
   );

--- a/src/components/views/EventLogContainer.tsx
+++ b/src/components/views/EventLogContainer.tsx
@@ -101,7 +101,7 @@ function selectUpcoming(state: AppStateType): UpcomingStoryEventType[] {
     const date = getDateFromMinute(event.startsMinute, game.startingYear);
     return {
       ...event,
-      label: `${date.month} ${date.year}`,
+      label: `Expected ${date.month} ${date.year}`,
     };
   });
   upcomingCache = { key, events };

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -94,18 +94,22 @@ describe("the fleet list", () => {
     renderFacilities(game, game.facilities[0].id);
     // One panel, not one per row -- getByText throws if a second facility opened too
     expect(screen.getByText("Lifetime profit")).toBeInTheDocument();
-    expect(screen.getByText("Capacity factor")).toBeInTheDocument();
-    expect(screen.getByText("Cost")).toBeInTheDocument();
-    expect(screen.getByText("Earned")).toBeInTheDocument();
+    expect(
+      screen.getByText("Average output (capacity factor)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Lifetime cost per MWh")).toBeInTheDocument();
+    expect(screen.getByText("Revenue per MWh")).toBeInTheDocument();
   });
 
   it("shows Coal starts and cost without gas-turbine service intervals", () => {
     const coal = game.facilities.find((facility) => facility.name === "Coal")!;
     renderFacilities(game, coal.id);
 
-    expect(screen.getByText("Equivalent starts")).toBeInTheDocument();
+    expect(
+      screen.getByText("Full start cycles (equivalent)"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Non-fuel start cost")).toBeInTheDocument();
-    expect(screen.queryByText("Service intervals")).toBeNull();
+    expect(screen.queryByText("Gas-turbine service")).toBeNull();
   });
 
   it("keeps gas-turbine service context on Natural Gas", () => {
@@ -114,9 +118,9 @@ describe("the fleet list", () => {
     )!;
     renderFacilities(game, gas.id);
 
-    expect(screen.getByText("Service intervals")).toBeInTheDocument();
+    expect(screen.getByText("Gas-turbine service")).toBeInTheDocument();
     expect(
-      screen.getByText("HGP 900 · major 1,800 starts"),
+      screen.getByText("Hot-gas-path: 900 starts · major: 1,800 starts"),
     ).toBeInTheDocument();
   });
 
@@ -125,14 +129,20 @@ describe("the fleet list", () => {
     const oil = oilGame.facilities.find((facility) => facility.name === "Oil")!;
     renderFacilities(oilGame, oil.id);
 
-    expect(screen.getByText("Equivalent operating hours")).toBeInTheDocument();
-    expect(screen.getByText("Fixed O&M")).toBeInTheDocument();
+    expect(
+      screen.getByText("Full-output hours (equivalent)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Fixed operations & maintenance"),
+    ).toBeInTheDocument();
     expect(screen.getByText("$3.09M/yr")).toBeInTheDocument();
-    expect(screen.getByText("Variable O&M")).toBeInTheDocument();
+    expect(
+      screen.getByText("Variable operations & maintenance"),
+    ).toBeInTheDocument();
     expect(screen.getByText("$25.71/MWh generated")).toBeInTheDocument();
-    expect(screen.queryByText("Equivalent starts")).toBeNull();
+    expect(screen.queryByText("Full start cycles (equivalent)")).toBeNull();
     expect(screen.queryByText("Non-fuel start cost")).toBeNull();
-    expect(screen.queryByText("Service intervals")).toBeNull();
+    expect(screen.queryByText("Gas-turbine service")).toBeNull();
   });
 
   it("leaves every row closed when nothing is selected", () => {
@@ -166,7 +176,9 @@ describe("the fleet list", () => {
       },
     ];
     renderFacilities(constrained, null);
-    expect(screen.getByText("Derated to 30%")).toBeInTheDocument();
+    expect(
+      screen.getByText("Temporarily limited to 30% of rated output"),
+    ).toBeInTheDocument();
   });
 
   it("renders the reasonable worst-case fleet size", () => {

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -419,7 +419,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                       className="storyDerateBadge"
                       color="warning"
                       size="small"
-                      label={`Derated to ${Math.round(storyOutputMultiplier * 100)}%`}
+                      label={`Temporarily limited to ${Math.round(storyOutputMultiplier * 100)}% of rated output`}
                     />
                   )}
                 </>

--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -148,8 +148,8 @@ describe("the Finances chart selectors", () => {
 
       // The second change is the one the throttle used to swallow: the first update after mount
       // always got through, and everything after it waited on the game clock
-      await choose(metricSelect(), "Net Worth");
-      expect(plottedMetric()).toContain("Net Worth");
+      await choose(metricSelect(), "Net worth");
+      expect(plottedMetric()).toContain("Net worth");
 
       await choose(metricSelect(), "Demand");
       expect(plottedMetric()).toContain("Demand");
@@ -193,12 +193,12 @@ describe("the Finances chart selectors", () => {
 
   it("remembers the metric across a remount, dropdown and chart together", async () => {
     const view = renderFinances(game, "PAUSED");
-    await choose(metricSelect(), "Net Worth");
+    await choose(metricSelect(), "Net worth");
     view.unmount();
 
     renderFinances(game, "PAUSED");
-    expect(metricSelect()).toHaveTextContent("Net Worth");
-    expect(plottedMetric()).toContain("Net Worth");
+    expect(metricSelect()).toHaveTextContent("Net worth");
+    expect(plottedMetric()).toContain("Net worth");
   });
 
   // A remount is what going off to build a facility and coming back amounts to, and the period

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -97,7 +97,7 @@ function buildChartKeys(units: UnitSystemType): {
       formatTable: formatMoneyStable,
     },
     profitPerkWh: {
-      label: "Unit profit",
+      label: "Profit per kWh",
       higherIsBetter: true,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
@@ -111,7 +111,7 @@ function buildChartKeys(units: UnitSystemType): {
       formatTable: formatMoneyStable,
     },
     revenuePerkWh: {
-      label: "Unit revenue",
+      label: "Revenue per kWh",
       higherIsBetter: true,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
@@ -119,7 +119,7 @@ function buildChartKeys(units: UnitSystemType): {
       nesting: 1,
     },
     supplyWh: {
-      label: "Power sold",
+      label: "Electricity sold",
       higherIsBetter: true,
       format: (n: number) => `${formatWatts(n, 0)}h`,
       nesting: 1,
@@ -149,7 +149,7 @@ function buildChartKeys(units: UnitSystemType): {
       nesting: 1,
     },
     expensesOM: {
-      label: "Operations",
+      label: "Operations & maintenance",
       higherIsBetter: false,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,
@@ -184,7 +184,7 @@ function buildChartKeys(units: UnitSystemType): {
       nesting: 2,
     },
     kgco2ePerMWh: {
-      label: "Emissions factor",
+      label: "Emissions per MWh",
       higherIsBetter: false,
       format: (n: number) =>
         numbro(toDisplayMass(n, units)).format({
@@ -195,7 +195,7 @@ function buildChartKeys(units: UnitSystemType): {
       nesting: 2,
     },
     netWorth: {
-      label: "Net Worth",
+      label: "Net worth",
       higherIsBetter: true,
       format: formatMoneyConcise,
       formatTable: formatMoneyStable,

--- a/src/components/views/Forecasts.tsx
+++ b/src/components/views/Forecasts.tsx
@@ -281,7 +281,9 @@ export default class Forecasts extends React.Component<Props, State> {
             <Table size="small">
               <TableBody>
                 <TableRow className="bold">
-                  <TableCell colSpan={2}>Blackouts forecasted</TableCell>
+                  <TableCell colSpan={2}>
+                    Predicted electricity shortfalls
+                  </TableCell>
                   <TableCell align="right">
                     ~{formatWattHours(blackoutTotalWh)}
                   </TableCell>

--- a/src/components/views/Forecasts.tsx
+++ b/src/components/views/Forecasts.tsx
@@ -41,6 +41,7 @@ import ChartLegend from "../base/ChartLegend";
 import GameCard from "../base/GameCard";
 import { TICK_MINUTES } from "../../Constants";
 import { chartPalette, fuelColors, fuelDashArrays } from "../../Theme";
+import { sampleForecastTimeline } from "../../helpers/ForecastSampling";
 
 const FORECAST_YEARS_KEY = "forecastYears";
 const FORECAST_YEARS_OPTIONS = [1, 5, 10, 20];
@@ -213,14 +214,12 @@ export default class Forecasts extends React.Component<Props, State> {
       game.startingYear,
     );
 
-    // Downsample the data to 6 per day @ 1 year, less at longer, to make it more vague / forecast-y
-    const sampledForecastedTimeline = forecastedTimeline.filter(
-      (t: TickPresentFutureType) => t.minute % (240 * years) < TICK_MINUTES,
-    );
-    // Make sure it gets the first + last entries for a full chart
-    sampledForecastedTimeline.unshift(forecastedTimeline[0]);
-    sampledForecastedTimeline.push(
-      forecastedTimeline[forecastedTimeline.length - 1],
+    // Keep regular samples plus one significant fuel-mix change between them. That preserves
+    // short events without making every chart draw the full projection.
+    const sampledForecastedTimeline = sampleForecastTimeline(
+      forecastedTimeline,
+      240 * years,
+      projectionStepMinutes,
     );
 
     // Derived here rather than inside the chart, since the legend beside the chart's title has

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -239,7 +239,7 @@ describe("Insights layers", () => {
       "Cash",
       "Profit",
       "Customers",
-      "CO2e Emitted",
+      "Greenhouse Gas Emissions (CO2e)",
     ];
     expect(headings).toHaveLength(expected.length);
     expected.forEach((label, index) =>
@@ -250,7 +250,7 @@ describe("Insights layers", () => {
   it("shows the market benchmark without repeating the rate unit", () => {
     renderInsights();
 
-    const levers = screen.getByRole("region", { name: "Planning levers" });
+    const levers = screen.getByRole("region", { name: "Planning controls" });
     expect(levers).toHaveTextContent(/Rate .*\/kWh/);
     expect(levers.textContent).not.toMatch(/market [^·]*\/kWh/);
   });
@@ -258,7 +258,7 @@ describe("Insights layers", () => {
   it("keeps the customer growth rate visible for public utilities", () => {
     renderInsights(107);
 
-    const levers = screen.getByRole("region", { name: "Planning levers" });
+    const levers = screen.getByRole("region", { name: "Planning controls" });
     expect(levers).toHaveTextContent(/customer growth \+1.5%\/yr/i);
     expect(levers).not.toHaveTextContent(/market/i);
   });
@@ -333,15 +333,15 @@ describe("Insights layers", () => {
     ).toHaveTextContent("Custom");
   });
 
-  it("offers renewable capacity factors as an insight layer", async () => {
+  it("offers expected renewable output as an insight layer", async () => {
     renderInsights();
     await user.click(screen.getByRole("button", { name: /Layers/ }));
     await user.click(
-      screen.getByRole("checkbox", { name: "Renewable Capacity Factors" }),
+      screen.getByRole("checkbox", { name: "Expected Renewable Output" }),
     );
 
     expect(
-      screen.getByText("Renewable Capacity Factors", { selector: "h6" }),
+      screen.getByText("Expected Renewable Output", { selector: "h6" }),
     ).toBeVisible();
     expect(
       screen.getByTestId("renewable-capacity-factor-chart"),
@@ -362,7 +362,7 @@ describe("Insights layers", () => {
     await user.click(ranges.getByText("All recorded"));
 
     expect(
-      screen.queryByRole("region", { name: "Planning levers" }),
+      screen.queryByRole("region", { name: "Planning controls" }),
     ).toBeNull();
     expect(
       screen.getByText(

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -126,11 +126,15 @@ export interface InsightLayerDefinition {
 
 export const INSIGHT_LAYERS: readonly InsightLayerDefinition[] = [
   { id: "supplyDemand", label: "Supply & Demand", group: "Grid" },
-  { id: "demandByType", label: "Demand by Load Type", group: "Grid" },
+  {
+    id: "demandByType",
+    label: "Demand by Customer or Use Type",
+    group: "Grid",
+  },
   { id: "supplyByFuel", label: "Supply by Fuel", group: "Grid" },
   {
     id: "storage",
-    label: "Stored Power",
+    label: "Stored Energy",
     group: "Grid",
     availability: "storage",
   },
@@ -141,10 +145,14 @@ export const INSIGHT_LAYERS: readonly InsightLayerDefinition[] = [
   { id: "cash", label: "Cash", group: "Economics" },
   { id: "financeDetails", label: "Financial Details", group: "Economics" },
   { id: "fuelPrices", label: "Fuel Prices", group: "Economics" },
-  { id: "emissions", label: "CO2e Emitted", group: "Environment" },
+  {
+    id: "emissions",
+    label: "Greenhouse Gas Emissions (CO2e)",
+    group: "Environment",
+  },
   {
     id: "solarCapacityFactor",
-    label: "Renewable Capacity Factors",
+    label: "Expected Renewable Output",
     group: "Environment",
   },
   { id: "weather", label: "Temperature", group: "Environment" },
@@ -183,7 +191,7 @@ export const INSIGHT_PRESETS: Record<
     layers: ["customers", "demandByType", "supplyDemand", "revenue", "profit"],
   },
   decarbonization: {
-    label: "Decarbonization",
+    label: "Cutting emissions",
     layers: [
       "emissions",
       "supplyByFuel",
@@ -743,13 +751,13 @@ export default class Insights extends React.Component<Props, State> {
           ]
         : RATE_MARKS;
     return (
-      <section className="insightsLevers" aria-label="Planning levers">
+      <section className="insightsLevers" aria-label="Planning controls">
         <Button
           startIcon={<TuneIcon />}
           onClick={() => this.setState({ leversOpen: !this.state.leversOpen })}
           aria-expanded={this.state.leversOpen}
         >
-          Levers
+          Rate controls
         </Button>
         <Typography variant="body2" color="textSecondary">
           Rate <strong>{formatMoneyConcise(game.dollarsPerkWh)}/kWh</strong>
@@ -951,9 +959,10 @@ export default class Insights extends React.Component<Props, State> {
                     </>
                   ) : (
                     <>
-                      Blackouts forecasted: ~
-                      {formatWattHours(projection.blackoutTotalWh)} · peak
-                      shortage {formatWatts(projection.largestBlackout.peakW)}
+                      Forecast electricity shortfall: ~
+                      {formatWattHours(projection.blackoutTotalWh)} of demand
+                      not met · largest shortage{" "}
+                      {formatWatts(projection.largestBlackout.peakW)}
                     </>
                   )}
                 </Typography>

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -94,6 +94,7 @@ import ChartLegend from "../base/ChartLegend";
 import GameCard from "../base/GameCard";
 import { UnitsContext } from "../base/UnitsContext";
 import { formatCustomerChange } from "./Finances";
+import { sampleForecastTimeline } from "../../helpers/ForecastSampling";
 
 export type InsightRange =
   "all" | "next1" | "next5" | "next10" | "next20" | `year:${number}`;
@@ -661,15 +662,11 @@ export default class Insights extends React.Component<Props, State> {
     }
 
     const sampleYears = Math.max(1, years);
-    const sampled = timeline.filter(
-      (tick) => tick.minute % (240 * sampleYears) < projectionStepMinutes,
+    const sampled = sampleForecastTimeline(
+      timeline,
+      240 * sampleYears,
+      projectionStepMinutes,
     );
-    if (sampled[0] !== timeline[0]) {
-      sampled.unshift(timeline[0]);
-    }
-    if (sampled[sampled.length - 1] !== timeline[timeline.length - 1]) {
-      sampled.push(timeline[timeline.length - 1]);
-    }
 
     const currentMonth = summarizeTimeline(game.timeline, game.startingYear);
     const projectedMonths = summarizeTimelineByMonth(

--- a/src/components/views/Manual.test.tsx
+++ b/src/components/views/Manual.test.tsx
@@ -49,7 +49,7 @@ describe("Manual", () => {
       ["merit order", MANUAL_ENTRY.FORECASTS],
       ["dispatch order", MANUAL_ENTRY.FORECASTS],
       ["peak shortage", MANUAL_ENTRY.FORECASTS],
-      ["board of directors", MANUAL_ENTRY.BLACKOUTS],
+      ["job security", MANUAL_ENTRY.BLACKOUTS],
       ["variable O&M", MANUAL_ENTRY.TOTAL_COST_OF_ENERGY],
     ]) {
       await search(term);
@@ -96,18 +96,18 @@ describe("Manual", () => {
       "aria-expanded",
       "false",
     );
-    await search("rolling blackouts");
+    await search("available supply");
     expect(entryHeader(MANUAL_ENTRY.BLACKOUTS)).toHaveAttribute(
       "aria-expanded",
       "true",
     );
     // The phrase is mid-paragraph, so only the highlight wrapper matches it exactly
-    expect(screen.getByText("rolling blackouts").tagName).toBe("MARK");
+    expect(screen.getByText("available supply").tagName).toBe("MARK");
   });
 
   it("lets the player collapse an auto-expanded result", async () => {
     renderManual();
-    await search("rolling blackouts");
+    await search("available supply");
     await userEvent.click(entryHeader(MANUAL_ENTRY.BLACKOUTS));
     expect(entryHeader(MANUAL_ENTRY.BLACKOUTS)).toHaveAttribute(
       "aria-expanded",
@@ -168,7 +168,9 @@ describe("Manual", () => {
     const row = screen
       .getAllByRole("row")
       .find((r: HTMLElement) =>
-        (r.textContent || "").includes("per TWh of blackouts"),
+        (r.textContent || "").includes(
+          "per TWh of demand not served during blackouts",
+        ),
       );
     expect(row).toBeDefined();
     // The investor penalty, in its own cell rather than run together with the text

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -78,7 +78,7 @@ describe("NewGame", () => {
       screen.getByRole("img", { name: "Data Center Boom icon" }),
     ).toHaveAttribute("src", "/images/ai data center boom.svg");
     expect(
-      screen.getByRole("img", { name: "Austin Deep Freeze icon" }),
+      screen.getByRole("img", { name: "Deep Freeze icon" }),
     ).toHaveAttribute("src", "/images/texas deep freeze.svg");
   });
 

--- a/src/components/views/NewGameDetails.test.tsx
+++ b/src/components/views/NewGameDetails.test.tsx
@@ -89,7 +89,7 @@ describe("NewGameDetails leaderboard", () => {
       screen.getByRole("button", { name: "What counts as a win" }),
     ).toBeVisible();
     expect(screen.getByRole("button", { name: "Start game" })).toBeVisible();
-    expect(screen.getByText(/Forgiving: lower costs/)).toBeVisible();
+    expect(screen.getByText(/Forgiving: lower game costs/)).toBeVisible();
     await screen.findByText("Finish this game to join the leaderboard");
   });
 

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -33,7 +33,7 @@ import PlayCircleIcon from "@mui/icons-material/PlayCircleOutlined";
 import CircularProgress from "@mui/material/CircularProgress";
 import VictoryConditions from "../base/VictoryConditions";
 import ConceptIcon, { ConceptNameType } from "../base/ConceptIcon";
-import { DIFFICULTIES } from "../../Constants";
+import { DIFFICULTIES, DIFFICULTY_LABELS } from "../../Constants";
 import { getDb, login } from "../../Globals";
 import { getScenario } from "../../data/Scenarios";
 import { getScenarioLocation } from "../../helpers/Locations";
@@ -49,14 +49,6 @@ import {
 } from "../../Types";
 
 import numbro from "numbro";
-
-const DIFFICULTY_LABELS: { [key: string]: string } = {
-  Intern: "Beginner",
-  Employee: "Easy",
-  Manager: "Medium",
-  VP: "Hard",
-  CEO: "Expert",
-};
 
 function formatScore(score: number): string {
   return numbro(score).format({ thousandSeparated: true, mantissa: 0 });

--- a/src/data/Facilities.tsx
+++ b/src/data/Facilities.tsx
@@ -256,7 +256,8 @@ export function GENERATORS(
     {
       name: "Coal",
       fuel: "Coal",
-      description: "On-demand but dirty and slow",
+      description:
+        "Can run on demand, but ramps slowly and produces high direct emissions",
       available: true, // Coal was first type of electric plant
       buildCost: scaledBuildCost(
         costBetween(year, 2019, 3.676 * CPI_2019_TO_2023, 2023, 4.103),
@@ -290,7 +291,8 @@ export function GENERATORS(
     {
       name: "Nuclear",
       fuel: "Uranium",
-      description: "On-demand and clean, but very slow",
+      description:
+        "Low direct emissions and steady output, but very slow to change",
       available: year > 1956, // First full scale plant was Calder Hall in 1956
       buildCost: scaledBuildCost(
         costBetween(year, 2019, 6.041 * CPI_2019_TO_2023, 2023, 7.861),
@@ -317,7 +319,8 @@ export function GENERATORS(
     {
       name: "Natural Gas",
       fuel: "Natural Gas",
-      description: "On-demand, faster and cleaner than coal",
+      description:
+        "Runs on demand and ramps faster than coal, with lower but still significant direct emissions",
       available: year > 1940, // First full scale plant was 4MW in Switzerland in 1940
       buildCost: scaledBuildCost(
         costBetween(year, 2019, 0.713 * CPI_2019_TO_2023, 2023, 0.836),
@@ -346,7 +349,8 @@ export function GENERATORS(
     {
       name: "Oil",
       fuel: "Oil",
-      description: "Fast but dirty",
+      description:
+        "Starts quickly, but fuel is costly and produces direct emissions",
       available: true,
       buildCost: scaledBuildCost(
         costBetween(year, 2019, 1.8 * CPI_2019_TO_2023, 2023, 1.248),
@@ -380,7 +384,8 @@ export function GENERATORS(
     {
       name: "Biomass",
       fuel: "Biomass",
-      description: "Renewable and dispatchable, but fuel-hungry",
+      description:
+        "Can run on demand using renewable fuel, but burns large amounts of material and releases CO2",
       available: true,
       // EIA's 50 MW fluidized-bed reference plant costs $4,843/kW in 2025 dollars. Converted
       // to the table's 2018 base with CPI-U (251.107 / 321.943), then split into the same
@@ -424,7 +429,8 @@ export function GENERATORS(
     {
       name: "Wind",
       fuel: "Wind",
-      description: "Windiest at spring and fall evenings",
+      description:
+        "Output changes with local wind and is often strongest in spring and fall",
       available: year > 1941, // First megawatt-size turbine was in Vermont in 1941
       buildCost: scaledBuildCost(windCostPerW(year), 200000000, peakW),
       // IRENA global installed cost fell from inflation-normalized $1,642/kW in 2020 to
@@ -483,7 +489,7 @@ export function GENERATORS(
       name: "Airborne Wind",
       fuel: "Airborne Wind",
       description:
-        "Higher, steadier winds with light infrastructure, but immature and maintenance-heavy",
+        "Uses steadier high-altitude winds, but the technology is new and needs frequent maintenance",
       // NAWEP's current schedule reaches commissioning in 2028 and mature operation in 2030.
       available: year >= 2030,
       buildCost: scaledBuildCost(airborneWindCostPerW(year), 1200000, peakW),
@@ -502,7 +508,8 @@ export function GENERATORS(
     {
       name: "Solar",
       fuel: "Sun",
-      description: "Sunniest at summer noon",
+      description:
+        "Produces only in daylight and usually peaks near sunny midday",
       available: year > 1982, // First megawatt-sized installations around 1982 https://www1.eere.energy.gov/solar/pdfs/solar_timeline.pdf
       buildCost: scaledBuildCost(solarCostPerW(year), 150000000, peakW),
       // IRENA global installed cost fell from inflation-normalized $1,070/kW in 2020 to
@@ -533,7 +540,8 @@ export function GENERATORS(
     {
       name: "Hydro",
       fuel: "Hydro",
-      description: "Clean and dispatchable, where rivers allow",
+      description:
+        "Low direct emissions and controllable output, but limited by water and suitable sites",
       available: year > 1882 && (hydroLocations || 0) > 0,
       buildCost: scaledBuildCost(hydroCostPerW(year), 100000000, peakW),
       // IRENA's inflation-normalized global installed cost was effectively flat from 2020 to
@@ -557,7 +565,8 @@ export function GENERATORS(
     {
       name: "Geothermal",
       fuel: "Geothermal",
-      description: "Consistent, but few locations",
+      description:
+        "Steady low-carbon output, but only at suitable underground heat sources",
       available: (geothermalLocations || 0) > 0,
       buildCost: scaledBuildCost(geothermalCostPerW(year), 50000000, peakW),
       // IRENA global installed cost fell from inflation-normalized $5,415/kW in 2020 to
@@ -579,7 +588,8 @@ export function GENERATORS(
     {
       name: "Enhanced Geothermal",
       fuel: "Geothermal",
-      description: "Clean, firm power nearly anywhere",
+      description:
+        "Steady low-carbon output in more locations than conventional geothermal",
       available: year >= 2030,
       buildCost: enhancedGeothermalCostPerW * peakW,
       // Fervo's $5.5/W Phase II estimate in 2028 declines to its $3/W long-term target
@@ -654,7 +664,8 @@ export function STORAGE(state: GameType, peakWh: number) {
   let storage = [
     {
       name: "Battery",
-      description: "Fast to build and charge / discharge",
+      description:
+        "Builds quickly and responds almost instantly, but stores a limited amount of energy",
       available: year > 2008, // Project Barbados, 2MW - https://en.wikipedia.org/wiki/List_of_energy_storage_projects
       buildCost: 10000 + batteryCostPerWh(year) * peakWh,
       // NREL's 2020 four-hour benchmark was $345/kWh (2020$); IRENA's global fully installed
@@ -683,7 +694,8 @@ export function STORAGE(state: GameType, peakWh: number) {
     },
     {
       name: "Pumped Hydro",
-      description: "Slow to build and charge / discharge",
+      description:
+        "Stores large amounts of energy, but needs a suitable site and takes years to build",
       available: year > 1930 && (pumpedHydroLocations || 0) > 0, // New Milford plant, 33MW - https://blogs.scientificamerican.com/plugged-in/throwback-thursday-the-first-u-s-energy-storage-plant/
       buildCost: 2000000 + 0.3319 * peakWh,
       // NREL's 2024 ATB closed-loop sites span $2,205-$4,434/kW. At this facility's ten-hour

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -145,10 +145,10 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          You're the incoming CEO of an electric utility. Every hour of game
-          time your customers demand a certain amount of power, and every hour
-          your generators have to supply it. Supply too little and you cause{" "}
-          blackouts; spend too much supplying it and you go broke.
+          You run an electric utility: a company that supplies electricity.
+          Every hour, your customers need a certain amount of power and your
+          generators must match it. Supply too little and you cause blackouts;
+          spend too much and the company runs out of money.
         </p>
         <p>
           <strong>Facilities</strong> is your fleet. Generators higher in the
@@ -182,7 +182,8 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
       <div>
         <p>
           These symbols mean the same thing in missions, controls, events and
-          results. Learn one once, then follow it everywhere.
+          results. The same symbol always represents the same idea throughout
+          the game.
         </p>
         <ConceptLegend />
       </div>
@@ -195,15 +196,16 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          Demand never sits still, so a fleet needs two very different kinds of
-          plant.
+          Electricity demand rises and falls during each day. Power companies
+          often meet it with a mix of plants that run steadily and plants that
+          can start quickly when demand peaks.
         </p>
         <p>
-          <strong>Baseload</strong> plants - nuclear, coal, large hydro - are
-          cheap per unit of energy but slow and expensive to start and stop, so
-          they run flat out around the clock and cover the demand that's always
-          there. They're the wrong answer to a four-hour evening peak: by the
-          time one has ramped up, the peak is over.
+          <strong>Baseload</strong> describes the plants used to cover the
+          demand that is present most of the time. Nuclear and coal plants often
+          fill this role because they can be costly or slow to start and stop.
+          Some hydro plants can also provide steady power, but many can change
+          output quickly.
         </p>
         <p>
           <strong>Peakers</strong> - typically gas turbines - are the opposite.
@@ -212,11 +214,11 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           their keep on the handful of days when demand spikes.
         </p>
         <p>
-          Most of the cost of a peaker is the fuel it burns, so an idle one
-          costs you little; most of the cost of a baseload plant is paid whether
-          it runs or not. That's why a fleet made only of peakers loses money on
-          fuel, and a fleet made only of baseload plants blacks out every summer
-          afternoon.
+          Most of a peaker's cost comes from the fuel it burns, so an idle one
+          costs relatively little. Much of a baseload plant's cost is paid
+          whether it runs or not. A grid usually needs a mix: steady plants for
+          regular demand and flexible plants for short peaks. These are
+          operating roles, and some generators can serve more than one role.
         </p>
       </div>
     ),
@@ -227,13 +229,12 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          If you don't supply enough electricity to meet demand, you'll cause
-          rolling blackouts that cost you customers (and thus revenue).
+          In Electrify, a blackout happens when available supply cannot meet
+          demand. Repeated blackouts cost you customers, which lowers revenue.
         </p>
         <p>
-          Like utilities in real life, you aren't financially responsible for
-          blackouts. But, if you have chronic blackouts, your board of directors
-          might fire you!
+          The game does not charge a separate damage bill for each blackout, but
+          outages still reduce customers, revenue, score, and job security.
         </p>
       </div>
     ),
@@ -244,8 +245,9 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     keywords: "british thermal unit mmbtu heat energy kwh mwh",
     entry: (
       <p>
-        The British Thermal Unit is a measure of heat energy. MMBTU is one
-        million BTU, and equals approximately 300 kWh of electrical energy.
+        A British thermal unit (Btu) measures heat energy. One MMBtu means one
+        million Btu, equal to about 293 kWh of heat. A power plant produces less
+        electricity because some energy is lost during conversion.
       </p>
     ),
   },
@@ -256,18 +258,18 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          Capacity factor is the share of a generator's nameplate capacity it
-          actually delivers over a year. A 100 MW plant at a 45% capacity factor
-          produces as much energy in a year as a 45 MW plant running
-          continuously would.
+          Capacity factor compares how much electricity a generator actually
+          produces with the most it could produce if it ran at full power all
+          year. A 100 MW plant at a 45% capacity factor produces as much energy
+          in a year as a 45 MW plant running continuously.
         </p>
         <p>
-          It's shown in the build screen as "% uptime", and it's why nameplate
-          size alone tells you very little. Nuclear runs above 90%. Coal and gas
-          sit in the middle, limited by fuel cost and by how often you choose to
-          dispatch them. Wind and solar are set by the weather and the seasons
-          at your location, not by you - which is why the same solar farm is a
-          much better deal in one scenario than another.
+          It is shown on the build screen as expected output, and it is why a
+          plant's maximum rated size alone tells you very little. Nuclear often
+          runs above 90%. Coal and gas depend on fuel costs and how often you
+          choose to run them. Wind and solar depend on local weather and
+          seasons, so the same solar farm can perform differently in each
+          scenario.
         </p>
         <p>
           Capacity factor is what turns a build cost into a cost per MWh, so
@@ -283,25 +285,22 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          A carbon fee is a charge on pollution, meant to cover the damage it
-          does to everyone else. It's billed by the amount of greenhouse gas
-          emitted, measured in <LargeMassUnit /> of CO2 equivalent, and it shows
-          up in your P&amp;L as an operating expense on every dirty MWh you
-          generate.
+          A carbon fee charges power plants for the greenhouse gases they
+          release. Plants with higher emissions pay more for each unit of
+          electricity they generate.
         </p>
         <p>
-          Electricity generation is the 2nd largest source of greenhouse gas in
-          the United States, and without a fee a utility has no financial reason
-          to cut its emissions - the cheapest plant to run wins no matter what
-          comes out of the stack. A fee changes the merit order itself: at{" "}
-          <ExampleCarbonFee /> a coal plant can become more expensive to run
-          than the gas plant beside it, without a single rule telling you to
-          shut it down.
+          The fee is based on greenhouse gas emissions, measured in{" "}
+          <LargeMassUnit /> of carbon dioxide equivalent (CO2e). It appears in
+          the profit-and-loss statement as an operating expense for each
+          megawatt-hour (MWh) generated. At <ExampleCarbonFee />, a coal plant
+          can become more expensive to run than a gas plant, changing the order
+          in which the grid uses them.
         </p>
         <p>
           Scenarios set their own fee, and custom games let you dial it from $0
           upwards. Turning it up is the fastest way to see how much of the
-          fossil fuel fleet is only economic because the pollution is free.
+          fossil fuel fleet remains profitable when its emissions have no price.
         </p>
       </div>
     ),
@@ -314,11 +313,15 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          Conventional hydro is dispatchable, but it is not an unlimited
-          generator. Rain and melting snow create runoff in the upstream
-          watershed, runoff fills the plant's reservoir, and every MWh the
-          turbines generate draws that reservoir down. Water above the dam's
-          capacity spills and cannot be recovered; a drought can empty it.
+          A hydroelectric plant generates power when operators release stored
+          water through its turbines. Its supply depends on rain, melting snow,
+          and the amount of water left in its reservoir.
+        </p>
+        <p>
+          Rain and snowmelt create runoff across the watershed, the land that
+          drains into the reservoir. Every MWh the turbines generate lowers the
+          reservoir. Water above the dam's capacity spills and cannot be
+          recovered, while a drought can empty the usable supply.
         </p>
         <p>
           The <strong>Water</strong> forecast appears once you own conventional
@@ -352,11 +355,10 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          More customers drives more demand. Although individual customer types
-          (residential, commercial, industrial) have different demand curves,
-          we've aggregated them into a single "customers" number that reflects a
-          blend of customer types. Here's what demand by type looks like in real
-          life:
+          More customers drive up electricity demand. Homes, businesses, and
+          factories use electricity in different patterns, so the game combines
+          them into one customer total. Here is what those patterns look like in
+          real life:
         </p>
         <Figure
           src="/images/manual-demand-customer-types.png"
@@ -401,23 +403,20 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          CO2e stands for Carbon Dioxide equivalent, a measure of the greenhouse
-          warming impact of various pollutants. Each generator lists the{" "}
-          <MassUnitName /> of CO2e it releases per MWh, which is what makes a
+          CO2e means carbon dioxide equivalent. It puts the warming effects of
+          different greenhouse gases on one common scale, so you can compare
+          power plants.
+        </p>
+        <p>
+          Each generator lists the <MassUnitName /> of CO2e it releases per
+          megawatt-hour (MWh) of electricity. This makes the emissions from a
           coal plant and a gas plant of the same size comparable.
         </p>
         <p>
-          Electricity generation is the 2nd largest source of greenhouse gas in
-          the United States, but our utilities have no financial incentive to
-          reduce their emissions.
-        </p>
-        <p>
-          One of the highest-rated proposals to reduce emissions is a Carbon
-          Fee, which creates a financial incentive for businesses to reduce
-          their carbon footprint through innovation. Electrify lets you
-          experiment with different levels of carbon fees, and see how
-          technology innovation can enable better business decisions than the
-          fossil fuels of the past.
+          A carbon fee is one policy option that gives businesses a financial
+          reason to lower emissions. Electrify lets you test different fee
+          levels and observe how they change costs, investment choices, and the
+          mix of power plants on the grid.
         </p>
       </div>
     ),
@@ -429,16 +428,15 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          Insights projects your company forward, so you can spot problems
-          before they cost you customers. Pick a preset for a common question,
-          or use Layers to build and reorder your own view. Every chart uses the
-          same range and cursor, so a weather change, shortage and profit dip
-          can be read at the same moment.
+          Insights shows what may happen to the grid and the company in the
+          future. Choose a preset question or use Layers to build your own view.
+          Every chart covers the same time period, and a shared marker lets you
+          compare values on the same date.
         </p>
         <p>
           <strong>Supply &amp; Demand</strong> plots your projected output
           against projected demand. Wherever demand rises above supply, the gap
-          is shaded as a blackout. If any are forecasted, the table underneath
+          is shaded as a blackout. If any are predicted, the table underneath
           breaks them down: total energy not served, the size of the single
           worst event, the peak shortage (how much extra capacity you'd need to
           cover it) and when it happens. That "when" is the most useful number
@@ -452,9 +450,9 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           ones fill the peaks. Re-ordering your facilities changes this chart.
         </p>
         <p>
-          <strong>Stored power</strong> (shown once you own storage) tracks the
-          energy in your batteries and reservoirs as they charge off surplus and
-          discharge into peaks.
+          <strong>Stored Energy</strong> (shown once you own storage) tracks how
+          much energy is available in batteries and reservoirs. Their power
+          rating tells you how quickly they can charge or discharge.
         </p>
         <p>
           <strong>Fuel Prices</strong> projects the cost of each fuel you can
@@ -500,12 +498,15 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          Companies prioritize their generation stack based on how long they
-          take to ramp up and down, their marginal cost (fuel) and whether
-          they're controllable. That ordering is called the merit order, and in
-          Electrify it's simply the order of your Facilities list: the top of
-          the list is asked to generate first, and each plant below only runs
-          once the ones above it are maxed out.
+          Power companies choose which generators run first. In Electrify,
+          plants at the top of the Facilities list are used before plants below
+          them. This ranking is called the dispatch order, or merit order.
+        </p>
+        <p>
+          Companies build that order around each plant's fuel cost, how quickly
+          it can change output, and whether operators can control when it runs.
+          Each plant below another runs only after the plants above reach their
+          maximum output.
         </p>
         <p>
           Here's a real-world generation stack from the PJM
@@ -529,23 +530,24 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          Ramp rate is how fast a plant can change its output, shown on the
-          build screen as the ramp up/down time needed to go from zero to full.
+          Ramp rate describes how quickly a generator can raise or lower its
+          power output. The build screen shows the approximate time needed to go
+          from zero to full power.
         </p>
         <p>
-          It's set by physics, not by choice. A gas turbine is essentially a jet
-          engine and reaches full power in a minute or two. A coal or nuclear
-          plant has to heat thousands of tons of metal and water evenly, and
-          rushing it cracks things, so it takes hours. Batteries respond in
-          under a second; pumped hydro needs about ten minutes to get the water
-          moving.
+          It's set by physics, not by choice. A gas turbine works on similar
+          principles to a jet engine and reaches full power in a minute or two.
+          A coal or nuclear plant has to heat thousands of tons of metal and
+          water evenly, and rushing it cracks things, so it takes hours.
+          Batteries respond in under a second; pumped hydro needs about ten
+          minutes to get the water moving.
         </p>
         <p>
           Thermal plants also have a <strong>minimum stable output</strong>.
           While online they cannot sit at a trace output: depending on the
           technology, Electrify holds them at 15% to 50% of nameplate. When
-          demand falls below that level, dispatch compares the forecasted cost
-          of running at minimum with the next start cost, then either keeps the
+          demand falls below that level, dispatch compares the predicted cost of
+          running at minimum with the next start cost, then either keeps the
           plant online or begins shutting it down.
         </p>
         <p>
@@ -566,17 +568,15 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
       <div>
         <p>
           Financing a plant means borrowing most of its cost over 30 years, and
-          the interest on that loan is an operating expense for every one of
-          them. What you're quoted is built from two things: what money costs
-          everybody, and what it costs <em>you</em>.
+          paying interest on that loan. The interest rate depends on two things:
+          economy-wide borrowing costs and your company's financial health.
         </p>
         <p>
-          The first is the <strong>prime rate</strong>, the benchmark banks lend
-          their best customers at. It moves on a cycle of eight to twelve years
-          rather than month to month, and you have no influence over it
-          whatsoever. It has been as low as 3.25% and, in December 1980, as high
-          as 21.5% - so a scenario set in 1980 is playing a genuinely different
-          game to one set in 2020.
+          The first is the <strong>prime rate</strong>, a benchmark interest
+          rate for strong borrowers. It changes with the wider economy, and you
+          cannot control it. It has been as low as 3.25% and, in December 1980,
+          as high as 21.5%, so a scenario set in 1980 plays differently from one
+          set in 2020.
         </p>
         <p>
           The second is your <strong>credit</strong>, and that part is entirely
@@ -586,8 +586,9 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           take to repay what you owe. Fall short on any of them and the premium
           over prime goes up. The important consequence is that{" "}
           <strong>debt makes debt more expensive</strong>: every plant you
-          finance raises the price of financing the next one, which is exactly
-          how it works for a real utility.
+          finance raises the price of financing the next one. This reflects the
+          real-world idea that heavily indebted companies often pay more to
+          borrow.
         </p>
         <p>
           A loan's rate is fixed on the day you sign it and never changes, so{" "}
@@ -597,12 +598,11 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           for it thirty years later.
         </p>
         <p>
-          <strong>Inflation</strong> is the other half of the same cycle, and it
-          leads it: prices run away first, and rates are raised to chase them.
-          It pushes up what fuel costs and what it costs to build and operate a
-          plant, year after year. Your rate per kWh does not rise on its own to
-          match, so on a long scenario inflation quietly eats your margin unless
-          you're a public utility and can raise the rate yourself.
+          <strong>Inflation</strong> is a broad rise in prices. Central banks
+          may raise interest rates when inflation is high. In the game,
+          inflation pushes up fuel, construction, and operating costs. Your rate
+          per kWh does not rise automatically, so inflation can reduce your
+          profit margin unless you adjust the rate when the scenario allows it.
         </p>
       </div>
     ),
@@ -615,9 +615,9 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
       <div>
         <p>
           Your rate is what you charge customers per kWh of electricity, and it
-          multiplied by the energy you supply is essentially all of your
-          revenue. Real US residential rates run somewhere around $0.10-$0.30
-          per kWh depending on the state.
+          creates nearly all of your revenue. Multiply this rate by the
+          electricity you sell to estimate your revenue. Real US residential the
+          game models each scenario's market and rules separately.
         </p>
         <p>
           In <strong>investor-owned</strong> scenarios you compete for
@@ -628,7 +628,7 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           is finite.
         </p>
         <p>
-          In <strong>public-owned</strong> scenarios you set the rate yourself
+          In <strong>publicly owned</strong> scenarios you set the rate yourself
           in Insights, and it's part of how you're scored: your lifetime average
           rate is compared against the scenario's target, and every cent per kWh
           above or below moves your score. Charging more makes the books easy
@@ -652,11 +652,10 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           as friction and evaporation moving water uphill and back down.
         </p>
         <p>
-          That loss is what storage costs you, on top of the build cost. It only
-          pays off when the power you charge with is much cheaper than the power
-          you displace, which is why storage earns its keep soaking up surplus
-          wind and solar and discharging into the evening peak, and loses money
-          shuttling energy around for its own sake.
+          That loss is one cost of storage, on top of the build cost. Storage is
+          most valuable when the power used to charge it is cheaper than the
+          power it replaces, such as when it absorbs surplus wind or solar and
+          discharges during the evening peak.
         </p>
       </div>
     ),
@@ -702,7 +701,7 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
             </tr>
             <tr>
               <td>-8</td>
-              <td>per TWh of blackouts</td>
+              <td>per TWh of demand not served during blackouts</td>
             </tr>
           </tbody>
         </table>
@@ -710,10 +709,17 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
         <table className="points">
           <tbody>
             <tr>
-              <td>+/-80</td>
+              <td>+80</td>
               <td>
-                per $0.01/kWh that your lifetime average rate lands below/above
-                the scenario's target rate
+                per $0.01/kWh that your lifetime average rate is below the
+                scenario's target rate
+              </td>
+            </tr>
+            <tr>
+              <td>-80</td>
+              <td>
+                per $0.01/kWh that your lifetime average rate is above the
+                scenario's target rate
               </td>
             </tr>
             <tr>
@@ -728,7 +734,7 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
             </tr>
             <tr>
               <td>-10</td>
-              <td>per TWh of blackouts</td>
+              <td>per TWh of demand not served during blackouts</td>
             </tr>
           </tbody>
         </table>
@@ -743,9 +749,10 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
     entry: (
       <div>
         <p>
-          Also known as "Levelized Cost of Energy", it's the expected cost of
-          all energy produced by the plant during its lifetime, including
-          construction, maintenance and fuel.
+          Total cost of energy estimates the average cost of all the electricity
+          a plant will produce during its lifetime. It includes construction,
+          financing, maintenance, and fuel. It is also called the levelized cost
+          of energy (LCOE).
         </p>
         <p>
           Operating and maintenance (O&amp;M) costs can be fixed or depend on

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -77,8 +77,8 @@ describe("tutorial mission metadata", () => {
     )!;
     render(generatorsMission.tutorialSteps![1].content);
 
-    expect(screen.getByText(/Compare build cost/)).toHaveTextContent(
-      "O&M (Operations & Maintenance)",
+    expect(screen.getByText(/Compare construction cost/)).toHaveTextContent(
+      "operations and maintenance (O&M)",
     );
   });
 
@@ -221,7 +221,7 @@ describe("authored starting fleets", () => {
       minimumDemandServed: 1,
     });
     expect(heatwave).toMatchObject({
-      name: "Heatwave + Drought in Spain",
+      name: "Heatwave + Drought",
       locationId: "Madrid",
       startingDemandScale: 0.73,
     });
@@ -232,7 +232,7 @@ describe("authored starting fleets", () => {
       expect.arrayContaining(["Uranium", "Hydro", "Sun", "Wind", "Battery"]),
     );
     expect(eclipse).toMatchObject({
-      name: "Solar Eclipse in China",
+      name: "Solar Eclipse",
       locationId: "Beijing",
       startingYear: 2033,
       durationMonths: 33,
@@ -250,7 +250,7 @@ describe("authored starting fleets", () => {
       durationMonths: 18,
     });
     expect(trip).toMatchObject({
-      name: "Sudden Nuclear Trip in France",
+      name: "Sudden Nuclear Shutdown",
       icon: "sudden-nuclear-trip",
     });
     expect(
@@ -258,6 +258,20 @@ describe("authored starting fleets", () => {
         (facility) => facility.label === "Grand Nuclear Unit",
       ),
     ).toMatchObject({ fuel: "Uranium", peakW: 500_000_000 });
+  });
+
+  it("keeps locations in scenario metadata rather than scenario names", () => {
+    expect(
+      [107, 108, 109, 110].map((id) => ({
+        name: getScenario(id)!.name,
+        location: getScenario(id)!.location?.name,
+      })),
+    ).toEqual([
+      { name: "Deep Freeze", location: "Austin, TX" },
+      { name: "Heatwave + Drought", location: "Madrid, Spain" },
+      { name: "Solar Eclipse", location: "Beijing, China" },
+      { name: "Sudden Nuclear Shutdown", location: "Paris, France" },
+    ]);
   });
 
   it("makes every plant in the aging coal fleet at least 20 years old", () => {

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -108,7 +108,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["supply", "demand"]}
-            text="Blue supply must stay above demand all day. Red means a blackout."
+            text="The supply line must stay at or above the demand line. If demand rises above supply, the chart marks a blackout."
           />
         ),
       },
@@ -153,14 +153,15 @@ export const SCENARIOS = [
             text="Your turn: keep the lights on for a full day with no blackout."
           />
         ),
-        hint: "Check the reserve readout, then choose a speed. Positive reserve means available capacity exceeds demand right now.",
+        hint: "Reserve is unused capacity that could supply the grid right now. Positive reserve means available capacity is greater than demand.",
         capstone: {
           success: (s: AppStateType) =>
             s.game.date.minute >= 1440 && !hasBlackout(s),
           failure: hasBlackout,
-          successMessage: "Success!",
+          successMessage:
+            "You kept electricity supply above demand for the full day.",
           failureMessage:
-            "Demand outran available supply, so some electricity went unserved. Watch reserve before running the clock and retry from the same forecast.",
+            "Demand exceeded available supply. Check the reserve and forecast before you retry.",
         },
       },
     ],
@@ -203,7 +204,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["money", "time", "fuel"]}
-            text="Compare build cost, time, fuel and O&M (Operations & Maintenance)"
+            text="Compare construction cost and time, fuel, and operations and maintenance (O&M)—the cost of keeping a plant running."
           />
         ),
       },
@@ -214,7 +215,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["buy", "generator"]}
-            text="Buy one - cash or loan."
+            text="Choose a generator and decide whether to pay with cash or a loan."
             action={["buy"]}
           />
         ),
@@ -225,7 +226,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["construction", "time"]}
-            text="It's being built."
+            text="Construction has started. The generator cannot supply the grid until it is complete."
           />
         ),
       },
@@ -254,7 +255,7 @@ export const SCENARIOS = [
           preserveProgress: true,
           success: generatorCapstoneSucceeded,
           successMessage:
-            "Capstone complete - you built two different types of generator.",
+            "Final challenge complete—you built two different types of generator.",
           failureMessage:
             "Build another generator with a different fuel or technology from your first purchase.",
         },
@@ -276,7 +277,7 @@ export const SCENARIOS = [
     durationMonths: 6,
     endTitle: "Mission complete!",
     endMessage:
-      "You stored spare power and used dispatch order to control the grid.",
+      "You stored extra energy and used the facility order to control the grid.",
     facilities: [
       { name: "Pumped Hydro", peakWh: 500000000, initialAgeYears: 35 },
       { fuel: "Coal", peakW: 480000000, initialAgeYears: 25 },
@@ -302,7 +303,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["buy", "storage"]}
-            text="Buy one."
+            text="Choose a storage system and decide whether to pay with cash or a loan."
             action={["buy"]}
           />
         ),
@@ -324,7 +325,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["reorder"]}
-            text="Drag to re-order - the top runs first and charges storage below it."
+            text="Drag facilities to change their dispatch order. Generators higher in the list run first; storage charges when they make more electricity than customers need."
             action={["reorder"]}
           />
         ),
@@ -346,10 +347,10 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["storage", "supply", "time"]}
-            text="Your turn: charge from spare supply, then discharge through an evening peak within two days without a blackout."
+            text="Your turn: store extra energy when demand is low, then use it during the evening peak within two days without a blackout."
           />
         ),
-        hint: "Run the clock and watch the storage bar and power readout. Stored energy should rise off-peak, then fall while storage supplies the grid at peak.",
+        hint: "Run the clock and watch how full the storage is. It should fill when demand is low, then empty while helping meet the evening peak.",
         capstone: {
           checkpoint: {
             facilities: [
@@ -366,9 +367,9 @@ export const SCENARIOS = [
             hasBlackout(s) ||
             (s.game.date.minute >= 2880 && !storageCapstoneSucceeded(s)),
           successMessage:
-            "Capstone complete - surplus charged storage, and its later discharge carried demand through the peak without unserved energy.",
+            "Final challenge complete—the storage charged with extra energy, then supplied the grid during peak demand without a blackout.",
           failureMessage:
-            "Storage did not complete a charge-and-discharge cycle before the deadline, or demand went unserved. Watch its state of charge and dispatch order before retrying.",
+            "The storage did not fill and empty before the deadline, or demand exceeded supply. Check how full it is and the facility order before retrying.",
         },
       },
     ],
@@ -401,7 +402,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["finances", "money"]}
-            text="Your money lives in Insights."
+            text="Insights shows your revenue, expenses, cash, and profit over time."
           />
         ),
         desktop: {
@@ -409,7 +410,7 @@ export const SCENARIOS = [
           content: (
             <TutorialPrompt
               concepts={["finances", "money"]}
-              text="Your money lives in the Insights pane."
+              text="The Insights pane shows your revenue, expenses, cash, and profit over time."
             />
           ),
         },
@@ -420,7 +421,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["forecast", "money"]}
-            text="Chart any metric, any year."
+            text="Choose a financial measure and time period to see how it changes."
           />
         ),
       },
@@ -430,7 +431,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["finances"]}
-            text="Choose presets or Layers to decide which questions this view answers."
+            text="Choose a preset question, or use Layers to select the information you want to compare."
           />
         ),
       },
@@ -451,19 +452,19 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["finances", "rate", "money"]}
-            text="Your turn: turn the projected loss into a profitable month without causing a blackout."
+            text="Your turn: turn the forecast monthly loss into a profit without causing a blackout."
           />
         ),
-        hint: "Compare revenue with fuel and O&M expenses. The rate control changes revenue per unit sold; choose a rate that makes the next month profitable.",
+        hint: "Compare revenue with fuel and operations and maintenance expenses. The rate control changes revenue for each unit sold; choose a rate that makes the next month profitable.",
         capstone: {
           checkpoint: { dollarsPerkWh: 0.03 },
           success: financesCapstoneSucceeded,
           failure: (s: AppStateType) =>
             s.game.date.monthsElapsed >= 1 && !financesCapstoneSucceeded(s),
           successMessage:
-            "Capstone complete - revenue covered fuel and operating costs, leaving a positive monthly profit while the grid stayed reliable.",
+            "Final challenge complete—revenue covered fuel and operating costs, leaving a monthly profit while the grid stayed reliable.",
           failureMessage:
-            "Revenue did not cover fuel, O&M and financing costs for the month, or demand went unserved. Use the financial layers to set a sustainable rate before retrying.",
+            "Revenue did not cover fuel, operating, and loan costs, or demand exceeded supply. Use the financial layers to set a workable rate before retrying.",
         },
       },
     ],
@@ -515,7 +516,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["rate", "customers"]}
-            text="Lower the rate below market to win customers."
+            text="Lower the rate below the market price so more customers choose your utility."
             action={["rate"]}
           />
         ),
@@ -526,7 +527,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["customers", "forecast"]}
-            text="The Customers layer shows growth beside the grid consequences."
+            text="The Customers layer shows how customer growth changes demand, revenue, and profit."
           />
         ),
       },
@@ -557,7 +558,7 @@ export const SCENARIOS = [
             hasBlackout(s) ||
             (s.game.date.monthsElapsed >= 6 && !pricingCapstoneSucceeded(s)),
           successMessage:
-            "Capstone complete - the lower rate grew the customer base by 5% while monthly revenue still covered costs and every unit of demand was served.",
+            "Final challenge complete—the lower rate grew the customer base by 5% while monthly revenue covered costs and supply met demand.",
           failureMessage:
             "The customer target, positive monthly profit and reliable supply did not all hold for six months. Balance the rate against both demand growth and cost before retrying.",
         },
@@ -590,7 +591,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["pause", "generator"]}
-            text="Pause your only plant - see what the future thinks."
+            text="Pause your only plant and watch how the supply forecast changes."
             action={["pause"]}
           />
         ),
@@ -601,7 +602,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["forecast", "blackout"]}
-            text="Blackouts ahead - forecasts show the year to come."
+            text="A blackout is predicted. Forecasts show what may happen during the coming year."
           />
         ),
       },
@@ -613,7 +614,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["play", "blackout"]}
-            text="Tap 1× and let the forecasted blackout begin."
+            text="Tap 1× and let the predicted blackout begin."
             action={["play"]}
           />
         ),
@@ -624,7 +625,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["time", "blackout"]}
-            text="This dated event explains what changed. Fuel cost crossovers appear here too, and only interrupt you the first time each fuel crosses."
+            text="This dated event explains what changed. Events also report the first time one fuel becomes more expensive than another."
           />
         ),
         desktop: {
@@ -632,7 +633,7 @@ export const SCENARIOS = [
           content: (
             <TutorialPrompt
               concepts={["time", "blackout"]}
-              text="This pane keeps dated explanations of important changes. Fuel cost crossovers appear here too, and only interrupt you the first time each fuel crosses."
+              text="This pane keeps dated explanations of important changes. It also reports the first time one fuel becomes more expensive than another."
             />
           ),
         },
@@ -687,7 +688,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["forecast", "build", "blackout"]}
-            text="Your turn: commission enough generation before the forecast summer shortage, then reach month seven without a blackout."
+            text="Your turn: finish building enough generation before the predicted summer shortage, then reach month seven without a blackout."
           />
         ),
         hint: "Inspect the supply-and-demand forecast, then choose any generator with enough capacity and a construction time shorter than the shortage deadline.",
@@ -698,9 +699,9 @@ export const SCENARIOS = [
             (s.game.date.monthsElapsed >= 7 &&
               !forecastingCapstoneSucceeded(s)),
           successMessage:
-            "Capstone complete - construction finished before the forecast peak, and the added generator prevented the projected summer shortage.",
+            "Final challenge complete—construction finished before peak demand, and the added generator prevented the predicted summer shortage.",
           failureMessage:
-            "Demand reached available capacity before enough new generation was online. Recheck the forecast gap and construction time, then commission earlier.",
+            "Demand exceeded available supply before the new generator was ready. Recheck the forecast shortage and start construction sooner.",
         },
       },
     ],
@@ -714,7 +715,7 @@ export const SCENARIOS = [
     briefing: {
       tone: "transition",
       fantasy: "Modernize an aging grid as pollution gets more expensive.",
-      objective: "Replace dirty power while keeping the lights on.",
+      objective: "Replace high-emission power while keeping the lights on.",
       threat: "Old coal plants and tight finances leave little room for delay.",
     },
     ownership: "Investor",
@@ -782,7 +783,8 @@ export const SCENARIOS = [
       tone: "innovation",
       fantasy: "Build the next generation of clean power.",
       objective: "Replace aging oil plants with cleaner options.",
-      threat: "Invest too early and overpay; wait too long and demand wins.",
+      threat:
+        "Invest too early and overpay; wait too long and demand may exceed supply.",
     },
     ownership: "Investor",
     startingYear: 2002,
@@ -804,7 +806,8 @@ export const SCENARIOS = [
     briefing: {
       tone: "storm",
       fantasy: "Protect an island grid through years of fierce storms.",
-      objective: "Build a grid that keeps essential power flowing.",
+      objective:
+        "Build a grid that keeps demand supplied during severe storms.",
       threat: "A major storm can overwhelm a small backup margin.",
     },
     ownership: "Public",
@@ -864,7 +867,8 @@ export const SCENARIOS = [
     briefing: {
       tone: "boom",
       fantasy: "Guide a small city grid through explosive growth.",
-      objective: "Get enough reliable power ready before data centers arrive.",
+      objective:
+        "Build enough dependable generation and storage before data-center demand arrives.",
       threat: "New demand will overwhelm the grid if you build too late.",
     },
     ownership: "Public",
@@ -904,7 +908,7 @@ export const SCENARIOS = [
   },
   {
     id: 107, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
-    name: "Austin Deep Freeze",
+    name: "Deep Freeze",
     icon: "texas deep freeze",
     locationId: "Austin",
     location: {
@@ -957,7 +961,7 @@ export const SCENARIOS = [
   },
   {
     id: 108, // Scenario IDs are persisted and shared; append rather than renumbering.
-    name: "Heatwave + Drought in Spain",
+    name: "Heatwave + Drought",
     icon: "heatwave-drought",
     locationId: "Madrid",
     location: {
@@ -981,7 +985,7 @@ export const SCENARIOS = [
       objective:
         "Serve every customer through three months of rising demand and falling water availability.",
       threat:
-        "Hydro inflows and nuclear output will decline together as the heat intensifies.",
+        "Water flowing into hydro reservoirs and nuclear output will decline as the heat intensifies.",
     },
     ownership: "Public",
     startingYear: 2024,
@@ -1014,11 +1018,11 @@ export const SCENARIOS = [
     ],
     endTitle: "The heat finally breaks",
     endMessage:
-      "The long hot summer tested whether your portfolio could conserve energy for the days it mattered most.",
+      "The long hot summer tested whether your mix of generators and storage could save energy for the days it mattered most.",
   },
   {
     id: 109,
-    name: "Solar Eclipse in China",
+    name: "Solar Eclipse",
     icon: "solar-eclipse",
     locationId: "Beijing",
     location: {
@@ -1038,9 +1042,9 @@ export const SCENARIOS = [
       fantasy:
         "Turn a rare celestial event into a demonstration of preparation.",
       objective:
-        "Charge storage or add firm capacity before solar output plunges and recovers.",
+        "Charge storage or add generators that can run when solar output drops.",
       threat:
-        "Enough stored energy will not help if its discharge power cannot cover the rapid drop.",
+        "Storage needs enough energy to last (MWh) and enough power to discharge quickly (MW).",
     },
     ownership: "Public",
     startingYear: 2033,
@@ -1082,7 +1086,7 @@ export const SCENARIOS = [
   },
   {
     id: 110,
-    name: "Sudden Nuclear Trip in France",
+    name: "Sudden Nuclear Shutdown",
     icon: "sudden-nuclear-trip",
     locationId: "Paris",
     location: {
@@ -1096,15 +1100,15 @@ export const SCENARIOS = [
       resources: { hydro: false },
     },
     summary:
-      "Carry enough contingency capacity for an unannounced nuclear outage in France.",
+      "Keep enough backup capacity for an unexpected nuclear shutdown in France.",
     briefing: {
       tone: "legacy",
       fantasy:
         "Keep France's grid steady when its largest generator suddenly disappears.",
       objective:
-        "Build a portfolio that can absorb the loss of the main nuclear unit at any time in the risk window.",
+        "Build a mix of resources that can replace the main nuclear unit if it shuts down.",
       threat:
-        "The trip month is hidden, and the reactor will remain offline for the rest of the mission.",
+        "The shutdown date is hidden, and the reactor will remain offline for the rest of the mission.",
     },
     ownership: "Public",
     startingYear: 2024,
@@ -1120,7 +1124,7 @@ export const SCENARIOS = [
       month: 7,
       durationMonths: 18,
       minimumDemandServed: 1,
-      label: "nuclear contingency window and recovery",
+      label: "possible nuclear shutdown period and recovery",
     },
     facilities: [
       {
@@ -1136,7 +1140,7 @@ export const SCENARIOS = [
     ],
     endTitle: "Reserve proved its value",
     endMessage:
-      "The sudden trip tested the contingency capacity your normal operating plan rarely needed.",
+      "The sudden shutdown tested the backup capacity your normal plan rarely needed.",
   },
 ] as ScenarioType[];
 

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -359,7 +359,7 @@ export const SCENARIOS = [
                 peakWh: 500000000,
                 initialAgeYears: 35,
               },
-              { fuel: "Coal", peakW: 375000000, initialAgeYears: 25 },
+              { fuel: "Coal", peakW: 370000000, initialAgeYears: 25 },
             ],
           },
           success: storageCapstoneSucceeded,

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -440,6 +440,30 @@ describe("generation and storage reliability scenarios", () => {
       "Grand Nuclear Unit",
     ]);
   });
+
+  it("uses short preview copy before the eclipse and precise copy at onset", () => {
+    const upcoming = upcomingStoryPhases(context(0, 109));
+    const warning = upcoming.find((phase) =>
+      phase.key.endsWith(":advance-warning"),
+    )!;
+    const eclipse = upcoming.find((phase) => phase.key.endsWith(":eclipse"))!;
+
+    expect(warning).toMatchObject({
+      title: "Eclipse planning ahead",
+      message: "Grid planners will begin preparing for a total eclipse.",
+      details: undefined,
+    });
+    expect(eclipse).toMatchObject({
+      title: "Total solar eclipse",
+      message: "A total eclipse will briefly reduce solar generation.",
+      details: undefined,
+    });
+    expect(eclipse.message).not.toMatch(/underway|08:30|10:00|11:30/i);
+
+    const live = resolveStoryAtDate(context(32, 109)).occurrences[0];
+    expect(live.title).toBe("The eclipse is underway");
+    expect(live.details).toMatch(/08:30.*10:00.*11:30/i);
+  });
 });
 
 describe("remaining scored story arcs", () => {

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -268,7 +268,7 @@ const SHALE_BOOM_ARC: StoryArcDefinitionType = {
       schedule: { atMonth: 99 },
       describe: ({ difficulty }) => ({
         title: "Winter freeze ends",
-        message: `Gas output is fully restored and prices return to the continuing ${Math.round((1 - SHALE_BOOM_BALANCE[difficulty].boomGasMultiplier) * 100)}% shale discount.`,
+        message: `Gas output is fully restored, and prices return to the ${Math.round((1 - SHALE_BOOM_BALANCE[difficulty].boomGasMultiplier) * 100)}% reduction caused by the shale gas boom.`,
         concept: "supply",
         kind: "WORLD_EVENT",
         importance: "ROUTINE",
@@ -484,9 +484,9 @@ const CARBON_FEE_ARC: StoryArcDefinitionType = {
         return {
           title: "Clean-grid check-in",
           message: onTrack
-            ? "Your cleaner grid is reliable and profitable."
-            : "The transition is still falling short on clean power, reliability, or profit.",
-          details: `Last year: ${percent(combustionShare)} fossil power, ${percent(1 - unservedShare)} of demand met, and a ${snapshot.netIncome12m >= 0 ? "profit" : "loss"}.`,
+            ? "Your lower-emission grid is reliable and profitable."
+            : "The transition is still falling short on low-emission power, reliability, or profit.",
+          details: `Last year: ${percent(combustionShare)} fuel-burning generation, ${percent(1 - unservedShare)} of demand met, and a ${snapshot.netIncome12m >= 0 ? "profit" : "loss"}.`,
           concept: "goal",
           kind: "WORLD_EVENT",
           importance: "NOTABLE",
@@ -543,7 +543,7 @@ const PARADISE_ARC: StoryArcDefinitionType = {
       describe: ({ difficulty }) => ({
         title: "Fuel delivery warning",
         message: `A late fuel shipment could raise oil prices ${Math.round((PARADISE_BALANCE[difficulty].oilShock - 1) * 100)}% this fall.`,
-        details: "Prepare local power or reserves before September.",
+        details: "Prepare local generation or stored energy before September.",
         concept: "danger",
         kind: "WORLD_EVENT",
         importance: "NOTABLE",
@@ -681,7 +681,7 @@ const RENEWABLES_ARC: StoryArcDefinitionType = {
         const balance = RENEWABLES_BALANCE[difficulty];
         return {
           title: "Solar and wind prices fall",
-          message: `New Solar costs ${Math.round((1 - balance.solarBuildCost) * 100)}% less and new Wind costs ${Math.round((1 - balance.windBuildCost) * 100)}% less through mission end.`,
+          message: `New solar plants cost ${Math.round((1 - balance.solarBuildCost) * 100)}% less and new wind farms cost ${Math.round((1 - balance.windBuildCost) * 100)}% less through mission end.`,
           details: "The discount applies to new projects only.",
           concept: "build",
           kind: "WORLD_EVENT",
@@ -832,9 +832,9 @@ const HURRICANE_ARC: StoryArcDefinitionType = {
           title: `${balance.severity} hurricane hits`,
           message:
             selectedNames.length > 0
-              ? `${selectedNames.join(", ")} ${selectedNames.length === 1 ? "is" : "are"} running at ${percent(balance.outputMultiplier)} output until repairs finish.`
+              ? `${selectedNames.join(", ")} ${selectedNames.length === 1 ? "is" : "are"} limited to ${percent(balance.outputMultiplier)} of normal maximum output until repairs finish.`
               : `No plant is operating, but oil prices still rise ${Math.round((balance.oilMultiplier - 1) * 100)}%.`,
-          details: `Oil prices are up ${Math.round((balance.oilMultiplier - 1) * 100)}%. Storage remains available.`,
+          details: `Oil prices are up ${Math.round((balance.oilMultiplier - 1) * 100)}%. In this scenario, storage remains available.`,
           concept: "danger",
           kind: "WORLD_EVENT",
           importance: "CRITICAL",
@@ -933,7 +933,7 @@ const END_OF_ERA_ARC: StoryArcDefinitionType = {
         );
         return {
           title: "Aging coal slowdown",
-          message: `${selected.length} aging coal ${selected.length === 1 ? "plant is" : "plants are"} limited to ${percent(outputMultiplier)} output through December 1987.`,
+          message: `${selected.length} aging coal ${selected.length === 1 ? "plant is" : "plants are"} limited to ${percent(outputMultiplier)} of normal maximum output through December 1987.`,
           concept: "generator",
           kind: "WORLD_EVENT",
           importance: "NOTABLE",
@@ -1085,7 +1085,7 @@ const TEXAS_DEEP_FREEZE_ARC: StoryArcDefinitionType = {
           title: "The deep freeze",
           message:
             "Record cold is straining power supplies across Texas just as demand surges.",
-          details: `Demand is ${Math.round((demandMultiplier - 1) * 100)}% above normal this month while gas, coal, nuclear, and wind plants can produce less and gas costs spike.`,
+          details: `Demand is ${Math.round((demandMultiplier - 1) * 100)}% above normal this month while gas, coal, nuclear, and wind plants can produce less and natural-gas prices rise sharply.`,
           concept: "blackout",
           kind: "WORLD_EVENT",
           importance: "CRITICAL",
@@ -1195,9 +1195,9 @@ const HEATWAVE_DROUGHT_ARC: StoryArcDefinitionType = {
       describe: () => ({
         title: "A hot, dry summer ahead",
         message:
-          "Forecasts warn that heat will raise demand while drought limits hydro and river cooling.",
+          "Forecasts warn that heat will raise demand while drought reduces hydro output and the river water available to cool nuclear plants.",
         details:
-          "The stress will build from June through August 2026. Preserve energy and add resilient capacity before then.",
+          "The stress will build from June through August 2026. Save stored energy and add generators that can perform during heat and drought.",
         concept: "forecast",
         kind: "WORLD_EVENT",
         importance: "NOTABLE",
@@ -1223,7 +1223,7 @@ const HEATWAVE_DROUGHT_ARC: StoryArcDefinitionType = {
                 : "Peak heat and drought",
           message:
             "Demand is climbing as low water constrains hydro and nuclear generation.",
-          details: `Demand is ${Math.round((demandMultiplier - 1) * 100)}% above normal; hydro inflow falls to ${Math.round(hydroRunoffMultiplier * 100)}%, hydro power to ${Math.round(hydroOutputMultiplier * 100)}%, and nuclear power to ${Math.round(nuclearOutputMultiplier * 100)}%.`,
+          details: `Demand is ${Math.round((demandMultiplier - 1) * 100)}% above normal. Water flowing into hydro reservoirs falls to ${Math.round(hydroRunoffMultiplier * 100)}% of normal, maximum hydro output to ${Math.round(hydroOutputMultiplier * 100)}%, and maximum nuclear output to ${Math.round(nuclearOutputMultiplier * 100)}%.`,
           concept: "weather" as const,
           kind: "WORLD_EVENT" as const,
           importance:
@@ -1270,7 +1270,7 @@ const SOLAR_ECLIPSE_ARC: StoryArcDefinitionType = {
         message:
           "China's September 2035 total eclipse will sharply reduce morning solar output before a rapid recovery.",
         details:
-          "The timing is known. Check both the MW and MWh available from storage before the event.",
+          "The timing is known. Check storage power (MW: how quickly it can discharge) and stored energy (MWh: how long it can last).",
         concept: "forecast",
         kind: "WORLD_EVENT",
         importance: "NOTABLE",
@@ -1287,7 +1287,7 @@ const SOLAR_ECLIPSE_ARC: StoryArcDefinitionType = {
         return {
           title: "The eclipse is underway",
           message:
-            "Solar generation is falling on schedule. Stored and firm power must bridge the gap.",
+            "Solar generation is falling on schedule. Stored energy and generators that can run on demand must cover the shortage.",
           details: `Solar output falls from normal at 08:30 to ${Math.round(minimumOutputMultiplier * 100)}% at 10:00, then recovers by 11:30.`,
           concept: "storage",
           kind: "WORLD_EVENT",
@@ -1316,11 +1316,11 @@ const NUCLEAR_TRIP_ARC: StoryArcDefinitionType = {
       id: "contingency-review",
       schedule: { atMonth: 24 },
       describe: () => ({
-        title: "Contingency review",
+        title: "Backup-power review",
         message:
-          "The regulator asks whether the grid can lose its largest generator without blackouts.",
+          "The grid regulator asks whether backup resources can replace the largest generator if it suddenly shuts down.",
         details:
-          "A trip is possible from July 2026 through January 2027, but its exact timing cannot be forecast.",
+          "An automatic reactor shutdown could happen from July 2026 through January 2027, but its exact timing cannot be predicted.",
         concept: "danger",
         kind: "WORLD_EVENT",
         importance: "NOTABLE",
@@ -1344,9 +1344,9 @@ const NUCLEAR_TRIP_ARC: StoryArcDefinitionType = {
           ? { [String(unit.id)]: 0 }
           : {};
         return {
-          title: "Grand Nuclear Unit trips offline",
+          title: "Grand Nuclear Unit shuts down",
           message:
-            "The grid has suddenly lost its largest generator. Contingency resources must carry the system.",
+            "The grid has suddenly lost its largest generator. Backup generators and storage must replace the missing power.",
           details:
             "The reactor will remain unavailable for the rest of the mission.",
           concept: "danger",

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -51,6 +51,12 @@ export interface StoryPhaseDescriptionType {
   turningPointPriority?: number;
 }
 
+export interface StoryPhasePreviewType {
+  title?: string;
+  message: string;
+  details?: string;
+}
+
 export interface StoryPhaseDefinitionType {
   id: string;
   schedule: StoryScheduleType;
@@ -61,6 +67,11 @@ export interface StoryPhaseDefinitionType {
   /** Allows linked seeded phases (for example landfall/restoration) to share one addressed draw. */
   scheduleAddress?: string;
   scheduleOffsetMonths?: number | ((context: StoryContextType) => number);
+  /** Short, future-tense copy for the Events tab. Live logs continue to use `describe`. */
+  preview?: (
+    context: StoryContextType,
+    random: StoryRandomType,
+  ) => StoryPhasePreviewType;
   describe: (
     context: StoryContextType,
     random: StoryRandomType,
@@ -1265,6 +1276,10 @@ const SOLAR_ECLIPSE_ARC: StoryArcDefinitionType = {
     {
       id: "advance-warning",
       schedule: { atMonth: 24 },
+      preview: () => ({
+        title: "Eclipse planning ahead",
+        message: "Grid planners will begin preparing for a total eclipse.",
+      }),
       describe: () => ({
         title: "Eclipse preparations begin",
         message:
@@ -1281,6 +1296,10 @@ const SOLAR_ECLIPSE_ARC: StoryArcDefinitionType = {
       id: "eclipse",
       schedule: { atMonth: 32 },
       durationMonths: 1,
+      preview: () => ({
+        title: "Total solar eclipse",
+        message: "A total eclipse will briefly reduce solar generation.",
+      }),
       describe: ({ difficulty }) => {
         const minimumOutputMultiplier =
           SOLAR_ECLIPSE_MINIMUM_OUTPUT[difficulty];
@@ -1776,7 +1795,25 @@ export function upcomingStoryPhases(
     .flatMap((arc) =>
       arc.phases
         .filter((phase) => phase.forecastable !== false)
-        .map((phase) => resolveStoryPhase(arc, phase, context)),
+        .map((phase) => {
+          const resolved = resolveStoryPhase(arc, phase, context);
+          if (!phase.preview) {
+            return resolved;
+          }
+          const random = (attribute: string) =>
+            randomAt(
+              context.seed,
+              RANDOM_STREAM.worldEvents,
+              storyHash(`${resolved.key}|${attribute}`),
+            );
+          const preview = phase.preview(context, random);
+          return {
+            ...resolved,
+            title: preview.title,
+            message: preview.message,
+            details: preview.details,
+          };
+        }),
     )
     .filter(
       (phase) =>

--- a/src/helpers/Debrief.test.tsx
+++ b/src/helpers/Debrief.test.tsx
@@ -121,19 +121,19 @@ it("surfaces the researched Uri outcome metrics", () => {
 
   expect(debrief.scenarioMetrics).toEqual([
     expect.objectContaining({
-      label: "Uri energy unserved · Feb 2021",
+      label: "Demand not met during Winter Storm Uri · Feb 2021",
       value: "100MWh",
     }),
     expect.objectContaining({
-      label: "Maximum Uri supply deficit",
+      label: "Largest shortage during Winter Storm Uri",
       value: "100MW",
     }),
     expect.objectContaining({
-      label: "Common rate · before → after",
+      label: "Electricity rate · before → after",
       value: "$0.09/kWh → $0.1/kWh",
     }),
     expect.objectContaining({
-      label: "Positive cash through Mar 2021",
+      label: "Cash stayed above $0 through Mar 2021",
       value: "Yes",
     }),
   ]);

--- a/src/helpers/Debrief.tsx
+++ b/src/helpers/Debrief.tsx
@@ -136,7 +136,7 @@ function scenarioMetrics(
     );
     return [
       {
-        label: "Blackout months after load arrival",
+        label: "Months with blackouts after data centers arrived",
         value:
           afterArrival.length === 0
             ? "Not reached"
@@ -148,12 +148,12 @@ function scenarioMetrics(
         concept: "blackout",
       },
       {
-        label: "Common rate",
+        label: "Electricity rate",
         value: `${rate(scenario.dollarsPerkWh)} → ${rate(endingRate)}`,
         concept: "rate",
       },
       {
-        label: "Tightest supply margin · 2026",
+        label: "Smallest spare capacity · 2026",
         value:
           minimumMargin === undefined
             ? "Not reached"
@@ -175,19 +175,19 @@ function scenarioMetrics(
     const maximumDeficit = Math.max(0, -(february?.minimumSupplyMarginW || 0));
     return [
       {
-        label: "Uri energy unserved · Feb 2021",
+        label: "Demand not met during Winter Storm Uri · Feb 2021",
         value: february
           ? formatWattHours(Math.max(0, february.demandWh - february.supplyWh))
           : "Not reached",
         concept: "blackout",
       },
       {
-        label: "Maximum Uri supply deficit",
+        label: "Largest shortage during Winter Storm Uri",
         value: february ? formatWatts(maximumDeficit) : "Not reached",
         concept: "supply",
       },
       {
-        label: "Common rate · before → after",
+        label: "Electricity rate · before → after",
         value:
           beforeRate === undefined || afterRate === undefined
             ? "Not reached"
@@ -195,7 +195,7 @@ function scenarioMetrics(
         concept: "rate",
       },
       {
-        label: "Positive cash through Mar 2021",
+        label: "Cash stayed above $0 through Mar 2021",
         value:
           january && february && march
             ? january.cash > 0 && february.cash > 0 && march.cash > 0

--- a/src/helpers/ForecastSampling.test.tsx
+++ b/src/helpers/ForecastSampling.test.tsx
@@ -1,0 +1,38 @@
+import { TickPresentFutureType } from "../Types";
+import { sampleForecastTimeline } from "./ForecastSampling";
+
+function tick(minute: number, sunW: number): TickPresentFutureType {
+  return {
+    minute,
+    supplyW: sunW,
+    demandW: 100,
+    supplyByFuel: { Sun: sunW },
+  } as TickPresentFutureType;
+}
+
+describe("sampleForecastTimeline", () => {
+  it("keeps a short fuel-output dip between regular forecast samples", () => {
+    const timeline = [
+      tick(0, 100),
+      tick(60, 100),
+      tick(120, 10),
+      tick(180, 100),
+      tick(240, 100),
+    ];
+
+    expect(sampleForecastTimeline(timeline, 240, 15)).toEqual([
+      timeline[0],
+      timeline[2],
+      timeline[4],
+    ]);
+  });
+
+  it("does not add a redundant point to a linear fuel forecast", () => {
+    const timeline = [tick(0, 0), tick(60, 25), tick(120, 50)];
+
+    expect(sampleForecastTimeline(timeline, 120, 15)).toEqual([
+      timeline[0],
+      timeline[2],
+    ]);
+  });
+});

--- a/src/helpers/ForecastSampling.tsx
+++ b/src/helpers/ForecastSampling.tsx
@@ -1,0 +1,67 @@
+import { FuelNameType, TickPresentFutureType } from "../Types";
+
+/**
+ * Keeps regularly spaced forecast points plus the fuel-mix point that differs most from a
+ * straight line between each pair. A periodic-only sample can completely skip a short event --
+ * notably the solar eclipse between the 08:00 and 12:00 points -- even though the simulation
+ * modeled it. One extra point per interval preserves those meaningful shapes without handing
+ * every chart the full forecast timeline.
+ */
+export function sampleForecastTimeline(
+  timeline: TickPresentFutureType[],
+  intervalMinutes: number,
+  projectionStepMinutes: number,
+): TickPresentFutureType[] {
+  if (timeline.length <= 2) {
+    return [...timeline];
+  }
+
+  const included = new Set<number>([0, timeline.length - 1]);
+  timeline.forEach((tick, index) => {
+    if (tick.minute % intervalMinutes < projectionStepMinutes) {
+      included.add(index);
+    }
+  });
+
+  const anchors = [...included].sort((a, b) => a - b);
+  for (let anchor = 1; anchor < anchors.length; anchor++) {
+    const startIndex = anchors[anchor - 1];
+    const endIndex = anchors[anchor];
+    if (endIndex <= startIndex + 1) {
+      continue;
+    }
+
+    const start = timeline[startIndex];
+    const end = timeline[endIndex];
+    const duration = end.minute - start.minute;
+    let greatestDeviation = 0;
+    let significantIndex = -1;
+
+    for (let index = startIndex + 1; index < endIndex; index++) {
+      const tick = timeline[index];
+      const progress = duration ? (tick.minute - start.minute) / duration : 0;
+      const fuels = new Set<FuelNameType>([
+        ...(Object.keys(start.supplyByFuel) as FuelNameType[]),
+        ...(Object.keys(tick.supplyByFuel) as FuelNameType[]),
+        ...(Object.keys(end.supplyByFuel) as FuelNameType[]),
+      ]);
+      let deviation = 0;
+      fuels.forEach((fuel) => {
+        const startW = start.supplyByFuel[fuel] || 0;
+        const endW = end.supplyByFuel[fuel] || 0;
+        const expectedW = startW + (endW - startW) * progress;
+        deviation += Math.abs((tick.supplyByFuel[fuel] || 0) - expectedW);
+      });
+      if (deviation > greatestDeviation) {
+        greatestDeviation = deviation;
+        significantIndex = index;
+      }
+    }
+
+    if (significantIndex >= 0) {
+      included.add(significantIndex);
+    }
+  }
+
+  return [...included].sort((a, b) => a - b).map((index) => timeline[index]);
+}

--- a/src/helpers/Math.test.tsx
+++ b/src/helpers/Math.test.tsx
@@ -6,6 +6,7 @@ import {
   normalAt,
   randomAt,
   RANDOM_STREAM,
+  roundToSignificantDigits,
 } from "./Math";
 
 const STREAM = 1;
@@ -21,6 +22,15 @@ describe("getIntersectionX", () => {
   // Parallel lines never meet, so there is no x to return. Callers treat the 0 as "no crossing"
   it("returns zero for parallel lines rather than dividing by zero", () => {
     expect(getIntersectionX(0, 0, 10, 10, 0, 5, 10, 15)).toEqual(0);
+  });
+});
+
+describe("roundToSignificantDigits", () => {
+  it("rounds capacities at their own scale", () => {
+    expect(roundToSignificantDigits(722_225_000, 2)).toBe(720_000_000);
+    expect(roundToSignificantDigits(60_830_000, 2)).toBe(61_000_000);
+    expect(roundToSignificantDigits(1_497_000_000, 2)).toBe(1_500_000_000);
+    expect(roundToSignificantDigits(55_000_000, 2)).toBe(55_000_000);
   });
 });
 

--- a/src/helpers/Math.tsx
+++ b/src/helpers/Math.tsx
@@ -115,6 +115,14 @@ export function newSeed(): number {
   return Math.floor(Math.random() * 2 ** 32);
 }
 
+/** Rounds a finite measurement without tying its precision to a particular display unit. */
+export function roundToSignificantDigits(
+  value: number,
+  digits: number,
+): number {
+  return Number(value.toPrecision(digits));
+}
+
 // https://stackoverflow.com/questions/5306680/move-an-array-element-from-one-array-position-to-another
 export function arrayMove<T>(
   arr: Array<T | undefined>,

--- a/src/reducers/CustomGame.test.tsx
+++ b/src/reducers/CustomGame.test.tsx
@@ -81,6 +81,33 @@ describe("a custom game", () => {
     });
   });
 
+  it("rounds starting facility capacities to two significant digits", () => {
+    const facilities = [
+      { name: "Coal", peakW: 722_225_000 },
+      { name: "Battery", peakWh: 243_456_000 },
+    ];
+    const state = createGame({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: {
+        ...CUSTOM,
+        startingYear: 2033,
+        facilities,
+      } as ScenarioType,
+    });
+
+    expect(
+      state.facilities.find((facility) => facility.name === "Coal")?.peakW,
+    ).toBe(720_000_000);
+    expect(
+      state.facilities.find((facility) => facility.name === "Battery")?.peakWh,
+    ).toBe(240_000_000);
+    // Scenario definitions remain the source record; rounding belongs to created assets.
+    expect(facilities).toEqual([
+      { name: "Coal", peakW: 722_225_000 },
+      { name: "Battery", peakWh: 243_456_000 },
+    ]);
+  });
+
   it("commissions an authored starting facility at its supplied age", () => {
     const state = createGame({
       scenarioId: CUSTOM_SCENARIO_ID,

--- a/src/reducers/EventLog.test.tsx
+++ b/src/reducers/EventLog.test.tsx
@@ -71,8 +71,8 @@ describe("the event log", () => {
       (e: GameEventType) => e.kind === "BLACKOUT_OVER",
     );
     expect(over).toBeDefined();
-    expect(over?.message).toMatch(/unserved/);
-    // Something was actually unserved, rather than the sentence being drawn around a zero
+    expect(over?.message).toMatch(/could not supply/);
+    // Some demand was actually unmet, rather than the sentence being drawn around a zero
     expect(over?.message).not.toMatch(/\b0Wh\b/);
   });
 

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -33,7 +33,7 @@ import {
   formatWatts,
   formatWattHours,
 } from "../helpers/Format";
-import { arrayMove, newSeed } from "../helpers/Math";
+import { arrayMove, newSeed, roundToSignificantDigits } from "../helpers/Math";
 import { computeScoreBreakdown, totalScore } from "../helpers/Scoring";
 import { formatLargeMass } from "../helpers/Units";
 import { buildStartedMessage } from "../helpers/BuildConsequences";
@@ -765,6 +765,21 @@ export const gameSlice = createSlice({
         // Age is scenario metadata rather than a catalog property, so exclude it from the exact
         // technology match and pass it to the completed operating asset separately.
         const { initialAgeYears = 0, label, ...facilitySearch } = search;
+        // Scenario research may carry more precision than is useful to a player. Resolve the
+        // catalog quote from the rounded size so its costs and technology-derived fields agree
+        // with the two-significant-digit nameplate the operating facility receives.
+        if (facilitySearch.peakW !== undefined) {
+          facilitySearch.peakW = roundToSignificantDigits(
+            facilitySearch.peakW,
+            2,
+          );
+        }
+        if (facilitySearch.peakWh !== undefined) {
+          facilitySearch.peakWh = roundToSignificantDigits(
+            facilitySearch.peakWh,
+            2,
+          );
+        }
         const generator = GENERATORS(
           state,
           facilitySearch.peakW || 1000000,

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -2421,12 +2421,18 @@ function reforecastSupply(
   // of remaining online with the cost of the next start. Keeping this as two linear passes avoids
   // recursively re-simulating the fleet for every plant on every tick.
   const baseline = supplyForecastPass(state, true, true, stepMinutes);
+  // Recorded ticks can be Immer drafts when this is called from a reducer. Commitment metadata
+  // is deliberately attached with Object.defineProperty, which Immer forbids on a draft; the
+  // optimizer only reads from the current tick onwards anyway, so leave the recorded past alone.
+  const futureBaseline = baseline.slice(
+    forecastIndexAt(state, state.date.minute),
+  );
   state.facilities.forEach((facility) => {
     const generator = facility as GeneratorOperatingType;
     if (!facility.peakWh && (generator.minimumStableOutput || 0) > 0) {
       prepareGeneratorCommitment({
         facilityId: facility.id,
-        forecast: baseline,
+        forecast: futureBaseline,
         minimumOperatingCost: (futureTick) =>
           minimumStableOperatingCost(state, generator, futureTick, stepMinutes),
       });

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -299,7 +299,7 @@ function logFuelPriceMoves(
     logGameEvent(
       state,
       "FUEL_PRICE",
-      `${fuel} ${change > 0 ? "up" : "down"} ${Math.round(Math.abs(change) * 100)}% to ${formatMoneyConcise(prices[fuel])}/MBTU`,
+      `${fuel} ${change > 0 ? "up" : "down"} ${Math.round(Math.abs(change) * 100)}% to ${formatMoneyConcise(prices[fuel])}/MMBtu`,
     );
   });
 }
@@ -1279,7 +1279,7 @@ export function tickState(state: GameType) {
         logGameEvent(
           state,
           "BLACKOUT_OVER",
-          `Blackout over after ${blackoutLength(state.date.minute - blackoutStartMinute)} - ${formatWattHours(blackoutUnservedWh)} unserved`,
+          `Blackout ended after ${blackoutLength(state.date.minute - blackoutStartMinute)}. The grid could not supply ${formatWattHours(blackoutUnservedWh)} of electricity demand.`,
         );
       }
       const message = inBlackout
@@ -1452,7 +1452,7 @@ export function tickState(state: GameType) {
                 outcome: "fired",
                 title: "Fired!",
                 reason:
-                  "You've allowed chronic blackouts for 3 months, causing the utility board to remove you from office.",
+                  "Blackouts continued for 3 months, so the utility board ended your term.",
               } as const)
             : objectiveFailure
               ? ({
@@ -1473,7 +1473,7 @@ export function tickState(state: GameType) {
           }
                 You survived for ${yearsSurvived} years,
                 earned ${formatMoneyConcise(summary.revenue)} in revenue
-                and emitted ${formatLargeMass(summary.kgco2e, getStore().getState().settings.units)} of pollution.`;
+                and emitted ${formatLargeMass(summary.kgco2e, getStore().getState().settings.units)} of greenhouse gases, measured as CO2e.`;
 
         // Tutorials are intentionally unscored even when completed, so retain their guided
         // failure dialog rather than putting one tutorial attempt on the global leaderboard.

--- a/src/reducers/ReprioritizeFacility.test.tsx
+++ b/src/reducers/ReprioritizeFacility.test.tsx
@@ -1,0 +1,22 @@
+import cloneDeep from "lodash.clonedeep";
+import gameReducer, { reprioritizeFacility, tickState } from "./Game";
+import { createGame } from "../testing/Simulator";
+
+describe("reprioritizeFacility", () => {
+  it("reorders after recorded ticks have entered the forecast timeline", () => {
+    let state = createGame({ scenarioId: 106 });
+    tickState(state);
+    state = cloneDeep(state);
+    const before = state.facilities.map((facility) => facility.id);
+
+    const after = gameReducer(
+      state,
+      reprioritizeFacility({ spotInList: 0, delta: 1 }),
+    );
+
+    expect(after.facilities.map((facility) => facility.id)).toEqual([
+      before[1],
+      before[0],
+    ]);
+  });
+});

--- a/src/reducers/Tutorial.test.tsx
+++ b/src/reducers/Tutorial.test.tsx
@@ -267,9 +267,9 @@ describe("tutorialGateMiddleware", () => {
     expect(store.getState().ui.dialog).toEqual(
       expect.objectContaining({
         open: true,
-        title: "Capstone needs another try",
+        title: "Final challenge needs another try",
         message: "Construction finished after the forecast peak.",
-        actionLabel: "Retry capstone",
+        actionLabel: "Retry final challenge",
         secondaryLabel: "Exit tutorial",
       }),
     );

--- a/src/reducers/Tutorial.tsx
+++ b/src/reducers/Tutorial.tsx
@@ -175,14 +175,14 @@ export const tutorialGateMiddleware: Middleware =
           (api.dispatch as AppDispatch)(setSpeed("PAUSED"));
           api.dispatch(
             dialogOpen({
-              title: "Capstone needs another try",
+              title: "Final challenge needs another try",
               message: failureMessage,
               open: true,
               notCancellable: true,
               secondaryLabel: "Exit tutorial",
               secondaryAction: () =>
                 (api.dispatch as AppDispatch)(quit({ toScenarioList: true })),
-              actionLabel: "Retry capstone",
+              actionLabel: "Retry final challenge",
               action: () =>
                 restartTutorialAtStep(
                   api.dispatch as AppDispatch,


### PR DESCRIPTION
## Summary
- incorporate reviews from 10th-, 11th-, and 12th-grade teacher perspectives
- rewrite tutorials, scenarios, facilities, events, controls, charts, and supporting site copy for high-school learners
- correct or clarify grid concepts including MW vs. MWh, capacity factor, storage, MMBtu, reserves, emissions, and generator roles
- remove locations from the new scenario names while retaining their location metadata
- fix facility drag reordering after simulation time has advanced
- preserve short fuel-mix events such as the September 2035 eclipse in downsampled forecasts
- distinguish upcoming scenario events from event history and use concise forecast copy
- round every scenario starting-facility capacity to two significant digits, including generator MW and storage MWh
- keep manual introductions approachable while allowing later paragraphs to add technical depth

## Validation
- npm run check — 848 tests passed and all scenarios held every invariant
- npm run build
- live UI verification of facility dragging at fast speed