### PR TITLE
Add filters to event history

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -2475,8 +2475,24 @@ html[data-theme="dark"] .uplot {
 
   .eventLogSectionHeader {
     display: grid;
+    grid-template-columns: 1fr auto;
     gap: 1px;
+    align-items: center;
     padding: 0 size(base) size(small);
+  }
+
+  .eventHistoryFilterButton {
+    margin: -5px -8px -5px 0;
+    color: $font_color_faded;
+
+    &.active {
+      background: var(--interactive-tint);
+      color: $interactive_blue;
+    }
+  }
+
+  .eventHistoryFilterCheck {
+    width: 24px;
   }
 
   // Forecasts are grouped on a sunken surface and deliberately stay neutral: a future critical

--- a/src/components/views/EventLog.test.tsx
+++ b/src/components/views/EventLog.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import EventLog from "./EventLog";
 
 jest.mock("../base/GameCard", () => (props: { children: React.ReactNode }) => (
@@ -94,5 +95,114 @@ describe("EventLog", () => {
     expect(
       screen.queryByText(/recorded after they happen/i),
     ).not.toBeInTheDocument();
+  });
+
+  it("filters event history into useful event groups", async () => {
+    const user = userEvent.setup();
+    render(
+      <EventLog
+        events={[
+          {
+            id: 1,
+            kind: "WORLD_EVENT",
+            label: "Jan 2024",
+            message: "A scenario event happened.",
+          },
+          {
+            id: 2,
+            kind: "BLACKOUT",
+            label: "Feb 2024",
+            message: "A blackout started.",
+          },
+          {
+            id: 3,
+            kind: "BUILD",
+            label: "Mar 2024",
+            message: "A solar project started.",
+          },
+          {
+            id: 4,
+            kind: "LOAN",
+            label: "Apr 2024",
+            message: "A loan was issued.",
+          },
+          {
+            id: 5,
+            kind: "FUEL_PRICE",
+            label: "May 2024",
+            message: "Gas became more expensive.",
+          },
+        ]}
+        upcoming={[
+          {
+            key: "next",
+            label: "Jun 2024",
+            message: "An upcoming event remains visible.",
+          },
+        ]}
+        onOpen={jest.fn()}
+        onSelect={jest.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Filter event history, All events" }),
+    );
+    expect(
+      screen.getByRole("menuitemradio", { name: "All events" }),
+    ).toBeChecked();
+    await user.click(screen.getByRole("menuitemradio", { name: "Blackouts" }));
+
+    expect(screen.getByText("A blackout started.")).toBeVisible();
+    expect(screen.queryByText("A scenario event happened.")).toBeNull();
+    expect(screen.queryByText("A solar project started.")).toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: "Filter event history, Blackouts",
+      }),
+    ).toBeVisible();
+    expect(
+      screen.getByText("An upcoming event remains visible."),
+    ).toBeVisible();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Filter event history, Blackouts",
+      }),
+    );
+    expect(
+      screen.getByRole("menuitemradio", { name: "Blackouts" }),
+    ).toBeChecked();
+    await user.click(screen.getByRole("menuitemradio", { name: "All events" }));
+
+    expect(screen.getByText("A scenario event happened.")).toBeVisible();
+    expect(screen.getByText("A solar project started.")).toBeVisible();
+    expect(screen.getByText("A loan was issued.")).toBeVisible();
+    expect(screen.getByText("Gas became more expensive.")).toBeVisible();
+  });
+
+  it("explains when the selected event group is empty", async () => {
+    const user = userEvent.setup();
+    render(
+      <EventLog
+        events={[
+          {
+            id: 1,
+            kind: "WORLD_EVENT",
+            label: "Jan 2024",
+            message: "A scenario event happened.",
+          },
+        ]}
+        onOpen={jest.fn()}
+        onSelect={jest.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Filter event history, All events" }),
+    );
+    await user.click(screen.getByRole("menuitemradio", { name: "Projects" }));
+
+    expect(screen.getByText("No project events yet.")).toBeVisible();
   });
 });

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -1,5 +1,15 @@
 import * as React from "react";
-import { Typography } from "@mui/material";
+import {
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import CheckIcon from "@mui/icons-material/Check";
+import FilterListIcon from "@mui/icons-material/FilterList";
 import GameCard from "../base/GameCard";
 import {
   ConceptNameType,
@@ -31,6 +41,42 @@ const KIND_CONCEPTS: { [k in GameEventKindType]: ConceptNameType } = {
   WORLD_EVENT: "forecast",
 };
 
+type EventHistoryFilterType =
+  "ALL" | "SCENARIO" | "BLACKOUTS" | "PROJECTS" | "MARKET_FINANCE";
+
+const EVENT_HISTORY_FILTERS: {
+  value: EventHistoryFilterType;
+  label: string;
+  emptyMessage?: string;
+  kinds?: GameEventKindType[];
+}[] = [
+  { value: "ALL", label: "All events" },
+  {
+    value: "SCENARIO",
+    label: "Scenario",
+    emptyMessage: "No scenario events yet.",
+    kinds: ["WORLD_EVENT"],
+  },
+  {
+    value: "BLACKOUTS",
+    label: "Blackouts",
+    emptyMessage: "No blackout events yet.",
+    kinds: ["BLACKOUT", "BLACKOUT_OVER"],
+  },
+  {
+    value: "PROJECTS",
+    label: "Projects",
+    emptyMessage: "No project events yet.",
+    kinds: ["BUILD", "CONSTRUCTION", "SELL"],
+  },
+  {
+    value: "MARKET_FINANCE",
+    label: "Market & finance",
+    emptyMessage: "No market or finance events yet.",
+    kinds: ["FUEL_PRICE", "FUEL_CROSSOVER", "LOAN"],
+  },
+];
+
 export interface UpcomingStoryEventType {
   key: string;
   label: string;
@@ -56,6 +102,17 @@ export interface Props extends StateProps, DispatchProps {}
 
 export default function EventLog(props: Props): React.JSX.Element {
   const { events, onOpen, onSelect, upcoming = [] } = props;
+  const [historyFilter, setHistoryFilter] =
+    React.useState<EventHistoryFilterType>("ALL");
+  const [filterAnchor, setFilterAnchor] = React.useState<HTMLElement | null>(
+    null,
+  );
+  const activeFilter = EVENT_HISTORY_FILTERS.find(
+    (filter) => filter.value === historyFilter,
+  )!;
+  const visibleEvents = activeFilter.kinds
+    ? events.filter((event) => activeFilter.kinds?.includes(event.kind))
+    : events;
   // An effect may only return a cleanup function. Redux dispatch returns the dispatched action,
   // so the expression-bodied form returned an object here; React later tried to call that object
   // while unmounting this phone-only pane and crashed the app to a blank screen.
@@ -142,6 +199,59 @@ export default function EventLog(props: Props): React.JSX.Element {
             <Typography id="eventHistoryTitle" variant="subtitle2">
               Event history
             </Typography>
+            <Tooltip
+              title={
+                historyFilter === "ALL"
+                  ? "Filter event history"
+                  : `Filter: ${activeFilter.label}`
+              }
+            >
+              <IconButton
+                id="eventHistoryFilterButton"
+                className={`eventHistoryFilterButton${historyFilter === "ALL" ? "" : " active"}`}
+                size="small"
+                onClick={(event) => setFilterAnchor(event.currentTarget)}
+                aria-label={`Filter event history, ${activeFilter.label}`}
+                aria-controls={
+                  filterAnchor ? "eventHistoryFilterMenu" : undefined
+                }
+                aria-expanded={filterAnchor ? true : undefined}
+                aria-haspopup="menu"
+              >
+                <FilterListIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Menu
+              id="eventHistoryFilterMenu"
+              anchorEl={filterAnchor}
+              open={Boolean(filterAnchor)}
+              onClose={() => setFilterAnchor(null)}
+              anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+              transformOrigin={{ vertical: "top", horizontal: "right" }}
+              slotProps={{
+                list: { "aria-labelledby": "eventHistoryFilterButton" },
+              }}
+            >
+              {EVENT_HISTORY_FILTERS.map((filter) => (
+                <MenuItem
+                  key={filter.value}
+                  role="menuitemradio"
+                  aria-checked={historyFilter === filter.value}
+                  selected={historyFilter === filter.value}
+                  onClick={() => {
+                    setHistoryFilter(filter.value);
+                    setFilterAnchor(null);
+                  }}
+                >
+                  <ListItemIcon className="eventHistoryFilterCheck">
+                    {historyFilter === filter.value && (
+                      <CheckIcon fontSize="small" />
+                    )}
+                  </ListItemIcon>
+                  <ListItemText>{filter.label}</ListItemText>
+                </MenuItem>
+              ))}
+            </Menu>
           </header>
           {events.length === 0 && (
             <Typography
@@ -153,8 +263,17 @@ export default function EventLog(props: Props): React.JSX.Element {
               here.
             </Typography>
           )}
+          {events.length > 0 && visibleEvents.length === 0 && (
+            <Typography
+              className="eventLogEmpty"
+              variant="body2"
+              color="textSecondary"
+            >
+              {activeFilter.emptyMessage}
+            </Typography>
+          )}
           <ul className="eventLogList">
-            {events.map((event: GameEventType) => (
+            {visibleEvents.map((event: GameEventType) => (
               <li
                 className={`eventLogItem kind-${event.kind} importance-${event.importance || "ROUTINE"}${event.actionTarget ? " actionable" : ""}`}
                 key={event.id}


### PR DESCRIPTION
## Summary
- add a compact event-history filter menu for scenario, blackout, project, and market/finance events
- keep upcoming events unfiltered and show clear empty states for selected categories
- add responsive active-state styling and accessible radio-menu semantics

## Design QA
- verified at 1280x720 desktop and 360x740 mobile
- confirmed end-aligned menu placement, active tint, responsive wrapping, and coarse-pointer touch targets

## Validation
- npm run check
- 92 Jest suites / 881 tests passed
- all simulation scenarios passed their invariants