### PR TITLE
Rebalance solar eclipse reserve margin

### DIFF
--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -244,6 +244,9 @@ describe("authored starting fleets", () => {
       eclipse.facilities.find((facility) => facility.name === "Battery")
         ?.peakWh,
     ).toBe(240_000_000);
+    expect(
+      eclipse.facilities.find((facility) => facility.fuel === "Coal")?.peakW,
+    ).toBe(625_000_000);
     expect(trip.reliabilityObjective).toMatchObject({
       year: 2026,
       month: 7,

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -1065,15 +1065,15 @@ export const SCENARIOS = [
       label: "September 2035 total eclipse in China",
     },
     // Low-carbon capacity is a 0.1%-scale model of China's 2024 national fleet. This
-    // solar-heavy balancing area receives 0.05% of national thermal capacity; the 240MWh
-    // battery represents 0.1% of China's 60GW new-storage fleet at four-hour duration.
+    // solar-heavy balancing area receives 625MW (about 0.04%) of national thermal capacity;
+    // the 240MWh battery represents 0.1% of China's 60GW new-storage fleet at four-hour duration.
     // https://www.nea.gov.cn/20250121/097bfd7c1cd3498897639857d86d5dac/c.html
     // https://www.nea.gov.cn/20241220/39938141b6e74baaa4601e940d12b022/c.html
     facilities: [
       { fuel: "Sun", peakW: 886660000, initialAgeYears: 4 },
       { fuel: "Wind", peakW: 520680000, initialAgeYears: 6 },
       { fuel: "Hydro", peakW: 435950000, initialAgeYears: 20 },
-      { fuel: "Coal", peakW: 722225000, initialAgeYears: 15 },
+      { fuel: "Coal", peakW: 625000000, initialAgeYears: 15 },
       { fuel: "Uranium", peakW: 60830000, initialAgeYears: 12 },
       { name: "Battery", peakWh: 240000000, initialAgeYears: 3 },
     ],

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -12,7 +12,7 @@ import {
 } from "./BalancePlaybooks";
 import { loadSimData } from "./SimData";
 import { LOCATIONS, TICKS_PER_MONTH } from "../Constants";
-import { getTimeFromTimeline } from "../helpers/DateTime";
+import { getDateFromMinute, getTimeFromTimeline } from "../helpers/DateTime";
 import { tickState } from "../reducers/Game";
 import { parseSave, serializeSave } from "../SaveGame";
 import { serializeReplay } from "../Replay";
@@ -382,6 +382,52 @@ describe("researched public-utility scenarios", () => {
       expect(tick["Natural Gas"]).toBe(control.timeline[index]["Natural Gas"]);
     });
   });
+
+  it.each(["Intern", "Employee"] as DifficultyType[])(
+    "blackouts during the eclipse when the player takes no action on %s",
+    (difficulty) => {
+      const eclipse = createGame({ scenarioId: 109, difficulty });
+      const control = createGame({
+        scenarioId: 109,
+        difficulty,
+        storyEffectsEnabled: false,
+      });
+      runMonths(eclipse, 32);
+      runMonths(control, 32);
+
+      expect(eclipse.date).toMatchObject({ year: 2035, monthNumber: 9 });
+      expect(eclipse.replayLog).toHaveLength(0);
+      const eclipseTickIndexes = eclipse.timeline
+        .map((tick, index) => ({
+          index,
+          minuteOfDay: getDateFromMinute(tick.minute, eclipse.startingYear)
+            .minuteOfDay,
+        }))
+        .filter(
+          ({ minuteOfDay }) =>
+            minuteOfDay >= 8 * 60 + 30 && minuteOfDay <= 11 * 60 + 30,
+        )
+        .map(({ index }) => index);
+
+      expect(eclipseTickIndexes).not.toHaveLength(0);
+      expect(
+        Math.min(
+          ...eclipseTickIndexes.map(
+            (index) =>
+              eclipse.timeline[index].supplyW - eclipse.timeline[index].demandW,
+          ),
+        ),
+      ).toBeLessThan(0);
+      expect(
+        Math.min(
+          ...eclipseTickIndexes.map(
+            (index) =>
+              control.timeline[index].supplyW - control.timeline[index].demandW,
+          ),
+        ),
+      ).toBeGreaterThanOrEqual(0);
+    },
+  );
 
   const difficulties: DifficultyType[] = [
     "Intern",


### PR DESCRIPTION
## Summary
- reduce the Solar Eclipse scenario's starting coal capacity from 722.225 MW to 625 MW
- keep the simulation and eclipse dynamics unchanged
- add a no-action regression proving the eclipse creates a shortfall on Intern and Employee while the same window remains fully served with eclipse effects disabled

## Validation
- focused scenario and simulation tests pass
- all 17 headless scenarios pass their invariants with \
pm run sim -- --all\
- typecheck, lint, and formatting pass
- the full coverage run reached and passed the eclipse tests; the shared checkout's unrelated in-progress world-event edits caused one assertion failure, and a UI test timeout passed when rerun in isolation