### PR TITLE
Move account-free note below Sign in

### DIFF
--- a/.github/pr-screenshots/homepage-sign-in-caption/desktop.png
+++ b/.github/pr-screenshots/homepage-sign-in-caption/desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5d6d0da51299af8d88fcccbc5cffb7811dfc813a5234fb4a0ea1b064f98e4b1
+size 36702

--- a/.github/pr-screenshots/homepage-sign-in-caption/desktop.png
+++ b/.github/pr-screenshots/homepage-sign-in-caption/desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5d6d0da51299af8d88fcccbc5cffb7811dfc813a5234fb4a0ea1b064f98e4b1
-size 36702
+oid sha256:e06fd30fd4291ffef9e279c9be82d6865e1714155a305bcb921822390dec8f07
+size 36731

--- a/.github/pr-screenshots/homepage-sign-in-caption/mobile.png
+++ b/.github/pr-screenshots/homepage-sign-in-caption/mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f7ed485d54d29fd075f3539348c1d2f2025363f05b895612727c160bdcbe926
+size 22695

--- a/.github/pr-screenshots/homepage-sign-in-caption/mobile.png
+++ b/.github/pr-screenshots/homepage-sign-in-caption/mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3f7ed485d54d29fd075f3539348c1d2f2025363f05b895612727c160bdcbe926
-size 22695
+oid sha256:9d141262763e3bd8ef4b2e118fd1b1c1b8e37739b4c80aa9ae05a779fe447844
+size 22755

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,16 @@ files are large, so broad rewrites create expensive review diffs.
 - Build with `npm run build`. Browser-level responsive and tutorial checks live under `e2e/` and
   run with `npm run test:e2e` when the changed path warrants them.
 
+## Pull requests
+
+- When opening a pull request with user-visible UI changes, capture 1-3 screenshots of the
+  finished interface and embed them in the pull request description. Choose views that clearly
+  show the change, including both desktop and mobile layouts when responsive behavior is relevant.
+- Review screenshots before uploading them: exclude sensitive or user-specific data, transient
+  errors, debug UI, and unrelated windows or overlays. Non-UI changes do not need screenshots.
+- If the current environment cannot capture or upload images, say so in the pull request
+  description and tell the user instead of silently omitting the screenshots.
+
 ## Repository map
 
 - `src/Store.tsx` assembles the `card`, `game`, `settings`, `ui`, and `user` slices. Use the typed

--- a/src/app.scss
+++ b/src/app.scss
@@ -1736,8 +1736,18 @@ html[data-theme="dark"] .uplot {
         margin: 0 auto;
       }
 
+      .accountActions {
+        align-items: center;
+        margin-top: 6px;
+
+        .MuiTypography-caption {
+          font-size: 0.8125rem;
+          line-height: 1.4;
+        }
+      }
+
       .discoveryActions {
-        margin-top: 2px;
+        margin-top: 14px;
       }
 
       button {

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -39,7 +39,15 @@ describe("MainMenu", () => {
 
   it("only advertises account-free play before sign-in", () => {
     const { rerender } = render(<MainMenu {...props({ uid: undefined })} />);
-    expect(screen.getByText("Free · no sign-up needed")).toBeInTheDocument();
+    const signInOptions = screen.getByRole("group", {
+      name: "Sign-in options",
+    });
+    expect(
+      within(signInOptions).getByRole("button", { name: "Sign in" }),
+    ).toBeInTheDocument();
+    expect(
+      within(signInOptions).getByText("Free · no sign-up needed"),
+    ).toBeInTheDocument();
 
     rerender(<MainMenu {...props({ uid: "player" })} />);
     expect(

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -39,14 +39,14 @@ describe("MainMenu", () => {
 
   it("only advertises account-free play before sign-in", () => {
     const { rerender } = render(<MainMenu {...props({ uid: undefined })} />);
-    const signInOptions = screen.getByRole("group", {
-      name: "Sign-in options",
+    const accountActions = screen.getByRole("region", {
+      name: "Account actions",
     });
     expect(
-      within(signInOptions).getByRole("button", { name: "Sign in" }),
+      within(accountActions).getByRole("button", { name: "Sign in" }),
     ).toBeInTheDocument();
     expect(
-      within(signInOptions).getByText("Free · no sign-up needed"),
+      within(accountActions).getByText("Free · no sign-up needed"),
     ).toBeInTheDocument();
 
     rerender(<MainMenu {...props({ uid: "player" })} />);
@@ -93,6 +93,9 @@ describe("MainMenu", () => {
 
     expect(primary).toHaveStyle({ flexDirection: "column" });
     expect(resources).toHaveStyle({ flexDirection: "row", gap: "6px" });
+    expect(
+      within(resources).queryByRole("button", { name: "Sign in" }),
+    ).not.toBeInTheDocument();
     expect(discovery).toHaveStyle({ flexDirection: "row", gap: "6px" });
   });
 

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -109,24 +109,24 @@ const MainMenu = (props: Props): React.JSX.Element => {
           >
             Settings
           </Button>
-          {!props.uid && (
-            <Stack
-              role="group"
-              aria-label="Sign-in options"
-              spacing={0}
-              sx={{ alignItems: "center" }}
-            >
-              <Button variant="text" color="primary" onClick={login}>
-                Sign in
-              </Button>
-              {!props.hasSavedGame && (
-                <Typography variant="caption">
-                  Free · no sign-up needed
-                </Typography>
-              )}
-            </Stack>
-          )}
         </Stack>
+        {!props.uid && (
+          <Stack
+            component="section"
+            aria-label="Account actions"
+            className="accountActions"
+            spacing={0}
+          >
+            <Button variant="text" color="primary" onClick={login}>
+              Sign in
+            </Button>
+            {!props.hasSavedGame && (
+              <Typography variant="caption" color="text.secondary">
+                Free · no sign-up needed
+              </Typography>
+            )}
+          </Stack>
+        )}
         <Stack
           component="section"
           aria-label="Discovery actions"

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -84,9 +84,6 @@ const MainMenu = (props: Props): React.JSX.Element => {
           >
             {startLabel}
           </Button>
-          {!props.hasSavedGame && !props.uid && (
-            <Typography variant="caption">Free · no sign-up needed</Typography>
-          )}
         </Stack>
         <Stack
           component="nav"
@@ -113,9 +110,21 @@ const MainMenu = (props: Props): React.JSX.Element => {
             Settings
           </Button>
           {!props.uid && (
-            <Button variant="text" color="primary" onClick={login}>
-              Sign in
-            </Button>
+            <Stack
+              role="group"
+              aria-label="Sign-in options"
+              spacing={0}
+              sx={{ alignItems: "center" }}
+            >
+              <Button variant="text" color="primary" onClick={login}>
+                Sign in
+              </Button>
+              {!props.hasSavedGame && (
+                <Typography variant="caption">
+                  Free · no sign-up needed
+                </Typography>
+              )}
+            </Stack>
           )}
         </Stack>
         <Stack


### PR DESCRIPTION
## Summary

- keep How to play and Settings aligned in their own centered resource row
- place a separate centered account section beneath it with Sign in directly above the subdued “Free · no sign-up needed” caption
- add deliberate spacing before discovery actions and cover the structure with a focused component test
- document the 1–3 screenshot requirement for future UI pull requests

## Screenshots

### Desktop

![Homepage at 1280×800](https://github.com/toddmedema/electrify/blob/codex/homepage-sign-in-caption/.github/pr-screenshots/homepage-sign-in-caption/desktop.png?raw=true)

### Mobile

![Homepage at 390×844](https://github.com/toddmedema/electrify/blob/codex/homepage-sign-in-caption/.github/pr-screenshots/homepage-sign-in-caption/mobile.png?raw=true)

## Testing

- `npm run check`
- Playwright screenshot capture at 1280×800 and 390×844
- `npm run test:e2e`: all homepage, responsive, and tutorial coverage passed; the unrelated custom-location-picker keyboard-focus assertion failed at the 390px and 320px mobile widths (30 passed, 8 skipped, 2 failed)