### PR TITLE
Streamline tutorial guidance

### DIFF
--- a/.github/pr-screenshots/tutorial-guidance/desktop-1440px.png
+++ b/.github/pr-screenshots/tutorial-guidance/desktop-1440px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a96dc8508e65f881639d2263fdcde68cd239b1b8edbb5f510c72688a29552ec
+size 115932

--- a/.github/pr-screenshots/tutorial-guidance/mobile-390px.png
+++ b/.github/pr-screenshots/tutorial-guidance/mobile-390px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e16f5296fd880cc982e60777bb9790cd33d0d615e38612df8f04f044209b0bf
+size 42239

--- a/e2e/tutorial-capstone.spec.ts
+++ b/e2e/tutorial-capstone.spec.ts
@@ -63,14 +63,13 @@ test("guided objective reaches a retryable capstone and succeeds", async ({
   }
 
   await page.getByRole("button", { name: "fast speed" }).click();
-  await expect(page.getByText("Watch one full day go by")).toBeVisible();
   await expect(
     page.getByText("Your turn: keep the lights on for a full day"),
   ).toBeVisible();
 
   // Remove firm capacity so the first attempt demonstrates consequence feedback and retry. The
-  // expanded objective is docked outside the game surface, so the same control remains operable at
-  // every viewport without a small-screen workaround.
+  // objective is docked outside the game surface, so the same control remains operable at every
+  // viewport without a small-screen workaround.
   const naturalGas = page.locator(".facilityRow", { hasText: "Natural Gas" });
   await naturalGas.click();
   await page.getByRole("button", { name: "Pause Natural Gas" }).click();

--- a/src/app.scss
+++ b/src/app.scss
@@ -1130,10 +1130,6 @@ $pane_header_height: 40px;
 
   .tutorialHudContent .tutorialPrompt {
     grid-template-columns: minmax(0, 1fr);
-
-    .tutorialPromptAction {
-      grid-column: auto;
-    }
   }
 }
 
@@ -1798,8 +1794,7 @@ html[data-theme="dark"] .uplot {
     border-radius: 0;
   }
 
-  // Icon-led step content: symbols on top, one confirming line of text, and for gated
-  // steps a "do this" chip naming the deed in the same symbols
+  // Icon-led step content: symbols on top and one confirming line of text
   .tutorialPrompt {
     text-align: center;
 
@@ -1813,16 +1808,6 @@ html[data-theme="dark"] .uplot {
 
     .tutorialPromptArrow {
       opacity: 0.5;
-    }
-
-    .tutorialPromptAction {
-      display: inline-flex;
-      align-items: center;
-      gap: size(tiny);
-      margin-top: size(small);
-      padding: size(tiny) size(small);
-      border: 1px solid var(--border-strong);
-      border-radius: 100px;
     }
   }
 
@@ -2788,12 +2773,6 @@ html[data-theme="dark"] .uplot {
   backdrop-filter: blur(10px);
 }
 
-.tutorialHud-collapsed {
-  width: 100%;
-  max-height: none;
-  overflow: hidden;
-}
-
 .tutorialHudHeader {
   display: flex;
   min-width: 0;
@@ -2821,33 +2800,6 @@ html[data-theme="dark"] .uplot {
   }
 }
 
-.tutorialHudToggle {
-  flex: 0 0 auto;
-}
-
-.tutorialHudProgressRing {
-  position: relative;
-  display: grid;
-  width: 42px;
-  height: 42px;
-  flex: 0 0 42px;
-  place-items: center;
-}
-
-.tutorialHudProgressRing > * {
-  grid-area: 1 / 1;
-}
-
-.tutorialHudProgressIcon {
-  display: grid;
-  place-items: center;
-
-  .conceptIcon {
-    width: 20px;
-    height: 20px;
-  }
-}
-
 .tutorialHudContent {
   min-width: 0;
   margin-top: 6px;
@@ -2864,11 +2816,6 @@ html[data-theme="dark"] .uplot {
     min-height: 32px;
     margin-bottom: 0;
     padding: 4px 8px;
-  }
-
-  .tutorialPromptAction {
-    grid-column: 1 / -1;
-    margin-top: 2px;
   }
 }
 
@@ -2893,52 +2840,41 @@ html[data-theme="dark"] .uplot {
   flex: 1 1 auto;
 }
 
-.tutorialHudGate {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  color: $interactive_blue;
-  font-size: 0.75rem;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.tutorialHudScreenReader {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  overflow: hidden !important;
-  clip: rect(0 0 0 0) !important;
-  clip-path: inset(50%) !important;
-  white-space: nowrap !important;
-}
-
 // A restrained cue rather than a spotlight: it names the relevant control without dimming the
-// surrounding choices. Capstones never receive this class.
+// surrounding choices. If the player has not acted after ten seconds, a short pulse repeats every
+// ten seconds. Capstones never receive either class.
 .tutorialTarget {
-  outline: 3px solid var(--interactive-blue) !important;
+  outline: 2px solid var(--interactive-blue) !important;
   outline-offset: 3px;
-  animation: tutorialTargetPulse 1.6s ease-in-out infinite;
+}
+
+.tutorialTargetReminder {
+  animation: tutorialTargetPulse 10s ease-in-out infinite;
 }
 
 @keyframes tutorialTargetPulse {
   0%,
+  16%,
   100% {
     box-shadow: 0 0 0 0 var(--interactive-tint);
   }
-  50% {
+  8% {
     box-shadow: 0 0 0 7px transparent;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .tutorialTarget {
+  .tutorialTargetReminder {
     animation: none;
+  }
+
+  .tutorialTarget {
+    outline-width: 3px !important;
   }
 }
 
 @media screen and (min-width: 700px) {
-  .tutorialHud-expanded {
+  .tutorialHud {
     display: grid;
     grid-template-areas:
       "header content footer"

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -270,9 +270,9 @@ describe("walkthrough steps", () => {
   });
 
   it("uses the same symbols as the generator and storage buttons it highlights", () => {
-    const actionOf = (step: TutorialStepType) =>
-      React.isValidElement<{ action?: string[] }>(step.content)
-        ? step.content.props.action
+    const conceptsOf = (step: TutorialStepType) =>
+      React.isValidElement<{ concepts?: string[] }>(step.content)
+        ? step.content.props.concepts
         : undefined;
     const generatorStep = walkthrough("Mission 2: Generators").find(
       (step) => step.target === ".button-buildGenerator",
@@ -281,8 +281,8 @@ describe("walkthrough steps", () => {
       (step) => step.target === ".button-buildStorage",
     )!;
 
-    expect(actionOf(generatorStep)).toEqual(["generator"]);
-    expect(actionOf(storageStep)).toEqual(["storage"]);
+    expect(conceptsOf(generatorStep)).toEqual(["build", "generator"]);
+    expect(conceptsOf(storageStep)).toEqual(["build", "storage"]);
   });
 
   it("declares the card every tutorial target lives on", () => {

--- a/src/components/base/TutorialHud.test.tsx
+++ b/src/components/base/TutorialHud.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import { TutorialStepType } from "../../Types";
@@ -55,35 +55,12 @@ describe("TutorialHud", () => {
     expect(hudProps.onExit).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps collapsed state across objective changes and expands on focus", async () => {
-    const user = userEvent.setup();
-    const hudProps = props();
-    const { rerender } = render(<TutorialHud {...hudProps} />);
+  it("keeps the compact objective visible without collapse controls", () => {
+    render(<TutorialHud {...props()} />);
 
-    await user.click(
-      screen.getByRole("button", { name: "Collapse objective" }),
-    );
-    expect(
-      screen.getByRole("button", { name: "Expand objective" }),
-    ).toHaveAttribute("aria-expanded", "false");
-
-    rerender(
-      <TutorialHud
-        {...hudProps}
-        step={objective({
-          content: (
-            <TutorialPrompt concepts={["money"]} text="Protect your cash." />
-          ),
-        })}
-        stepIndex={1}
-      />,
-    );
-    const expand = screen.getByRole("button", { name: "Expand objective" });
-    fireEvent.focus(expand);
-    expect(
-      screen.getByRole("button", { name: "Collapse objective" }),
-    ).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByText("Protect your cash.")).toBeInTheDocument();
+    expect(screen.getByText("Keep supply above demand.")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Collapse objective")).toBeNull();
+    expect(screen.queryByLabelText("Expand objective")).toBeNull();
   });
 
   it("reveals help only when requested and has no redundant Next for gates", async () => {
@@ -101,7 +78,7 @@ describe("TutorialHud", () => {
 
     expect(screen.queryByText("Look at the reserve readout.")).toBeNull();
     expect(screen.queryByRole("button", { name: "Next" })).toBeNull();
-    expect(screen.getByText("Complete objective")).toBeInTheDocument();
+    expect(screen.queryByText("Complete objective")).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "Hint" }));
     expect(screen.getByRole("note")).toHaveTextContent(
@@ -110,7 +87,8 @@ describe("TutorialHud", () => {
     expect(screen.getByRole("button", { name: "Hide hint" })).toHaveFocus();
   });
 
-  it("outlines guided targets but never points out a capstone answer", () => {
+  it("delays target reminders and never points out a capstone answer", () => {
+    jest.useFakeTimers();
     const target = document.createElement("button");
     target.id = "tutorial-target";
     document.body.appendChild(target);
@@ -118,6 +96,12 @@ describe("TutorialHud", () => {
     const hudProps = props();
     const { rerender, unmount } = render(<TutorialHud {...hudProps} />);
     expect(target).toHaveClass("tutorialTarget");
+    expect(target).not.toHaveClass("tutorialTargetReminder");
+
+    act(() => jest.advanceTimersByTime(9_999));
+    expect(target).not.toHaveClass("tutorialTargetReminder");
+    act(() => jest.advanceTimersByTime(1));
+    expect(target).toHaveClass("tutorialTargetReminder");
 
     rerender(
       <TutorialHud
@@ -138,5 +122,6 @@ describe("TutorialHud", () => {
 
     unmount();
     target.remove();
+    jest.useRealTimers();
   });
 });

--- a/src/components/base/TutorialHud.tsx
+++ b/src/components/base/TutorialHud.tsx
@@ -1,17 +1,6 @@
-import ExpandLessIcon from "@mui/icons-material/ExpandLess";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import FlagIcon from "@mui/icons-material/Flag";
-import TouchAppIcon from "@mui/icons-material/TouchApp";
-import {
-  Button,
-  CircularProgress,
-  IconButton,
-  Typography,
-} from "@mui/material";
+import { Button, Typography } from "@mui/material";
 import * as React from "react";
 import { TutorialStepType, isGatedStep } from "../../Types";
-import ConceptIcon from "./ConceptIcon";
-import TutorialPrompt, { TutorialPromptProps } from "./TutorialPrompt";
 
 export interface TutorialHudProps {
   desktop: boolean;
@@ -33,20 +22,10 @@ function resolveStep(step: TutorialStepType, desktop: boolean) {
   };
 }
 
-function promptProps(
-  content: React.ReactNode,
-): TutorialPromptProps | undefined {
-  return React.isValidElement<TutorialPromptProps>(content) &&
-    content.type === TutorialPrompt
-    ? content.props
-    : undefined;
-}
-
 /**
  * A non-modal tutorial objective that leaves the game visible and interactive.
  *
- * Expansion is local UI state, so it survives card navigation without leaking into saves. The
- * target treatment is likewise presentation-only and cleaned up whenever the step changes.
+ * Target treatment is presentation-only and cleaned up whenever the step changes.
  */
 export default function TutorialHud({
   desktop,
@@ -58,13 +37,8 @@ export default function TutorialHud({
   totalSteps,
   canGoBack,
 }: TutorialHudProps): React.JSX.Element {
-  const [expanded, setExpanded] = React.useState(true);
   const [hintVisible, setHintVisible] = React.useState(false);
-  const pointerOpened = React.useRef(false);
   const { content, target } = resolveStep(step, desktop);
-  const prompt = promptProps(content);
-  const primaryConcept = prompt?.concepts[0];
-  const progress = ((stepIndex + 1) / totalSteps) * 100;
   const progressText = `Objective ${stepIndex + 1} of ${totalSteps}`;
 
   React.useEffect(() => setHintVisible(false), [stepIndex]);
@@ -80,44 +54,28 @@ export default function TutorialHud({
     } catch {
       // An invalid or temporarily absent selector must not take down the game or objective HUD.
     }
-    return () =>
-      targets.forEach((element) => element.classList.remove("tutorialTarget"));
+    const reminder = window.setTimeout(
+      () =>
+        targets.forEach((element) =>
+          element.classList.add("tutorialTargetReminder"),
+        ),
+      10_000,
+    );
+    return () => {
+      window.clearTimeout(reminder);
+      targets.forEach((element) => {
+        element.classList.remove("tutorialTarget");
+        element.classList.remove("tutorialTargetReminder");
+      });
+    };
   }, [step, target]);
-
-  const toggleExpanded = () => {
-    // Pointer focus happens before click. Remember that it was the focus which opened the HUD so
-    // the same tap does not immediately collapse it again after React commits the focus update.
-    if (pointerOpened.current) {
-      pointerOpened.current = false;
-      setExpanded(true);
-      return;
-    }
-    setExpanded((value) => !value);
-  };
 
   return (
     <section
-      className={`tutorialHud ${expanded ? "tutorialHud-expanded" : "tutorialHud-collapsed"}${step.capstone ? " tutorialHud-capstone" : ""}`}
+      className={`tutorialHud${step.capstone ? " tutorialHud-capstone" : ""}`}
       aria-labelledby="tutorial-objective-title"
     >
       <div className="tutorialHudHeader">
-        {!expanded && (
-          <div className="tutorialHudProgressRing" aria-hidden>
-            <CircularProgress
-              variant="determinate"
-              value={progress}
-              size={42}
-              thickness={4}
-            />
-            <span className="tutorialHudProgressIcon">
-              {primaryConcept ? (
-                <ConceptIcon concept={primaryConcept} fontSize="small" />
-              ) : (
-                <FlagIcon fontSize="small" />
-              )}
-            </span>
-          </div>
-        )}
         <div className="tutorialHudHeading">
           <Typography
             id="tutorial-objective-title"
@@ -134,78 +92,49 @@ export default function TutorialHud({
             {stepIndex + 1} / {totalSteps}
           </Typography>
         </div>
-        <IconButton
-          className="tutorialHudToggle"
-          size="small"
-          aria-expanded={expanded}
-          aria-controls="tutorial-objective-content"
-          aria-label={expanded ? "Collapse objective" : "Expand objective"}
-          onPointerDown={() => {
-            pointerOpened.current = !expanded;
-          }}
-          onFocus={() => {
-            if (!expanded) {
-              setExpanded(true);
-            }
-          }}
-          onClick={toggleExpanded}
-        >
-          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-        </IconButton>
       </div>
 
-      <div
-        id="tutorial-objective-content"
-        className={expanded ? "tutorialHudContent" : "tutorialHudScreenReader"}
-        aria-live="polite"
-      >
+      <div className="tutorialHudContent" aria-live="polite">
         {content}
       </div>
 
-      {expanded && hintVisible && step.hint && (
+      {hintVisible && step.hint && (
         <div className="tutorialHudHint" role="note">
           <strong>Hint:</strong> {step.hint}
         </div>
       )}
 
-      {expanded && (
-        <div className="tutorialHudFooter">
-          <Button color="primary" size="small" onClick={onExit}>
-            Exit
+      <div className="tutorialHudFooter">
+        <Button color="primary" size="small" onClick={onExit}>
+          Exit
+        </Button>
+        {step.hint && (
+          <Button
+            color="primary"
+            size="small"
+            aria-expanded={hintVisible}
+            onClick={() => setHintVisible((value) => !value)}
+          >
+            {hintVisible ? "Hide hint" : "Hint"}
           </Button>
-          {step.hint && (
-            <Button
-              color="primary"
-              size="small"
-              aria-expanded={hintVisible}
-              onClick={() => setHintVisible((value) => !value)}
-            >
-              {hintVisible ? "Hide hint" : "Hint"}
-            </Button>
-          )}
-          <span className="tutorialHudFooterSpacer" />
-          {canGoBack && (
-            <Button color="primary" size="small" onClick={onBack}>
-              Back
-            </Button>
-          )}
-          {isGatedStep(step) ? (
-            <span className="tutorialHudGate" role="status">
-              <TouchAppIcon fontSize="small" aria-hidden />
-              Complete objective
-            </span>
-          ) : (
-            <Button
-              color="primary"
-              size="small"
-              variant="contained"
-              onClick={onNext}
-            >
-              Next
-            </Button>
-          )}
-        </div>
-      )}
+        )}
+        <span className="tutorialHudFooterSpacer" />
+        {canGoBack && (
+          <Button color="primary" size="small" onClick={onBack}>
+            Back
+          </Button>
+        )}
+        {!isGatedStep(step) && (
+          <Button
+            color="primary"
+            size="small"
+            variant="contained"
+            onClick={onNext}
+          >
+            Next
+          </Button>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/components/base/TutorialPrompt.test.tsx
+++ b/src/components/base/TutorialPrompt.test.tsx
@@ -3,22 +3,17 @@ import { render, screen } from "@testing-library/react";
 import TutorialPrompt from "./TutorialPrompt";
 
 describe("TutorialPrompt", () => {
-  it("names the required action for a gated step", () => {
+  it("keeps the instruction to one concise line", () => {
     render(
       <TutorialPrompt
         concepts={["build", "generator"]}
         text="Open the generator shop."
-        action={["build", "generator"]}
       />,
     );
 
-    expect(screen.getByText("Do this to continue:")).toBeInTheDocument();
-    expect(screen.getByText("build then generator")).toBeInTheDocument();
-    expect(
-      screen.getByRole("status", {
-        name: "Required action: build then generator",
-      }),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Open the generator shop.")).toBeInTheDocument();
+    expect(screen.queryByText("Do this to continue:")).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
   });
 
   it("gives the concept sequence an accessible summary", () => {

--- a/src/components/base/TutorialPrompt.tsx
+++ b/src/components/base/TutorialPrompt.tsx
@@ -1,5 +1,4 @@
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
-import TouchAppIcon from "@mui/icons-material/TouchApp";
 import { Box, Stack, Typography } from "@mui/material";
 import * as React from "react";
 import ConceptIcon, { CONCEPT_LABELS, ConceptNameType } from "./ConceptIcon";
@@ -9,20 +8,12 @@ export interface TutorialPromptProps {
   concepts: ConceptNameType[];
   // At most one short sentence - the symbols carry the teaching, the words only confirm it
   text?: string;
-  // For gated steps: the deed being asked for, as a "do this" chip matching the pulsing
-  // affordance in the objective HUD
-  action?: ConceptNameType[];
 }
 
 export default function TutorialPrompt({
   concepts,
   text,
-  action,
 }: TutorialPromptProps): React.JSX.Element {
-  const actionLabel = action
-    ?.map((concept) => CONCEPT_LABELS[concept].toLowerCase())
-    .join(" then ");
-
   return (
     <Stack
       className="tutorialPrompt"
@@ -59,34 +50,6 @@ export default function TutorialPrompt({
         <Typography variant="body1" sx={{ lineHeight: 1.45 }}>
           {text}
         </Typography>
-      )}
-      {action && (
-        <Box
-          className="tutorialPromptAction"
-          role="status"
-          aria-label={`Required action: ${actionLabel}`}
-          sx={{
-            alignSelf: "stretch",
-            justifyContent: "flex-start",
-            bgcolor: "action.selected",
-            borderColor: "primary.main !important",
-          }}
-        >
-          <TouchAppIcon fontSize="small" color="primary" aria-hidden />
-          <Typography
-            variant="caption"
-            component="span"
-            sx={{ fontWeight: 700, mr: 0.5 }}
-          >
-            Do this to continue:
-          </Typography>
-          {action.map((concept, i) => (
-            <ConceptIcon key={i} concept={concept} fontSize="small" />
-          ))}
-          <Typography variant="caption" component="span">
-            {actionLabel}
-          </Typography>
-        </Box>
       )}
     </Stack>
   );

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -182,6 +182,16 @@ describe("the fleet list", () => {
     ).toBeInTheDocument();
   });
 
+  it("uses the nuclear icon for the France scenario's named reactor", () => {
+    const france = createGame({ scenarioId: 110 });
+    renderFacilities(france, null);
+
+    expect(screen.getByAltText("Grand Nuclear Unit")).toHaveAttribute(
+      "src",
+      "/images/nuclear.svg",
+    );
+  });
+
   it("renders the reasonable worst-case fleet size", () => {
     const tenFacilities = createGame({ scenarioId: 103 });
     const template = tenFacilities.facilities[0];

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -82,6 +82,14 @@ function storyOutputMultiplierForFacility(
   );
 }
 
+function facilityIconName(facility: FacilityOperatingType): string {
+  // Authored scenarios may give a plant a narrative label, but uranium facilities still use
+  // the standard Nuclear artwork instead of looking for an image named after that label.
+  return "fuel" in facility && facility.fuel === "Uranium"
+    ? "nuclear"
+    : facility.name.toLowerCase();
+}
+
 const getDraggableStyle = (
   isDragging: boolean,
   draggableStyle: DraggingStyle | NotDraggingStyle | undefined,
@@ -385,7 +393,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
                 <Avatar
                   className={facility.currentWh === 0 ? "offline" : ""}
                   alt={facility.name}
-                  src={`/images/${facility.name.toLowerCase()}.svg`}
+                  src={`/images/${facilityIconName(facility)}.svg`}
                 />
                 {facility.peakWh > 0 && !underConstruction && (
                   <div className="capacityProgressBar">

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -105,6 +105,18 @@ describe("tutorial mission metadata", () => {
       expect(capstones[0].hint).toBeTruthy();
     });
   });
+
+  it("ends the electricity mission after a single one-day challenge", () => {
+    const electricity = TUTORIALS.find(
+      (tutorial) => tutorial.name === "Mission 1: Electricity",
+    )!;
+    const steps = electricity.tutorialSteps!;
+
+    expect(steps).toHaveLength(5);
+    expect(steps[3].advanceOn).toBeDefined();
+    expect(steps[4].advanceOn).toBeUndefined();
+    expect(steps[4].capstone).toBeDefined();
+  });
 });
 
 describe("authored scenario briefings", () => {

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -127,22 +127,7 @@ export const SCENARIOS = [
         target: "#speedChangeButtons",
         advanceOn: (s: AppStateType) => s.game.speed !== "PAUSED",
         content: (
-          <TutorialPrompt
-            concepts={["play"]}
-            text="Tap 1× to start time."
-            action={["play"]}
-          />
-        ),
-      },
-      {
-        card: "FACILITIES",
-        target: "#chartSupplyDemand",
-        advanceOn: (s: AppStateType) => s.game.date.minute >= 1440,
-        content: (
-          <TutorialPrompt
-            concepts={["weather", "time"]}
-            text="Watch one full day go by."
-          />
+          <TutorialPrompt concepts={["play"]} text="Tap 1× to start time." />
         ),
       },
       {
@@ -194,7 +179,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["build", "generator"]}
             text="Open the generator shop."
-            action={["generator"]}
           />
         ),
       },
@@ -216,7 +200,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["buy", "generator"]}
             text="Choose a generator and decide whether to pay with cash or a loan."
-            action={["buy"]}
           />
         ),
       },
@@ -235,11 +218,7 @@ export const SCENARIOS = [
         target: "#speedChangeButtons",
         advanceOn: (s: AppStateType) => s.game.speed !== "PAUSED",
         content: (
-          <TutorialPrompt
-            concepts={["play"]}
-            text="Tap 1× to run the year."
-            action={["play"]}
-          />
+          <TutorialPrompt concepts={["play"]} text="Tap 1× to run the year." />
         ),
       },
       {
@@ -292,7 +271,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["build", "storage"]}
             text="Store spare power for when you need it - open the storage shop."
-            action={["storage"]}
           />
         ),
       },
@@ -304,7 +282,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["buy", "storage"]}
             text="Choose a storage system and decide whether to pay with cash or a loan."
-            action={["buy"]}
           />
         ),
       },
@@ -326,7 +303,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["reorder"]}
             text="Drag facilities to change their dispatch order. Generators higher in the list run first; storage charges when they make more electricity than customers need."
-            action={["reorder"]}
           />
         ),
       },
@@ -335,11 +311,7 @@ export const SCENARIOS = [
         target: "#speedChangeButtons",
         advanceOn: (s: AppStateType) => s.game.speed !== "PAUSED",
         content: (
-          <TutorialPrompt
-            concepts={["play"]}
-            text="Tap 1× to run it."
-            action={["play"]}
-          />
+          <TutorialPrompt concepts={["play"]} text="Tap 1× to run it." />
         ),
       },
       {
@@ -443,7 +415,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["play", "money"]}
             text="Tap 1× to run a month and watch the numbers."
-            action={["play"]}
           />
         ),
       },
@@ -517,7 +488,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["rate", "customers"]}
             text="Lower the rate below the market price so more customers choose your utility."
-            action={["rate"]}
           />
         ),
       },
@@ -536,11 +506,7 @@ export const SCENARIOS = [
         target: "#speedChangeButtons",
         advanceOn: (s: AppStateType) => s.game.speed !== "PAUSED",
         content: (
-          <TutorialPrompt
-            concepts={["play"]}
-            text="Tap 1× to run the year."
-            action={["play"]}
-          />
+          <TutorialPrompt concepts={["play"]} text="Tap 1× to run the year." />
         ),
       },
       {
@@ -592,7 +558,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["pause", "generator"]}
             text="Pause your only plant and watch how the supply forecast changes."
-            action={["pause"]}
           />
         ),
       },
@@ -615,7 +580,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["play", "blackout"]}
             text="Tap 1× and let the predicted blackout begin."
-            action={["play"]}
           />
         ),
       },
@@ -647,7 +611,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["play", "generator"]}
             text="Turn it back on."
-            action={["play"]}
           />
         ),
       },
@@ -679,7 +642,6 @@ export const SCENARIOS = [
           <TutorialPrompt
             concepts={["play"]}
             text="Tap 1× to run the year. The Manual has the deep dives."
-            action={["play"]}
           />
         ),
       },


### PR DESCRIPTION
## Summary
- use the standard nuclear artwork for the France scenario's named uranium unit
- remove the duplicate one-day walkthrough step so Mission 1 ends after one successful day
- simplify tutorial prompts by removing redundant action/status bars and collapse controls
- keep a subtle target outline, then add a brief reminder pulse after 10 seconds and every 10 seconds thereafter
- preserve a stronger static outline for reduced-motion users

## Screenshots
### Desktop
![Streamlined tutorial objective on desktop](https://github.com/toddmedema/electrify/blob/codex/streamline-tutorial-guidance/.github/pr-screenshots/tutorial-guidance/desktop-1440px.png?raw=1)

### Mobile
![Streamlined tutorial objective on mobile](https://github.com/toddmedema/electrify/blob/codex/streamline-tutorial-guidance/.github/pr-screenshots/tutorial-guidance/mobile-390px.png?raw=1)

## Testing
- npm run check
- npm run test:e2e -- e2e/tutorial-capstone.spec.ts (5 responsive projects)