### PR TITLE
Add Mailchimp launch signup to About page

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -115,6 +115,48 @@
         </ul>
       </section>
 
+      <section class="panel panel--signup" aria-labelledby="signup-title">
+        <div>
+          <h2 id="signup-title">Stay in the loop</h2>
+          <p>Get occasional updates as Electrify approaches launch.</p>
+        </div>
+        <form
+          class="signup-form"
+          action="https://electrifygame.us10.list-manage.com/subscribe/post?u=792afb261df839e73b669f83f&amp;id=8ccd05ccba&amp;f_id=00f857e4f0"
+          method="post"
+          target="_blank"
+        >
+          <label for="signup-email">Email address</label>
+          <div class="signup-form__fields">
+            <input
+              id="signup-email"
+              name="EMAIL"
+              type="email"
+              autocomplete="email"
+              placeholder="you@example.com"
+              required
+            />
+            <button class="button button--primary" type="submit">
+              Subscribe
+            </button>
+          </div>
+          <div class="signup-form__bot-field" aria-hidden="true">
+            <label for="signup-website">Leave this field empty</label>
+            <input
+              id="signup-website"
+              name="b_792afb261df839e73b669f83f_8ccd05ccba"
+              type="text"
+              tabindex="-1"
+              value=""
+            />
+          </div>
+          <p class="signup-form__note">
+            Unsubscribe anytime. See our
+            <a href="/privacy.html">privacy policy</a>.
+          </p>
+        </form>
+      </section>
+
       <section class="panel panel--contact" id="feedback">
         <div class="panel__intro">
           <h2 id="feedback-title">Help us build a better grid</h2>

--- a/public/legal.css
+++ b/public/legal.css
@@ -299,6 +299,64 @@ a:hover {
   background: var(--surface-soft);
 }
 
+.panel--signup {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(14rem, 0.72fr) minmax(20rem, 1.28fr);
+  align-items: center;
+  gap: 2rem;
+  background: var(--surface-soft);
+}
+
+.signup-form {
+  position: relative;
+  min-width: 0;
+}
+
+.signup-form > label {
+  display: block;
+  margin-bottom: 0.45rem;
+  font-size: 0.9rem;
+  font-weight: 750;
+}
+
+.signup-form__fields {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.signup-form__fields input {
+  width: 100%;
+  min-width: 0;
+  min-height: 3rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: var(--surface-solid);
+  color: var(--text);
+  font: inherit;
+  line-height: 1.2;
+}
+
+.signup-form__fields input::placeholder {
+  color: var(--text-muted);
+  opacity: 0.8;
+}
+
+.signup-form__fields input:hover {
+  border-color: var(--brand);
+}
+
+.signup-form__bot-field {
+  position: absolute;
+  left: -5000px;
+}
+
+.panel .signup-form__note {
+  margin-top: 0.55rem;
+  font-size: 0.8rem;
+}
+
 .panel--contact {
   grid-column: 1 / -1;
   display: grid;
@@ -508,6 +566,7 @@ a:hover {
   }
 
   .panel--contact,
+  .panel--signup,
   .privacy-layout {
     grid-template-columns: 1fr;
   }
@@ -553,6 +612,11 @@ a:hover {
   .panel__actions,
   .button {
     width: 100%;
+  }
+
+  .signup-form__fields {
+    align-items: stretch;
+    flex-direction: column;
   }
 
   .site-footer__inner {

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -44,7 +44,7 @@
 
     <main class="page-content privacy-layout" id="main-content">
       <article class="policy-article">
-        <p class="updated">Last updated August 27, 2026</p>
+        <p class="updated">Last updated September 1, 2026</p>
 
         <section class="policy-section" aria-labelledby="local-data">
           <h2 id="local-data">Your game stays in your browser</h2>
@@ -74,6 +74,15 @@
           </p>
         </section>
 
+        <section class="policy-section" aria-labelledby="email-updates">
+          <h2 id="email-updates">Email updates</h2>
+          <p>
+            If you subscribe to launch updates, your email address is submitted
+            to Mailchimp and used only to send those updates. You can
+            unsubscribe at any time using the link in an email.
+          </p>
+        </section>
+
         <section class="policy-section" aria-labelledby="choices">
           <h2 id="choices">Your choices</h2>
           <p>
@@ -91,6 +100,7 @@
           <li>No account is required to play.</li>
           <li>Game progress and preferences are stored on your device.</li>
           <li>Leaderboard participation and replays are optional.</li>
+          <li>Email updates are optional and you can unsubscribe anytime.</li>
           <li>You can request deletion of leaderboard data.</li>
         </ul>
       </aside>


### PR DESCRIPTION
## Summary
- add a minimal email-only Mailchimp signup panel to the About page
- match the existing responsive light/dark styling without loading Mailchimp's external CSS or JavaScript
- disclose optional Mailchimp email collection in the privacy policy

## Validation
- npm run build
- npm run sim -- --all
- npm test -- BuildGenerators.test.tsx --watchAll=false --runInBand
- npx prettier --check public/about.html public/legal.css public/privacy.html
- desktop and 375px mobile browser checks (no overflow or console errors)

## Note
- npm run check reached 91 passing suites and one unrelated BuildGenerators timeout in the parallel Jest run; the affected suite passed immediately when rerun in isolation.