### PR TITLE
Simplify build decisions and tutorial guidance

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -36,6 +36,18 @@ export default defineConfig({
         viewport: { width: 320, height: 568 },
       },
     },
+    {
+      name: "tablet-768px",
+      use: {
+        browserName: "chromium",
+        hasTouch: true,
+        viewport: { width: 768, height: 1024 },
+      },
+    },
+    {
+      name: "desktop-1440px",
+      use: { browserName: "chromium", viewport: { width: 1440, height: 900 } },
+    },
   ],
   webServer: {
     command: "npm start",

--- a/e2e/tutorial-capstone.spec.ts
+++ b/e2e/tutorial-capstone.spec.ts
@@ -14,6 +14,31 @@ test("guided objective reaches a retryable capstone and succeeds", async ({
   ).toBeVisible();
   await expect(page.getByText("Your goal: keep the lights on")).toBeVisible();
 
+  const expectObjectiveDocked = async () => {
+    const objective = page.locator(".tutorialHud");
+    const game = page.locator(".cardTransitions");
+    const [objectiveBox, gameBox] = await Promise.all([
+      objective.boundingBox(),
+      game.boundingBox(),
+    ]);
+    expect(objectiveBox).not.toBeNull();
+    expect(gameBox).not.toBeNull();
+    expect(objectiveBox!.y + objectiveBox!.height).toBeLessThanOrEqual(
+      gameBox!.y + 1,
+    );
+    expect(
+      await objective.evaluate(
+        (element) => element.scrollWidth <= element.clientWidth,
+      ),
+    ).toBe(true);
+  };
+  await expectObjectiveDocked();
+
+  if (testInfo.project.name === "desktop-1440px") {
+    await expect(page.locator(".desktop-layout")).toHaveCount(1);
+    await expect(page.locator(".pane-layout")).toHaveCount(0);
+  }
+
   await page.getByRole("button", { name: "Next" }).click();
   await expect(
     page.getByText(/supply line must stay at or above the demand line/i),
@@ -43,16 +68,11 @@ test("guided objective reaches a retryable capstone and succeeds", async ({
     page.getByText("Your turn: keep the lights on for a full day"),
   ).toBeVisible();
 
-  // Remove firm capacity so the first attempt demonstrates consequence feedback and retry.
-  if (testInfo.project.name === "mobile-320px") {
-    await page.getByRole("button", { name: "Collapse objective" }).click();
-  }
+  // Remove firm capacity so the first attempt demonstrates consequence feedback and retry. The
+  // expanded objective is docked outside the game surface, so the same control remains operable at
+  // every viewport without a small-screen workaround.
   const naturalGas = page.locator(".facilityRow", { hasText: "Natural Gas" });
-  if (testInfo.project.name === "mobile-320px") {
-    await naturalGas.click({ position: { x: 12, y: 12 } });
-  } else {
-    await naturalGas.click();
-  }
+  await naturalGas.click();
   await page.getByRole("button", { name: "Pause Natural Gas" }).click();
   await page.getByRole("button", { name: "fast speed" }).click();
   await expect(

--- a/src/app.scss
+++ b/src/app.scss
@@ -295,9 +295,17 @@ button,
 }
 
 .app_container {
-  &,
-  & > div:first-child {
-    height: 100%;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
+  width: 100%;
+
+  // TransitionGroup renders this wrapper around the active card. Keep it in the flexible row so
+  // game chrome such as the tutorial objective can reserve space without covering the card.
+  & > .cardTransitions {
+    position: relative;
+    grid-row: 2;
+    min-height: 0;
     width: 100%;
   }
 }
@@ -914,6 +922,13 @@ $pane_header_height: 40px;
   padding: 0 16px 12px;
 }
 
+.generatorBuildSubtitle {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
 .generatorComparison {
   padding: 8px 16px 10px;
   border-bottom: 1px solid var(--border-selected);
@@ -957,6 +972,39 @@ $pane_header_height: 40px;
   .decisionImpactFacts,
   .generatorComparisonChoices {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .build-list-item .MuiCardHeader-root {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+
+    .MuiCardHeader-content {
+      min-width: 0;
+    }
+
+    .MuiCardHeader-action {
+      grid-row: 2;
+      grid-column: 1 / -1;
+      width: 100%;
+      margin: 8px 0 0 !important;
+
+      & > span,
+      .MuiStack-root {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+    }
+  }
+
+  .tutorialHudContent .tutorialPrompt {
+    grid-template-columns: minmax(0, 1fr);
+
+    .tutorialPromptAction {
+      grid-column: auto;
+    }
   }
 }
 
@@ -2365,29 +2413,29 @@ html[data-theme="dark"] .uplot {
   }
 }
 
-// A mission objective is game chrome, not a modal: it stays out of the bottom navigation,
-// leaves the whole grid interactive and collapses to one progress-marked concept.
+// A mission objective is game chrome, not a modal. It occupies its own row above the active card,
+// so its instructions never cover the control they name and the whole grid remains interactive.
 .tutorialHud {
-  position: fixed;
+  position: relative;
+  grid-row: 1;
   z-index: 1250;
-  right: max(8px, env(safe-area-inset-right));
-  bottom: calc(56px + env(safe-area-inset-bottom) + 8px);
-  left: max(8px, env(safe-area-inset-left));
   box-sizing: border-box;
-  max-height: calc(100vh - 80px - env(safe-area-inset-bottom));
+  width: 100%;
+  max-height: min(42vh, 360px);
   overflow: auto;
-  padding: 8px 10px;
-  border: 1px solid var(--tooltip-border);
-  border-radius: 12px;
+  padding: calc(6px + env(safe-area-inset-top))
+    max(10px, env(safe-area-inset-right)) 6px
+    max(10px, env(safe-area-inset-left));
+  border-bottom: 1px solid var(--tooltip-border);
   background: var(--tooltip-bg);
-  box-shadow: 0 8px 24px var(--tooltip-shadow);
+  box-shadow: 0 3px 12px var(--tooltip-shadow);
   color: $font_color_primary;
   backdrop-filter: blur(10px);
 }
 
 .tutorialHud-collapsed {
-  left: auto;
-  width: min(230px, calc(100vw - 16px));
+  width: 100%;
+  max-height: none;
   overflow: hidden;
 }
 
@@ -2446,9 +2494,14 @@ html[data-theme="dark"] .uplot {
 }
 
 .tutorialHudContent {
+  min-width: 0;
   margin-top: 6px;
+  overflow-wrap: anywhere;
 
   .tutorialPrompt {
+    display: grid !important;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
     gap: 4px !important;
   }
 
@@ -2459,6 +2512,7 @@ html[data-theme="dark"] .uplot {
   }
 
   .tutorialPromptAction {
+    grid-column: 1 / -1;
     margin-top: 2px;
   }
 }
@@ -2528,18 +2582,34 @@ html[data-theme="dark"] .uplot {
   }
 }
 
-@media screen and (min-width: $desktop_breakpoint) {
-  .tutorialHud {
-    top: calc(82px + env(safe-area-inset-top));
-    right: max(16px, env(safe-area-inset-right));
-    bottom: auto;
-    left: auto;
-    width: min(360px, calc(100vw - 32px));
-    max-height: calc(100vh - 98px - env(safe-area-inset-top));
+@media screen and (min-width: 700px) {
+  .tutorialHud-expanded {
+    display: grid;
+    grid-template-areas:
+      "header content footer"
+      "hint hint hint";
+    grid-template-columns: minmax(160px, 0.4fr) minmax(0, 1.6fr) auto;
+    align-items: center;
+    column-gap: 16px;
+    padding-top: calc(6px + env(safe-area-inset-top));
   }
 
-  .tutorialHud-collapsed {
-    width: 230px;
+  .tutorialHudHeader {
+    grid-area: header;
+  }
+
+  .tutorialHudContent {
+    grid-area: content;
+    margin-top: 0;
+  }
+
+  .tutorialHudHint {
+    grid-area: hint;
+  }
+
+  .tutorialHudFooter {
+    grid-area: footer;
+    margin-top: 0;
   }
 }
 
@@ -2574,7 +2644,7 @@ $sizemap: (
 
   .app_container {
     position: relative;
-    display: block;
+    display: grid;
     width: 100%;
     height: 100%;
     max-width: 100%;

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -513,6 +513,7 @@ export default class Compositor extends React.Component<Props, {}> {
       <div className="app_container">
         <GlobalHotKeys keyMap={keyMap} handlers={shortcutHandlers} />
         <TransitionGroup
+          className="cardTransitions"
           childFactory={(child) =>
             // @types/react 19 defaults ReactElement's props to unknown rather than any,
             // so the element has to be named before cloneElement will accept classNames

--- a/src/components/views/BuildGenerators.test.tsx
+++ b/src/components/views/BuildGenerators.test.tsx
@@ -1,12 +1,18 @@
 import * as React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { GENERATORS } from "../../data/Facilities";
 import { createGame } from "../../testing/Simulator";
 import BuildGenerators, { GeneratorBuildItem } from "./BuildGenerators";
 
 jest.mock("../base/ManualLink", () => () => null);
 
-it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
+it("shows natural-gas base, per-start, and daily-start estimated O&M", async () => {
   const game = createGame({ scenarioId: 104, difficulty: "CEO" });
   const generator = GENERATORS(game, 419000000, [], []).find(
     (candidate) => candidate.name === "Natural Gas",
@@ -25,8 +31,10 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
     />,
   );
 
-  expect(screen.getByText("Est. operations & maintenance")).toBeInTheDocument();
-  expect(screen.getByText("$13.4M/yr")).toBeInTheDocument();
+  expect(
+    screen.queryByText("Est. operations & maintenance"),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByText("$13.4M/yr")).not.toBeInTheDocument();
   expect(screen.queryByText("Flexible power")).toBeNull();
   expect(screen.getByText(/typical output/)).toBeInTheDocument();
   fireEvent.click(
@@ -57,6 +65,52 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", () => {
   expect(impact).toHaveTextContent("Cash purchase");
   expect(impact).toHaveTextContent("Online in");
   expect(impact).toHaveTextContent("Estimated average output");
+  expect(impact).not.toHaveTextContent("Loan:");
+  expect(
+    screen.queryByRole("table", { name: "Financing terms" }),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByText("Cash cost")).not.toBeInTheDocument();
+  expect(screen.queryByText("Time to build")).not.toBeInTheDocument();
+
+  const showFinancing = screen.getByRole("button", {
+    name: "Show financing terms",
+  });
+  expect(showFinancing).toHaveAttribute("aria-expanded", "false");
+  fireEvent.click(showFinancing);
+
+  const financingTerms = screen.getByRole("table", {
+    name: "Financing terms",
+  });
+  expect(
+    screen.getByRole("row", { name: /Downpayment \$[\d.]+[kMB]?/ }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("row", { name: /Interest rate.*\d+\.\d+%/ }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("row", { name: /Monthly payments \$[\d.]+[kMB]?\/mo/ }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("row", {
+      name: /Loan duration Construction \+ \d+ years/,
+    }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Hide financing terms" }),
+  ).toHaveAttribute("aria-expanded", "true");
+  expect(financingTerms).not.toHaveTextContent("Cash cost");
+  expect(financingTerms).not.toHaveTextContent("Time to build");
+
+  fireEvent.click(
+    within(screen.getByRole("dialog")).getByRole("button", { name: "close" }),
+  );
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  fireEvent.click(
+    screen.getByRole("button", { name: "Review purchase of Natural Gas" }),
+  );
+  expect(
+    screen.getByRole("button", { name: "Show financing terms" }),
+  ).toHaveAttribute("aria-expanded", "false");
 });
 
 it("shows Coal's physical and representative-day start charges", () => {
@@ -110,8 +164,10 @@ it("shows Oil's fixed, variable, and expected-output O&M", () => {
     />,
   );
 
-  expect(screen.getByText("Est. operations & maintenance")).toBeInTheDocument();
-  expect(screen.getByText("$7.59M/yr")).toBeInTheDocument();
+  expect(
+    screen.queryByText("Est. operations & maintenance"),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByText("$7.59M/yr")).not.toBeInTheDocument();
   fireEvent.click(screen.getByRole("button", { name: "Show Oil details" }));
 
   expect(
@@ -130,6 +186,68 @@ it("shows Oil's fixed, variable, and expected-output O&M", () => {
     }),
   ).toBeInTheDocument();
   expect(screen.queryByText("Non-fuel start cost")).toBeNull();
+});
+
+it("keeps primary generator metrics visible and discloses secondary details", () => {
+  const game = createGame({ scenarioId: 104, difficulty: "CEO" });
+  const generator = GENERATORS(game, 419000000, [], []).find(
+    (candidate) => candidate.name === "Natural Gas",
+  )!;
+
+  render(
+    <GeneratorBuildItem
+      cash={1000000000}
+      date={game.date}
+      interestRate={game.interestRate}
+      generator={generator}
+      location={game.location}
+      seed={game.seed}
+      forecastGapW={generator.peakW}
+      advantages={["Fastest online", "Lowest lifetime cost"]}
+      onBuild={jest.fn()}
+    />,
+  );
+
+  expect(screen.getByText("Natural Gas")).toBeInTheDocument();
+  expect(screen.getByText(/typical output/)).toBeInTheDocument();
+  expect(screen.getByText(/largest forecast shortage/)).toBeInTheDocument();
+  expect(screen.getByText("Build cost")).toBeInTheDocument();
+  expect(screen.getByText("Build time")).toBeInTheDocument();
+  expect(screen.queryByText("Fastest online")).not.toBeInTheDocument();
+  expect(screen.queryByText("Lifetime cost / MWh")).not.toBeInTheDocument();
+  expect(screen.queryByText("Emissions")).not.toBeInTheDocument();
+
+  fireEvent.click(
+    screen.getByRole("button", { name: "Show Natural Gas details" }),
+  );
+
+  expect(
+    screen.getByRole("group", { name: "Generator advantages" }),
+  ).toHaveTextContent("Fastest online");
+  expect(screen.getByText("Estimated lifetime cost per MWh")).toBeVisible();
+  expect(screen.getByText("Direct greenhouse gas emissions")).toBeVisible();
+});
+
+it("keeps the active lifetime-cost sort metric visible on collapsed cards", () => {
+  const game = createGame({ scenarioId: 104, difficulty: "CEO" });
+  const generator = GENERATORS(game, 419000000, [], []).find(
+    (candidate) => candidate.name === "Natural Gas",
+  )!;
+
+  render(
+    <GeneratorBuildItem
+      cash={1000000000}
+      date={game.date}
+      interestRate={game.interestRate}
+      generator={generator}
+      location={game.location}
+      seed={game.seed}
+      secondaryMetric="lcWh"
+      onBuild={jest.fn()}
+    />,
+  );
+
+  expect(screen.getByText("Lifetime cost / MWh")).toBeVisible();
 });
 
 it("submits a generator purchase only once on a double-click", () => {

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -89,6 +89,8 @@ export function GeneratorBuildItem(
   );
   const [expanded, setExpanded] = React.useState(false);
   const [open, setOpen] = React.useState(false);
+  const [financingExpanded, setFinancingExpanded] = React.useState(false);
+  const financingTermsId = React.useId();
   const purchaseSubmitted = React.useRef(false);
   const downpayment = DOWNPAYMENT_PERCENT * props.generator.buildCost;
   const loanAmount = props.generator.buildCost - downpayment;
@@ -128,12 +130,11 @@ export function GeneratorBuildItem(
   };
 
   const toggleOpen = (e: React.SyntheticEvent) => {
-    setOpen((wasOpen: boolean) => {
-      if (!wasOpen) {
-        purchaseSubmitted.current = false;
-      }
-      return !wasOpen;
-    });
+    if (!open) {
+      purchaseSubmitted.current = false;
+      setFinancingExpanded(false);
+    }
+    setOpen(!open);
     e.stopPropagation();
   };
 
@@ -192,7 +193,17 @@ export function GeneratorBuildItem(
           </Stack>
         }
         title={generator.name}
-        subheader={buildSubtitle}
+        subheader={
+          <span
+            className={
+              buildable && financingGap === 0
+                ? "generatorBuildSubtitle"
+                : undefined
+            }
+          >
+            {buildSubtitle}
+          </span>
+        }
       />
       <Box className="generatorDecisionLead">
         <Stack
@@ -213,9 +224,6 @@ export function GeneratorBuildItem(
               label={`~${gapCoverage}% of largest forecast shortage`}
             />
           )}
-          {(props.advantages || []).map((advantage) => (
-            <Chip key={advantage} size="small" label={advantage} />
-          ))}
         </Stack>
       </Box>
       <Box
@@ -235,22 +243,12 @@ export function GeneratorBuildItem(
           label="Build time"
           value={`${Math.round(generator.yearsToBuild * 12)} mo`}
         />
-        <GeneratorMetric
-          label="Est. operations & maintenance"
-          value={`${formatMoneyConcise(estimatedAnnualOperatingCost(generator))}/yr`}
-        />
-        <GeneratorMetric
-          label="Lifetime cost / MWh"
-          value={`${fuelPrices[generator.fuel] ? "~" : ""}${formatMoneyConcise(generator.lcWh * 1000000)}/MWh`}
-        />
-        <GeneratorMetric
-          label="Emissions"
-          value={
-            kgCO2ePerMWh > 0
-              ? `${formatMass(kgCO2ePerMWh, units)}/MWh`
-              : "No direct emissions modeled"
-          }
-        />
+        {props.secondaryMetric === "lcWh" && (
+          <GeneratorMetric
+            label="Lifetime cost / MWh"
+            value={`${fuelPrices[generator.fuel] ? "~" : ""}${formatMoneyConcise(generator.lcWh * 1000000)}/MWh`}
+          />
+        )}
       </Box>
       <Button
         color="primary"
@@ -268,6 +266,22 @@ export function GeneratorBuildItem(
       </Button>
 
       <Collapse in={expanded} timeout="auto" unmountOnExit>
+        {(props.advantages || []).length > 0 && (
+          <Box sx={{ px: 2, pb: 1 }}>
+            <Stack
+              direction="row"
+              spacing={0.75}
+              useFlexGap
+              sx={{ flexWrap: "wrap" }}
+              role="group"
+              aria-label="Generator advantages"
+            >
+              {(props.advantages || []).map((advantage) => (
+                <Chip key={advantage} size="small" label={advantage} />
+              ))}
+            </Stack>
+          </Box>
+        )}
         <TableContainer>
           <Table size="small" aria-label="generator properties">
             <TableBody>
@@ -290,21 +304,6 @@ export function GeneratorBuildItem(
                   </TableCell>
                 </TableRow>
               )}
-              <TableRow>
-                <TableCell>
-                  Estimated average output
-                  <ManualLink
-                    entry={MANUAL_ENTRY.CAPACITY_FACTOR}
-                    label="capacity factor"
-                  />
-                  <Typography variant="body2" color="textSecondary">
-                    Across a year
-                  </Typography>
-                </TableCell>
-                <TableCell align="right">
-                  {formatWatts(generator.peakW * generator.capacityFactor)}
-                </TableCell>
-              </TableRow>
               {generator.minimumStableOutput !== undefined && (
                 <TableRow>
                   <TableCell>
@@ -442,14 +441,6 @@ export function GeneratorBuildItem(
               <ViableLocationsRow
                 remaining={generator.viableLocationsRemaining}
               />
-              {props.secondaryMetric !== "yearsToBuild" && (
-                <TableRow>
-                  <TableCell>Time to build</TableCell>
-                  <TableCell align="right">
-                    {Math.round(generator.yearsToBuild * 12)} mo
-                  </TableCell>
-                </TableRow>
-              )}
               <TableRow>
                 <TableCell>
                   Direct greenhouse gas emissions
@@ -491,7 +482,6 @@ export function GeneratorBuildItem(
                 concept: "money",
                 label: "Cash purchase",
                 value: `${formatMoneyConcise(cash)} → ${formatMoneyConcise(cash - generator.buildCost)}`,
-                detail: `Loan: ${formatMoneyConcise(cash)} → ${formatMoneyConcise(cash - downpayment)}, then ${formatMoneyConcise(monthlyPayment)}/mo`,
               },
               {
                 concept: "time",
@@ -518,57 +508,59 @@ export function GeneratorBuildItem(
               },
             ]}
           />
-          <TableContainer>
-            <Table size="small">
-              <TableBody>
-                <TableRow>
-                  <TableCell>Time to build</TableCell>
-                  <TableCell align="right">
-                    {Math.round(generator.yearsToBuild * 12)} mo
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>Cash cost</TableCell>
-                  <TableCell align="right">
-                    {formatMoneyConcise(generator.buildCost)}
-                  </TableCell>
-                </TableRow>
-                <TableRow className="bold">
-                  <TableCell colSpan={2}>Loan info</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>Downpayment</TableCell>
-                  <TableCell align="right">
-                    {formatMoneyConcise(downpayment)}
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>
-                    Interest rate
-                    <ManualLink
-                      entry={MANUAL_ENTRY.INTEREST_RATES}
-                      label="interest rate"
-                    />
-                  </TableCell>
-                  <TableCell align="right">
-                    {(props.interestRate * 100).toFixed(2)}%
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>Monthly payments</TableCell>
-                  <TableCell align="right">
-                    {formatMoneyConcise(monthlyPayment)}/mo
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>Loan duration</TableCell>
-                  <TableCell align="right">
-                    Construction + {LOAN_MONTHS / 12} years
-                  </TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </TableContainer>
+          <Button
+            color="primary"
+            size="small"
+            fullWidth
+            aria-expanded={financingExpanded}
+            aria-controls={financingTermsId}
+            endIcon={
+              financingExpanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />
+            }
+            onClick={() => setFinancingExpanded((value) => !value)}
+          >
+            {financingExpanded
+              ? "Hide financing terms"
+              : "Show financing terms"}
+          </Button>
+          <Collapse in={financingExpanded} timeout="auto" unmountOnExit>
+            <TableContainer id={financingTermsId}>
+              <Table size="small" aria-label="Financing terms">
+                <TableBody>
+                  <TableRow>
+                    <TableCell>Downpayment</TableCell>
+                    <TableCell align="right">
+                      {formatMoneyConcise(downpayment)}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>
+                      Interest rate
+                      <ManualLink
+                        entry={MANUAL_ENTRY.INTEREST_RATES}
+                        label="interest rate"
+                      />
+                    </TableCell>
+                    <TableCell align="right">
+                      {(props.interestRate * 100).toFixed(2)}%
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>Monthly payments</TableCell>
+                    <TableCell align="right">
+                      {formatMoneyConcise(monthlyPayment)}/mo
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>Loan duration</TableCell>
+                    <TableCell align="right">
+                      Construction + {LOAN_MONTHS / 12} years
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Collapse>
         </DialogContent>
         <DialogActions>
           <Button

--- a/src/components/views/BuildStorage.test.tsx
+++ b/src/components/views/BuildStorage.test.tsx
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { createGame } from "../../testing/Simulator";
 import { GameType } from "../../Types";
 import BuildStorage from "./BuildStorage";
@@ -121,4 +127,46 @@ it("submits a storage purchase only once on a double-click", () => {
   fireEvent.click(takeLoan);
 
   expect(onBuildStorage).toHaveBeenCalledTimes(1);
+});
+
+it("deduplicates storage purchase impact and discloses financing terms", async () => {
+  render(
+    <BuildStorage
+      game={game()}
+      onBuildStorage={jest.fn()}
+      onBack={jest.fn()}
+    />,
+  );
+
+  fireEvent.click(screen.getAllByRole("button", { name: /^\$/ })[0]);
+
+  const impact = screen.getByRole("region", { name: "Expected impact" });
+  expect(impact).toHaveTextContent("Cash purchase");
+  expect(impact).toHaveTextContent("Online in");
+  expect(impact).not.toHaveTextContent("Loan:");
+  expect(screen.queryByText("Cash cost")).not.toBeInTheDocument();
+  expect(screen.queryByText("Time to build")).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("table", { name: "Financing terms" }),
+  ).not.toBeInTheDocument();
+
+  const toggle = screen.getByRole("button", { name: "Show financing terms" });
+  expect(toggle).toHaveAttribute("aria-expanded", "false");
+  fireEvent.click(toggle);
+
+  expect(toggle).toHaveAttribute("aria-expanded", "true");
+  const terms = screen.getByRole("table", { name: "Financing terms" });
+  expect(terms).toHaveTextContent("Downpayment");
+  expect(terms).toHaveTextContent("Interest rate");
+  expect(terms).toHaveTextContent("Monthly payments");
+  expect(terms).toHaveTextContent("Loan duration");
+
+  fireEvent.click(
+    within(screen.getByRole("dialog")).getByRole("button", { name: "close" }),
+  );
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  fireEvent.click(screen.getAllByRole("button", { name: /^\$/ })[0]);
+  expect(
+    screen.getByRole("button", { name: "Show financing terms" }),
+  ).toHaveAttribute("aria-expanded", "false");
 });

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -52,6 +52,8 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
   const { storage, cash } = props;
   const [expanded, setExpanded] = React.useState(false);
   const [open, setOpen] = React.useState(false);
+  const [financingExpanded, setFinancingExpanded] = React.useState(false);
+  const financingTermsId = React.useId();
   const purchaseSubmitted = React.useRef(false);
   const downpayment = DOWNPAYMENT_PERCENT * props.storage.buildCost;
   const loanAmount = props.storage.buildCost - downpayment;
@@ -79,12 +81,11 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
   };
 
   const toggleOpen = (e: React.SyntheticEvent) => {
-    setOpen((wasOpen: boolean) => {
-      if (!wasOpen) {
-        purchaseSubmitted.current = false;
-      }
-      return !wasOpen;
-    });
+    if (!open) {
+      purchaseSubmitted.current = false;
+      setFinancingExpanded(false);
+    }
+    setOpen(!open);
     e.stopPropagation();
   };
 
@@ -208,7 +209,6 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
                 concept: "money",
                 label: "Cash purchase",
                 value: `${formatMoneyConcise(cash)} → ${formatMoneyConcise(cash - storage.buildCost)}`,
-                detail: `Loan: ${formatMoneyConcise(cash)} → ${formatMoneyConcise(cash - downpayment)}, then ${formatMoneyConcise(monthlyPayment)}/mo`,
               },
               {
                 concept: "time",
@@ -230,57 +230,59 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
               },
             ]}
           />
-          <TableContainer>
-            <Table size="small">
-              <TableBody>
-                <TableRow>
-                  <TableCell>Time to build</TableCell>
-                  <TableCell align="right">
-                    {Math.round(storage.yearsToBuild * 12)} mo
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>Cash cost</TableCell>
-                  <TableCell align="right">
-                    {formatMoneyConcise(storage.buildCost)}
-                  </TableCell>
-                </TableRow>
-                <TableRow className="bold">
-                  <TableCell colSpan={2}>Loan info</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>Downpayment</TableCell>
-                  <TableCell align="right">
-                    {formatMoneyConcise(downpayment)}
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>
-                    Interest rate
-                    <ManualLink
-                      entry={MANUAL_ENTRY.INTEREST_RATES}
-                      label="interest rate"
-                    />
-                  </TableCell>
-                  <TableCell align="right">
-                    {(props.interestRate * 100).toFixed(2)}%
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>Monthly payments</TableCell>
-                  <TableCell align="right">
-                    {formatMoneyConcise(monthlyPayment)}/mo
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>Loan duration</TableCell>
-                  <TableCell align="right">
-                    Construction + {LOAN_MONTHS / 12} years
-                  </TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </TableContainer>
+          <Button
+            color="primary"
+            size="small"
+            fullWidth
+            aria-expanded={financingExpanded}
+            aria-controls={financingTermsId}
+            endIcon={
+              financingExpanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />
+            }
+            onClick={() => setFinancingExpanded((value) => !value)}
+          >
+            {financingExpanded
+              ? "Hide financing terms"
+              : "Show financing terms"}
+          </Button>
+          <Collapse in={financingExpanded} timeout="auto" unmountOnExit>
+            <TableContainer id={financingTermsId}>
+              <Table size="small" aria-label="Financing terms">
+                <TableBody>
+                  <TableRow>
+                    <TableCell>Downpayment</TableCell>
+                    <TableCell align="right">
+                      {formatMoneyConcise(downpayment)}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>
+                      Interest rate
+                      <ManualLink
+                        entry={MANUAL_ENTRY.INTEREST_RATES}
+                        label="interest rate"
+                      />
+                    </TableCell>
+                    <TableCell align="right">
+                      {(props.interestRate * 100).toFixed(2)}%
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>Monthly payments</TableCell>
+                    <TableCell align="right">
+                      {formatMoneyConcise(monthlyPayment)}/mo
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell>Loan duration</TableCell>
+                    <TableCell align="right">
+                      Construction + {LOAN_MONTHS / 12} years
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Collapse>
         </DialogContent>
         <DialogActions>
           <Button

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -77,7 +77,7 @@ describe("tutorial mission metadata", () => {
     )!;
     render(generatorsMission.tutorialSteps![1].content);
 
-    expect(screen.getByText(/Compare construction cost/)).toHaveTextContent(
+    expect(screen.getByText(/Compare cost and build time/)).toHaveTextContent(
       "operations and maintenance (O&M)",
     );
   });

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -204,7 +204,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["money", "time", "fuel"]}
-            text="Compare construction cost and time, fuel, and operations and maintenance (O&M)—the cost of keeping a plant running."
+            text="Compare cost and build time. Open Show details for fuel and operations and maintenance (O&M)."
           />
         ),
       },


### PR DESCRIPTION
## Summary

Three independent design reviews covered mobile (390x844), tablet (768x1024), and desktop (1440x900). The reviewers unanimously selected these simplifications:

- make generator cards easier to scan by keeping primary decision metrics visible and moving secondary metrics into Show details
- remove repeated purchase information while keeping complete generator and storage financing terms behind an accessible disclosure
- dock tutorial objectives in reserved layout space so instructions never cover the controls they reference

The active cost-per-MWh sort metric remains visible on collapsed cards, critical affordability messages remain untruncated, and tutorial/economic behavior is unchanged.

## Verification

- `npm run check` (typecheck, lint, formatting, 853 tests, all simulation scenarios)
- `npm run test:e2e` (7 passed, 8 intentionally skipped across 320, 390, 768, 1280, and 1440 widths)
- `npm run build`
- manual responsive visual review of the tutorial dock, generator cards, and purchase dialog