### PR TITLE
Fix resilience scenario forecast and shutdown edge cases

### DIFF
--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -198,6 +198,15 @@ describe("story effect composition", () => {
       ]),
     ).toThrow(/overlapping story carbon-fee/i);
   });
+
+  it("preserves a complete hydro-inflow cutoff when effects are combined", () => {
+    expect(
+      combineStoryEffects([
+        { effects: { hydroRunoffMultiplier: 0 } },
+        { effects: { hydroRunoffMultiplier: 0.5 } },
+      ]).hydroRunoffMultiplier,
+    ).toBe(0);
+  });
 });
 
 describe("The Shale Boom pilot arc", () => {
@@ -403,7 +412,7 @@ describe("generation and storage reliability scenarios", () => {
     expect(solarEclipseOutputMultiplier(effects, 690)).toBe(1);
   });
 
-  it("keeps the seeded nuclear trip hidden until it occurs", () => {
+  it("keeps the seeded nuclear trip hidden and targets a paused unit at onset", () => {
     const snapshot: StorySnapshotType = {
       ...EMPTY_SNAPSHOT,
       facilities: [
@@ -413,7 +422,8 @@ describe("generation and storage reliability scenarios", () => {
           fuel: "Uranium",
           ageYears: 22,
           peakW: 500_000_000,
-          operational: true,
+          // Pausing the reactor must not let it escape a mechanical shutdown and resume later.
+          operational: false,
         },
       ],
     };

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -1356,8 +1356,7 @@ const NUCLEAR_TRIP_ARC: StoryArcDefinitionType = {
       durationMonths: 48,
       describe: ({ snapshot }) => {
         const unit = snapshot.facilities.find(
-          (facility) =>
-            facility.name === "Grand Nuclear Unit" && facility.operational,
+          (facility) => facility.name === "Grand Nuclear Unit",
         );
         const facilityOutputMultipliersById = unit
           ? { [String(unit.id)]: 0 }
@@ -1623,8 +1622,8 @@ export function combineStoryEffects(
       effects.hydroRunoffMultiplier !== undefined
     ) {
       combined.hydroRunoffMultiplier =
-        (combined.hydroRunoffMultiplier || 1) *
-        (effects.hydroRunoffMultiplier || 1);
+        (combined.hydroRunoffMultiplier ?? 1) *
+        (effects.hydroRunoffMultiplier ?? 1);
     }
     if (effects.solarEclipse !== undefined) {
       if (combined.solarEclipse !== undefined) {

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1773,11 +1773,13 @@ function reforecastWeatherAndPrices(
       const forecast = {
         ...t,
         ...fuelPrices,
-        solarIrradianceWM2: getRawSolarIrradianceWM2(
-          date,
-          state.location,
-          weather.CLOUD_PCT,
-        ),
+        // Keep the forecast weather series aligned with dispatch. An eclipse physically reduces
+        // the irradiance available to solar generators, so recording the effective irradiance
+        // here lets renewable-output charts and build estimates show the same known event without
+        // applying the loss a second time in the supply pass.
+        solarIrradianceWM2:
+          getRawSolarIrradianceWM2(date, state.location, weather.CLOUD_PCT) *
+          solarEclipseOutputMultiplier(effects, date.minuteOfDay),
         windKph: OUTSKIRTS_WIND_MULTIPLIER * weather.WIND_KPH,
         windAirborneKph: getAirborneWindReferenceKph(weather.WIND_KPH),
         temperatureC: weather.TEMP_C + (effects.temperatureOffsetC || 0),
@@ -1961,15 +1963,8 @@ function updateSupplyFacilitiesFinances(
       : 1;
     const facilityOutputMultiplier =
       tickStoryEffects.facilityOutputMultipliersById?.[String(g.id)] ?? 1;
-    const solarEclipseMultiplier =
-      generatorFuel === "Sun"
-        ? solarEclipseOutputMultiplier(tickStoryEffects, tickDate.minuteOfDay)
-        : 1;
     const availablePeakW =
-      g.peakW *
-      fuelOutputMultiplier *
-      facilityOutputMultiplier *
-      solarEclipseMultiplier;
+      g.peakW * fuelOutputMultiplier * facilityOutputMultiplier;
     let dispatchPeakW = availablePeakW;
     const outputFactor = facilityOutputFactor(g, now.minute);
     let mandatedW = 0;

--- a/src/reducers/StoryEffects.test.tsx
+++ b/src/reducers/StoryEffects.test.tsx
@@ -108,6 +108,43 @@ describe("story effects in dispatch", () => {
     expect(story.demandW / baseline.demandW).toBeCloseTo(1.06, 6);
   });
 
+  it("records a known eclipse in forecast irradiance and applies it once to supply", () => {
+    const game = createGame({ scenarioId: 109, difficulty: "Manager" });
+    game.date = getDateFromMinute(32 * MINUTES_PER_MONTH, game.startingYear);
+    const solar = game.facilities.find((facility) => facility.fuel === "Sun")!;
+    game.facilities = [solar];
+    const baselineGame = cloneDeep(game);
+    baselineGame.storyEffectsDisabled = true;
+
+    const story = generateNewTimeline(
+      game,
+      1_000_000_000,
+      20_000_000,
+      TICKS_PER_DAY,
+    );
+    const baseline = generateNewTimeline(
+      baselineGame,
+      1_000_000_000,
+      20_000_000,
+      TICKS_PER_DAY,
+    );
+    const totalityIndex = story.findIndex(
+      (tick) =>
+        getDateFromMinute(tick.minute, game.startingYear).minuteOfDay === 600,
+    );
+
+    expect(totalityIndex).toBeGreaterThanOrEqual(0);
+    expect(baseline[totalityIndex].solarIrradianceWM2).toBeGreaterThan(0);
+    expect(
+      story[totalityIndex].solarIrradianceWM2 /
+        baseline[totalityIndex].solarIrradianceWM2,
+    ).toBeCloseTo(0.08, 6);
+    expect(
+      story[totalityIndex].supplyByFuel.Sun! /
+        baseline[totalityIndex].supplyByFuel.Sun!,
+    ).toBeCloseTo(0.08, 6);
+  });
+
   it("pauses exactly once at freeze onset and logs the authored price change once", () => {
     const game = createGame({
       scenarioId: 103,


### PR DESCRIPTION
Fixes three issues found while reviewing the latest 20 commits to master: known eclipse losses now appear in forecast irradiance and renewable-output estimates without being applied twice during dispatch; the hidden nuclear shutdown targets the authored unit even when it is paused at onset; and composed story effects preserve a valid zero hydro-runoff multiplier. Adds focused regression coverage. Verification: npm run check; npm run build; focused simulations for scenarios 109 and 110; Playwright completed all 9 cases with 5 passed and 4 expected project skips, then required manual termination after the Windows dev-server teardown hung.