### PR TITLE
Add named insight chart presets

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -710,12 +710,121 @@ $pane_header_height: 40px;
 .insightsHeader {
   gap: 8px;
 
+  > h6 {
+    flex: 0 0 auto;
+  }
+}
+
+.insightsHeaderControls {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+
   .headerControl {
-    min-width: 132px;
+    min-width: 112px;
+    flex: 1 1 132px;
+    margin-left: 0;
+  }
+
+  .insightsLayerControls {
+    min-height: 36px;
+    flex: 0 0 auto;
+  }
+}
+
+.insightsPresetControls {
+  display: flex;
+  min-width: 218px;
+  flex: 1.35 1 284px;
+  align-items: stretch;
+  overflow: hidden;
+  border: 1px solid var(--border-tile);
+  border-radius: 6px;
+  background: var(--bg-raised);
+
+  &.insightsPresetControls-edited {
+    border-color: $interactive_blue;
+    box-shadow: inset 3px 0 0 $interactive_blue;
   }
 
   .insightsPreset {
-    min-width: 138px;
+    min-width: 0;
+    flex: 1 1 138px;
+  }
+
+  .insightsPresetSave,
+  .insightsPresetActions {
+    min-width: auto;
+    min-height: 36px;
+    flex: 0 0 auto;
+    border-left: 1px solid var(--border-tile);
+    border-radius: 0;
+  }
+
+  .insightsPresetSave:not(:disabled) {
+    background: var(--interactive-tint);
+  }
+
+  .insightsPresetActions {
+    padding-right: 8px;
+    padding-left: 8px;
+  }
+}
+
+.insightsPresetValue {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.insightsPresetName,
+.insightsPresetMenuName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.insightsPresetEdited,
+.insightsPresetCustomized,
+.insightsPresetMenuHint {
+  flex: 0 0 auto;
+  padding: 1px 5px;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.insightsPresetEdited {
+  background: $interactive_blue;
+  color: $bg_primary;
+}
+
+.insightsPresetCustomized,
+.insightsPresetMenuHint {
+  background: var(--interactive-tint);
+  color: $interactive_blue;
+}
+
+.insightsPresetMenuHint {
+  margin-left: auto;
+}
+
+.insightsPresetDialog {
+  .MuiDialogContentText-root + .MuiTextField-root {
+    margin-top: 16px;
+  }
+
+  .MuiDialogActions-root {
+    padding: 8px 24px 16px;
+  }
+
+  .MuiButton-root {
+    min-height: 40px;
   }
 }
 
@@ -793,22 +902,61 @@ $pane_header_height: 40px;
 @media screen and (max-width: 700px) {
   .base_main .MuiToolbar-root.insightsHeader {
     min-height: auto !important;
-    flex-wrap: wrap;
-    padding-top: 4px;
-    padding-bottom: 4px;
-
-    .headerControl {
-      margin-left: 0;
-    }
+    display: block;
+    padding-top: 6px;
+    padding-bottom: 8px;
   }
 
   .insightsHeader > h6 {
     width: 100%;
+    margin-bottom: 6px;
   }
 
-  .insightsHeader .MuiSelect-root,
-  .insightsHeader .MuiButton-root {
-    flex: 1 1 120px;
+  .insightsHeaderControls {
+    display: grid;
+    grid-template-areas:
+      "range layers"
+      "preset preset";
+    grid-template-columns: minmax(0, 1fr) auto;
+    width: 100%;
+    gap: 8px;
+    margin-left: 0;
+
+    .headerControl {
+      grid-area: range;
+      width: 100%;
+      min-width: 0;
+    }
+
+    .insightsPresetControls {
+      grid-area: preset;
+      width: 100%;
+      min-width: 0;
+    }
+
+    .insightsLayerControls {
+      grid-area: layers;
+      min-height: 44px;
+    }
+  }
+
+  .insightsPresetControls {
+    .insightsPreset,
+    .insightsPresetSave,
+    .insightsPresetActions {
+      min-height: 44px;
+    }
+  }
+
+  .insightsPresetDialog {
+    .MuiDialogActions-root {
+      padding-right: 16px;
+      padding-left: 16px;
+    }
+
+    .MuiButton-root {
+      min-height: 44px;
+    }
   }
 }
 

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -7,6 +7,7 @@ import { GameType } from "../../Types";
 import Insights, {
   INSIGHT_LAYERS,
   INSIGHT_PRESETS,
+  MAX_CUSTOM_INSIGHT_PRESETS,
   presetForLayers,
   withRequiredLayers,
 } from "./Insights";
@@ -330,7 +331,126 @@ describe("Insights layers", () => {
     expect(screen.getByText("Revenue", { selector: "h6" })).toBeVisible();
     expect(
       screen.getByRole("combobox", { name: "Insight preset" }),
-    ).toHaveTextContent("Custom");
+    ).toHaveTextContent("OverviewEdited");
+  });
+
+  it("saves changes back to a default preset and restores them on remount", async () => {
+    const view = renderInsights();
+    await user.click(screen.getByRole("button", { name: /Layers/ }));
+    await user.click(screen.getByRole("checkbox", { name: "Revenue" }));
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    const library = JSON.parse(
+      localStorage.getItem("insightsPresetLibrary") || "{}",
+    );
+    expect(library.defaults.overview).toContain("revenue");
+    view.unmount();
+
+    renderInsights();
+    expect(screen.getByText("Revenue", { selector: "h6" })).toBeVisible();
+    expect(
+      screen.getByRole("combobox", { name: "Insight preset" }),
+    ).toHaveTextContent("Overview");
+    expect(
+      screen.getByRole("combobox", { name: "Insight preset" }),
+    ).not.toHaveTextContent("Edited");
+  });
+
+  it("restores a modified default preset to its original layers", async () => {
+    renderInsights();
+    await user.click(screen.getByRole("button", { name: /Layers/ }));
+    await user.click(screen.getByRole("checkbox", { name: "Revenue" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await user.click(screen.getByRole("button", { name: "Preset actions" }));
+    await user.click(
+      screen.getByRole("menuitem", { name: /Restore original preset/ }),
+    );
+    await user.click(screen.getByRole("button", { name: "Restore" }));
+
+    expect(screen.queryByText("Revenue", { selector: "h6" })).toBeNull();
+    const library = JSON.parse(
+      localStorage.getItem("insightsPresetLibrary") || "{}",
+    );
+    expect(library.defaults.overview).toBeUndefined();
+  });
+
+  it("creates, updates, renames, and deletes a named preset", async () => {
+    const view = renderInsights();
+    await user.click(screen.getByRole("button", { name: "Preset actions" }));
+    await user.click(
+      screen.getByRole("menuitem", { name: /Save as new preset/ }),
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Preset name" }),
+      "Peak watch",
+    );
+    await user.click(screen.getByRole("button", { name: "Save preset" }));
+
+    expect(
+      screen.getByRole("combobox", { name: "Insight preset" }),
+    ).toHaveTextContent("Peak watch");
+
+    await user.click(screen.getByRole("button", { name: /Layers/ }));
+    await user.click(screen.getByRole("checkbox", { name: "Revenue" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    let library = JSON.parse(
+      localStorage.getItem("insightsPresetLibrary") || "{}",
+    );
+    expect(library.custom[0]).toMatchObject({
+      name: "Peak watch",
+      layers: expect.arrayContaining(["revenue"]),
+    });
+
+    await user.click(screen.getByRole("button", { name: "Preset actions" }));
+    await user.click(screen.getByRole("menuitem", { name: /Rename preset/ }));
+    const name = screen.getByRole("textbox", { name: "Preset name" });
+    await user.clear(name);
+    await user.type(name, "Morning peak");
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    expect(
+      screen.getByRole("combobox", { name: "Insight preset" }),
+    ).toHaveTextContent("Morning peak");
+
+    view.unmount();
+    renderInsights();
+    expect(
+      screen.getByRole("combobox", { name: "Insight preset" }),
+    ).toHaveTextContent("Morning peak");
+
+    await user.click(screen.getByRole("button", { name: "Preset actions" }));
+    await user.click(screen.getByRole("menuitem", { name: /Delete preset/ }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(
+      screen.getByRole("combobox", { name: "Insight preset" }),
+    ).toHaveTextContent("Unsaved view");
+    library = JSON.parse(localStorage.getItem("insightsPresetLibrary") || "{}");
+    expect(library.custom).toEqual([]);
+  });
+
+  it("caps the custom preset library at ten entries", async () => {
+    localStorage.setItem(
+      "insightsPresetLibrary",
+      JSON.stringify({
+        defaults: {},
+        custom: Array.from(
+          { length: MAX_CUSTOM_INSIGHT_PRESETS },
+          (_, index) => ({
+            id: String(index + 1),
+            name: `Preset ${index + 1}`,
+            layers: ["supplyDemand"],
+          }),
+        ),
+      }),
+    );
+    renderInsights();
+
+    await user.click(screen.getByRole("button", { name: "Preset actions" }));
+    expect(
+      screen.getByRole("menuitem", { name: /Save as new preset/ }),
+    ).toHaveAttribute("aria-disabled", "true");
   });
 
   it("offers expected renewable output as an insight layer", async () => {

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -2,8 +2,15 @@ import * as React from "react";
 import {
   Button,
   Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   FormControlLabel,
   IconButton,
+  ListSubheader,
+  Menu,
   MenuItem,
   Select,
   SelectChangeEvent,
@@ -12,13 +19,17 @@ import {
   TableBody,
   TableCell,
   TableRow,
+  TextField,
   Toolbar,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import CloseIcon from "@mui/icons-material/Close";
 import LayersIcon from "@mui/icons-material/Layers";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import SaveIcon from "@mui/icons-material/Save";
 import TuneIcon from "@mui/icons-material/Tune";
 import {
   GAME_TO_REAL_YEARS,
@@ -65,6 +76,7 @@ import {
 import {
   getStorageChoice,
   getStorageJson,
+  getStorageString,
   setStorageKeyValue,
 } from "../../LocalStorage";
 import { generateNewTimeline } from "../../reducers/Game";
@@ -160,16 +172,25 @@ export const INSIGHT_LAYERS: readonly InsightLayerDefinition[] = [
   { id: "water", label: "Water", group: "Environment", availability: "hydro" },
 ] as const;
 
+export type DefaultInsightPresetId =
+  "overview" | "reliability" | "profitability" | "growth" | "decarbonization";
+
 export type InsightPresetId =
-  | "overview"
-  | "reliability"
-  | "profitability"
-  | "growth"
-  | "decarbonization"
-  | "custom";
+  DefaultInsightPresetId | "custom" | `saved:${string}`;
+
+export interface CustomInsightPreset {
+  id: string;
+  name: string;
+  layers: InsightLayerId[];
+}
+
+interface InsightPresetLibrary {
+  defaults: Partial<Record<DefaultInsightPresetId, InsightLayerId[]>>;
+  custom: CustomInsightPreset[];
+}
 
 export const INSIGHT_PRESETS: Record<
-  Exclude<InsightPresetId, "custom">,
+  DefaultInsightPresetId,
   { label: string; layers: InsightLayerId[] }
 > = {
   // Each preset reads from the outcome a player is trying to protect into the causes they can
@@ -205,6 +226,10 @@ export const INSIGHT_PRESETS: Record<
 
 const RANGE_KEY = "insightsRange";
 const LAYERS_KEY = "insightsLayers";
+const ACTIVE_PRESET_KEY = "insightsActivePreset";
+const PRESET_LIBRARY_KEY = "insightsPresetLibrary";
+export const MAX_CUSTOM_INSIGHT_PRESETS = 10;
+const MAX_PRESET_NAME_LENGTH = 40;
 const FORECAST_RANGE_OPTIONS: readonly InsightRange[] = [
   "next1",
   "next5",
@@ -267,16 +292,140 @@ interface State {
   range: InsightRange;
   layers: InsightLayerId[];
   preset: InsightPresetId;
+  presetDirty: boolean;
+  presetLibrary: InsightPresetLibrary;
+  presetMenuAnchor: HTMLElement | null;
+  presetDialog: "saveAs" | "rename" | "delete" | "restore" | null;
+  presetName: string;
+  presetNameError: string;
   layersOpen: boolean;
   leversOpen: boolean;
 }
 
-function storedLayers(): InsightLayerId[] {
-  const value = getStorageJson<string[]>(LAYERS_KEY, []);
-  const valid = value.filter(
-    (id, index): id is InsightLayerId =>
-      ALL_LAYER_IDS.has(id as InsightLayerId) && value.indexOf(id) === index,
+function sameLayers(left: InsightLayerId[], right: InsightLayerId[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((layer, index) => layer === right[index])
   );
+}
+
+function validLayers(value: unknown): InsightLayerId[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (id, index): id is InsightLayerId =>
+      typeof id === "string" &&
+      ALL_LAYER_IDS.has(id as InsightLayerId) &&
+      value.indexOf(id) === index,
+  );
+}
+
+function storedPresetLibrary(): InsightPresetLibrary {
+  const stored = getStorageJson<{
+    defaults?: Partial<Record<DefaultInsightPresetId, unknown>>;
+    custom?: unknown[];
+  }>(PRESET_LIBRARY_KEY, {});
+  const defaults: InsightPresetLibrary["defaults"] = {};
+  for (const id of Object.keys(INSIGHT_PRESETS) as DefaultInsightPresetId[]) {
+    const layers = validLayers(stored.defaults?.[id]);
+    if (layers.length) {
+      defaults[id] = layers;
+    }
+  }
+
+  const names = new Set<string>();
+  const ids = new Set<string>();
+  const custom: CustomInsightPreset[] = [];
+  for (const value of stored.custom || []) {
+    if (!value || typeof value !== "object") {
+      continue;
+    }
+    const candidate = value as Partial<CustomInsightPreset>;
+    const id = typeof candidate.id === "string" ? candidate.id : "";
+    const name =
+      typeof candidate.name === "string" ? candidate.name.trim() : "";
+    const layers = validLayers(candidate.layers);
+    const normalizedName = name.toLocaleLowerCase();
+    if (
+      !id ||
+      !name ||
+      name.length > MAX_PRESET_NAME_LENGTH ||
+      !layers.length ||
+      ids.has(id) ||
+      names.has(normalizedName)
+    ) {
+      continue;
+    }
+    ids.add(id);
+    names.add(normalizedName);
+    custom.push({ id, name, layers });
+    if (custom.length === MAX_CUSTOM_INSIGHT_PRESETS) {
+      break;
+    }
+  }
+  return { defaults, custom };
+}
+
+function presetDefinition(
+  id: InsightPresetId,
+  library: InsightPresetLibrary,
+): { label: string; layers: InsightLayerId[] } | undefined {
+  if (id === "custom") {
+    return undefined;
+  }
+  if (id.startsWith("saved:")) {
+    const saved = library.custom.find(
+      (preset) => preset.id === id.slice("saved:".length),
+    );
+    return saved ? { label: saved.name, layers: saved.layers } : undefined;
+  }
+  const defaultPreset = INSIGHT_PRESETS[id as DefaultInsightPresetId];
+  return defaultPreset
+    ? {
+        label: defaultPreset.label,
+        layers:
+          library.defaults[id as DefaultInsightPresetId] ||
+          defaultPreset.layers,
+      }
+    : undefined;
+}
+
+function matchingPreset(
+  layers: InsightLayerId[],
+  library: InsightPresetLibrary,
+): InsightPresetId {
+  for (const id of Object.keys(INSIGHT_PRESETS) as DefaultInsightPresetId[]) {
+    if (sameLayers(layers, presetDefinition(id, library)!.layers)) {
+      return id;
+    }
+  }
+  const custom = library.custom.find((preset) =>
+    sameLayers(layers, preset.layers),
+  );
+  return custom ? `saved:${custom.id}` : "custom";
+}
+
+function isStoredPreset(
+  id: string,
+  library: InsightPresetLibrary,
+): id is InsightPresetId {
+  return !!presetDefinition(id as InsightPresetId, library);
+}
+
+function nextCustomPresetId(custom: CustomInsightPreset[]): string {
+  return String(
+    custom.reduce((highest, preset) => {
+      const numericId = Number(preset.id);
+      return Number.isInteger(numericId)
+        ? Math.max(highest, numericId)
+        : highest;
+    }, 0) + 1,
+  );
+}
+
+function storedLayers(): InsightLayerId[] {
+  const valid = validLayers(getStorageJson<string[]>(LAYERS_KEY, []));
   return valid.length ? valid : [...INSIGHT_PRESETS.overview.layers];
 }
 
@@ -432,14 +581,26 @@ export default class Insights extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
+    const presetLibrary = storedPresetLibrary();
     const layers = withRequiredLayers(storedLayers(), props.game.scenarioId);
     if (props.focusLayer && !layers.includes(props.focusLayer)) {
       layers.push(props.focusLayer);
     }
+    const storedPreset = getStorageString(ACTIVE_PRESET_KEY, "");
+    const preset = isStoredPreset(storedPreset, presetLibrary)
+      ? storedPreset
+      : matchingPreset(layers, presetLibrary);
+    const savedLayers = presetDefinition(preset, presetLibrary)?.layers;
     this.state = {
       range: getStorageChoice(RANGE_KEY, rangeOptions(props.game), "next1"),
       layers,
-      preset: presetForLayers(layers),
+      preset,
+      presetDirty: !savedLayers || !sameLayers(layers, savedLayers),
+      presetLibrary,
+      presetMenuAnchor: null,
+      presetDialog: null,
+      presetName: "",
+      presetNameError: "",
       layersOpen: false,
       leversOpen: true,
     };
@@ -485,11 +646,20 @@ export default class Insights extends React.Component<Props, State> {
 
   private setLayers(
     layers: InsightLayerId[],
-    preset: InsightPresetId = "custom",
+    preset: InsightPresetId = this.state.preset,
   ) {
     const required = withRequiredLayers(layers, this.props.game.scenarioId);
+    const savedLayers = presetDefinition(
+      preset,
+      this.state.presetLibrary,
+    )?.layers;
     setStorageKeyValue(LAYERS_KEY, required);
-    this.setState({ layers: required, preset });
+    setStorageKeyValue(ACTIVE_PRESET_KEY, preset);
+    this.setState({
+      layers: required,
+      preset,
+      presetDirty: !savedLayers || !sameLayers(required, savedLayers),
+    });
   }
 
   private toggleLayer(id: InsightLayerId) {
@@ -504,7 +674,17 @@ export default class Insights extends React.Component<Props, State> {
   }
 
   private applyPreset(id: Exclude<InsightPresetId, "custom">) {
-    this.setLayers([...INSIGHT_PRESETS[id].layers], id);
+    const preset = presetDefinition(id, this.state.presetLibrary);
+    if (!preset) {
+      return;
+    }
+    const layers = withRequiredLayers(
+      preset.layers,
+      this.props.game.scenarioId,
+    );
+    setStorageKeyValue(LAYERS_KEY, layers);
+    setStorageKeyValue(ACTIVE_PRESET_KEY, id);
+    this.setState({ layers, preset: id, presetDirty: false });
   }
 
   private moveLayer(id: InsightLayerId, neighbour: InsightLayerId) {
@@ -516,6 +696,192 @@ export default class Insights extends React.Component<Props, State> {
     }
     [layers[from], layers[to]] = [layers[to], layers[from]];
     this.setLayers(layers);
+  }
+
+  private savePresetLibrary(library: InsightPresetLibrary) {
+    setStorageKeyValue(PRESET_LIBRARY_KEY, library);
+  }
+
+  private selectedCustomPreset(): CustomInsightPreset | undefined {
+    if (!this.state.preset.startsWith("saved:")) {
+      return undefined;
+    }
+    return this.state.presetLibrary.custom.find(
+      (preset) => preset.id === this.state.preset.slice("saved:".length),
+    );
+  }
+
+  private savePresetChanges() {
+    const { layers, preset, presetLibrary } = this.state;
+    if (!layers.length || preset === "custom") {
+      this.openPresetDialog("saveAs");
+      return;
+    }
+
+    let library: InsightPresetLibrary;
+    if (preset.startsWith("saved:")) {
+      const id = preset.slice("saved:".length);
+      library = {
+        ...presetLibrary,
+        custom: presetLibrary.custom.map((saved) =>
+          saved.id === id ? { ...saved, layers: [...layers] } : saved,
+        ),
+      };
+    } else {
+      const defaultId = preset as DefaultInsightPresetId;
+      const defaults = { ...presetLibrary.defaults };
+      if (sameLayers(layers, INSIGHT_PRESETS[defaultId].layers)) {
+        delete defaults[defaultId];
+      } else {
+        defaults[defaultId] = [...layers];
+      }
+      library = { ...presetLibrary, defaults };
+    }
+    this.savePresetLibrary(library);
+    setStorageKeyValue(ACTIVE_PRESET_KEY, preset);
+    this.setState({ presetLibrary: library, presetDirty: false });
+  }
+
+  private openPresetDialog(dialog: Exclude<State["presetDialog"], null>) {
+    const selected = this.selectedCustomPreset();
+    this.setState({
+      presetMenuAnchor: null,
+      presetDialog: dialog,
+      presetName: dialog === "rename" ? selected?.name || "" : "",
+      presetNameError: "",
+    });
+  }
+
+  private closePresetDialog() {
+    this.setState({
+      presetDialog: null,
+      presetName: "",
+      presetNameError: "",
+    });
+  }
+
+  private validatedPresetName(excludeId?: string): string | null {
+    const name = this.state.presetName.trim();
+    if (!name) {
+      this.setState({ presetNameError: "Enter a name." });
+      return null;
+    }
+    const duplicateDefault = Object.values(INSIGHT_PRESETS).some(
+      (preset) => preset.label.toLocaleLowerCase() === name.toLocaleLowerCase(),
+    );
+    const duplicateCustom = this.state.presetLibrary.custom.some(
+      (preset) =>
+        preset.id !== excludeId &&
+        preset.name.toLocaleLowerCase() === name.toLocaleLowerCase(),
+    );
+    if (duplicateDefault || duplicateCustom) {
+      this.setState({ presetNameError: "That name is already in use." });
+      return null;
+    }
+    return name;
+  }
+
+  private createCustomPreset() {
+    if (
+      !this.state.layers.length ||
+      this.state.presetLibrary.custom.length >= MAX_CUSTOM_INSIGHT_PRESETS
+    ) {
+      return;
+    }
+    const name = this.validatedPresetName();
+    if (!name) {
+      return;
+    }
+    const id = nextCustomPresetId(this.state.presetLibrary.custom);
+    const preset: CustomInsightPreset = {
+      id,
+      name,
+      layers: [...this.state.layers],
+    };
+    const library = {
+      ...this.state.presetLibrary,
+      custom: [...this.state.presetLibrary.custom, preset],
+    };
+    const presetId = `saved:${id}` as const;
+    this.savePresetLibrary(library);
+    setStorageKeyValue(ACTIVE_PRESET_KEY, presetId);
+    this.setState({
+      presetLibrary: library,
+      preset: presetId,
+      presetDirty: false,
+      presetDialog: null,
+      presetName: "",
+      presetNameError: "",
+    });
+  }
+
+  private renameCustomPreset() {
+    const selected = this.selectedCustomPreset();
+    if (!selected) {
+      return;
+    }
+    const name = this.validatedPresetName(selected.id);
+    if (!name) {
+      return;
+    }
+    const library = {
+      ...this.state.presetLibrary,
+      custom: this.state.presetLibrary.custom.map((preset) =>
+        preset.id === selected.id ? { ...preset, name } : preset,
+      ),
+    };
+    this.savePresetLibrary(library);
+    this.setState({
+      presetLibrary: library,
+      presetDialog: null,
+      presetName: "",
+      presetNameError: "",
+    });
+  }
+
+  private deleteCustomPreset() {
+    const selected = this.selectedCustomPreset();
+    if (!selected) {
+      return;
+    }
+    const library = {
+      ...this.state.presetLibrary,
+      custom: this.state.presetLibrary.custom.filter(
+        (preset) => preset.id !== selected.id,
+      ),
+    };
+    this.savePresetLibrary(library);
+    setStorageKeyValue(ACTIVE_PRESET_KEY, "custom");
+    this.setState({
+      presetLibrary: library,
+      preset: "custom",
+      presetDirty: true,
+      presetDialog: null,
+    });
+  }
+
+  private restoreDefaultPreset() {
+    const { preset, presetLibrary } = this.state;
+    if (preset === "custom" || preset.startsWith("saved:")) {
+      return;
+    }
+    const defaultId = preset as DefaultInsightPresetId;
+    const defaults = { ...presetLibrary.defaults };
+    delete defaults[defaultId];
+    const library = { ...presetLibrary, defaults };
+    const layers = withRequiredLayers(
+      INSIGHT_PRESETS[defaultId].layers,
+      this.props.game.scenarioId,
+    );
+    this.savePresetLibrary(library);
+    setStorageKeyValue(LAYERS_KEY, layers);
+    setStorageKeyValue(ACTIVE_PRESET_KEY, preset);
+    this.setState({
+      presetLibrary: library,
+      layers,
+      presetDirty: false,
+      presetDialog: null,
+    });
   }
 
   private getHistoricalProjection(now: TickPresentFutureType): ProjectionView {
@@ -809,7 +1175,11 @@ export default class Insights extends React.Component<Props, State> {
     }
     const required = requiredTutorialLayers(this.props.game.scenarioId);
     return (
-      <section className="insightsLayerPanel" aria-label="Data layers">
+      <section
+        id="insightsLayerPanel"
+        className="insightsLayerPanel"
+        aria-label="Data layers"
+      >
         {GROUPS.map((group) => {
           const layers = INSIGHT_LAYERS.filter(
             (layer) =>
@@ -1160,6 +1530,110 @@ export default class Insights extends React.Component<Props, State> {
     );
   }
 
+  private renderPresetDialogs() {
+    const { presetDialog, presetName, presetNameError, presetLibrary } =
+      this.state;
+    if (!presetDialog) {
+      return <></>;
+    }
+    const selected =
+      presetDefinition(this.state.preset, presetLibrary)?.label || "preset";
+    const naming = presetDialog === "saveAs" || presetDialog === "rename";
+    const title =
+      presetDialog === "saveAs"
+        ? "Save as a new preset"
+        : presetDialog === "rename"
+          ? "Rename preset"
+          : presetDialog === "delete"
+            ? `Delete “${selected}”?`
+            : `Restore “${selected}”?`;
+    const description =
+      presetDialog === "saveAs"
+        ? `Save the current ${this.state.layers.length} charts and their order as a reusable preset.`
+        : presetDialog === "rename"
+          ? "Give this preset a short, recognizable name."
+          : presetDialog === "delete"
+            ? "The charts stay open as an unsaved view, but this named preset will be removed."
+            : "This replaces your saved changes with the original charts and order. Your custom presets are not affected.";
+
+    return (
+      <Dialog
+        className="insightsPresetDialog"
+        open={presetDialog !== null}
+        onClose={() => this.closePresetDialog()}
+        fullWidth
+        maxWidth="xs"
+        aria-labelledby="insight-preset-dialog-title"
+        aria-describedby="insight-preset-dialog-description"
+      >
+        <DialogTitle id="insight-preset-dialog-title">{title}</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="insight-preset-dialog-description">
+            {description}
+          </DialogContentText>
+          {naming ? (
+            <TextField
+              autoFocus
+              fullWidth
+              margin="dense"
+              label="Preset name"
+              value={presetName}
+              error={!!presetNameError}
+              helperText={
+                presetNameError ||
+                (presetDialog === "saveAs"
+                  ? `${presetName.length}/${MAX_PRESET_NAME_LENGTH} characters · ${presetLibrary.custom.length}/${MAX_CUSTOM_INSIGHT_PRESETS} custom presets`
+                  : `${presetName.length}/${MAX_PRESET_NAME_LENGTH} characters`)
+              }
+              slotProps={{ htmlInput: { maxLength: MAX_PRESET_NAME_LENGTH } }}
+              onChange={(event) =>
+                this.setState({
+                  presetName: event.target.value,
+                  presetNameError: "",
+                })
+              }
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  if (presetDialog === "saveAs") {
+                    this.createCustomPreset();
+                  } else {
+                    this.renameCustomPreset();
+                  }
+                }
+              }}
+            />
+          ) : null}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => this.closePresetDialog()}>Cancel</Button>
+          <Button
+            variant="contained"
+            color={presetDialog === "delete" ? "error" : "primary"}
+            onClick={() => {
+              if (presetDialog === "saveAs") {
+                this.createCustomPreset();
+              } else if (presetDialog === "rename") {
+                this.renameCustomPreset();
+              } else if (presetDialog === "delete") {
+                this.deleteCustomPreset();
+              } else {
+                this.restoreDefaultPreset();
+              }
+            }}
+          >
+            {presetDialog === "saveAs"
+              ? "Save preset"
+              : presetDialog === "rename"
+                ? "Rename"
+                : presetDialog === "delete"
+                  ? "Delete"
+                  : "Restore"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
   public render() {
     const { game } = this.props;
     const now = getTimeFromTimeline(game.date.minute, game.timeline);
@@ -1172,66 +1646,205 @@ export default class Insights extends React.Component<Props, State> {
       const definition = INSIGHT_LAYERS.find((layer) => layer.id === id);
       return !!definition && this.available(definition, projection);
     });
+    const selectedPreset = presetDefinition(
+      this.state.preset,
+      this.state.presetLibrary,
+    );
+    const selectedCustom = this.selectedCustomPreset();
+    const selectedDefault =
+      this.state.preset !== "custom" && !this.state.preset.startsWith("saved:")
+        ? (this.state.preset as DefaultInsightPresetId)
+        : null;
+    const customLimitReached =
+      this.state.presetLibrary.custom.length >= MAX_CUSTOM_INSIGHT_PRESETS;
+    const selectedDefaultCustomized =
+      !!selectedDefault &&
+      !!this.state.presetLibrary.defaults[selectedDefault] &&
+      !this.state.presetDirty;
 
     return (
       <GameCard className="insights" id="insightsPane">
         <div className="scrollable">
           <Toolbar className="paneHeader insightsHeader">
             <Typography variant="h6">Insights</Typography>
-            <Select
-              id="insightsRange"
-              value={this.state.range}
-              onChange={(event: SelectChangeEvent<InsightRange>) =>
-                this.setRange(event.target.value as InsightRange)
-              }
-              className="headerControl"
-              aria-label="Insight range"
-            >
-              <MenuItem value="next1">Next 12 months</MenuItem>
-              <MenuItem value="next5">Next 5 years</MenuItem>
-              <MenuItem value="next10">Next 10 years</MenuItem>
-              <MenuItem value="next20">Next 20 years</MenuItem>
-              {!!game.monthlyHistory.length && (
-                <MenuItem value="all">All recorded</MenuItem>
-              )}
-              {years.map((year) => (
-                <MenuItem value={historyRange(year)} key={year}>
-                  {year}
-                </MenuItem>
-              ))}
-            </Select>
-            <Select
-              id="insightsPreset"
-              value={this.state.preset}
-              onChange={(event: SelectChangeEvent<InsightPresetId>) => {
-                const preset = event.target.value as InsightPresetId;
-                if (preset !== "custom") {
-                  this.applyPreset(preset);
+            <div className="insightsHeaderControls">
+              <Select
+                id="insightsRange"
+                value={this.state.range}
+                onChange={(event: SelectChangeEvent<InsightRange>) =>
+                  this.setRange(event.target.value as InsightRange)
                 }
-              }}
-              className="insightsPreset"
-              aria-label="Insight preset"
+                className="headerControl insightsRange"
+                aria-label="Insight range"
+              >
+                <MenuItem value="next1">Next 12 months</MenuItem>
+                <MenuItem value="next5">Next 5 years</MenuItem>
+                <MenuItem value="next10">Next 10 years</MenuItem>
+                <MenuItem value="next20">Next 20 years</MenuItem>
+                {!!game.monthlyHistory.length && (
+                  <MenuItem value="all">All recorded</MenuItem>
+                )}
+                {years.map((year) => (
+                  <MenuItem value={historyRange(year)} key={year}>
+                    {year}
+                  </MenuItem>
+                ))}
+              </Select>
+              <div
+                className={`insightsPresetControls${
+                  this.state.presetDirty ? " insightsPresetControls-edited" : ""
+                }`}
+                aria-label="Preset controls"
+              >
+                <Select
+                  id="insightsPreset"
+                  value={this.state.preset}
+                  onChange={(event: SelectChangeEvent<InsightPresetId>) => {
+                    const preset = event.target.value as InsightPresetId;
+                    if (preset !== "custom") {
+                      this.applyPreset(preset);
+                    }
+                  }}
+                  className="insightsPreset"
+                  aria-label="Insight preset"
+                  renderValue={() => (
+                    <span className="insightsPresetValue">
+                      <span className="insightsPresetName">
+                        {selectedPreset?.label || "Unsaved view"}
+                      </span>
+                      {this.state.presetDirty && selectedPreset && (
+                        <span
+                          className="insightsPresetEdited"
+                          role="status"
+                          aria-label="Unsaved changes"
+                        >
+                          Edited
+                        </span>
+                      )}
+                      {selectedDefaultCustomized && (
+                        <span className="insightsPresetCustomized">
+                          Customized
+                        </span>
+                      )}
+                    </span>
+                  )}
+                >
+                  <ListSubheader>Default presets</ListSubheader>
+                  {Object.entries(INSIGHT_PRESETS).map(([id, preset]) => {
+                    const modified =
+                      !!this.state.presetLibrary.defaults[
+                        id as DefaultInsightPresetId
+                      ];
+                    return (
+                      <MenuItem key={id} value={id}>
+                        <span>{preset.label}</span>
+                        {modified && (
+                          <span className="insightsPresetMenuHint">
+                            Modified
+                          </span>
+                        )}
+                      </MenuItem>
+                    );
+                  })}
+                  {!!this.state.presetLibrary.custom.length && (
+                    <ListSubheader>
+                      Your presets ({this.state.presetLibrary.custom.length}/
+                      {MAX_CUSTOM_INSIGHT_PRESETS})
+                    </ListSubheader>
+                  )}
+                  {this.state.presetLibrary.custom.map((preset) => (
+                    <MenuItem key={preset.id} value={`saved:${preset.id}`}>
+                      <span className="insightsPresetMenuName">
+                        {preset.name}
+                      </span>
+                    </MenuItem>
+                  ))}
+                  <MenuItem value="custom" disabled>
+                    Unsaved view
+                  </MenuItem>
+                </Select>
+                <Button
+                  className="insightsPresetSave"
+                  size="small"
+                  startIcon={<SaveIcon />}
+                  disabled={
+                    !this.state.layers.length ||
+                    (this.state.preset !== "custom" &&
+                      !this.state.presetDirty) ||
+                    (this.state.preset === "custom" && customLimitReached)
+                  }
+                  title={
+                    this.state.preset === "custom" && customLimitReached
+                      ? `Limit of ${MAX_CUSTOM_INSIGHT_PRESETS} custom presets reached`
+                      : undefined
+                  }
+                  onClick={() => this.savePresetChanges()}
+                >
+                  {this.state.preset === "custom" ? "Save as" : "Save"}
+                </Button>
+                <Tooltip title="Rename, save a copy, restore, or delete">
+                  <Button
+                    className="insightsPresetActions"
+                    size="small"
+                    startIcon={<MoreVertIcon />}
+                    aria-label="Preset actions"
+                    aria-haspopup="menu"
+                    aria-controls={
+                      this.state.presetMenuAnchor
+                        ? "insightsPresetActionsMenu"
+                        : undefined
+                    }
+                    aria-expanded={!!this.state.presetMenuAnchor}
+                    onClick={(event) =>
+                      this.setState({ presetMenuAnchor: event.currentTarget })
+                    }
+                  >
+                    More
+                  </Button>
+                </Tooltip>
+              </div>
+              <Button
+                id="insightsLayersButton"
+                className="insightsLayerControls"
+                startIcon={<LayersIcon />}
+                onClick={() =>
+                  this.setState({ layersOpen: !this.state.layersOpen })
+                }
+                aria-expanded={this.state.layersOpen}
+                aria-controls="insightsLayerPanel"
+              >
+                Layers ({visible.length})
+              </Button>
+            </div>
+            <Menu
+              id="insightsPresetActionsMenu"
+              anchorEl={this.state.presetMenuAnchor}
+              open={!!this.state.presetMenuAnchor}
+              onClose={() => this.setState({ presetMenuAnchor: null })}
             >
-              {Object.entries(INSIGHT_PRESETS).map(([id, preset]) => (
-                <MenuItem key={id} value={id}>
-                  {preset.label}
-                </MenuItem>
-              ))}
-              <MenuItem value="custom" disabled>
-                Custom
+              <MenuItem
+                disabled={customLimitReached || !this.state.layers.length}
+                onClick={() => this.openPresetDialog("saveAs")}
+              >
+                Save as new preset…
               </MenuItem>
-            </Select>
-            <Button
-              id="insightsLayersButton"
-              className="insightsLayerControls"
-              startIcon={<LayersIcon />}
-              onClick={() =>
-                this.setState({ layersOpen: !this.state.layersOpen })
-              }
-              aria-expanded={this.state.layersOpen}
-            >
-              Layers ({visible.length})
-            </Button>
+              {selectedCustom && (
+                <MenuItem onClick={() => this.openPresetDialog("rename")}>
+                  Rename preset…
+                </MenuItem>
+              )}
+              {selectedCustom && (
+                <MenuItem onClick={() => this.openPresetDialog("delete")}>
+                  Delete preset…
+                </MenuItem>
+              )}
+              {selectedDefault &&
+                this.state.presetLibrary.defaults[selectedDefault] && (
+                  <MenuItem onClick={() => this.openPresetDialog("restore")}>
+                    Restore original preset…
+                  </MenuItem>
+                )}
+            </Menu>
           </Toolbar>
           {this.renderLayerPanel(projection)}
           {projection.historical ? (
@@ -1252,6 +1865,7 @@ export default class Insights extends React.Component<Props, State> {
             )}
           </div>
         </div>
+        {this.renderPresetDialogs()}
       </GameCard>
     );
   }


### PR DESCRIPTION
Adds persistent Insights chart preset management. Players can save and name up to 10 custom presets, update custom or default presets in place, rename and delete custom presets, and restore authored defaults. The preset controls were critiqued and polished by a design sub-agent for clear edited/customized states, responsive mobile layout, touch targets, dialogs, and accessibility. Verification: npm run check; npm run build; focused Insights tests (17/17); Playwright browser suite with the two parallel mobile timeouts rerun serially and passing.