### PR TITLE
Fix mobile scenario rows and custom map panning

### DIFF
--- a/e2e/custom-location-picker.spec.ts
+++ b/e2e/custom-location-picker.spec.ts
@@ -72,7 +72,7 @@ test("world map location picker works with pointer, touch, search, and keyboard"
       Math.max(0, element.scrollWidth - element.clientWidth),
     );
   expect(overflow).toBeLessThanOrEqual(1);
-  await expect(map).toHaveCSS("touch-action", "pan-y");
+  await expect(map).toHaveCSS("touch-action", "none");
 
   const mapBox = await map.boundingBox();
   const searchBox = await search.boundingBox();
@@ -150,7 +150,7 @@ test("keyboard navigation retains one map stop and honors activation and zoom bo
   await expect(zoomOut).toBeDisabled();
 });
 
-test("pointer and touch interactions leave vertical scrolling available", async ({
+test("pointer and touch interactions pan when zoomed and leave page scrolling available", async ({
   page,
 }, testInfo) => {
   await openCustomSetup(page);
@@ -159,34 +159,63 @@ test("pointer and touch interactions leave vertical scrolling available", async 
   const search = page.getByRole("combobox", { name: "Search playable cities" });
   const startingSelection = await search.inputValue();
   const cluster = map.locator(".worldMapMarker.cluster").first();
+  await cluster.click();
+  await expect(map).toHaveClass(/zoomed/);
+  await expect(map).toHaveCSS("touch-action", "none");
+  const land = map.locator(".worldMapLand > g");
+  const startingTransform = await land.getAttribute("transform");
+  const mapBox = await map.boundingBox();
+  expect(mapBox).not.toBeNull();
 
   if (testInfo.project.name.startsWith("desktop")) {
-    await cluster.hover();
+    await page.mouse.move(
+      mapBox!.x + mapBox!.width / 2,
+      mapBox!.y + mapBox!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      mapBox!.x + mapBox!.width / 2 - 80,
+      mapBox!.y + mapBox!.height / 2 - 30,
+    );
+    await page.mouse.up();
+    await expect
+      .poll(() => land.getAttribute("transform"))
+      .not.toBe(startingTransform);
     await expect(search).toHaveValue(startingSelection);
-    await expect(cluster).toHaveCSS("cursor", "pointer");
     return;
   }
 
   await map.scrollIntoViewIfNeeded();
-  const clusterBox = await cluster.boundingBox();
-  expect(clusterBox).not.toBeNull();
-  await page.touchscreen.tap(
-    clusterBox!.x + clusterBox!.width / 2,
-    clusterBox!.y + clusterBox!.height / 2,
-  );
-  await expect(page.getByRole("button", { name: "Zoom out" })).toBeEnabled();
+  const session = await page.context().newCDPSession(page);
+  const panStartX = Math.round(mapBox!.x + mapBox!.width / 2);
+  const panStartY = Math.round(mapBox!.y + mapBox!.height / 2);
+  await session.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: [{ x: panStartX, y: panStartY }],
+  });
+  await session.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [{ x: panStartX - 60, y: panStartY - 30 }],
+  });
+  await session.send("Input.dispatchTouchEvent", {
+    type: "touchEnd",
+    touchPoints: [],
+  });
+  await expect
+    .poll(() => land.getAttribute("transform"))
+    .not.toBe(startingTransform);
   await expect(search).toHaveValue(startingSelection);
 
   await page.getByRole("button", { name: "Show world" }).click();
+  await expect(map).toHaveCSS("touch-action", "pan-y");
   await map.scrollIntoViewIfNeeded();
-  const mapBox = await map.boundingBox();
-  expect(mapBox).not.toBeNull();
+  const worldMapBox = await map.boundingBox();
+  expect(worldMapBox).not.toBeNull();
   const scroller = page.locator(".scrollable");
   const before = await scroller.evaluate((element) => element.scrollTop);
-  const session = await page.context().newCDPSession(page);
-  const x = Math.round(mapBox!.x + mapBox!.width / 2);
-  const startY = Math.round(mapBox!.y + mapBox!.height - 20);
-  const endY = Math.round(mapBox!.y + 20);
+  const x = Math.round(worldMapBox!.x + worldMapBox!.width / 2);
+  const startY = Math.round(worldMapBox!.y + worldMapBox!.height - 20);
+  const endY = Math.round(worldMapBox!.y + 20);
   await session.send("Input.dispatchTouchEvent", {
     type: "touchStart",
     touchPoints: [{ x, y: startY }],

--- a/e2e/responsive-320.spec.ts
+++ b/e2e/responsive-320.spec.ts
@@ -17,7 +17,25 @@ test("custom setup and settings stay usable on a 320px phone", async ({
   await page
     .getByRole("button", { name: "Start playing", exact: true })
     .click();
-  await page.getByRole("button", { name: "View Custom Game details" }).click();
+  const customGame = page.getByRole("button", {
+    name: "View Custom Game details",
+  });
+  await customGame.scrollIntoViewIfNeeded();
+  const avatarBox = await customGame
+    .locator(".MuiCardHeader-avatar")
+    .boundingBox();
+  const actionBox = await customGame
+    .locator(".MuiCardHeader-action")
+    .boundingBox();
+  expect(avatarBox).not.toBeNull();
+  expect(actionBox).not.toBeNull();
+  expect(
+    Math.min(
+      avatarBox!.y + avatarBox!.height,
+      actionBox!.y + actionBox!.height,
+    ) - Math.max(avatarBox!.y, actionBox!.y),
+  ).toBeGreaterThan(0);
+  await customGame.click();
 
   await expect(
     page.getByRole("heading", { name: "Custom setup" }),

--- a/src/app.scss
+++ b/src/app.scss
@@ -1919,6 +1919,16 @@ html[data-theme="dark"] .uplot {
     border-radius: 8px;
     background: var(--bg-sunken);
     touch-action: pan-y;
+
+    &.zoomed {
+      touch-action: none;
+      cursor: grab;
+    }
+
+    &.panning {
+      cursor: grabbing;
+      user-select: none;
+    }
   }
 
   .worldMapLand,
@@ -2113,14 +2123,25 @@ html[data-theme="dark"] .uplot {
     }
   }
 
-  .missionItem {
+  .build-list-item.missionItem {
     margin: 0 12px 8px;
     border: 1px solid var(--border-tile);
     border-radius: 10px;
     box-shadow: none;
 
     .MuiCardHeader-root {
+      grid-template-columns: auto minmax(0, 1fr) auto;
       padding: 10px 12px;
+    }
+
+    // A chevron is part of this compact row, unlike the multi-button build-card actions that
+    // deliberately wrap below 520px.
+    .MuiCardHeader-root .MuiCardHeader-action {
+      grid-row: 1;
+      grid-column: 3;
+      align-self: center;
+      width: auto;
+      margin: 0 0 0 8px !important;
     }
 
     .MuiCardHeader-title {

--- a/src/components/base/LocationPicker.test.tsx
+++ b/src/components/base/LocationPicker.test.tsx
@@ -91,6 +91,23 @@ it("supports arrow navigation, Enter and Space activation, and Home", () => {
   expect(screen.getByText("Showing the whole world")).toBeInTheDocument();
 });
 
+it("pans with scrolling while zoomed", () => {
+  render(
+    <LocationPicker
+      locations={cities}
+      value={cities[0]}
+      onChange={jest.fn()}
+    />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+  const map = screen.getByRole("group", { name: "Playable locations map" });
+  const content = screen.getByTestId("world-map-content");
+  const before = content.getAttribute("transform");
+
+  fireEvent.wheel(map, { deltaX: -30, deltaY: -20 });
+  expect(content).not.toHaveAttribute("transform", before);
+});
+
 it("drills into a cluster and lists unresolved cities at maximum zoom", async () => {
   const user = userEvent.setup();
   const closeCities: CityType[] = [

--- a/src/components/base/LocationPicker.tsx
+++ b/src/components/base/LocationPicker.tsx
@@ -22,6 +22,7 @@ import {
   MapPoint,
   MapViewport,
   MAP_ZOOM_SCALES,
+  panViewport,
   projectLocation,
 } from "../../helpers/WorldMap";
 
@@ -34,6 +35,13 @@ interface Props {
 
 const WORLD_VIEW: MapViewport = { center: { x: 0.5, y: 0.5 }, zoom: 0 };
 const MAX_ZOOM = 3;
+
+interface MapDrag {
+  pointerId: number;
+  x: number;
+  y: number;
+  moved: boolean;
+}
 
 function locationDetail(location: CityType): string {
   return [location.admin, location.country, location.region]
@@ -82,7 +90,10 @@ export default function LocationPicker({
   const [menuAnchor, setMenuAnchor] = React.useState<HTMLElement | null>(null);
   const [menuLocations, setMenuLocations] = React.useState<CityType[]>([]);
   const [focusAfterZoom, setFocusAfterZoom] = React.useState<MapPoint>();
+  const [panning, setPanning] = React.useState(false);
   const mapRef = React.useRef<HTMLDivElement>(null);
+  const dragRef = React.useRef<MapDrag>();
+  const suppressClickRef = React.useRef(false);
   const controlRefs = React.useRef<Record<string, HTMLButtonElement | null>>(
     {},
   );
@@ -215,6 +226,67 @@ export default function LocationPicker({
     }
   };
 
+  const startPan = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (
+      viewport.zoom === 0 ||
+      event.button !== 0 ||
+      (event.target as Element).closest(".worldMapControls")
+    ) {
+      return;
+    }
+    dragRef.current = {
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+      moved: false,
+    };
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    setPanning(true);
+  };
+
+  const movePan = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const deltaX = event.clientX - drag.x;
+    const deltaY = event.clientY - drag.y;
+    if (deltaX === 0 && deltaY === 0) return;
+    event.preventDefault();
+    drag.x = event.clientX;
+    drag.y = event.clientY;
+    drag.moved = true;
+    setViewport((current: MapViewport) =>
+      panViewport(current, -deltaX, -deltaY, mapSize.width, mapSize.height),
+    );
+  };
+
+  const endPan = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    suppressClickRef.current = drag.moved;
+    dragRef.current = undefined;
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setPanning(false);
+    window.setTimeout(() => {
+      suppressClickRef.current = false;
+    }, 0);
+  };
+
+  const scrollPan = (event: React.WheelEvent<HTMLDivElement>) => {
+    if (viewport.zoom === 0) return;
+    event.preventDefault();
+    setViewport((current: MapViewport) =>
+      panViewport(
+        current,
+        event.deltaX,
+        event.deltaY,
+        mapSize.width,
+        mapSize.height,
+      ),
+    );
+  };
+
   return (
     <section className="locationPicker" aria-labelledby="location-picker-title">
       <div className="locationPickerHeading">
@@ -257,15 +329,25 @@ export default function LocationPicker({
       </div>
 
       <div
-        className="worldMap"
+        className={`worldMap${viewport.zoom > 0 ? " zoomed" : ""}${panning ? " panning" : ""}`}
         ref={mapRef}
         role="group"
         aria-label="Playable locations map"
         aria-describedby="location-map-instructions"
+        onPointerDown={startPan}
+        onPointerMove={movePan}
+        onPointerUp={endPan}
+        onPointerCancel={endPan}
+        onLostPointerCapture={() => {
+          dragRef.current = undefined;
+          setPanning(false);
+        }}
+        onWheel={scrollPan}
       >
         <span id="location-map-instructions" className="visuallyHidden">
           Use arrow keys to move between map locations. Press Enter or Space to
-          select a city or zoom into a cluster. Press Home to show the world.
+          select a city or zoom into a cluster. When zoomed in, drag, swipe, or
+          scroll to pan the map. Press Home to show the world.
         </span>
         <svg
           className="worldMapLand"
@@ -274,6 +356,7 @@ export default function LocationPicker({
           aria-hidden="true"
         >
           <g
+            data-testid="world-map-content"
             transform={`translate(${500 - viewport.center.x * 1000 * MAP_ZOOM_SCALES[viewport.zoom]} ${250 - viewport.center.y * 500 * MAP_ZOOM_SCALES[viewport.zoom]}) scale(${MAP_ZOOM_SCALES[viewport.zoom]})`}
           >
             <g className="worldMapGrid">
@@ -318,7 +401,11 @@ export default function LocationPicker({
                 }
                 onFocus={() => setRovingId(control.id)}
                 onKeyDown={(event) => handleMapKey(event, control)}
-                onClick={(event) => activate(control, event.currentTarget)}
+                onClick={(event) => {
+                  if (!suppressClickRef.current) {
+                    activate(control, event.currentTarget);
+                  }
+                }}
               >
                 {control.kind === "cluster"
                   ? control.locations.length

--- a/src/helpers/WorldMap.test.ts
+++ b/src/helpers/WorldMap.test.ts
@@ -2,6 +2,7 @@ import {
   clampViewport,
   clusterLocations,
   directionalNeighbor,
+  panViewport,
   pointInViewport,
   projectLocation,
 } from "./WorldMap";
@@ -22,6 +23,22 @@ it("clamps zoom and map centers to visible bounds", () => {
     center: { x: 0.0625, y: 0.9375 },
     zoom: 3,
   });
+});
+
+it("pans zoomed viewports in screen pixels and stops at the world edge", () => {
+  expect(
+    panViewport({ center: { x: 0.5, y: 0.5 }, zoom: 1 }, 100, -50, 400, 200),
+  ).toEqual({ center: { x: 0.625, y: 0.375 }, zoom: 1 });
+  expect(
+    panViewport(
+      { center: { x: 0.5, y: 0.5 }, zoom: 3 },
+      10000,
+      10000,
+      400,
+      200,
+    ),
+  ).toEqual({ center: { x: 0.9375, y: 0.9375 }, zoom: 3 });
+  expect(panViewport(world, 100, 100, 400, 200)).toEqual(world);
 });
 
 it("clusters close locations deterministically but keeps selection visible", () => {

--- a/src/helpers/WorldMap.ts
+++ b/src/helpers/WorldMap.ts
@@ -52,6 +52,28 @@ export function clampViewport(viewport: MapViewport): MapViewport {
   };
 }
 
+/** Moves a zoomed viewport by screen pixels, clamping it at the edge of the world. */
+export function panViewport(
+  viewport: MapViewport,
+  deltaX: number,
+  deltaY: number,
+  width: number,
+  height: number,
+): MapViewport {
+  const clamped = clampViewport(viewport);
+  if (clamped.zoom === 0 || width <= 0 || height <= 0) {
+    return clamped;
+  }
+  const scale = MAP_ZOOM_SCALES[clamped.zoom];
+  return clampViewport({
+    zoom: clamped.zoom,
+    center: {
+      x: clamped.center.x + deltaX / (width * scale),
+      y: clamped.center.y + deltaY / (height * scale),
+    },
+  });
+}
+
 export function pointInViewport(
   point: MapPoint,
   viewport: MapViewport,


### PR DESCRIPTION
## Summary
- keep scenario chevrons in the main card row on narrow screens
- allow bounded drag, swipe, wheel, and trackpad panning while the custom location map is zoomed
- preserve page scrolling at the whole-world zoom level and add responsive interaction coverage

## Verification
- npm run check
- npm run build
- focused Playwright checks on desktop Chromium and the mobile 320px profile