### PR TITLE
Streamline Insights controls on mobile

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -739,38 +739,19 @@ $pane_header_height: 40px;
   display: flex;
   min-width: 218px;
   flex: 1.35 1 284px;
-  align-items: stretch;
-  overflow: hidden;
-  border: 1px solid var(--border-tile);
-  border-radius: 6px;
-  background: var(--bg-raised);
-
-  &.insightsPresetControls-edited {
-    border-color: $interactive_blue;
-    box-shadow: inset 3px 0 0 $interactive_blue;
-  }
+  align-items: center;
+  gap: 4px;
 
   .insightsPreset {
     min-width: 0;
     flex: 1 1 138px;
+    margin-left: 0;
   }
 
   .insightsPresetSave,
   .insightsPresetActions {
-    min-width: auto;
-    min-height: 36px;
     flex: 0 0 auto;
-    border-left: 1px solid var(--border-tile);
-    border-radius: 0;
-  }
-
-  .insightsPresetSave:not(:disabled) {
-    background: var(--interactive-tint);
-  }
-
-  .insightsPresetActions {
-    padding-right: 8px;
-    padding-left: 8px;
+    color: $interactive_blue;
   }
 }
 
@@ -908,8 +889,7 @@ $pane_header_height: 40px;
   }
 
   .insightsHeader > h6 {
-    width: 100%;
-    margin-bottom: 6px;
+    display: none;
   }
 
   .insightsHeaderControls {
@@ -932,6 +912,11 @@ $pane_header_height: 40px;
       grid-area: preset;
       width: 100%;
       min-width: 0;
+
+      .headerControl {
+        width: 100%;
+        min-width: 0;
+      }
     }
 
     .insightsLayerControls {
@@ -940,12 +925,8 @@ $pane_header_height: 40px;
     }
   }
 
-  .insightsPresetControls {
-    .insightsPreset,
-    .insightsPresetSave,
-    .insightsPresetActions {
-      min-height: 44px;
-    }
+  .insightsPresetControls .insightsPreset {
+    min-height: 44px;
   }
 
   .insightsPresetDialog {

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -1691,9 +1691,8 @@ export default class Insights extends React.Component<Props, State> {
                 ))}
               </Select>
               <div
-                className={`insightsPresetControls${
-                  this.state.presetDirty ? " insightsPresetControls-edited" : ""
-                }`}
+                className="insightsPresetControls"
+                role="group"
                 aria-label="Preset controls"
               >
                 <Select
@@ -1705,7 +1704,7 @@ export default class Insights extends React.Component<Props, State> {
                       this.applyPreset(preset);
                     }
                   }}
-                  className="insightsPreset"
+                  className="headerControl insightsPreset"
                   aria-label="Insight preset"
                   renderValue={() => (
                     <span className="insightsPresetValue">
@@ -1763,10 +1762,12 @@ export default class Insights extends React.Component<Props, State> {
                     Unsaved view
                   </MenuItem>
                 </Select>
-                <Button
+                <IconButton
                   className="insightsPresetSave"
                   size="small"
-                  startIcon={<SaveIcon />}
+                  aria-label={
+                    this.state.preset === "custom" ? "Save as" : "Save"
+                  }
                   disabled={
                     !this.state.layers.length ||
                     (this.state.preset !== "custom" &&
@@ -1780,13 +1781,12 @@ export default class Insights extends React.Component<Props, State> {
                   }
                   onClick={() => this.savePresetChanges()}
                 >
-                  {this.state.preset === "custom" ? "Save as" : "Save"}
-                </Button>
+                  <SaveIcon fontSize="small" />
+                </IconButton>
                 <Tooltip title="Rename, save a copy, restore, or delete">
-                  <Button
+                  <IconButton
                     className="insightsPresetActions"
                     size="small"
-                    startIcon={<MoreVertIcon />}
                     aria-label="Preset actions"
                     aria-haspopup="menu"
                     aria-controls={
@@ -1799,8 +1799,8 @@ export default class Insights extends React.Component<Props, State> {
                       this.setState({ presetMenuAnchor: event.currentTarget })
                     }
                   >
-                    More
-                  </Button>
+                    <MoreVertIcon fontSize="small" />
+                  </IconButton>
                 </Tooltip>
               </div>
               <Button


### PR DESCRIPTION
Removes the duplicate Insights pane title at the mobile breakpoint and aligns the preset selector with the range selector by replacing the heavy segmented control with a lightweight select and compact icon actions. Preserves edited/customized preset states and 44px mobile touch targets. Validation: npm run check; responsive browser QA at 320px, 390px, and 1440px.