### PR TITLE
Add world map location picker to custom games

### DIFF
--- a/e2e/custom-location-picker.spec.ts
+++ b/e2e/custom-location-picker.spec.ts
@@ -1,0 +1,259 @@
+import { expect, Page, test } from "@playwright/test";
+
+async function openCustomSetup(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem(
+      "plays",
+      JSON.stringify({
+        plays: [{ scenarioId: 0, date: new Date().toString() }],
+      }),
+    );
+  });
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: "Start playing", exact: true })
+    .click();
+  await page.getByRole("button", { name: "View Custom Game details" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Custom setup" }),
+  ).toBeVisible();
+}
+
+test("world map location picker works with pointer, touch, search, and keyboard", async ({
+  page,
+}, testInfo) => {
+  await openCustomSetup(page);
+
+  const search = page.getByRole("combobox", { name: "Search playable cities" });
+  const map = page.getByRole("group", { name: "Playable locations map" });
+  const selectedSanFrancisco = page.getByRole("button", {
+    name: "Select San Francisco, CA, United States",
+  });
+  await expect(search).toHaveValue("San Francisco, CA");
+  await expect(map).toBeVisible();
+  await expect(selectedSanFrancisco).toHaveAttribute("aria-pressed", "true");
+
+  const tabbableMapControls = await map
+    .locator(".worldMapMarker")
+    .evaluateAll(
+      (controls) => controls.filter((control) => control.tabIndex === 0).length,
+    );
+  expect(tabbableMapControls).toBe(1);
+
+  const startingSelection = await search.inputValue();
+  await map.locator(".worldMapMarker.cluster").first().click();
+  await expect(search).toHaveValue(startingSelection);
+  await expect(page.getByRole("button", { name: "Zoom out" })).toBeEnabled();
+  await page.getByRole("button", { name: "Show world" }).click();
+
+  await selectedSanFrancisco.focus();
+  await selectedSanFrancisco.press("ArrowLeft");
+  const focusedLabel = await page.evaluate(
+    () => document.activeElement?.getAttribute("aria-label") || "",
+  );
+  expect(focusedLabel).not.toBe("Select San Francisco, CA, United States");
+  await page.keyboard.press("Enter");
+  await expect(search).toHaveValue("Honolulu, HI");
+
+  await expect(page.locator(".locationPickerCount")).toHaveText(
+    /\d+ playable locations/,
+  );
+  await search.fill("Paris");
+  await page.getByRole("option", { name: "Paris, France" }).click();
+  await expect(search).toHaveValue("Paris, France");
+  await expect(
+    page.getByRole("button", { name: "Select Paris, France" }),
+  ).toHaveAttribute("aria-pressed", "true");
+
+  const overflow = await page
+    .locator(".scrollable")
+    .evaluate((element) =>
+      Math.max(0, element.scrollWidth - element.clientWidth),
+    );
+  expect(overflow).toBeLessThanOrEqual(1);
+  await expect(map).toHaveCSS("touch-action", "pan-y");
+
+  const mapBox = await map.boundingBox();
+  const searchBox = await search.boundingBox();
+  expect(mapBox).not.toBeNull();
+  expect(searchBox).not.toBeNull();
+  if (testInfo.project.name.startsWith("mobile")) {
+    expect(searchBox!.y).toBeLessThan(mapBox!.y);
+  }
+  if (
+    testInfo.project.name.startsWith("mobile") ||
+    testInfo.project.name.startsWith("tablet")
+  ) {
+    const target = await map.locator(".worldMapMarker").first().boundingBox();
+    expect(target).not.toBeNull();
+    expect(target!.width).toBeGreaterThanOrEqual(44);
+    expect(target!.height).toBeGreaterThanOrEqual(44);
+  } else if (testInfo.project.name.startsWith("desktop")) {
+    expect(Math.abs(searchBox!.y - mapBox!.y)).toBeLessThan(12);
+    expect(searchBox!.x).toBeGreaterThan(mapBox!.x);
+  }
+});
+
+test("keyboard navigation retains one map stop and honors activation and zoom bounds", async ({
+  page,
+}) => {
+  await openCustomSetup(page);
+
+  const search = page.getByRole("combobox", { name: "Search playable cities" });
+  const map = page.getByRole("group", { name: "Playable locations map" });
+  const sanFrancisco = page.getByRole("button", {
+    name: "Select San Francisco, CA, United States",
+  });
+  const honolulu = page.getByRole("button", {
+    name: "Select Honolulu, HI, United States",
+  });
+
+  await sanFrancisco.focus();
+  await sanFrancisco.press("ArrowLeft");
+  await expect(honolulu).toBeFocused();
+  await honolulu.press(" ");
+  await expect(search).toHaveValue("Honolulu, HI");
+  await expect(page.getByLabel("Selected location")).toContainText(
+    "Honolulu, HI",
+  );
+
+  await search.fill("San Francisco");
+  await page.getByRole("option", { name: "San Francisco, CA" }).click();
+  await page.getByRole("button", { name: "Show world" }).click();
+  await sanFrancisco.focus();
+  await sanFrancisco.press("ArrowLeft");
+  await expect(honolulu).toBeFocused();
+  await honolulu.press("Enter");
+  await expect(search).toHaveValue("Honolulu, HI");
+
+  const cluster = map.locator(".worldMapMarker.cluster").first();
+  await cluster.focus();
+  await cluster.press("Enter");
+  await expect(page.getByRole("button", { name: "Zoom out" })).toBeEnabled();
+  await expect(page.locator(":focus")).toHaveClass(/worldMapMarker/);
+
+  await page.locator(":focus").press("Home");
+  await expect(page.getByRole("button", { name: "Zoom out" })).toBeDisabled();
+  await expect(page.locator(":focus")).toHaveClass(/worldMapMarker/);
+  await expect(map.locator(".worldMapMarker[tabindex='0']")).toHaveCount(1);
+
+  await page.locator(":focus").press("Tab");
+  await expect(page.getByRole("button", { name: "Zoom in" })).toBeFocused();
+
+  const zoomIn = page.getByRole("button", { name: "Zoom in" });
+  const zoomOut = page.getByRole("button", { name: "Zoom out" });
+  await zoomIn.click();
+  await zoomIn.click();
+  await zoomIn.click();
+  await expect(zoomIn).toBeDisabled();
+  await zoomOut.click();
+  await zoomOut.click();
+  await zoomOut.click();
+  await expect(zoomOut).toBeDisabled();
+});
+
+test("pointer and touch interactions leave vertical scrolling available", async ({
+  page,
+}, testInfo) => {
+  await openCustomSetup(page);
+
+  const map = page.getByRole("group", { name: "Playable locations map" });
+  const search = page.getByRole("combobox", { name: "Search playable cities" });
+  const startingSelection = await search.inputValue();
+  const cluster = map.locator(".worldMapMarker.cluster").first();
+
+  if (testInfo.project.name.startsWith("desktop")) {
+    await cluster.hover();
+    await expect(search).toHaveValue(startingSelection);
+    await expect(cluster).toHaveCSS("cursor", "pointer");
+    return;
+  }
+
+  await map.scrollIntoViewIfNeeded();
+  const clusterBox = await cluster.boundingBox();
+  expect(clusterBox).not.toBeNull();
+  await page.touchscreen.tap(
+    clusterBox!.x + clusterBox!.width / 2,
+    clusterBox!.y + clusterBox!.height / 2,
+  );
+  await expect(page.getByRole("button", { name: "Zoom out" })).toBeEnabled();
+  await expect(search).toHaveValue(startingSelection);
+
+  await page.getByRole("button", { name: "Show world" }).click();
+  await map.scrollIntoViewIfNeeded();
+  const mapBox = await map.boundingBox();
+  expect(mapBox).not.toBeNull();
+  const scroller = page.locator(".scrollable");
+  const before = await scroller.evaluate((element) => element.scrollTop);
+  const session = await page.context().newCDPSession(page);
+  const x = Math.round(mapBox!.x + mapBox!.width / 2);
+  const startY = Math.round(mapBox!.y + mapBox!.height - 20);
+  const endY = Math.round(mapBox!.y + 20);
+  await session.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: [{ x, y: startY }],
+  });
+  await session.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [{ x, y: endY }],
+  });
+  await session.send("Input.dispatchTouchEvent", {
+    type: "touchEnd",
+    touchPoints: [],
+  });
+  await expect
+    .poll(() => scroller.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(before);
+});
+
+test("location constraints keep Play valid only where the starting fleet is viable", async ({
+  page,
+}) => {
+  await openCustomSetup(page);
+
+  const play = page.getByRole("button", { name: "Play", exact: true });
+  await expect(play).toBeEnabled();
+  await page.getByRole("combobox", { name: "Facility type" }).click();
+  await page.getByRole("option", { name: "Geothermal" }).click();
+  await page.getByRole("button", { name: "Add facility" }).click();
+  await expect(play).toBeEnabled();
+
+  const search = page.getByRole("combobox", { name: "Search playable cities" });
+  await search.fill("Paris");
+  await page.getByRole("option", { name: "Paris, France" }).click();
+  await expect(play).toBeDisabled();
+
+  await search.fill("San Francisco");
+  await page.getByRole("option", { name: "San Francisco, CA" }).click();
+  await expect(play).toBeEnabled();
+});
+
+test("dark theme and reduced motion keep the map legible and still", async ({
+  page,
+}) => {
+  await page.emulateMedia({ colorScheme: "dark", reducedMotion: "reduce" });
+  await openCustomSetup(page);
+
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  const map = page.getByRole("group", { name: "Playable locations map" });
+  const marker = map.locator(".worldMapMarker").first();
+  await expect(map).toBeVisible();
+  await expect(marker).toBeVisible();
+  await expect(marker).toHaveCSS("transition-duration", "0s");
+  const colors = await map.evaluate((element) => {
+    const land = element.querySelector<SVGPathElement>(
+      ".worldMapContinents path",
+    );
+    const mapStyle = getComputedStyle(element);
+    const landStyle = land && getComputedStyle(land);
+    return {
+      background: mapStyle.backgroundColor,
+      land: landStyle?.fill || "",
+      border: mapStyle.borderColor,
+    };
+  });
+  expect(colors.background).not.toBe("rgba(0, 0, 0, 0)");
+  expect(colors.land).not.toBe(colors.background);
+  expect(colors.border).not.toBe(colors.background);
+});

--- a/e2e/responsive-320.spec.ts
+++ b/e2e/responsive-320.spec.ts
@@ -22,7 +22,9 @@ test("custom setup and settings stay usable on a 320px phone", async ({
   await expect(
     page.getByRole("heading", { name: "Custom setup" }),
   ).toBeVisible();
-  await expect(page.getByRole("combobox", { name: "Location" })).toBeVisible();
+  await expect(
+    page.getByRole("combobox", { name: "Search playable cities" }),
+  ).toBeVisible();
   const setupOverflow = await page
     .locator("#gameSetupTable")
     .locator("..")

--- a/src/app.scss
+++ b/src/app.scss
@@ -1881,6 +1881,201 @@ html[data-theme="dark"] .uplot {
     }
   }
 
+  .locationPicker {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(220px, 1fr);
+    grid-template-areas:
+      "heading heading"
+      "map details";
+    gap: 12px 16px;
+    width: calc(100% - 32px);
+    max-width: 960px;
+    margin: 16px auto 8px;
+  }
+
+  .locationPickerHeading {
+    grid-area: heading;
+  }
+
+  .locationPickerDetails {
+    grid-area: details;
+    min-width: 0;
+  }
+
+  .locationPickerSelection {
+    margin-top: 12px;
+    padding: 10px 12px;
+    border: 1px solid var(--border-tile);
+    border-radius: 8px;
+    background: var(--bg-raised);
+
+    p {
+      font-weight: 600;
+    }
+  }
+
+  .locationPickerCount {
+    display: block;
+    margin-top: 8px;
+    color: $font_color_faded;
+  }
+
+  .worldMap {
+    position: relative;
+    grid-area: map;
+    width: 100%;
+    max-width: 820px;
+    aspect-ratio: 2 / 1;
+    overflow: hidden;
+    border: 1px solid var(--border-tile);
+    border-radius: 8px;
+    background: var(--bg-sunken);
+    touch-action: pan-y;
+  }
+
+  .worldMapLand,
+  .worldMapMarkers {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .worldMapGrid {
+    fill: none;
+    stroke: var(--border-tile);
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .worldMapContinents {
+    fill: var(--bg-raised);
+    stroke: var(--border-strong);
+    stroke-width: 1.5;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .worldMapMarker {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    transform: translate(-50%, -50%);
+    border: 0;
+    border-radius: 50%;
+    color: #fff;
+    background: $interactive_blue;
+    box-shadow: 0 1px 3px var(--shadow-ring);
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 700;
+
+    &.marker {
+      width: 18px;
+      height: 18px;
+      border: 3px solid var(--bg-primary);
+    }
+
+    &.selected {
+      width: 28px;
+      height: 28px;
+      border: 4px solid var(--bg-primary);
+      box-shadow:
+        0 0 0 3px $interactive_blue,
+        0 2px 4px var(--shadow-ring);
+      z-index: 2;
+      font-size: 14px;
+    }
+  }
+
+  .worldMapControls {
+    position: absolute;
+    right: 8px;
+    bottom: 8px;
+    display: flex;
+    gap: 2px;
+    padding: 2px;
+    border: 1px solid var(--border-tile);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    box-shadow: 0 1px 4px var(--shadow-ring);
+    z-index: 3;
+  }
+
+  .visuallyHidden {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+  }
+
+  @media screen and (max-width: 699px) {
+    .locationPicker {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-areas:
+        "heading"
+        "details"
+        "map";
+      width: calc(100% - 24px);
+      margin-top: 12px;
+    }
+  }
+
+  @media screen and (max-width: 699px), (pointer: coarse) {
+    .worldMapMarker {
+      width: 44px;
+      height: 44px;
+
+      &.marker {
+        width: 44px;
+        height: 44px;
+        border-color: transparent;
+        background: transparent;
+        box-shadow: none;
+
+        &:after {
+          content: "";
+          width: 16px;
+          height: 16px;
+          border: 3px solid var(--bg-primary);
+          border-radius: 50%;
+          background: $interactive_blue;
+          box-shadow: 0 1px 3px var(--shadow-ring);
+        }
+      }
+
+      &.selected {
+        color: #fff;
+        border: 8px solid transparent;
+        background: $interactive_blue;
+        background-clip: padding-box;
+        box-shadow:
+          inset 0 0 0 2px var(--bg-primary),
+          0 0 0 3px $interactive_blue;
+
+        &:after {
+          display: none;
+        }
+      }
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .worldMapLand,
+    .worldMapMarker {
+      transition: none !important;
+    }
+  }
+
   .customFacilityPicker {
     display: flex;
     flex-wrap: wrap;

--- a/src/components/base/LocationPicker.test.tsx
+++ b/src/components/base/LocationPicker.test.tsx
@@ -1,0 +1,121 @@
+import * as React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CityType } from "../../data/Cities";
+import LocationPicker from "./LocationPicker";
+
+const cities: CityType[] = [
+  {
+    id: "west",
+    name: "West City",
+    lat: 35,
+    long: -120,
+    region: "North America",
+    country: "United States",
+  },
+  {
+    id: "east",
+    name: "East City",
+    lat: 40,
+    long: 80,
+    region: "East Asia",
+    country: "Exampleland",
+  },
+];
+
+it("exposes the selected city and one roving map stop", () => {
+  render(
+    <LocationPicker
+      locations={cities}
+      value={cities[0]}
+      onChange={jest.fn()}
+    />,
+  );
+
+  expect(
+    screen.getByRole("combobox", { name: "Search playable cities" }),
+  ).toHaveValue("West City");
+  expect(
+    screen.getByRole("button", { name: /Select West City/ }),
+  ).toHaveAttribute("aria-pressed", "true");
+  const locationControls = screen
+    .getAllByRole("button")
+    .filter((button) => button.classList.contains("worldMapMarker"));
+  expect(
+    locationControls.filter((button) => button.tabIndex === 0),
+  ).toHaveLength(1);
+});
+
+it("selects the same city from the map and searchable list", async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+  const { rerender } = render(
+    <LocationPicker locations={cities} value={cities[0]} onChange={onChange} />,
+  );
+
+  await user.click(screen.getByRole("button", { name: /Select East City/ }));
+  expect(onChange).toHaveBeenLastCalledWith(cities[1]);
+
+  rerender(
+    <LocationPicker locations={cities} value={cities[1]} onChange={onChange} />,
+  );
+  const search = screen.getByRole("combobox", {
+    name: "Search playable cities",
+  });
+  await user.click(search);
+  fireEvent.change(search, { target: { value: "West" } });
+  await user.click(await screen.findByRole("option", { name: "West City" }));
+  expect(onChange).toHaveBeenLastCalledWith(cities[0]);
+});
+
+it("supports arrow navigation, Enter and Space activation, and Home", () => {
+  const onChange = jest.fn();
+  render(
+    <LocationPicker locations={cities} value={cities[0]} onChange={onChange} />,
+  );
+  const west = screen.getByRole("button", { name: /Select West City/ });
+  const east = screen.getByRole("button", { name: /Select East City/ });
+  act(() => west.focus());
+  fireEvent.keyDown(west, { key: "ArrowRight" });
+  expect(east).toHaveFocus();
+  fireEvent.keyDown(east, { key: "Enter" });
+  expect(onChange).toHaveBeenCalledWith(cities[1]);
+  act(() => west.focus());
+  fireEvent.keyDown(west, { key: " " });
+  expect(onChange).toHaveBeenCalledWith(cities[0]);
+  fireEvent.keyDown(east, { key: "Home" });
+  expect(screen.getByText("Showing the whole world")).toBeInTheDocument();
+});
+
+it("drills into a cluster and lists unresolved cities at maximum zoom", async () => {
+  const user = userEvent.setup();
+  const closeCities: CityType[] = [
+    cities[0],
+    ...["one", "two", "three"].map((id) => ({
+      id,
+      name: `Close ${id}`,
+      lat: 40,
+      long: 80,
+      region: "East Asia",
+      country: "Exampleland",
+    })),
+  ];
+  const onChange = jest.fn();
+  render(
+    <LocationPicker
+      locations={closeCities}
+      value={closeCities[0]}
+      onChange={onChange}
+    />,
+  );
+
+  for (let level = 0; level < 4; level += 1) {
+    await user.click(
+      screen.getByRole("button", { name: /Zoom to 3 locations/ }),
+    );
+  }
+  await user.click(screen.getByRole("menuitem", { name: /Close two/ }));
+  expect(onChange).toHaveBeenCalledWith(
+    expect.objectContaining({ id: "two", name: "Close two" }),
+  );
+});

--- a/src/components/base/LocationPicker.tsx
+++ b/src/components/base/LocationPicker.tsx
@@ -1,0 +1,420 @@
+import * as React from "react";
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import ZoomOutIcon from "@mui/icons-material/ZoomOut";
+import PublicIcon from "@mui/icons-material/Public";
+import {
+  Autocomplete,
+  IconButton,
+  Menu,
+  MenuItem,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { CityType } from "../../data/Cities";
+import {
+  clampViewport,
+  clusterLocations,
+  directionalNeighbor,
+  MapControl,
+  MapDirection,
+  MapPoint,
+  MapViewport,
+  MAP_ZOOM_SCALES,
+  projectLocation,
+} from "../../helpers/WorldMap";
+
+interface Props {
+  locations: CityType[];
+  value?: CityType;
+  loading?: boolean;
+  onChange: (location: CityType) => void;
+}
+
+const WORLD_VIEW: MapViewport = { center: { x: 0.5, y: 0.5 }, zoom: 0 };
+const MAX_ZOOM = 3;
+
+function locationDetail(location: CityType): string {
+  return [location.admin, location.country, location.region]
+    .filter((part, index, all) => !!part && all.indexOf(part) === index)
+    .join(" · ");
+}
+
+function accessibleLocationName(location: CityType): string {
+  const country = location.country;
+  return country && !location.name.toLowerCase().includes(country.toLowerCase())
+    ? `${location.name}, ${country}`
+    : location.name;
+}
+
+function clusterArea(locations: CityType[]): string {
+  const regions = Array.from(
+    new Set(locations.map((location) => location.region)),
+  );
+  return regions.length === 1 ? regions[0] : "this area";
+}
+
+function nearestControl(
+  controls: MapControl<CityType>[],
+  point: MapPoint,
+): MapControl<CityType> | undefined {
+  return [...controls].sort(
+    (a, b) =>
+      Math.hypot(a.x - point.x, a.y - point.y) -
+        Math.hypot(b.x - point.x, b.y - point.y) || a.id.localeCompare(b.id),
+  )[0];
+}
+
+/** An offline, explicitly-controlled world map backed by the same city catalogue as search. */
+export default function LocationPicker({
+  locations,
+  value,
+  loading = false,
+  onChange,
+}: Props): React.JSX.Element {
+  const [viewport, setViewport] = React.useState<MapViewport>(WORLD_VIEW);
+  const [mapSize, setMapSize] = React.useState({ width: 600, height: 300 });
+  const [rovingId, setRovingId] = React.useState(
+    value ? `location-${value.id}` : "",
+  );
+  const [announcement, setAnnouncement] = React.useState("");
+  const [menuAnchor, setMenuAnchor] = React.useState<HTMLElement | null>(null);
+  const [menuLocations, setMenuLocations] = React.useState<CityType[]>([]);
+  const [focusAfterZoom, setFocusAfterZoom] = React.useState<MapPoint>();
+  const mapRef = React.useRef<HTMLDivElement>(null);
+  const controlRefs = React.useRef<Record<string, HTMLButtonElement | null>>(
+    {},
+  );
+
+  React.useLayoutEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const measure = () => {
+      const width = map.clientWidth;
+      if (width) setMapSize({ width, height: width / 2 });
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(map);
+    return () => observer.disconnect();
+  }, []);
+
+  const controls = React.useMemo(
+    () =>
+      clusterLocations(
+        locations,
+        viewport,
+        mapSize.width,
+        mapSize.height,
+        mapSize.width < 700 ? 44 : 32,
+        value?.id,
+      ),
+    [locations, viewport, mapSize, value?.id],
+  );
+
+  React.useEffect(() => {
+    if (controls.length === 0) return;
+    if (focusAfterZoom) {
+      const next = nearestControl(controls, focusAfterZoom);
+      if (next) {
+        setRovingId(next.id);
+        requestAnimationFrame(() => controlRefs.current[next.id]?.focus());
+      }
+      setFocusAfterZoom(undefined);
+      return;
+    }
+    if (!controls.some((control) => control.id === rovingId)) {
+      const selected = controls.find((control) =>
+        control.locations.some((location) => location.id === value?.id),
+      );
+      setRovingId((selected || controls[0]).id);
+    }
+  }, [controls, rovingId, value?.id, focusAfterZoom]);
+
+  const setZoom = (zoom: number, center = viewport.center, focus = false) => {
+    const next = clampViewport({ center, zoom });
+    setViewport(next);
+    setAnnouncement(
+      next.zoom === 0
+        ? "Showing the whole world"
+        : `Map zoom level ${next.zoom + 1}`,
+    );
+    if (focus) setFocusAfterZoom({ x: 0.5, y: 0.5 });
+  };
+
+  const select = (location: CityType, centerSearch = false) => {
+    onChange(location);
+    setAnnouncement(`${location.name} selected`);
+    setRovingId(`location-${location.id}`);
+    if (centerSearch) {
+      setViewport(
+        clampViewport({ center: projectLocation(location), zoom: 2 }),
+      );
+    }
+  };
+
+  const activate = (control: MapControl<CityType>, element: HTMLElement) => {
+    if (control.kind === "marker") {
+      select(control.locations[0]);
+      return;
+    }
+    if (viewport.zoom < MAX_ZOOM) {
+      setZoom(
+        viewport.zoom + 1,
+        projectLocation({
+          lat:
+            control.locations.reduce((sum, location) => sum + location.lat, 0) /
+            control.locations.length,
+          long:
+            control.locations.reduce(
+              (sum, location) => sum + location.long,
+              0,
+            ) / control.locations.length,
+        }),
+        true,
+      );
+      return;
+    }
+    setMenuLocations(control.locations);
+    setMenuAnchor(element);
+  };
+
+  const handleMapKey = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    control: MapControl<CityType>,
+  ) => {
+    const directions: Partial<Record<string, MapDirection>> = {
+      ArrowLeft: "left",
+      ArrowRight: "right",
+      ArrowUp: "up",
+      ArrowDown: "down",
+    };
+    if (
+      event.key === "Enter" ||
+      event.key === " " ||
+      event.key === "Spacebar"
+    ) {
+      event.preventDefault();
+      activate(control, event.currentTarget);
+      return;
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      setZoom(0, WORLD_VIEW.center, true);
+      return;
+    }
+    const direction = directions[event.key];
+    if (!direction) return;
+    event.preventDefault();
+    const next = directionalNeighbor(controls, control.id, direction);
+    if (next) {
+      setRovingId(next.id);
+      controlRefs.current[next.id]?.focus();
+    }
+  };
+
+  return (
+    <section className="locationPicker" aria-labelledby="location-picker-title">
+      <div className="locationPickerHeading">
+        <Typography id="location-picker-title" variant="h6" component="h2">
+          Location
+        </Typography>
+        <Typography variant="body2" color="textSecondary">
+          Choose a playable city. Location changes weather, demand, fuel prices,
+          and available build sites.
+        </Typography>
+      </div>
+
+      <div className="locationPickerDetails">
+        <Autocomplete
+          id="location"
+          options={locations}
+          groupBy={(location: CityType) => location.region}
+          getOptionLabel={(location: CityType) => location.name}
+          isOptionEqualToValue={(a: CityType, b: CityType) => a.id === b.id}
+          value={value}
+          onChange={(_event, picked: CityType | null) => {
+            if (picked) select(picked, true);
+          }}
+          disableClearable
+          autoHighlight
+          openOnFocus
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Search playable cities"
+              size="small"
+            />
+          )}
+        />
+        {value && (
+          <div
+            className="locationPickerSelection"
+            aria-label="Selected location"
+          >
+            <Typography variant="subtitle1" component="p">
+              {value.name}
+            </Typography>
+            <Typography variant="body2" color="textSecondary">
+              {locationDetail(value)}
+            </Typography>
+          </div>
+        )}
+        <Typography
+          className="locationPickerCount"
+          variant="caption"
+          aria-live="polite"
+        >
+          {loading
+            ? "Loading playable locations"
+            : `${locations.length} playable locations`}
+        </Typography>
+      </div>
+
+      <div
+        className="worldMap"
+        ref={mapRef}
+        role="group"
+        aria-label="Playable locations map"
+        aria-describedby="location-map-instructions"
+      >
+        <span id="location-map-instructions" className="visuallyHidden">
+          Use arrow keys to move between map locations. Press Enter or Space to
+          select a city or zoom into a cluster. Press Home to show the world.
+        </span>
+        <svg
+          className="worldMapLand"
+          viewBox="0 0 1000 500"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <g
+            transform={`translate(${500 - viewport.center.x * 1000 * MAP_ZOOM_SCALES[viewport.zoom]} ${250 - viewport.center.y * 500 * MAP_ZOOM_SCALES[viewport.zoom]}) scale(${MAP_ZOOM_SCALES[viewport.zoom]})`}
+          >
+            <g className="worldMapGrid">
+              <path d="M0 125H1000M0 250H1000M0 375H1000M250 0V500M500 0V500M750 0V500" />
+            </g>
+            <g className="worldMapContinents">
+              <path d="M45 86L115 42 230 54 286 102 258 145 204 157 170 211 118 196 92 145 48 127Z" />
+              <path d="M219 232L279 249 300 310 270 420 235 463 224 361 190 281Z" />
+              <path d="M430 92L492 69 548 92 572 128 645 112 715 69 862 78 953 130 905 188 804 180 745 226 670 211 620 165 569 173 525 143 468 151 420 125Z" />
+              <path d="M462 177L551 174 602 232 573 343 524 411 485 329 451 253Z" />
+              <path d="M797 315L861 289 929 325 912 388 846 405 800 364Z" />
+              <path d="M950 228L968 243 958 277 944 251Z" />
+            </g>
+          </g>
+        </svg>
+
+        <div className="worldMapMarkers">
+          {controls.map((control) => {
+            const selected =
+              control.kind === "marker" &&
+              control.locations[0].id === value?.id;
+            const label =
+              control.kind === "marker"
+                ? `Select ${accessibleLocationName(control.locations[0])}`
+                : `Zoom to ${control.locations.length} locations near ${clusterArea(
+                    control.locations,
+                  )}, including ${control.locations[0].name}`;
+            return (
+              <button
+                key={control.id}
+                ref={(element) => {
+                  controlRefs.current[control.id] = element;
+                }}
+                type="button"
+                className={`worldMapMarker ${control.kind}${selected ? " selected" : ""}`}
+                style={{
+                  left: `${control.x * 100}%`,
+                  top: `${control.y * 100}%`,
+                }}
+                aria-label={label}
+                aria-pressed={control.kind === "marker" ? selected : undefined}
+                tabIndex={control.id === rovingId ? 0 : -1}
+                title={
+                  control.kind === "marker"
+                    ? `${control.locations[0].name} — ${locationDetail(control.locations[0])}`
+                    : label
+                }
+                onFocus={() => setRovingId(control.id)}
+                onKeyDown={(event) => handleMapKey(event, control)}
+                onClick={(event) => activate(control, event.currentTarget)}
+              >
+                {control.kind === "cluster"
+                  ? control.locations.length
+                  : selected
+                    ? "✓"
+                    : ""}
+              </button>
+            );
+          })}
+        </div>
+
+        <div
+          className="worldMapControls"
+          role="group"
+          aria-label="Map zoom controls"
+        >
+          <Tooltip title="Zoom out">
+            <span>
+              <IconButton
+                size="small"
+                aria-label="Zoom out"
+                disabled={viewport.zoom === 0}
+                onClick={() => setZoom(viewport.zoom - 1)}
+              >
+                <ZoomOutIcon />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Zoom in">
+            <span>
+              <IconButton
+                size="small"
+                aria-label="Zoom in"
+                disabled={viewport.zoom === MAX_ZOOM}
+                onClick={() => setZoom(viewport.zoom + 1)}
+              >
+                <ZoomInIcon />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Show world">
+            <IconButton
+              size="small"
+              aria-label="Show world"
+              onClick={() => setZoom(0, WORLD_VIEW.center)}
+            >
+              <PublicIcon />
+            </IconButton>
+          </Tooltip>
+        </div>
+      </div>
+
+      <span className="visuallyHidden" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </span>
+
+      <Menu
+        anchorEl={menuAnchor}
+        open={!!menuAnchor}
+        onClose={() => setMenuAnchor(null)}
+        slotProps={{ list: { "aria-label": "Locations in this cluster" } }}
+      >
+        {menuLocations.map((location) => (
+          <MenuItem
+            key={location.id}
+            onClick={() => {
+              select(location);
+              setMenuAnchor(null);
+            }}
+          >
+            {location.name}{" "}
+            {locationDetail(location) && `— ${locationDetail(location)}`}
+          </MenuItem>
+        ))}
+      </Menu>
+    </section>
+  );
+}

--- a/src/components/views/CustomGame.test.tsx
+++ b/src/components/views/CustomGame.test.tsx
@@ -6,6 +6,8 @@ import {
   DEFAULT_CUSTOM_SCENARIO,
 } from "../../data/Scenarios";
 import { getFuelEscalation } from "../../data/FuelPrices";
+import { LOCATIONS } from "../../Constants";
+import { prefetchScenarioData } from "../../helpers/OfflineData";
 import { createGame } from "../../testing/Simulator";
 import CustomGame from "./CustomGame";
 
@@ -31,7 +33,7 @@ it("opens after economic data is loaded and names every setup control", () => {
     screen.getByRole("heading", { name: "Custom setup" }),
   ).toBeInTheDocument();
   [
-    "Location",
+    "Search playable cities",
     "Starting year",
     "Duration",
     "Ownership",
@@ -109,5 +111,73 @@ it("scales starting nameplate capacity with starting customers", () => {
   );
   expect(totalNameplateW).toBeGreaterThanOrEqual(
     state.timeline[0].demandW * (1 + RESERVE_MARGIN),
+  );
+});
+
+it("commits the complete location object when a map marker is selected", () => {
+  const onStart = jest.fn();
+  render(
+    <CustomGame
+      game={createGame({ scenarioId: 100 })}
+      scenario={{ ...DEFAULT_CUSTOM_SCENARIO }}
+      onBack={jest.fn()}
+      onDelta={jest.fn()}
+      onStart={onStart}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: /Select Honolulu, HI/ }));
+  fireEvent.click(screen.getByRole("button", { name: "Play" }));
+
+  expect(onStart).toHaveBeenCalledWith(
+    expect.objectContaining({
+      locationId: LOCATIONS.HNL.id,
+      location: expect.objectContaining(LOCATIONS.HNL),
+    }),
+  );
+  expect(prefetchScenarioData).toHaveBeenCalledWith(
+    expect.objectContaining({ id: LOCATIONS.HNL.id }),
+  );
+});
+
+it("preserves and exposes a playable custom location that is absent from the catalogue", () => {
+  const onStart = jest.fn();
+  const customLocation = {
+    id: "unlisted-grid",
+    name: "Unlisted Grid",
+    lat: 12.5,
+    long: 35.5,
+    timeZone: "Etc/UTC",
+  };
+  render(
+    <CustomGame
+      game={createGame({ scenarioId: 100 })}
+      scenario={{
+        ...DEFAULT_CUSTOM_SCENARIO,
+        locationId: customLocation.id,
+        location: customLocation,
+      }}
+      onBack={jest.fn()}
+      onDelta={jest.fn()}
+      onStart={onStart}
+    />,
+  );
+
+  expect(
+    screen.getByRole("combobox", { name: "Search playable cities" }),
+  ).toHaveValue("Unlisted Grid");
+  expect(screen.getByLabelText("Selected location")).toHaveTextContent(
+    "Unlisted Grid",
+  );
+  expect(
+    screen.getByRole("button", { name: "Select Unlisted Grid" }),
+  ).toHaveAttribute("aria-pressed", "true");
+
+  fireEvent.click(screen.getByRole("button", { name: "Play" }));
+  expect(onStart).toHaveBeenCalledWith(
+    expect.objectContaining({
+      locationId: customLocation.id,
+      location: customLocation,
+    }),
   );
 });

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {
-  Autocomplete,
   Button,
   Card,
   CardHeader,
@@ -28,6 +27,7 @@ import CasinoIcon from "@mui/icons-material/Casino";
 import CloseIcon from "@mui/icons-material/Close";
 import DeleteIcon from "@mui/icons-material/Delete";
 import InfoIcon from "@mui/icons-material/Info";
+import LocationPicker from "../base/LocationPicker";
 import VictoryConditions from "../base/VictoryConditions";
 import { DIFFICULTIES, DIFFICULTY_LABELS } from "../../Constants";
 import { CityType, getCities, initCities } from "../../data/Cities";
@@ -248,11 +248,13 @@ export default function CustomGame(props: Props): React.JSX.Element {
   // Every place that can be picked: the six in the bundle to begin with, and every city with
   // downloaded weather once the index arrives, which is a download rather than a rebuild
   const [cities, setCities] = React.useState<CityType[]>(getCities);
+  const [citiesLoading, setCitiesLoading] = React.useState(true);
   React.useEffect(() => {
     let live = true;
     initCities().then((loaded: CityType[]) => {
       if (live) {
         setCities(loaded);
+        setCitiesLoading(false);
       }
     });
     return () => {
@@ -374,54 +376,19 @@ export default function CustomGame(props: Props): React.JSX.Element {
       </div>
 
       <div className="scrollable">
+        <LocationPicker
+          locations={selectableLocations}
+          value={location}
+          loading={citiesLoading}
+          onChange={(picked: CityType) => {
+            changeStartingCustomers(getStartingCustomers(picked), {
+              locationId: picked.id,
+              location: picked,
+            });
+          }}
+        />
         <Table size="small" id="gameSetupTable">
           <TableBody>
-            <TableRow>
-              <TableCell>Location</TableCell>
-              <TableCell>
-                {/* The scenario carries the whole location rather than just its id, so a custom
-                    game stays playable even if the catalogue it was picked from changes
-                    underneath it - and so it can hold somewhere the catalogue never listed.
-                    Typed rather than scrolled: a few hundred cities is well past what a menu of
-                    them is any use for. */}
-                <Autocomplete
-                  id="location"
-                  options={selectableLocations}
-                  groupBy={(l: CityType) => l.region}
-                  getOptionLabel={(l: CityType) => l.name}
-                  isOptionEqualToValue={(a: CityType, b: CityType) =>
-                    a.id === b.id
-                  }
-                  value={location}
-                  onChange={(_e: unknown, picked: CityType | null) => {
-                    if (picked) {
-                      changeStartingCustomers(getStartingCustomers(picked), {
-                        locationId: picked.id,
-                        location: picked,
-                      });
-                    }
-                  }}
-                  disableClearable
-                  autoHighlight
-                  openOnFocus
-                  sx={{ minWidth: 0, width: "100%" }}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      variant="standard"
-                      placeholder="Search cities"
-                      slotProps={{
-                        ...params.slotProps,
-                        htmlInput: {
-                          ...params.slotProps.htmlInput,
-                          "aria-label": "Location",
-                        },
-                      }}
-                    />
-                  )}
-                />
-              </TableCell>
-            </TableRow>
             <TableRow>
               <TableCell>Customers</TableCell>
               <TableCell>

--- a/src/helpers/WorldMap.test.ts
+++ b/src/helpers/WorldMap.test.ts
@@ -1,0 +1,59 @@
+import {
+  clampViewport,
+  clusterLocations,
+  directionalNeighbor,
+  pointInViewport,
+  projectLocation,
+} from "./WorldMap";
+
+const world = { center: { x: 0.5, y: 0.5 }, zoom: 0 };
+
+it("projects geographic extremes onto the map", () => {
+  expect(projectLocation({ lat: 90, long: -180 })).toEqual({ x: 0, y: 0 });
+  expect(projectLocation({ lat: -90, long: 180 })).toEqual({ x: 1, y: 1 });
+  expect(pointInViewport({ x: 0.5, y: 0.5 }, world)).toEqual({
+    x: 0.5,
+    y: 0.5,
+  });
+});
+
+it("clamps zoom and map centers to visible bounds", () => {
+  expect(clampViewport({ center: { x: -2, y: 4 }, zoom: 99 })).toEqual({
+    center: { x: 0.0625, y: 0.9375 },
+    zoom: 3,
+  });
+});
+
+it("clusters close locations deterministically but keeps selection visible", () => {
+  const locations = [
+    { id: "b", lat: 40, long: -74 },
+    { id: "a", lat: 40.01, long: -74.01 },
+    { id: "far", lat: 0, long: 80 },
+  ];
+  const clustered = clusterLocations(locations, world, 800, 400, 32);
+  expect(
+    clustered.map((control) => [control.kind, control.locations.length]),
+  ).toEqual([
+    ["cluster", 2],
+    ["marker", 1],
+  ]);
+
+  const withSelection = clusterLocations(locations, world, 800, 400, 32, "a");
+  expect(
+    withSelection.find((control) => control.id === "location-a")?.kind,
+  ).toBe("marker");
+});
+
+it("finds the nearest directional control", () => {
+  const controls = [
+    { id: "center", x: 0.5, y: 0.5 },
+    { id: "right-near", x: 0.6, y: 0.52 },
+    { id: "right-far", x: 0.8, y: 0.5 },
+    { id: "up", x: 0.5, y: 0.2 },
+  ];
+  expect(directionalNeighbor(controls, "center", "right")?.id).toBe(
+    "right-near",
+  );
+  expect(directionalNeighbor(controls, "center", "up")?.id).toBe("up");
+  expect(directionalNeighbor(controls, "center", "left")).toBeUndefined();
+});

--- a/src/helpers/WorldMap.ts
+++ b/src/helpers/WorldMap.ts
@@ -1,0 +1,186 @@
+export interface MapLocation {
+  id: string;
+  lat: number;
+  long: number;
+}
+
+export interface MapPoint {
+  x: number;
+  y: number;
+}
+
+export interface MapViewport {
+  center: MapPoint;
+  zoom: number;
+}
+
+export interface MapMarker<T extends MapLocation> extends MapPoint {
+  kind: "marker";
+  id: string;
+  locations: [T];
+}
+
+export interface MapCluster<T extends MapLocation> extends MapPoint {
+  kind: "cluster";
+  id: string;
+  locations: T[];
+}
+
+export type MapControl<T extends MapLocation> = MapMarker<T> | MapCluster<T>;
+
+export const MAP_ZOOM_SCALES = [1, 2, 4, 8] as const;
+
+export function projectLocation(
+  location: Pick<MapLocation, "lat" | "long">,
+): MapPoint {
+  return {
+    x: (location.long + 180) / 360,
+    y: (90 - location.lat) / 180,
+  };
+}
+
+export function clampViewport(viewport: MapViewport): MapViewport {
+  const zoom = Math.max(0, Math.min(MAP_ZOOM_SCALES.length - 1, viewport.zoom));
+  const scale = MAP_ZOOM_SCALES[zoom];
+  const half = 0.5 / scale;
+  return {
+    zoom,
+    center: {
+      x: Math.max(half, Math.min(1 - half, viewport.center.x)),
+      y: Math.max(half, Math.min(1 - half, viewport.center.y)),
+    },
+  };
+}
+
+export function pointInViewport(
+  point: MapPoint,
+  viewport: MapViewport,
+): MapPoint | undefined {
+  const clamped = clampViewport(viewport);
+  const scale = MAP_ZOOM_SCALES[clamped.zoom];
+  const x = (point.x - clamped.center.x) * scale + 0.5;
+  const y = (point.y - clamped.center.y) * scale + 0.5;
+  if (x < 0 || x > 1 || y < 0 || y > 1) {
+    return undefined;
+  }
+  return { x, y };
+}
+
+/**
+ * Deterministically groups nearby projected locations. The selected location remains a marker,
+ * so the current game location is always represented as selected rather than disappearing into
+ * an anonymous count.
+ */
+export function clusterLocations<T extends MapLocation>(
+  locations: T[],
+  viewport: MapViewport,
+  width: number,
+  height: number,
+  thresholdPx: number,
+  selectedId?: string,
+): MapControl<T>[] {
+  const visible = locations
+    .map((location: T) => ({
+      location,
+      point: pointInViewport(projectLocation(location), viewport),
+    }))
+    .filter((entry): entry is { location: T; point: MapPoint } => !!entry.point)
+    .sort((a, b) => a.location.id.localeCompare(b.location.id));
+
+  const groups: Array<{ locations: T[]; x: number; y: number }> = [];
+  visible.forEach(({ location, point }) => {
+    if (location.id === selectedId) {
+      return;
+    }
+    const nearest = groups
+      .map((group, index) => ({
+        group,
+        index,
+        distance: Math.hypot(
+          (point.x - group.x) * width,
+          (point.y - group.y) * height,
+        ),
+      }))
+      .filter((candidate) => candidate.distance < thresholdPx)
+      .sort(
+        (a, b) =>
+          a.distance - b.distance ||
+          a.group.locations[0].id.localeCompare(b.group.locations[0].id),
+      )[0];
+    if (!nearest) {
+      groups.push({ locations: [location], x: point.x, y: point.y });
+      return;
+    }
+    const count = nearest.group.locations.length;
+    nearest.group.x = (nearest.group.x * count + point.x) / (count + 1);
+    nearest.group.y = (nearest.group.y * count + point.y) / (count + 1);
+    nearest.group.locations.push(location);
+  });
+
+  const controls: MapControl<T>[] = groups.map((group) =>
+    group.locations.length === 1
+      ? {
+          kind: "marker",
+          id: `location-${group.locations[0].id}`,
+          locations: [group.locations[0]],
+          x: group.x,
+          y: group.y,
+        }
+      : {
+          kind: "cluster",
+          id: `cluster-${group.locations.map((location) => location.id).join("-")}`,
+          locations: group.locations,
+          x: group.x,
+          y: group.y,
+        },
+  );
+
+  const selected = visible.find(({ location }) => location.id === selectedId);
+  if (selected) {
+    controls.push({
+      kind: "marker",
+      id: `location-${selected.location.id}`,
+      locations: [selected.location],
+      x: selected.point.x,
+      y: selected.point.y,
+    });
+  }
+  return controls.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export type MapDirection = "left" | "right" | "up" | "down";
+
+export function directionalNeighbor<T extends MapPoint & { id: string }>(
+  controls: T[],
+  currentId: string,
+  direction: MapDirection,
+): T | undefined {
+  const current = controls.find((control) => control.id === currentId);
+  if (!current) {
+    return undefined;
+  }
+  return controls
+    .filter((control) => {
+      if (control.id === currentId) return false;
+      if (direction === "left") return control.x < current.x;
+      if (direction === "right") return control.x > current.x;
+      if (direction === "up") return control.y < current.y;
+      return control.y > current.y;
+    })
+    .map((control) => {
+      const dx = control.x - current.x;
+      const dy = control.y - current.y;
+      const primary =
+        direction === "left" || direction === "right"
+          ? Math.abs(dx)
+          : Math.abs(dy);
+      const cross =
+        direction === "left" || direction === "right"
+          ? Math.abs(dy)
+          : Math.abs(dx);
+      return { control, score: primary + cross * 2 };
+    })
+    .sort(
+      (a, b) => a.score - b.score || a.control.id.localeCompare(b.control.id),
+    )[0]?.control;
+}


### PR DESCRIPTION
## Summary

- replace the custom-game location row with an offline world-map picker and retained city search
- add deterministic clustering, drill-down, explicit zoom controls, responsive layouts, and accessible keyboard/touch interactions
- preserve full location persistence, customer/fleet scaling, prefetching, custom locations, and facility viability validation
- add helper, component, integration, responsive, and five-viewport Playwright coverage

## Validation

- `npm run check` (92 suites / 863 tests, all simulation invariants)
- `npm run build`
- `npx playwright test --config e2e/playwright.config.ts custom-location-picker.spec.ts --workers=5` (25/25 across all configured projects)
- `npx playwright test --config e2e/playwright.config.ts responsive-320.spec.ts --project mobile-320px --workers=1` (2/2)
- `git diff --check`