### PR TITLE
Stabilize homepage layout and add map zoom gestures

### DIFF
--- a/e2e/custom-location-picker.spec.ts
+++ b/e2e/custom-location-picker.spec.ts
@@ -150,7 +150,7 @@ test("keyboard navigation retains one map stop and honors activation and zoom bo
   await expect(zoomOut).toBeDisabled();
 });
 
-test("pointer and touch interactions pan when zoomed and leave page scrolling available", async ({
+test("pointer, touch, pinch, and wheel interactions navigate the map", async ({
   page,
 }, testInfo) => {
   await openCustomSetup(page);
@@ -182,6 +182,18 @@ test("pointer and touch interactions pan when zoomed and leave page scrolling av
       .poll(() => land.getAttribute("transform"))
       .not.toBe(startingTransform);
     await expect(search).toHaveValue(startingSelection);
+
+    await page.getByRole("button", { name: "Show world" }).click();
+    const worldTransform = await land.getAttribute("transform");
+    await page.mouse.move(
+      mapBox!.x + mapBox!.width / 2,
+      mapBox!.y + mapBox!.height / 2,
+    );
+    await page.mouse.wheel(0, -100);
+    await expect
+      .poll(() => land.getAttribute("transform"))
+      .not.toBe(worldTransform);
+    await expect(page.getByRole("button", { name: "Zoom out" })).toBeEnabled();
     return;
   }
 
@@ -205,6 +217,30 @@ test("pointer and touch interactions pan when zoomed and leave page scrolling av
     .poll(() => land.getAttribute("transform"))
     .not.toBe(startingTransform);
   await expect(search).toHaveValue(startingSelection);
+
+  await page.getByRole("button", { name: "Show world" }).click();
+  const beforePinch = await land.getAttribute("transform");
+  const pinchY = Math.round(mapBox!.y + mapBox!.height / 2);
+  const pinchCenterX = Math.round(mapBox!.x + mapBox!.width / 2);
+  await session.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: [
+      { x: pinchCenterX - 40, y: pinchY },
+      { x: pinchCenterX + 40, y: pinchY },
+    ],
+  });
+  await session.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [
+      { x: pinchCenterX - 70, y: pinchY },
+      { x: pinchCenterX + 70, y: pinchY },
+    ],
+  });
+  await session.send("Input.dispatchTouchEvent", {
+    type: "touchEnd",
+    touchPoints: [],
+  });
+  await expect.poll(() => land.getAttribute("transform")).not.toBe(beforePinch);
 
   await page.getByRole("button", { name: "Show world" }).click();
   await expect(map).toHaveCSS("touch-action", "pan-y");

--- a/src/app.scss
+++ b/src/app.scss
@@ -1888,6 +1888,11 @@ html[data-theme="dark"] .uplot {
         margin-top: 2px;
       }
 
+      .accountActions {
+        align-items: center;
+        margin-top: 2px;
+      }
+
       button {
         margin: 0;
       }

--- a/src/components/base/LocationPicker.test.tsx
+++ b/src/components/base/LocationPicker.test.tsx
@@ -24,6 +24,20 @@ const cities: CityType[] = [
   },
 ];
 
+function firePointer(
+  element: Element,
+  type: string,
+  init: MouseEventInit & { pointerId: number },
+) {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  Object.defineProperty(event, "pointerId", { value: init.pointerId });
+  fireEvent(element, event);
+}
+
 it("combines the selected city and search in one field on an aligned detailed map", () => {
   render(
     <LocationPicker
@@ -91,7 +105,7 @@ it("supports arrow navigation, Enter and Space activation, and Home", () => {
   expect(screen.getByText("Showing the whole world")).toBeInTheDocument();
 });
 
-it("pans with scrolling while zoomed", () => {
+it("zooms in and out with the scroll wheel", () => {
   render(
     <LocationPicker
       locations={cities}
@@ -99,13 +113,62 @@ it("pans with scrolling while zoomed", () => {
       onChange={jest.fn()}
     />,
   );
-  fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
   const map = screen.getByRole("group", { name: "Playable locations map" });
   const content = screen.getByTestId("world-map-content");
   const before = content.getAttribute("transform");
 
-  fireEvent.wheel(map, { deltaX: -30, deltaY: -20 });
+  fireEvent.wheel(map, { deltaY: -100, clientX: 300, clientY: 150 });
   expect(content).not.toHaveAttribute("transform", before);
+  expect(screen.getByRole("button", { name: "Zoom out" })).toBeEnabled();
+
+  fireEvent.wheel(map, { deltaY: 100, clientX: 300, clientY: 150 });
+  expect(content).toHaveAttribute("transform", before);
+  expect(screen.getByRole("button", { name: "Zoom out" })).toBeDisabled();
+});
+
+it("zooms with a two-pointer pinch gesture and restores marker clicks", async () => {
+  const onChange = jest.fn();
+  render(
+    <LocationPicker locations={cities} value={cities[0]} onChange={onChange} />,
+  );
+  const map = screen.getByRole("group", { name: "Playable locations map" });
+  const content = screen.getByTestId("world-map-content");
+  const before = content.getAttribute("transform");
+
+  firePointer(map, "pointerdown", {
+    pointerId: 1,
+    button: 0,
+    clientX: 200,
+    clientY: 150,
+  });
+  firePointer(map, "pointerdown", {
+    pointerId: 2,
+    button: 0,
+    clientX: 400,
+    clientY: 150,
+  });
+  firePointer(map, "pointermove", {
+    pointerId: 2,
+    clientX: 480,
+    clientY: 150,
+  });
+
+  expect(content).not.toHaveAttribute("transform", before);
+  expect(screen.getByRole("button", { name: "Zoom out" })).toBeEnabled();
+
+  firePointer(map, "pointerup", {
+    pointerId: 2,
+    clientX: 480,
+    clientY: 150,
+  });
+  firePointer(map, "pointerup", {
+    pointerId: 1,
+    clientX: 200,
+    clientY: 150,
+  });
+  await act(() => new Promise((resolve) => window.setTimeout(resolve, 0)));
+  fireEvent.click(screen.getByRole("button", { name: /Select East City/ }));
+  expect(onChange).toHaveBeenCalledWith(cities[1]);
 });
 
 it("drills into a cluster and lists unresolved cities at maximum zoom", async () => {

--- a/src/components/base/LocationPicker.tsx
+++ b/src/components/base/LocationPicker.tsx
@@ -24,6 +24,7 @@ import {
   MAP_ZOOM_SCALES,
   panViewport,
   projectLocation,
+  zoomViewportAt,
 } from "../../helpers/WorldMap";
 
 interface Props {
@@ -42,6 +43,14 @@ interface MapDrag {
   y: number;
   moved: boolean;
 }
+
+interface MapPinch {
+  distance: number;
+}
+
+const PINCH_ZOOM_IN_RATIO = 1.25;
+const PINCH_ZOOM_OUT_RATIO = 0.8;
+const WHEEL_ZOOM_THRESHOLD = 40;
 
 function locationDetail(location: CityType): string {
   return [location.admin, location.country, location.region]
@@ -92,7 +101,11 @@ export default function LocationPicker({
   const [focusAfterZoom, setFocusAfterZoom] = React.useState<MapPoint>();
   const [panning, setPanning] = React.useState(false);
   const mapRef = React.useRef<HTMLDivElement>(null);
+  const viewportRef = React.useRef(viewport);
   const dragRef = React.useRef<MapDrag>();
+  const pinchRef = React.useRef<MapPinch>();
+  const pointersRef = React.useRef(new Map<number, MapPoint>());
+  const wheelDeltaRef = React.useRef(0);
   const suppressClickRef = React.useRef(false);
   const controlRefs = React.useRef<Record<string, HTMLButtonElement | null>>(
     {},
@@ -144,15 +157,46 @@ export default function LocationPicker({
     }
   }, [controls, rovingId, value?.id, focusAfterZoom]);
 
-  const setZoom = (zoom: number, center = viewport.center, focus = false) => {
-    const next = clampViewport({ center, zoom });
+  viewportRef.current = viewport;
+
+  const applyViewport = (next: MapViewport) => {
+    viewportRef.current = next;
     setViewport(next);
+  };
+
+  const announceZoom = (zoom: number) => {
     setAnnouncement(
-      next.zoom === 0
-        ? "Showing the whole world"
-        : `Map zoom level ${next.zoom + 1}`,
+      zoom === 0 ? "Showing the whole world" : `Map zoom level ${zoom + 1}`,
     );
+  };
+
+  const setZoom = (
+    zoom: number,
+    center = viewportRef.current.center,
+    focus = false,
+  ) => {
+    const next = clampViewport({ center, zoom });
+    applyViewport(next);
+    announceZoom(next.zoom);
     if (focus) setFocusAfterZoom({ x: 0.5, y: 0.5 });
+  };
+
+  const zoomAtPoint = (delta: number, point: MapPoint) => {
+    const current = viewportRef.current;
+    const next = zoomViewportAt(current, current.zoom + delta, point);
+    if (next.zoom === current.zoom) return;
+    applyViewport(next);
+    announceZoom(next.zoom);
+  };
+
+  const screenPoint = (clientX: number, clientY: number): MapPoint => {
+    const rect = mapRef.current?.getBoundingClientRect();
+    const width = rect?.width || mapSize.width;
+    const height = rect?.height || mapSize.height;
+    return {
+      x: (clientX - (rect?.left || 0)) / width,
+      y: (clientY - (rect?.top || 0)) / height,
+    };
   };
 
   const select = (location: CityType, centerSearch = false) => {
@@ -160,7 +204,7 @@ export default function LocationPicker({
     setAnnouncement(`${location.name} selected`);
     setRovingId(`location-${location.id}`);
     if (centerSearch) {
-      setViewport(
+      applyViewport(
         clampViewport({ center: projectLocation(location), zoom: 2 }),
       );
     }
@@ -228,12 +272,28 @@ export default function LocationPicker({
 
   const startPan = (event: React.PointerEvent<HTMLDivElement>) => {
     if (
-      viewport.zoom === 0 ||
       event.button !== 0 ||
       (event.target as Element).closest(".worldMapControls")
     ) {
       return;
     }
+    pointersRef.current.set(event.pointerId, {
+      x: event.clientX,
+      y: event.clientY,
+    });
+    if (pointersRef.current.size >= 2) {
+      const [a, b] = Array.from(pointersRef.current.values());
+      pinchRef.current = { distance: Math.hypot(a.x - b.x, a.y - b.y) };
+      dragRef.current = undefined;
+      suppressClickRef.current = true;
+      pointersRef.current.forEach((_point, pointerId) =>
+        event.currentTarget.setPointerCapture?.(pointerId),
+      );
+      setPanning(true);
+      event.preventDefault();
+      return;
+    }
+    if (viewportRef.current.zoom === 0) return;
     dragRef.current = {
       pointerId: event.pointerId,
       x: event.clientX,
@@ -245,6 +305,29 @@ export default function LocationPicker({
   };
 
   const movePan = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (pointersRef.current.has(event.pointerId)) {
+      pointersRef.current.set(event.pointerId, {
+        x: event.clientX,
+        y: event.clientY,
+      });
+    }
+    if (pinchRef.current && pointersRef.current.size >= 2) {
+      event.preventDefault();
+      const [a, b] = Array.from(pointersRef.current.values());
+      const distance = Math.hypot(a.x - b.x, a.y - b.y);
+      const ratio = distance / Math.max(1, pinchRef.current.distance);
+      const delta =
+        ratio >= PINCH_ZOOM_IN_RATIO
+          ? 1
+          : ratio <= PINCH_ZOOM_OUT_RATIO
+            ? -1
+            : 0;
+      if (delta !== 0) {
+        zoomAtPoint(delta, screenPoint((a.x + b.x) / 2, (a.y + b.y) / 2));
+        pinchRef.current.distance = distance;
+      }
+      return;
+    }
     const drag = dragRef.current;
     if (!drag || drag.pointerId !== event.pointerId) return;
     const deltaX = event.clientX - drag.x;
@@ -254,14 +337,46 @@ export default function LocationPicker({
     drag.x = event.clientX;
     drag.y = event.clientY;
     drag.moved = true;
-    setViewport((current: MapViewport) =>
-      panViewport(current, -deltaX, -deltaY, mapSize.width, mapSize.height),
+    applyViewport(
+      panViewport(
+        viewportRef.current,
+        -deltaX,
+        -deltaY,
+        mapSize.width,
+        mapSize.height,
+      ),
     );
   };
 
+  const resetClickSuppression = () => {
+    if (pointersRef.current.size === 0 && suppressClickRef.current) {
+      window.setTimeout(() => {
+        suppressClickRef.current = false;
+      }, 0);
+    }
+  };
+
   const endPan = (event: React.PointerEvent<HTMLDivElement>) => {
+    const wasPinching = !!pinchRef.current || pointersRef.current.size > 1;
+    pointersRef.current.delete(event.pointerId);
+    if (wasPinching) {
+      suppressClickRef.current = true;
+      dragRef.current = undefined;
+      if (pointersRef.current.size < 2) {
+        pinchRef.current = undefined;
+        setPanning(false);
+      }
+      if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      resetClickSuppression();
+      return;
+    }
     const drag = dragRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (!drag || drag.pointerId !== event.pointerId) {
+      resetClickSuppression();
+      return;
+    }
     suppressClickRef.current = drag.moved;
     dragRef.current = undefined;
     if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
@@ -273,18 +388,26 @@ export default function LocationPicker({
     }, 0);
   };
 
-  const scrollPan = (event: React.WheelEvent<HTMLDivElement>) => {
-    if (viewport.zoom === 0) return;
+  const wheelZoom = (event: React.WheelEvent<HTMLDivElement>) => {
+    const rawDelta = event.deltaY || event.deltaX;
+    if (rawDelta === 0) return;
     event.preventDefault();
-    setViewport((current: MapViewport) =>
-      panViewport(
-        current,
-        event.deltaX,
-        event.deltaY,
-        mapSize.width,
-        mapSize.height,
-      ),
+    const modeScale =
+      event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? 100 : 1;
+    const delta = rawDelta * modeScale;
+    if (
+      wheelDeltaRef.current !== 0 &&
+      Math.sign(wheelDeltaRef.current) !== Math.sign(delta)
+    ) {
+      wheelDeltaRef.current = 0;
+    }
+    wheelDeltaRef.current += delta;
+    if (Math.abs(wheelDeltaRef.current) < WHEEL_ZOOM_THRESHOLD) return;
+    zoomAtPoint(
+      wheelDeltaRef.current < 0 ? 1 : -1,
+      screenPoint(event.clientX, event.clientY),
     );
+    wheelDeltaRef.current = 0;
   };
 
   return (
@@ -338,16 +461,22 @@ export default function LocationPicker({
         onPointerMove={movePan}
         onPointerUp={endPan}
         onPointerCancel={endPan}
-        onLostPointerCapture={() => {
-          dragRef.current = undefined;
-          setPanning(false);
+        onLostPointerCapture={(event) => {
+          pointersRef.current.delete(event.pointerId);
+          if (dragRef.current?.pointerId === event.pointerId) {
+            dragRef.current = undefined;
+          }
+          if (pointersRef.current.size < 2) pinchRef.current = undefined;
+          if (!dragRef.current && !pinchRef.current) setPanning(false);
+          resetClickSuppression();
         }}
-        onWheel={scrollPan}
+        onWheel={wheelZoom}
       >
         <span id="location-map-instructions" className="visuallyHidden">
           Use arrow keys to move between map locations. Press Enter or Space to
           select a city or zoom into a cluster. When zoomed in, drag, swipe, or
-          scroll to pan the map. Press Home to show the world.
+          pinch to explore the map. Scroll to zoom in or out. Press Home to show
+          the world.
         </span>
         <svg
           className="worldMapLand"

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -47,6 +47,31 @@ describe("MainMenu", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("places transient account actions after the fixed menu actions", () => {
+    render(
+      <MainMenu
+        {...props({
+          audioEnabled: undefined,
+          hasSavedGame: false,
+          uid: undefined,
+        })}
+      />,
+    );
+
+    const discovery = screen.getByRole("region", {
+      name: "Discovery actions",
+    });
+    const account = screen.getByRole("region", { name: "Account actions" });
+    expect(
+      discovery.compareDocumentPosition(account) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(within(account).getByText("Free · no sign-up needed")).toBeVisible();
+    expect(
+      within(account).getByRole("button", { name: "Sign in" }),
+    ).toBeVisible();
+  });
+
   it("prioritizes continuing a save while offering mission selection", () => {
     render(<MainMenu {...props({ hasSavedGame: true })} />);
 

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -84,9 +84,6 @@ const MainMenu = (props: Props): React.JSX.Element => {
           >
             {startLabel}
           </Button>
-          {!props.hasSavedGame && !props.uid && (
-            <Typography variant="caption">Free · no sign-up needed</Typography>
-          )}
         </Stack>
         <Stack
           component="nav"
@@ -112,11 +109,6 @@ const MainMenu = (props: Props): React.JSX.Element => {
           >
             Settings
           </Button>
-          {!props.uid && (
-            <Button variant="text" color="primary" onClick={login}>
-              Sign in
-            </Button>
-          )}
         </Stack>
         <Stack
           component="section"
@@ -142,6 +134,24 @@ const MainMenu = (props: Props): React.JSX.Element => {
             </Button>
           )}
         </Stack>
+        {!props.uid && (
+          <Stack
+            component="section"
+            aria-label="Account actions"
+            className="accountActions"
+            spacing={0.25}
+            useFlexGap
+          >
+            {!props.hasSavedGame && (
+              <Typography variant="caption">
+                Free · no sign-up needed
+              </Typography>
+            )}
+            <Button variant="text" color="primary" onClick={login}>
+              Sign in
+            </Button>
+          </Stack>
+        )}
         <Typography className="srOnly" role="status" aria-live="polite">
           {shareStatus}
         </Typography>

--- a/src/helpers/WorldMap.test.ts
+++ b/src/helpers/WorldMap.test.ts
@@ -5,6 +5,7 @@ import {
   panViewport,
   pointInViewport,
   projectLocation,
+  zoomViewportAt,
 } from "./WorldMap";
 
 const world = { center: { x: 0.5, y: 0.5 }, zoom: 0 };
@@ -39,6 +40,15 @@ it("pans zoomed viewports in screen pixels and stops at the world edge", () => {
     ),
   ).toEqual({ center: { x: 0.9375, y: 0.9375 }, zoom: 3 });
   expect(panViewport(world, 100, 100, 400, 200)).toEqual(world);
+});
+
+it("zooms around a screen point and keeps its world location stationary", () => {
+  const anchor = { x: 0.75, y: 0.25 };
+  const zoomed = zoomViewportAt(world, 1, anchor);
+
+  expect(zoomed).toEqual({ center: { x: 0.625, y: 0.375 }, zoom: 1 });
+  expect(pointInViewport({ x: 0.75, y: 0.25 }, zoomed)).toEqual(anchor);
+  expect(zoomViewportAt(zoomed, 99, anchor).zoom).toBe(3);
 });
 
 it("clusters close locations deterministically but keeps selection visible", () => {

--- a/src/helpers/WorldMap.ts
+++ b/src/helpers/WorldMap.ts
@@ -52,6 +52,36 @@ export function clampViewport(viewport: MapViewport): MapViewport {
   };
 }
 
+/** Changes zoom while keeping the world point under a screen-space anchor stationary. */
+export function zoomViewportAt(
+  viewport: MapViewport,
+  zoom: number,
+  anchor: MapPoint,
+): MapViewport {
+  const current = clampViewport(viewport);
+  const targetZoom = Math.max(
+    0,
+    Math.min(MAP_ZOOM_SCALES.length - 1, Math.round(zoom)),
+  );
+  const currentScale = MAP_ZOOM_SCALES[current.zoom];
+  const targetScale = MAP_ZOOM_SCALES[targetZoom];
+  const screen = {
+    x: Math.max(0, Math.min(1, anchor.x)),
+    y: Math.max(0, Math.min(1, anchor.y)),
+  };
+  const world = {
+    x: current.center.x + (screen.x - 0.5) / currentScale,
+    y: current.center.y + (screen.y - 0.5) / currentScale,
+  };
+  return clampViewport({
+    zoom: targetZoom,
+    center: {
+      x: world.x - (screen.x - 0.5) / targetScale,
+      y: world.y - (screen.y - 0.5) / targetScale,
+    },
+  });
+}
+
 /** Moves a zoomed viewport by screen pixels, clamping it at the edge of the world. */
 export function panViewport(
   viewport: MapViewport,


### PR DESCRIPTION
Moves transient account messaging below fixed homepage actions so authentication loading does not shift the menu. Adds cursor-centered mouse-wheel zoom and midpoint-centered two-finger pinch zoom to the custom-game location map while preserving drag panning and page scrolling. Coverage includes focused Jest tests and the responsive Playwright location-picker matrix. Validation: typecheck, lint, formatting, 92-suite Jest coverage run (871 of 872 passed; an unrelated BuildGenerators test timed out under parallel load and passed in isolation), all simulation scenarios, and the production build.