### PR TITLE
Fix custom map interactions and start layout

### DIFF
--- a/e2e/custom-location-picker.spec.ts
+++ b/e2e/custom-location-picker.spec.ts
@@ -34,6 +34,14 @@ test("world map location picker works with pointer, touch, search, and keyboard"
   await expect(map).toBeVisible();
   await expect(selectedSanFrancisco).toHaveAttribute("aria-pressed", "true");
 
+  await page
+    .getByRole("button", { name: "Select Honolulu, HI, United States" })
+    .click();
+  await expect(search).toHaveValue("Honolulu, HI");
+  await search.fill("San Francisco");
+  await page.getByRole("option", { name: "San Francisco, CA" }).click();
+  await expect(search).toHaveValue("San Francisco, CA");
+
   const tabbableMapControls = await map
     .locator(".worldMapMarker")
     .evaluateAll(
@@ -72,7 +80,7 @@ test("world map location picker works with pointer, touch, search, and keyboard"
       Math.max(0, element.scrollWidth - element.clientWidth),
     );
   expect(overflow).toBeLessThanOrEqual(1);
-  await expect(map).toHaveCSS("touch-action", "pan-y");
+  await expect(map).toHaveCSS("touch-action", "none");
 
   const mapBox = await map.boundingBox();
   const searchBox = await search.boundingBox();
@@ -150,7 +158,7 @@ test("keyboard navigation retains one map stop and honors activation and zoom bo
   await expect(zoomOut).toBeDisabled();
 });
 
-test("pointer and touch interactions leave vertical scrolling available", async ({
+test("pointer and touch interactions stay within the map", async ({
   page,
 }, testInfo) => {
   await openCustomSetup(page);
@@ -164,6 +172,13 @@ test("pointer and touch interactions leave vertical scrolling available", async 
     await cluster.hover();
     await expect(search).toHaveValue(startingSelection);
     await expect(cluster).toHaveCSS("cursor", "pointer");
+
+    const scroller = page.locator(".scrollable");
+    const before = await scroller.evaluate((element) => element.scrollTop);
+    await page.mouse.wheel(0, 240);
+    await expect
+      .poll(() => scroller.evaluate((element) => element.scrollTop))
+      .toBe(before);
     return;
   }
 
@@ -201,7 +216,7 @@ test("pointer and touch interactions leave vertical scrolling available", async 
   });
   await expect
     .poll(() => scroller.evaluate((element) => element.scrollTop))
-    .toBeGreaterThan(before);
+    .toBe(before);
 });
 
 test("location constraints keep Play valid only where the starting fleet is viable", async ({

--- a/src/app.scss
+++ b/src/app.scss
@@ -1251,11 +1251,18 @@ html[data-theme="dark"] .uplot {
 
 .scenarioStartControls {
   display: grid;
-  grid-template-columns: minmax(360px, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr);
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   margin-top: 4px;
   padding-top: 12px;
+}
+
+.scenarioStartButton.MuiButton-root {
+  justify-self: center;
+  min-width: 190px;
+  min-height: 52px;
+  padding-inline: 28px;
 }
 
 .difficultyPicker {
@@ -1302,6 +1309,11 @@ html[data-theme="dark"] .uplot {
 
   .scenarioStartControls {
     grid-template-columns: 1fr;
+  }
+
+  .scenarioStartButton.MuiButton-root {
+    justify-self: stretch;
+    width: 100%;
   }
 
   .difficultyPicker .MuiToggleButton-root {
@@ -1918,7 +1930,9 @@ html[data-theme="dark"] .uplot {
     border: 1px solid var(--border-tile);
     border-radius: 8px;
     background: var(--bg-sunken);
-    touch-action: pan-y;
+    // Prevent a tap from turning into a scroll gesture and cancelling marker activation. The
+    // setup pane remains scrollable everywhere outside this bounded interactive surface.
+    touch-action: none;
   }
 
   .worldMapLand,

--- a/src/components/base/LocationPicker.test.tsx
+++ b/src/components/base/LocationPicker.test.tsx
@@ -72,6 +72,22 @@ it("selects the same city from the map and searchable list", async () => {
   expect(onChange).toHaveBeenLastCalledWith(cities[0]);
 });
 
+it("captures wheel gestures inside the map", () => {
+  render(
+    <LocationPicker
+      locations={cities}
+      value={cities[0]}
+      onChange={jest.fn()}
+    />,
+  );
+
+  const wheel = new WheelEvent("wheel", { bubbles: true, cancelable: true });
+  screen
+    .getByRole("group", { name: "Playable locations map" })
+    .dispatchEvent(wheel);
+  expect(wheel.defaultPrevented).toBe(true);
+});
+
 it("supports arrow navigation, Enter and Space activation, and Home", () => {
   const onChange = jest.fn();
   render(

--- a/src/components/base/LocationPicker.tsx
+++ b/src/components/base/LocationPicker.tsx
@@ -101,6 +101,20 @@ export default function LocationPicker({
     return () => observer.disconnect();
   }, []);
 
+  React.useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    // A wheel gesture begun over the map belongs to the map, even though zoom is exposed through
+    // explicit controls. A non-passive native listener is required here: delegated wheel handlers
+    // may be passive in browsers, which lets the setup pane scroll underneath the interaction.
+    const captureWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    map.addEventListener("wheel", captureWheel, { passive: false });
+    return () => map.removeEventListener("wheel", captureWheel);
+  }, []);
+
   const controls = React.useMemo(
     () =>
       clusterLocations(

--- a/src/components/views/CustomGame.test.tsx
+++ b/src/components/views/CustomGame.test.tsx
@@ -47,6 +47,9 @@ it("opens after economic data is loaded and names every setup control", () => {
     expect(screen.getByRole("combobox", { name })).toBeInTheDocument();
   });
   expect(screen.getByRole("textbox", { name: "Seed" })).toBeInTheDocument();
+  expect(
+    screen.queryByText("Same seed, same weather and fuel prices."),
+  ).not.toBeInTheDocument();
 });
 
 it("re-quotes starting cash when the starting year changes", () => {

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -616,9 +616,6 @@ export default function CustomGame(props: Props): React.JSX.Element {
                 >
                   <CasinoIcon />
                 </IconButton>
-                <Typography variant="caption" color="textSecondary">
-                  Same seed, same weather and fuel prices.
-                </Typography>
               </TableCell>
             </TableRow>
           </TableBody>

--- a/src/components/views/NewGameDetails.test.tsx
+++ b/src/components/views/NewGameDetails.test.tsx
@@ -88,7 +88,7 @@ describe("NewGameDetails leaderboard", () => {
     expect(
       screen.getByRole("button", { name: "What counts as a win" }),
     ).toBeVisible();
-    expect(screen.getByRole("button", { name: "Start" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Start game" })).toBeVisible();
     expect(screen.getByText(/Forgiving: lower game costs/)).toBeVisible();
     await screen.findByText("Finish this game to join the leaderboard");
   });

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -459,6 +459,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   </Typography>
                 </div>
                 <Button
+                  className="scenarioStartButton"
                   size="large"
                   variant="contained"
                   color="primary"
@@ -466,7 +467,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                   autoFocus
                   startIcon={<PlayCircleIcon />}
                 >
-                  Start
+                  Start game
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- contain wheel and touch gestures within the custom-game location map so the setup page does not scroll and marker taps reliably activate
- remove the seed explanatory side label
- rebalance the scenario details CTA using the design review recommendation: a centered desktop Start game button below the full-width difficulty picker, with a full-width mobile treatment
- add component and cross-device browser regression coverage

## Verification
- npm run check
- npx playwright test --config e2e/playwright.config.ts custom-location-picker.spec.ts --workers=1 (25 passed across five viewports)