### PR TITLE
Restore saved cash in custom game setup

### DIFF
--- a/src/components/views/CustomGame.test.tsx
+++ b/src/components/views/CustomGame.test.tsx
@@ -52,6 +52,36 @@ it("opens after economic data is loaded and names every setup control", () => {
   ).not.toBeInTheDocument();
 });
 
+it("populates cash from a saved setup that predates year-adjusted cash", () => {
+  const onStart = jest.fn();
+  const inflation = getFuelEscalation(2040) / getFuelEscalation(2020);
+  render(
+    <CustomGame
+      game={createGame({ scenarioId: 100 })}
+      scenario={{
+        ...DEFAULT_CUSTOM_SCENARIO,
+        startingYear: 2040,
+        cash: 200000000,
+        dollarsPerkWh: Number((0.07 * inflation).toPrecision(2)),
+      }}
+      onBack={jest.fn()}
+      onDelta={jest.fn()}
+      onStart={onStart}
+    />,
+  );
+
+  expect(
+    screen.getByRole("combobox", { name: "Starting cash" }),
+  ).toHaveTextContent(/\$\d/);
+
+  fireEvent.click(screen.getByRole("button", { name: "Play" }));
+  expect(onStart).toHaveBeenCalledWith(
+    expect.objectContaining({
+      cash: Number((200000000 * inflation).toPrecision(2)),
+    }),
+  );
+});
+
 it("re-quotes starting cash when the starting year changes", () => {
   const onStart = jest.fn();
   render(

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -127,6 +127,26 @@ const GENERATOR_SIZES_W = [
 ];
 const STORAGE_SIZES_WH = [100000000, 500000000, 1000000000, 2000000000];
 
+function startingCashOptions(startingYear: number): number[] {
+  return STARTING_CASH.map((cash: number) => inEraMoney(cash, startingYear));
+}
+
+/**
+ * Bring a saved cash choice forward when opening a setup recorded before cash started scaling
+ * with the game's year. Without this migration, the saved amount is absent from the Select's
+ * options and MUI renders the control as an empty dropdown.
+ */
+function normalizeStartingCash(scenario: ScenarioType): ScenarioType {
+  const options = startingCashOptions(scenario.startingYear);
+  if (options.includes(scenario.cash)) {
+    return scenario;
+  }
+  const legacyIndex = STARTING_CASH.indexOf(scenario.cash);
+  const index =
+    legacyIndex === -1 ? nearestIndex(options, scenario.cash) : legacyIndex;
+  return { ...scenario, cash: options[index] };
+}
+
 interface TechnologyType {
   name: string;
   storage: boolean;
@@ -212,7 +232,9 @@ function facilitiesForStartingCustomers(
 export default function CustomGame(props: Props): React.JSX.Element {
   const { game, onBack, onDelta, onStart } = props;
   const units = useUnits();
-  const [scenario, setScenario] = React.useState<ScenarioType>(props.scenario);
+  const [scenario, setScenario] = React.useState<ScenarioType>(() =>
+    normalizeStartingCash(props.scenario),
+  );
   const [victoryDialogOpen, setVictoryDialogOpen] = React.useState(false);
   const [feeDialogOpen, setFeeDialogOpen] = React.useState(false);
   const [addName, setAddName] = React.useState("");
@@ -231,8 +253,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
   // which is why changing that year has to re-quote whatever was already chosen rather than
   // leaving a 2020 amount on a 2080 game -- see changeStartingYear below.
   const cashOptions = React.useMemo(
-    () =>
-      STARTING_CASH.map((c: number) => inEraMoney(c, scenario.startingYear)),
+    () => startingCashOptions(scenario.startingYear),
     [scenario.startingYear],
   );
   const rateOptions = React.useMemo(


### PR DESCRIPTION
## Summary
- migrate legacy custom-game cash values to the equivalent year-adjusted tier when setup opens
- keep the cash select on a valid option so saved future-year setups no longer render blank
- add a regression test covering a saved 2040 setup from before cash scaling

## Testing
- npm run check
- npm run build
- e2e/responsive-320.spec.ts (mobile-320px; 2 passed on an isolated dev server)