### PR TITLE
Add facility artwork to About page hero

### DIFF
--- a/.github/pr-screenshots/about-facility-hero/desktop-1270px.png
+++ b/.github/pr-screenshots/about-facility-hero/desktop-1270px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3643d19ba21580667a977b2721810946ae0bd3394017ee6a214cf6b694b63916
+size 99801

--- a/.github/pr-screenshots/about-facility-hero/mobile-390px.png
+++ b/.github/pr-screenshots/about-facility-hero/mobile-390px.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3bb23da23585df40a2d192ec001741b9bb73609209ed4a77b55a8f267119775
+size 44121

--- a/public/about.html
+++ b/public/about.html
@@ -59,18 +59,28 @@
       </div>
     </header>
 
-    <section class="hero" aria-labelledby="page-title">
+    <section class="hero hero--illustrated" aria-labelledby="page-title">
       <div class="hero__inner">
-        <h1 id="page-title">Power markets, made playable.</h1>
-        <p class="hero__lede">
-          Build a cleaner, reliable grid—one power plant at a time.
-        </p>
-        <div class="hero__actions">
-          <a class="button button--primary" href="/">Play Electrify</a>
-          <a class="button" href="https://github.com/toddmedema/electrify"
-            >View source</a
-          >
+        <div class="hero__copy">
+          <h1 id="page-title">Power markets, made playable.</h1>
+          <p class="hero__lede">
+            Build a cleaner, reliable grid—one power plant at a time.
+          </p>
+          <div class="hero__actions">
+            <a class="button button--primary" href="/">Play Electrify</a>
+            <a class="button" href="https://github.com/toddmedema/electrify"
+              >View source</a
+            >
+          </div>
         </div>
+        <img
+          class="hero__art"
+          src="/images/about-hero-facility-tokens.svg"
+          alt=""
+          aria-hidden="true"
+          width="560"
+          height="360"
+        />
       </div>
     </section>
 

--- a/public/images/about-hero-facility-tokens.svg
+++ b/public/images/about-hero-facility-tokens.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:541f9c1d4e536069c918443b1268392a27aa1d111f7f3225ce416693ad8a32be
+size 16769

--- a/public/legal.css
+++ b/public/legal.css
@@ -184,6 +184,25 @@ a:hover {
   padding: clamp(4rem, 9vw, 7.5rem) 0 clamp(3.5rem, 8vw, 6rem);
 }
 
+.hero--illustrated .hero__inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(19rem, 0.85fr);
+  align-items: center;
+  gap: clamp(2rem, 6vw, 5rem);
+}
+
+.hero__copy {
+  min-width: 0;
+}
+
+.hero__art {
+  width: 100%;
+  max-width: 32rem;
+  height: auto;
+  display: block;
+  justify-self: end;
+}
+
 .eyebrow {
   margin: 0 0 0.8rem;
   color: var(--brand-strong);
@@ -560,6 +579,16 @@ a:hover {
 }
 
 @media (max-width: 48rem) {
+  .hero--illustrated .hero__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .hero__art {
+    width: min(24rem, 82%);
+    margin-top: 1rem;
+    justify-self: center;
+  }
+
   .panel--story,
   .panel--impact {
     grid-column: 1 / -1;
@@ -612,6 +641,10 @@ a:hover {
   .panel__actions,
   .button {
     width: 100%;
+  }
+
+  .hero--illustrated .hero__art {
+    display: none;
   }
 
   .signup-form__fields {


### PR DESCRIPTION
## Summary
- add a triangular hero illustration built from the existing Solar, Wind, and Battery facility tokens
- give the About hero a responsive two-column layout while leaving the Privacy hero unchanged
- scale the artwork below the copy on tablets and hide the decorative image on narrow mobile screens

## Screenshots
### Desktop — 1270px
![About page desktop](https://raw.githubusercontent.com/toddmedema/electrify/codex/about-page-facility-hero/.github/pr-screenshots/about-facility-hero/desktop-1270px.png)

### Mobile — 390px
![About page mobile](https://raw.githubusercontent.com/toddmedema/electrify/codex/about-page-facility-hero/.github/pr-screenshots/about-facility-hero/mobile-390px.png)

## Validation
- npm run build
- npm run sim -- --all
- npm test -- BuildGenerators.test --watchAll=false
- npm run check: typecheck, lint, and formatting passed; 91 of 92 Jest suites passed, with one BuildGenerators test timing out once under the full parallel run. Its focused rerun passed all 9 tests.