### PR TITLE
Simplify the responsive settings experience

### DIFF
--- a/e2e/settings-responsive.spec.ts
+++ b/e2e/settings-responsive.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+
+async function openSettings(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Settings" }).click();
+  await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+}
+
+test("settings use a centered readable measure on desktop", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop-1440px");
+  await openSettings(page);
+
+  const preferences = page.getByRole("region", { name: "Preferences" });
+  await expect
+    .poll(async () => {
+      const bounds = await preferences.boundingBox();
+      if (!bounds) return Number.POSITIVE_INFINITY;
+      return Math.abs(bounds.x + bounds.width / 2 - 1440 / 2);
+    })
+    .toBeLessThanOrEqual(1);
+
+  const bounds = await preferences.boundingBox();
+  expect(bounds).not.toBeNull();
+  expect(bounds!.width).toBeLessThanOrEqual(760);
+});
+
+test("settings remain direct and overflow-free on a common phone", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "mobile-390px");
+  await openSettings(page);
+
+  await expect(page.getByRole("group", { name: "Appearance" })).toBeVisible();
+  await expect(page.getByRole("group", { name: "Units" })).toBeVisible();
+  await page.getByRole("switch", { name: "Sound" }).click();
+  await expect(
+    page.getByRole("slider", { name: "Music volume" }),
+  ).toBeVisible();
+
+  const overflow = await page
+    .locator(".scrollable")
+    .evaluate((element) =>
+      Math.max(0, element.scrollWidth - element.clientWidth),
+    );
+  expect(overflow).toBeLessThanOrEqual(1);
+});

--- a/src/app.scss
+++ b/src/app.scss
@@ -1471,12 +1471,14 @@ html[data-theme="dark"] .uplot {
   border-collapse: collapse;
   text-align: left;
 
-  td {
+  td,
+  th {
     padding: 4px 8px;
+    font-weight: inherit;
     vertical-align: middle;
   }
 
-  td:first-child {
+  th:first-child {
     text-align: right;
     white-space: nowrap;
   }
@@ -2729,20 +2731,6 @@ html[data-theme="dark"] .uplot {
       width: 100%;
       min-width: 0 !important;
       max-width: 100%;
-    }
-  }
-
-  .settingsSection {
-    grid-template-columns: minmax(0, 1fr) !important;
-    gap: 4px !important;
-
-    .shortcuts {
-      width: 100%;
-      margin: 0;
-
-      td {
-        padding: 4px;
-      }
     }
   }
 

--- a/src/components/base/InstallAppButton.tsx
+++ b/src/components/base/InstallAppButton.tsx
@@ -42,6 +42,28 @@ export function useIsInstalledApp(): boolean {
   return React.useContext(InstallContext).installed || standalone();
 }
 
+/** Whether this visit can currently offer a real install action. */
+export function useCanInstallApp(afterMilestone = false): boolean {
+  const install = React.useContext(InstallContext);
+  const [repeatVisit] = React.useState(() => {
+    let visits = Number(localStorage.getItem(INSTALL_VISITS_KEY) || 0);
+    if (!sessionStorage.getItem(INSTALL_VISIT_COUNTED_KEY)) {
+      visits += 1;
+      localStorage.setItem(INSTALL_VISITS_KEY, String(visits));
+      sessionStorage.setItem(INSTALL_VISIT_COUNTED_KEY, "1");
+    }
+    return visits > 1;
+  });
+  const iosEligible =
+    afterMilestone || repeatVisit || getPlayedScenarioIds().length > 0;
+
+  return (
+    !install.installed &&
+    !install.snoozed &&
+    Boolean(install.installPrompt || (install.isIos && iosEligible))
+  );
+}
+
 const INSTALL_SNOOZE_KEY = "installPromptSnoozedAt";
 const INSTALL_VISITS_KEY = "installVisits";
 const INSTALL_VISIT_COUNTED_KEY = "installVisitCounted";
@@ -136,21 +158,7 @@ export default function InstallAppButton(props: {
 }): React.JSX.Element | null {
   const install = React.useContext(InstallContext);
   const [instructionsOpen, setInstructionsOpen] = React.useState(false);
-  const [repeatVisit] = React.useState(() => {
-    let visits = Number(localStorage.getItem(INSTALL_VISITS_KEY) || 0);
-    if (!sessionStorage.getItem(INSTALL_VISIT_COUNTED_KEY)) {
-      visits += 1;
-      localStorage.setItem(INSTALL_VISITS_KEY, String(visits));
-      sessionStorage.setItem(INSTALL_VISIT_COUNTED_KEY, "1");
-    }
-    return visits > 1;
-  });
-  const iosEligible =
-    props.afterMilestone || repeatVisit || getPlayedScenarioIds().length > 0;
-  const visible =
-    !install.installed &&
-    !install.snoozed &&
-    Boolean(install.installPrompt || (install.isIos && iosEligible));
+  const visible = useCanInstallApp(props.afterMilestone);
 
   if (!visible) {
     return null;

--- a/src/components/base/KeyboardShortcuts.tsx
+++ b/src/components/base/KeyboardShortcuts.tsx
@@ -38,14 +38,15 @@ export const SHORTCUTS_SEARCH_TEXT = SHORTCUTS.map(
 export default function KeyboardShortcuts(): React.JSX.Element {
   return (
     <table className="shortcuts">
+      <caption className="srOnly">Keyboard shortcuts</caption>
       <tbody>
         {SHORTCUTS.map((shortcut: ShortcutType) => (
           <tr key={shortcut.description}>
-            <td>
+            <th scope="row">
               {shortcut.keys.map((key: string) => (
                 <kbd key={key}>{key}</kbd>
               ))}
-            </td>
+            </th>
             <td>{shortcut.description}</td>
           </tr>
         ))}

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -181,6 +181,19 @@ async function choosePreset(label: string) {
   await user.click(within(await screen.findByRole("listbox")).getByText(label));
 }
 
+function storeCustomPreset(name: string) {
+  const layers = [...INSIGHT_PRESETS.overview.layers];
+  localStorage.setItem(
+    "insightsPresetLibrary",
+    JSON.stringify({
+      defaults: {},
+      custom: [{ id: "1", name, layers }],
+    }),
+  );
+  localStorage.setItem("insightsLayers", JSON.stringify(layers));
+  localStorage.setItem("insightsActivePreset", "saved:1");
+}
+
 describe("Insights layers", () => {
   beforeEach(() => localStorage.clear());
 
@@ -377,8 +390,8 @@ describe("Insights layers", () => {
     expect(library.defaults.overview).toBeUndefined();
   });
 
-  it("creates, updates, renames, and deletes a named preset", async () => {
-    const view = renderInsights();
+  it("creates and updates a named preset", async () => {
+    renderInsights();
     await user.click(screen.getByRole("button", { name: "Preset actions" }));
     await user.click(
       screen.getByRole("menuitem", { name: /Save as new preset/ }),
@@ -396,13 +409,18 @@ describe("Insights layers", () => {
     await user.click(screen.getByRole("button", { name: /Layers/ }));
     await user.click(screen.getByRole("checkbox", { name: "Revenue" }));
     await user.click(screen.getByRole("button", { name: "Save" }));
-    let library = JSON.parse(
+    const library = JSON.parse(
       localStorage.getItem("insightsPresetLibrary") || "{}",
     );
     expect(library.custom[0]).toMatchObject({
       name: "Peak watch",
       layers: expect.arrayContaining(["revenue"]),
     });
+  });
+
+  it("renames a named preset and restores it across mounts", async () => {
+    storeCustomPreset("Peak watch");
+    const view = renderInsights();
 
     await user.click(screen.getByRole("button", { name: "Preset actions" }));
     await user.click(screen.getByRole("menuitem", { name: /Rename preset/ }));
@@ -419,6 +437,11 @@ describe("Insights layers", () => {
     expect(
       screen.getByRole("combobox", { name: "Insight preset" }),
     ).toHaveTextContent("Morning peak");
+  });
+
+  it("deletes a named preset", async () => {
+    storeCustomPreset("Morning peak");
+    renderInsights();
 
     await user.click(screen.getByRole("button", { name: "Preset actions" }));
     await user.click(screen.getByRole("menuitem", { name: /Delete preset/ }));
@@ -426,7 +449,9 @@ describe("Insights layers", () => {
     expect(
       screen.getByRole("combobox", { name: "Insight preset" }),
     ).toHaveTextContent("Unsaved view");
-    library = JSON.parse(localStorage.getItem("insightsPresetLibrary") || "{}");
+    const library = JSON.parse(
+      localStorage.getItem("insightsPresetLibrary") || "{}",
+    );
     expect(library.custom).toEqual([]);
   });
 

--- a/src/components/views/Settings.test.tsx
+++ b/src/components/views/Settings.test.tsx
@@ -38,7 +38,9 @@ function renderSettings(overrides: Partial<Props> = {}) {
 }
 
 function exportButton(): HTMLButtonElement {
-  return screen.getByText("Export").closest("button") as HTMLButtonElement;
+  return screen.getByRole("button", {
+    name: "Export save",
+  }) as HTMLButtonElement;
 }
 
 function fileInput(): HTMLInputElement {
@@ -49,20 +51,27 @@ describe("Settings", () => {
   it("groups controls into labeled, scannable sections", () => {
     renderSettings();
 
-    ["Sound", "Account", "Units", "Appearance", "Saved Game"].forEach((name) =>
-      expect(screen.getByRole("region", { name })).toBeInTheDocument(),
+    ["Preferences", "Leaderboard", "Game data", "Keyboard shortcuts"].forEach(
+      (name) =>
+        expect(screen.getByRole("region", { name })).toBeInTheDocument(),
     );
+    expect(screen.getByRole("switch", { name: "Sound" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Units" })).toBeInTheDocument();
     expect(
-      screen.getByRole("checkbox", {
-        name: "Music and sound effects disabled",
-      }),
+      screen.getByRole("group", { name: "Appearance" }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("combobox", { name: "Measurement system" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("combobox", { name: "Color theme" }),
-    ).toBeInTheDocument();
+  });
+
+  it("changes appearance and units with direct choices", async () => {
+    const onThemeChange = jest.fn();
+    const onUnitsChange = jest.fn();
+    renderSettings({ onThemeChange, onUnitsChange });
+
+    await userEvent.click(screen.getByRole("button", { name: "Dark" }));
+    await userEvent.click(screen.getByRole("button", { name: "Imperial" }));
+
+    expect(onThemeChange).toHaveBeenCalledWith("dark");
+    expect(onUnitsChange).toHaveBeenCalledWith("imperial");
   });
 
   it("controls music and sound-effects volume independently", () => {
@@ -83,10 +92,9 @@ describe("Settings", () => {
     fireEvent.change(screen.getByRole("slider", { name: /music volume/i }), {
       target: { value: 35 },
     });
-    fireEvent.change(
-      screen.getByRole("slider", { name: /sound effects volume/i }),
-      { target: { value: 80 } },
-    );
+    fireEvent.change(screen.getByRole("slider", { name: /effects volume/i }), {
+      target: { value: 80 },
+    });
     expect(onMusicVolumeChange).toHaveBeenCalledWith(0.35);
     expect(onSoundEffectsVolumeChange).toHaveBeenCalledWith(0.8);
   });
@@ -96,7 +104,7 @@ describe("Settings", () => {
 
     expect(screen.queryByRole("slider", { name: /music volume/i })).toBeNull();
     expect(
-      screen.queryByRole("slider", { name: /sound effects volume/i }),
+      screen.queryByRole("slider", { name: /effects volume/i }),
     ).toBeNull();
 
     view.unmount();
@@ -112,7 +120,21 @@ describe("Settings", () => {
 
     expect(screen.getByRole("slider", { name: /music volume/i })).toBeVisible();
     expect(
-      screen.getByRole("slider", { name: /sound effects volume/i }),
+      screen.getByRole("slider", { name: /effects volume/i }),
+    ).toBeVisible();
+  });
+
+  it("keeps keyboard shortcuts available without letting them dominate the page", async () => {
+    renderSettings();
+
+    expect(
+      screen.queryByRole("table", { name: "Keyboard shortcuts" }),
+    ).toBeNull();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Keys for faster play/ }),
+    );
+    expect(
+      screen.getByRole("table", { name: "Keyboard shortcuts" }),
     ).toBeVisible();
   });
 
@@ -133,7 +155,7 @@ describe("Settings", () => {
     renderSettings();
     expect(exportButton().disabled).toBe(true);
     expect(
-      screen.getByText(/need a game in progress to export/),
+      screen.getByText(/Start a game to enable export/),
     ).toBeInTheDocument();
   });
 
@@ -147,8 +169,8 @@ describe("Settings", () => {
     const onChangeName = jest.fn();
     renderSettings({ loggedIn: true, displayName: "Ada", onChangeName });
 
-    expect(screen.getByText(/On the leaderboard as Ada/)).toBeInTheDocument();
-    await userEvent.click(screen.getByText("Change name"));
+    expect(screen.getByText("Ada")).toBeInTheDocument();
+    await userEvent.click(screen.getByText("Edit name"));
     expect(onChangeName).toHaveBeenCalled();
   });
 
@@ -157,9 +179,9 @@ describe("Settings", () => {
   it("prompts for a name when a logged-in player hasn't picked one", () => {
     renderSettings({ loggedIn: true });
     expect(
-      screen.getByText(/haven't picked a leaderboard name/),
+      screen.getByText(/Choose a name to appear with your scores/),
     ).toBeInTheDocument();
-    expect(screen.getByText("Pick a name")).toBeInTheDocument();
+    expect(screen.getByText("Choose a name")).toBeInTheDocument();
   });
 
   it("imports whichever file the player picks, saved game or not", async () => {
@@ -174,7 +196,7 @@ describe("Settings", () => {
     expect(fileInput().value).toBe("");
   });
 
-  it("hides installation controls when already running as an installed app", () => {
+  it("does not show an install group when no install action is available", () => {
     const originalMatchMedia = window.matchMedia;
     window.matchMedia = jest.fn().mockReturnValue({
       matches: true,
@@ -190,7 +212,7 @@ describe("Settings", () => {
     renderSettings();
 
     expect(
-      screen.queryByRole("region", { name: "App" }),
+      screen.queryByRole("region", { name: "Install Electrify" }),
     ).not.toBeInTheDocument();
     window.matchMedia = originalMatchMedia;
   });
@@ -198,10 +220,10 @@ describe("Settings", () => {
   it("offers a subtle cache reset at the bottom", async () => {
     renderSettings();
 
-    const button = screen.getByRole("button", { name: "Clear cache" });
+    const button = screen.getByRole("button", { name: "Clear cached data" });
     expect(
       within(screen.getByRole("contentinfo")).getByRole("button", {
-        name: "Clear cache",
+        name: "Clear cached data",
       }),
     ).toBe(button);
     await userEvent.click(button);
@@ -217,7 +239,7 @@ describe("Settings", () => {
     const onBack = jest.fn();
     renderSettings({ onBack });
 
-    fireEvent.click(screen.getByRole("button", { name: "back" }));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
     act(() => jest.advanceTimersByTime(350));
 
     expect(onBack).toHaveBeenCalled();

--- a/src/components/views/Settings.tsx
+++ b/src/components/views/Settings.tsx
@@ -1,26 +1,28 @@
 import * as React from "react";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
-  Checkbox,
-  FormControl,
-  FormControlLabel,
+  Divider,
   IconButton,
-  InputLabel,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
+  Paper,
   Slider,
   Stack,
+  Switch,
   Toolbar,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from "@mui/material";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { SettingsType, ThemeChoiceType, UnitSystemType } from "../../Types";
 import { UNIT_SYSTEMS, UNIT_SYSTEM_LABELS } from "../../helpers/Units";
 import { THEME_CHOICES, THEME_LABELS } from "../../Theme";
-import KeyboardShortcuts from "../base/KeyboardShortcuts";
-import InstallAppButton, { useIsInstalledApp } from "../base/InstallAppButton";
+import KeyboardShortcuts, { SHORTCUTS } from "../base/KeyboardShortcuts";
+import InstallAppButton, { useCanInstallApp } from "../base/InstallAppButton";
 import packageJson from "../../../package.json";
 import { clearAppCache } from "../../helpers/Cache";
 
@@ -49,52 +51,136 @@ export interface DispatchProps {
 
 export interface Props extends StateProps, DispatchProps {}
 
-interface SettingsSectionProps {
+interface SettingsGroupProps {
   id: string;
   title: string;
   children: React.ReactNode;
 }
 
-function SettingsSection({
+function SettingsGroup({
   id,
   title,
   children,
-}: SettingsSectionProps): React.JSX.Element {
+}: SettingsGroupProps): React.JSX.Element {
   return (
-    <Box
-      component="section"
-      className="settingsSection"
-      aria-labelledby={id}
-      sx={{
-        display: "grid",
-        gridTemplateColumns: {
-          xs: "88px minmax(0, 1fr)",
-          sm: "160px minmax(0, 1fr)",
-        },
-        gap: { xs: 1.5, sm: 2 },
-        alignItems: "start",
-        py: 1.25,
-        borderBottom: 1,
-        borderColor: "divider",
-      }}
-    >
+    <Box component="section" className="settingsGroup" aria-labelledby={id}>
       <Typography
         id={id}
         component="h2"
-        variant="subtitle2"
-        sx={{ pt: 0.75, fontWeight: 700 }}
+        variant="overline"
+        color="text.secondary"
+        sx={{ display: "block", mb: 0.75, px: 0.5, fontWeight: 700 }}
       >
         {title}
       </Typography>
-      <Stack spacing={0.75} sx={{ alignItems: "flex-start", minWidth: 0 }}>
+      <Paper variant="outlined" sx={{ borderRadius: 2.5, overflow: "hidden" }}>
         {children}
-      </Stack>
+      </Paper>
+    </Box>
+  );
+}
+
+interface SettingRowProps {
+  label: string;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+  stackOnMobile?: boolean;
+}
+
+function SettingRow({
+  label,
+  description,
+  children,
+  stackOnMobile = false,
+}: SettingRowProps): React.JSX.Element {
+  return (
+    <Box
+      className="settingsRow"
+      sx={{
+        display: "grid",
+        gridTemplateColumns: {
+          xs: stackOnMobile ? "minmax(0, 1fr)" : "minmax(0, 1fr) auto",
+          sm: "minmax(180px, 1fr) minmax(260px, auto)",
+        },
+        alignItems: "center",
+        gap: { xs: stackOnMobile ? 1.5 : 1, sm: 3 },
+        minHeight: 56,
+        px: 2,
+        py: 1.5,
+      }}
+    >
+      <Box sx={{ minWidth: 0 }}>
+        <Typography sx={{ fontWeight: 600 }}>{label}</Typography>
+        {description && (
+          <Typography
+            component="div"
+            variant="body2"
+            color="text.secondary"
+            sx={{ mt: 0.25, lineHeight: 1.45 }}
+          >
+            {description}
+          </Typography>
+        )}
+      </Box>
+      <Box
+        sx={{
+          minWidth: 0,
+          width: stackOnMobile ? "100%" : "auto",
+          justifySelf: { xs: stackOnMobile ? "stretch" : "end", sm: "end" },
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+function VolumeSlider(props: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}): React.JSX.Element {
+  const value = Math.round(props.value * 100);
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: {
+          xs: "64px minmax(0, 1fr) 42px",
+          sm: "140px minmax(0, 1fr) 46px",
+        },
+        alignItems: "center",
+        gap: 1.5,
+        minHeight: 48,
+        px: 2,
+      }}
+    >
+      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+        {props.label}
+      </Typography>
+      <Slider
+        aria-label={`${props.label} volume`}
+        getAriaValueText={(sliderValue: number) => `${sliderValue} percent`}
+        value={value}
+        onChange={(_e: Event, sliderValue: number | number[]) =>
+          props.onChange((sliderValue as number) / 100)
+        }
+        sx={{ width: "100% !important" }}
+      />
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        aria-hidden="true"
+        sx={{ textAlign: "right", fontVariantNumeric: "tabular-nums" }}
+      >
+        {value}%
+      </Typography>
     </Box>
   );
 }
 
 export default function Settings(props: Props): React.JSX.Element {
-  const installedApp = useIsInstalledApp();
+  const canInstallApp = useCanInstallApp();
   // The file picker is driven by the Import button rather than wrapping it, so that both buttons
   // are plainly buttons and the disabled Export one behaves like one
   const fileInput = React.useRef<HTMLInputElement>(null);
@@ -119,17 +205,27 @@ export default function Settings(props: Props): React.JSX.Element {
   return (
     <div className="flexContainer" id="gameCard">
       <div id="topbar">
-        <Toolbar>
+        <Toolbar
+          sx={{ position: "relative", borderBottom: 1, borderColor: "divider" }}
+        >
           <IconButton
             onClick={onBack}
-            aria-label="back"
+            aria-label="Back"
             edge="start"
             color="primary"
             size="large"
           >
             <ChevronLeftIcon />
           </IconButton>
-          <Typography component="h1" variant="h6">
+          <Typography
+            component="h1"
+            variant="h6"
+            sx={{
+              position: { xs: "absolute", sm: "static" },
+              left: { xs: "50%", sm: "auto" },
+              transform: { xs: "translateX(-50%)", sm: "none" },
+            }}
+          >
             Settings
           </Typography>
         </Toolbar>
@@ -138,247 +234,300 @@ export default function Settings(props: Props): React.JSX.Element {
         className="scrollable"
         sx={{
           width: "100%",
-          maxWidth: 720,
-          mx: "auto",
-          px: { xs: 2, sm: 3 },
-          py: 0.5,
           boxSizing: "border-box",
           overflowY: "auto",
+          backgroundColor: "var(--bg-sunken)",
         }}
       >
-        <Stack spacing={0}>
-          <SettingsSection id="sound-settings" title="Sound">
-            <FormControlLabel
-              control={
-                <Checkbox
+        <Stack
+          spacing={2.5}
+          sx={{
+            width: "100%",
+            maxWidth: 760,
+            mx: "auto",
+            px: { xs: 2, sm: 3 },
+            pt: { xs: 2, sm: 3 },
+            pb: "max(24px, env(safe-area-inset-bottom))",
+            boxSizing: "border-box",
+          }}
+        >
+          <SettingsGroup id="preferences-settings" title="Preferences">
+            <Stack divider={<Divider flexItem />}>
+              <SettingRow
+                label="Appearance"
+                description={
+                  props.settings.theme === "system"
+                    ? "Uses your device setting."
+                    : undefined
+                }
+                stackOnMobile
+              >
+                <ToggleButtonGroup
+                  exclusive
+                  size="small"
+                  value={props.settings.theme}
+                  aria-label="Appearance"
+                  onChange={(
+                    _e: React.MouseEvent<HTMLElement>,
+                    value: ThemeChoiceType | null,
+                  ) => value && props.onThemeChange(value)}
+                  sx={{
+                    width: { xs: "100%", sm: "auto" },
+                    "& .MuiToggleButton-root": {
+                      flex: { xs: 1, sm: "0 0 auto" },
+                      minWidth: { sm: 76 },
+                      px: { xs: 1, sm: 1.5 },
+                      textTransform: "none",
+                    },
+                  }}
+                >
+                  {THEME_CHOICES.map((choice: ThemeChoiceType) => (
+                    <ToggleButton value={choice} key={choice}>
+                      {choice === "system" ? "System" : THEME_LABELS[choice]}
+                    </ToggleButton>
+                  ))}
+                </ToggleButtonGroup>
+              </SettingRow>
+
+              <SettingRow label="Sound" description="Music and effects">
+                <Switch
                   color="primary"
                   id="sound"
+                  slotProps={{ input: { "aria-label": "Sound" } }}
                   checked={!!props.settings.audioEnabled}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     props.onAudioChange(e.target.checked)
                   }
                 />
-              }
-              label={
-                props.settings.audioEnabled
-                  ? "Music and sound effects enabled"
-                  : "Music and sound effects disabled"
-              }
-            />
-            {!!props.settings.audioEnabled && (
-              <Box sx={{ width: "100%", maxWidth: 360, px: 1 }}>
-                <Typography id="music-volume-label" variant="body2">
-                  Music volume: {Math.round(props.settings.musicVolume * 100)}%
-                </Typography>
-                <Slider
-                  aria-labelledby="music-volume-label"
-                  value={Math.round(props.settings.musicVolume * 100)}
-                  onChange={(_e: Event, value: number | number[]) =>
-                    props.onMusicVolumeChange((value as number) / 100)
-                  }
-                />
-                <Typography id="effects-volume-label" variant="body2">
-                  Sound effects volume:{" "}
-                  {Math.round(props.settings.soundEffectsVolume * 100)}%
-                </Typography>
-                <Slider
-                  aria-labelledby="effects-volume-label"
-                  value={Math.round(props.settings.soundEffectsVolume * 100)}
-                  onChange={(_e: Event, value: number | number[]) =>
-                    props.onSoundEffectsVolumeChange((value as number) / 100)
-                  }
-                />
-              </Box>
-            )}
-          </SettingsSection>
+              </SettingRow>
 
-          <SettingsSection id="account-settings" title="Account">
-            <Typography variant="body2" color="textSecondary">
-              {props.loggedIn
-                ? props.displayName
-                  ? `On the leaderboard as ${props.displayName}.`
-                  : "You're logged in, but haven't picked a leaderboard name yet."
-                : "Optional: sign in with Google to put a public display name and score on the leaderboard."}
-            </Typography>
-            <Stack
-              direction="row"
-              spacing={1}
-              useFlexGap
-              sx={{ flexWrap: "wrap" }}
+              {!!props.settings.audioEnabled && (
+                <Box>
+                  <VolumeSlider
+                    label="Music"
+                    value={props.settings.musicVolume}
+                    onChange={props.onMusicVolumeChange}
+                  />
+                  <VolumeSlider
+                    label="Effects"
+                    value={props.settings.soundEffectsVolume}
+                    onChange={props.onSoundEffectsVolumeChange}
+                  />
+                </Box>
+              )}
+
+              <SettingRow
+                label="Units"
+                description={
+                  props.settings.units === "imperial"
+                    ? "°F · mph · lb · tons"
+                    : "°C · km/h · kg · tonnes"
+                }
+                stackOnMobile
+              >
+                <ToggleButtonGroup
+                  exclusive
+                  size="small"
+                  value={props.settings.units}
+                  aria-label="Units"
+                  onChange={(
+                    _e: React.MouseEvent<HTMLElement>,
+                    value: UnitSystemType | null,
+                  ) => value && props.onUnitsChange(value)}
+                  sx={{
+                    width: { xs: "100%", sm: "auto" },
+                    "& .MuiToggleButton-root": {
+                      flex: { xs: 1, sm: "0 0 auto" },
+                      minWidth: { sm: 112 },
+                      textTransform: "none",
+                    },
+                  }}
+                >
+                  {UNIT_SYSTEMS.map((system: UnitSystemType) => (
+                    <ToggleButton value={system} key={system}>
+                      {UNIT_SYSTEM_LABELS[system]}
+                    </ToggleButton>
+                  ))}
+                </ToggleButtonGroup>
+              </SettingRow>
+            </Stack>
+          </SettingsGroup>
+
+          <SettingsGroup id="leaderboard-settings" title="Leaderboard">
+            <SettingRow
+              label={props.loggedIn ? "Leaderboard name" : "Public profile"}
+              description={
+                props.loggedIn
+                  ? props.displayName
+                    ? props.displayName
+                    : "Choose a name to appear with your scores."
+                  : "Sign in to add a public name and score to the leaderboard."
+              }
+              stackOnMobile
             >
-              {props.loggedIn ? (
-                <>
-                  <Button
-                    variant="outlined"
-                    color="primary"
-                    onClick={props.onChangeName}
-                  >
-                    {props.displayName ? "Change name" : "Pick a name"}
+              <Stack
+                direction="row"
+                spacing={1}
+                useFlexGap
+                sx={{
+                  width: { xs: "100%", sm: "auto" },
+                  flexWrap: "wrap",
+                  "& .MuiButton-root": {
+                    flex: { xs: "1 1 140px", sm: "0 0 auto" },
+                  },
+                }}
+              >
+                {props.loggedIn ? (
+                  <>
+                    <Button variant="outlined" onClick={props.onChangeName}>
+                      {props.displayName ? "Edit name" : "Choose a name"}
+                    </Button>
+                    <Button variant="text" onClick={props.onLogout}>
+                      Sign out
+                    </Button>
+                  </>
+                ) : (
+                  <Button variant="outlined" onClick={props.onLogin}>
+                    Sign in with Google
                   </Button>
-                  <Button
-                    variant="outlined"
-                    color="primary"
-                    onClick={props.onLogout}
-                  >
-                    Log out
-                  </Button>
-                </>
-              ) : (
+                )}
+              </Stack>
+            </SettingRow>
+          </SettingsGroup>
+
+          <SettingsGroup id="saved-game-settings" title="Game data">
+            <SettingRow
+              label="Saved game"
+              description={
+                props.savedGame
+                  ? `Export “${props.savedGame}” to keep or share. Importing replaces your current save.`
+                  : "Start a game to enable export. You can still import a shared save."
+              }
+              stackOnMobile
+            >
+              <Stack
+                direction="row"
+                spacing={1}
+                useFlexGap
+                sx={{
+                  width: { xs: "100%", sm: "auto" },
+                  flexWrap: "wrap",
+                  "& .MuiButton-root": {
+                    flex: { xs: "1 1 120px", sm: "0 0 auto" },
+                  },
+                }}
+              >
                 <Button
                   variant="outlined"
-                  color="primary"
-                  onClick={props.onLogin}
+                  disabled={!props.savedGame}
+                  onClick={props.onExportSave}
                 >
-                  Sign in with Google
+                  Export save
                 </Button>
-              )}
-            </Stack>
-          </SettingsSection>
+                <Button
+                  variant="outlined"
+                  onClick={() => fileInput.current?.click()}
+                >
+                  Import save
+                </Button>
+              </Stack>
+              <input
+                ref={fileInput}
+                type="file"
+                accept="application/json,.json"
+                style={{ display: "none" }}
+                aria-label="Save game file"
+                onChange={onFileChosen}
+              />
+            </SettingRow>
+          </SettingsGroup>
 
-          <SettingsSection id="units-settings" title="Units">
-            <FormControl fullWidth>
-              <InputLabel id="units-label">Measurement system</InputLabel>
-              <Select
-                labelId="units-label"
-                id="units"
-                label="Measurement system"
-                value={props.settings.units}
-                onChange={(e: SelectChangeEvent<UnitSystemType>) =>
-                  props.onUnitsChange(e.target.value as UnitSystemType)
-                }
+          {canInstallApp && (
+            <SettingsGroup id="app-settings" title="Install Electrify">
+              <SettingRow
+                label="Install app"
+                description="Play full screen and offline."
               >
-                {UNIT_SYSTEMS.map((system: UnitSystemType) => (
-                  <MenuItem value={system} key={system}>
-                    {UNIT_SYSTEM_LABELS[system]}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <Typography variant="body2" color="textSecondary">
-              {props.settings.units === "imperial"
-                ? "Temperatures in °F, wind in mph, emissions in pounds and tons."
-                : "Temperatures in °C, wind in km/h, emissions in kilograms and tonnes."}
-            </Typography>
-          </SettingsSection>
-
-          <SettingsSection id="appearance-settings" title="Appearance">
-            <FormControl fullWidth>
-              <InputLabel id="theme-label">Color theme</InputLabel>
-              <Select
-                labelId="theme-label"
-                id="theme"
-                label="Color theme"
-                value={props.settings.theme}
-                onChange={(e: SelectChangeEvent<ThemeChoiceType>) =>
-                  props.onThemeChange(e.target.value as ThemeChoiceType)
-                }
-              >
-                {THEME_CHOICES.map((choice: ThemeChoiceType) => (
-                  <MenuItem value={choice} key={choice}>
-                    {THEME_LABELS[choice]}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <Typography variant="body2" color="textSecondary">
-              {props.settings.theme === "system"
-                ? "Follows whatever your device is set to, and changes with it."
-                : "Sessions run long; the charts are drawn for both."}
-            </Typography>
-          </SettingsSection>
-
-          {!installedApp && (
-            <SettingsSection id="app-settings" title="App">
-              <InstallAppButton />
-              <Typography variant="body2" color="textSecondary">
-                Install availability depends on your browser. Once installed,
-                Electrify opens like an app and caches every location for
-                offline play.
-              </Typography>
-            </SettingsSection>
+                <InstallAppButton label="Install" />
+              </SettingRow>
+            </SettingsGroup>
           )}
 
-          <SettingsSection id="saved-game-settings" title="Saved Game">
-            <Stack
-              direction="row"
-              spacing={1}
-              useFlexGap
-              sx={{ flexWrap: "wrap" }}
+          <SettingsGroup id="keyboard-settings" title="Keyboard shortcuts">
+            <Accordion
+              disableGutters
+              elevation={0}
+              sx={{
+                "&::before": { display: "none" },
+                backgroundColor: "transparent",
+              }}
             >
-              <Button
-                variant="outlined"
-                color="primary"
-                disabled={!props.savedGame}
-                onClick={props.onExportSave}
+              <AccordionSummary
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls="keyboard-shortcuts-content"
+                id="keyboard-shortcuts-summary"
+                sx={{ minHeight: 56, px: 2 }}
               >
-                Export
-              </Button>
-              <Button
-                variant="outlined"
-                color="primary"
-                onClick={() => fileInput.current?.click()}
+                <Box>
+                  <Typography sx={{ fontWeight: 600 }}>
+                    Keys for faster play
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    View {SHORTCUTS.length} shortcuts
+                  </Typography>
+                </Box>
+              </AccordionSummary>
+              <AccordionDetails
+                id="keyboard-shortcuts-content"
+                sx={{ px: 2, pt: 0 }}
               >
-                Import
-              </Button>
-            </Stack>
-            <input
-              ref={fileInput}
-              type="file"
-              accept="application/json,.json"
-              style={{ display: "none" }}
-              aria-label="Save game file"
-              onChange={onFileChosen}
-            />
-            <Typography variant="body2" color="textSecondary">
-              {props.savedGame
-                ? `Export downloads your saved game (${props.savedGame}) to keep or share. Importing one replaces it.`
-                : "You need a game in progress to export one - start a game, then come back here. You can still import a save that someone shared with you."}
-            </Typography>
-          </SettingsSection>
-
-          <SettingsSection id="keyboard-settings" title="Keyboard Shortcuts">
-            <KeyboardShortcuts />
-          </SettingsSection>
+                <KeyboardShortcuts />
+              </AccordionDetails>
+            </Accordion>
+          </SettingsGroup>
 
           <Stack
             component="footer"
             direction="row"
-            spacing={2}
+            spacing={0.5}
             useFlexGap
-            sx={{ justifyContent: "center", flexWrap: "wrap", py: 1.5 }}
+            sx={{
+              alignItems: "center",
+              justifyContent: "center",
+              flexWrap: "wrap",
+              color: "text.secondary",
+            }}
           >
-            <Typography variant="caption">
-              Electrify App v{packageJson.version}
+            <Typography variant="caption" sx={{ px: 1 }}>
+              Electrify v{packageJson.version}
             </Typography>
-            <Typography variant="caption">
-              <a
-                href="https://github.com/toddmedema/electrify"
-                target="_blank"
-                rel="noreferrer"
-              >
-                GitHub
-              </a>
-            </Typography>
-            <Typography variant="caption">
-              <a href="/privacy.html">Privacy</a>
-            </Typography>
+            <Button
+              component="a"
+              href="https://github.com/toddmedema/electrify"
+              target="_blank"
+              rel="noreferrer"
+              variant="text"
+              size="small"
+              sx={{ color: "text.secondary", fontSize: "0.75rem" }}
+            >
+              GitHub
+            </Button>
+            <Button
+              component="a"
+              href="/privacy.html"
+              variant="text"
+              size="small"
+              sx={{ color: "text.secondary", fontSize: "0.75rem" }}
+            >
+              Privacy
+            </Button>
             <Button
               variant="text"
               size="small"
               onClick={() => void clearAppCache()}
-              sx={{
-                color: "text.secondary",
-                display: "block",
-                fontSize: "0.75rem",
-                minWidth: 0,
-                mx: "auto",
-                mt: 0.5,
-                opacity: 0.75,
-                px: 0.5,
-                textTransform: "none",
-              }}
+              sx={{ color: "text.secondary", fontSize: "0.75rem" }}
             >
-              Clear cache
+              Clear cached data
             </Button>
           </Stack>
         </Stack>


### PR DESCRIPTION
Redesigns the Settings page around centered, grouped Material UI surfaces; replaces dense selects and checkbox copy with segmented choices and a stable sound switch; simplifies supporting text and actions; collapses keyboard shortcuts; hides the install group when no install action is available; and adds desktop and mobile responsive coverage. Verification: npm run typecheck; Settings.test.tsx (14 passed); responsive Playwright checks at 390px and 1440px; existing 320px responsive checks; npm run build; and all simulations. The full Jest run passed 865 of 866 tests, with one unrelated BuildGenerators timeout that passed on an immediate focused rerun.