### PR TITLE
Remove pre-release compatibility code

### DIFF
--- a/src/Replay.test.tsx
+++ b/src/Replay.test.tsx
@@ -1,7 +1,6 @@
 import {
   decodeReplay,
   encodeReplay,
-  replayVersionError,
   MAX_REPLAY_ACTIONS,
   recordReplayAction,
   recordedDelta,
@@ -26,9 +25,7 @@ function aReplay(overrides: Partial<ReplayType> = {}): ReplayType {
     scenarioId: 101,
     difficulty: "Employee",
     seed: 12345,
-    startingYear: 2020,
     location: LOCATIONS.SF,
-    durationMinutes: 43200,
     actions: [
       { minute: 0, type: "delta", payload: { dollarsPerkWh: 0.12 } },
       { minute: 1440, type: "sellFacility", payload: 3 },
@@ -196,22 +193,21 @@ describe("decodeReplay", () => {
     expect(decodeReplay({})).toBeNull();
   });
 
-  it("ignores a replay from a schema it doesn't understand", () => {
+  it("rejects a replay from a different schema", () => {
     expect(
       decodeReplay(encodeReplay(aReplay({ version: REPLAY_VERSION + 1 }))),
     ).toBeNull();
   });
 
-  it("explains that older simulation replays cannot be migrated", () => {
-    const old = encodeReplay(aReplay({ version: REPLAY_VERSION - 1 }));
-    expect(replayVersionError(old)).toMatch(
-      /created by an older simulation version/,
-    );
-  });
-
   it("ignores a replay missing the fields the run is rebuilt from", () => {
     const doc = encodeReplay(aReplay()) as unknown as Record<string, unknown>;
     delete doc.seed;
+    expect(decodeReplay(doc)).toBeNull();
+  });
+
+  it("rejects a replay without current envelope metadata", () => {
+    const doc = encodeReplay(aReplay()) as unknown as Record<string, unknown>;
+    delete doc.appVersion;
     expect(decodeReplay(doc)).toBeNull();
   });
 

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -28,22 +28,8 @@ import {
  * reducers/ImportOrder.test.tsx guards against.
  */
 
-// v6 rounds every scenario's starting facility capacity to two significant digits.
-// Older actions cannot reproduce the same monthly facts and are rejected rather than migrated.
-export const REPLAY_VERSION = 6;
-
-export function replayVersionError(raw: unknown): string | undefined {
-  if (typeof raw !== "object" || raw === null) {
-    return undefined;
-  }
-  const version = (raw as { version?: unknown }).version;
-  if (typeof version !== "number" || version === REPLAY_VERSION) {
-    return undefined;
-  }
-  return version < REPLAY_VERSION
-    ? "That replay was created by an older simulation version and can't be played."
-    : "That replay was created by a newer simulation version and can't be played.";
-}
+// Initial public schema. Increment this when a post-release change becomes incompatible.
+export const REPLAY_VERSION = 1;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few
@@ -145,9 +131,7 @@ export function serializeReplay(game: GameType): ReplayType | undefined {
     scenarioId: game.scenarioId,
     difficulty: game.difficulty,
     seed: game.seed,
-    startingYear: game.startingYear,
     location: cloneDeep(game.location),
-    durationMinutes: game.date.minute,
     actions: cloneDeep(game.replayLog),
   };
 }
@@ -225,6 +209,7 @@ export function decodeReplay(raw: unknown): ReplayType | null {
   if (
     !isFiniteNumber(doc.scenarioId) ||
     !isFiniteNumber(doc.seed) ||
+    typeof doc.appVersion !== "string" ||
     typeof doc.difficulty !== "string" ||
     // Checked in full rather than trusted: the location's id becomes the path of the weather file
     // the loading screen fetches, and its lat/long drive the sun model
@@ -238,18 +223,11 @@ export function decodeReplay(raw: unknown): ReplayType | null {
   }
   return {
     version: REPLAY_VERSION,
-    appVersion: typeof doc.appVersion === "string" ? doc.appVersion : "unknown",
+    appVersion: doc.appVersion,
     scenarioId: doc.scenarioId,
     difficulty: doc.difficulty as ReplayType["difficulty"],
     seed: doc.seed,
-    // Diagnostic only (see ReplayType), so a document without one is still a replay
-    startingYear: isFiniteNumber(doc.startingYear)
-      ? doc.startingYear
-      : undefined,
     location: doc.location,
-    durationMinutes: isFiniteNumber(doc.durationMinutes)
-      ? doc.durationMinutes
-      : 0,
     actions,
   };
 }

--- a/src/SaveFile.test.tsx
+++ b/src/SaveFile.test.tsx
@@ -148,20 +148,12 @@ describe("SaveFile", () => {
       expect(error).toMatch(/isn't an Electrify save/);
     });
 
-    it("rejects an incompatible save", async () => {
+    it("rejects a save from a different schema", async () => {
       const { save, error } = await readSaveFile(
         saveFile({ ...serializeSave(fakeGame()), version: SAVE_VERSION + 1 }),
       );
       expect(save).toBeUndefined();
-      expect(error).toMatch(/newer simulation version/);
-    });
-
-    it("explains that an older simulation save cannot be migrated", async () => {
-      const { save, error } = await readSaveFile(
-        saveFile({ ...serializeSave(fakeGame()), version: SAVE_VERSION - 1 }),
-      );
-      expect(save).toBeUndefined();
-      expect(error).toMatch(/created by an older simulation version/);
+      expect(error).toMatch(/isn't a valid Electrify save/);
     });
 
     it("rejects a save whose scenario this build doesn't have", async () => {

--- a/src/SaveFile.tsx
+++ b/src/SaveFile.tsx
@@ -1,10 +1,5 @@
 import { getScenario } from "./data/Scenarios";
-import {
-  parseSave,
-  readSave,
-  SaveGameType,
-  saveVersionError,
-} from "./SaveGame";
+import { parseSave, readSave, SaveGameType } from "./SaveGame";
 import { ScenarioType } from "./Types";
 
 /**
@@ -106,14 +101,10 @@ export async function readSaveFile(file: File): Promise<ImportedSaveType> {
   } catch (_err) {
     return { error: "That file isn't an Electrify save game." };
   }
-  const versionError = saveVersionError(parsed);
-  if (versionError) {
-    return { error: versionError };
-  }
   const save = parseSave(parsed);
   if (!save) {
     return {
-      error: "That file isn't a compatible Electrify save game.",
+      error: "That file isn't a valid Electrify save game.",
     };
   }
   if (!getScenario(save.game.scenarioId, save.game.customScenario)) {

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -76,10 +76,16 @@ describe("SaveGame", () => {
     expect(readSave()).toBeNull();
   });
 
-  it("ignores a save from a different schema version", () => {
+  it("rejects a save from a different schema version", () => {
     expect(
       parseSave({ ...serializeSave(game), version: SAVE_VERSION + 1 }),
     ).toBeNull();
+  });
+
+  it("rejects a save without current envelope metadata", () => {
+    const save = serializeSave(game);
+    expect(parseSave({ ...save, savedAt: undefined })).toBeNull();
+    expect(parseSave({ ...save, appVersion: undefined })).toBeNull();
   });
 
   it("rejects a current-version save without customer-market state", () => {
@@ -128,19 +134,17 @@ describe("SaveGame", () => {
     ).toBeNull();
   });
 
-  it("repairs the impossible extra opening-history row from older v4 sessions", () => {
+  it("rejects history from beyond the save's elapsed time", () => {
     const advanced = createGame(OPTIONS);
     while (advanced.date.monthsElapsed < 1) {
       tickState(advanced);
     }
     expect(advanced.monthlyHistory).toHaveLength(1);
-    const legacy = serializeSave({
+    const impossible = serializeSave({
       ...advanced,
       monthlyHistory: [...advanced.monthlyHistory, advanced.monthlyHistory[0]],
     });
-    expect(parseSave(legacy)!.game.monthlyHistory).toEqual(
-      advanced.monthlyHistory,
-    );
+    expect(parseSave(impossible)).toBeNull();
   });
 
   it("rejects a current-version save without current runtime state", () => {

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -25,21 +25,8 @@ import type { AppStore } from "./Store";
  */
 
 export const SAVE_KEY = "savedGame";
-// v4 persists calibrated demand and authored absolute-load schedules on the live game slice.
-export const SAVE_VERSION = 4;
-
-export function saveVersionError(raw: unknown): string | undefined {
-  if (typeof raw !== "object" || raw === null) {
-    return undefined;
-  }
-  const version = (raw as { version?: unknown }).version;
-  if (typeof version !== "number" || version === SAVE_VERSION) {
-    return undefined;
-  }
-  return version < SAVE_VERSION
-    ? "That save was created by an older simulation version and can't be resumed."
-    : "That save was created by a newer simulation version and can't be resumed.";
-}
+// Initial public schema. Increment this when a post-release change becomes incompatible.
+export const SAVE_VERSION = 1;
 
 export interface SaveGameType {
   version: number;
@@ -73,7 +60,11 @@ export function parseSave(raw: unknown): SaveGameType | null {
     return null;
   }
   const save = raw as Partial<SaveGameType>;
-  if (save.version !== SAVE_VERSION) {
+  if (
+    save.version !== SAVE_VERSION ||
+    typeof save.savedAt !== "string" ||
+    typeof save.appVersion !== "string"
+  ) {
     return null;
   }
   const game = save.game as Partial<GameType> | undefined;
@@ -173,6 +164,8 @@ export function parseSave(raw: unknown): SaveGameType | null {
     }) ||
     !Array.isArray(game.timeline) ||
     !Array.isArray(game.monthlyHistory) ||
+    game.monthlyHistory.length >
+      Math.floor(game.date.minute / MINUTES_PER_MONTH) ||
     game.monthlyHistory.some((month) => {
       if (typeof month !== "object" || month === null) {
         return true;
@@ -209,12 +202,6 @@ export function parseSave(raw: unknown): SaveGameType | null {
     !Array.isArray(worldEvents.checkedKeys)
   ) {
     return null;
-  }
-  // Older v4 sessions could record the opening forecast as an extra completed month. History is
-  // newest-first, so any impossible excess is the oldest tail and can be repaired losslessly.
-  const completedMonths = Math.floor(game.date.minute / MINUTES_PER_MONTH);
-  if (game.monthlyHistory.length > completedMonths) {
-    game.monthlyHistory = game.monthlyHistory.slice(0, completedMonths);
   }
   return save as SaveGameType;
 }

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -224,16 +224,10 @@ export interface ReplayType {
   scenarioId: number;
   difficulty: DifficultyType;
   seed: number;
-  // Recorded for bug reports, alongside appVersion, and deliberately not read back: playback
-  // reloads the scenario and takes the year from it, so a replay that disagreed with its own
-  // scenario would be describing a run that could not be reproduced anyway. Not required on the
-  // way in for the same reason
-  startingYear?: number;
   // Where the run was played. A scenario id no longer pins this down -- a custom game carries its
   // own location, and an authored one could be given a location that isn't in LOCATIONS -- so
   // without it a replay would silently be re-simulated against a different city's weather
   location: LocationType;
-  durationMinutes: number; // How far the recorded run got
   actions: ReplayActionType[];
 }
 
@@ -311,9 +305,6 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     // The exponentially smoothed bill customers respond to, rather than the slider's latest value
     customerRate: number;
     supplyByFuel: FuelProductionType;
-    // Legacy saves may contain the old enumerable commitment forecast. New forecasts keep this
-    // transient so it cannot inflate saves, chart copies, or Redux development scans.
-    dispatchTargetWByFacility?: Record<number, number>;
   };
 
 export type DerivedHistoryKeysType = Exclude<
@@ -602,8 +593,7 @@ export interface ScenarioType {
   // When absent, the location profile supplies the starting grid size.
   startingCustomers?: number;
   // Customer count and utility-scale load are not interchangeable. Authored scenarios can
-  // calibrate the ordinary customer-driven baseline while the absent default preserves every
-  // legacy scenario and custom game.
+  // calibrate the ordinary customer-driven baseline; otherwise the location profile is enough.
   startingDemandScale?: number;
   // Absolute loads owned by this scenario. A Data centers schedule replaces the generic regional
   // data-center curve instead of stacking on top of it.

--- a/src/audio/AudioNode.tsx
+++ b/src/audio/AudioNode.tsx
@@ -1,23 +1,11 @@
 import { MUSIC_FADE_SECONDS } from "../Constants";
 
-/**
- * Pre-standard Web Audio names this class still guards for. Browsers of the Safari 6 / Chrome 20
- * era exposed noteOn/noteOff rather than start/stop, and reported playback through
- * playbackState. None of them exist in a current browser, so every one of these is optional.
- */
-interface LegacyBufferSource extends AudioBufferSourceNode {
-  noteOn?: AudioBufferSourceNode["start"];
-  noteOff?: AudioBufferSourceNode["stop"];
-  playbackState?: number;
-  PLAYING_STATE?: number;
-}
-
 export class AudioNode {
   private context: AudioContext;
   private buffer: AudioBuffer;
   private output: AudioDestinationNode | GainNode;
   private gain: GainNode | null;
-  private source: LegacyBufferSource | null;
+  private source: AudioBufferSourceNode | null;
 
   constructor(
     audioContext: AudioContext,
@@ -61,11 +49,10 @@ export class AudioNode {
     if (fadeInVolume) {
       this.fadeIn(fadeInVolume);
     }
-    const source: LegacyBufferSource = this.context.createBufferSource();
+    const source = this.context.createBufferSource();
     this.source = source;
     source.buffer = this.buffer;
     source.connect(this.gain);
-    source.start = source.start || source.noteOn; // polyfill for old browsers
     source.start(when, offset);
   }
 
@@ -90,11 +77,10 @@ export class AudioNode {
     gain.gain.linearRampToValueAtTime(0, this.context.currentTime + seconds);
     if (stop && this.source) {
       const source = this.source;
-      source.stop = source.stop || source.noteOff; // polyfill for old browsers
       try {
         source.stop(this.context.currentTime + seconds);
       } catch (_err) {
-        // polyfill for iOS
+        // An already-stopped single-use source may reject another stop request.
         gain.disconnect();
       }
     }
@@ -107,14 +93,9 @@ export class AudioNode {
     return this.gain.gain.value;
   }
 
-  // NOTE: playbackState and PLAYING_STATE are both undefined in any browser released this
-  // decade, so this comparison holds whenever a source exists -- meaning the answer is really
-  // "has playOnce been called", and a node never reports itself as finished. Preserved as-is
-  // because the music fading in ThemeManager is tuned around the current behaviour; fixing it
-  // means tracking completion off the source's ended event.
+  // ThemeManager uses this as "has playOnce been called"; it intentionally keeps treating a
+  // naturally ended source as active so later intensity changes preserve the established mix.
   public isPlaying(): boolean {
-    return Boolean(
-      this.source && this.source.playbackState === this.source.PLAYING_STATE,
-    );
+    return this.source !== null;
   }
 }

--- a/src/components/views/BuildGenerators.test.tsx
+++ b/src/components/views/BuildGenerators.test.tsx
@@ -111,7 +111,7 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", async () 
   expect(
     screen.getByRole("button", { name: "Show financing terms" }),
   ).toHaveAttribute("aria-expanded", "false");
-});
+}, 15000);
 
 it("shows Coal's physical and representative-day start charges", () => {
   const game = createGame({ scenarioId: 104, difficulty: "CEO" });

--- a/src/components/views/CustomGame.test.tsx
+++ b/src/components/views/CustomGame.test.tsx
@@ -52,36 +52,6 @@ it("opens after economic data is loaded and names every setup control", () => {
   ).not.toBeInTheDocument();
 });
 
-it("populates cash from a saved setup that predates year-adjusted cash", () => {
-  const onStart = jest.fn();
-  const inflation = getFuelEscalation(2040) / getFuelEscalation(2020);
-  render(
-    <CustomGame
-      game={createGame({ scenarioId: 100 })}
-      scenario={{
-        ...DEFAULT_CUSTOM_SCENARIO,
-        startingYear: 2040,
-        cash: 200000000,
-        dollarsPerkWh: Number((0.07 * inflation).toPrecision(2)),
-      }}
-      onBack={jest.fn()}
-      onDelta={jest.fn()}
-      onStart={onStart}
-    />,
-  );
-
-  expect(
-    screen.getByRole("combobox", { name: "Starting cash" }),
-  ).toHaveTextContent(/\$\d/);
-
-  fireEvent.click(screen.getByRole("button", { name: "Play" }));
-  expect(onStart).toHaveBeenCalledWith(
-    expect.objectContaining({
-      cash: Number((200000000 * inflation).toPrecision(2)),
-    }),
-  );
-});
-
 it("re-quotes starting cash when the starting year changes", () => {
   const onStart = jest.fn();
   render(

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -127,26 +127,6 @@ const GENERATOR_SIZES_W = [
 ];
 const STORAGE_SIZES_WH = [100000000, 500000000, 1000000000, 2000000000];
 
-function startingCashOptions(startingYear: number): number[] {
-  return STARTING_CASH.map((cash: number) => inEraMoney(cash, startingYear));
-}
-
-/**
- * Bring a saved cash choice forward when opening a setup recorded before cash started scaling
- * with the game's year. Without this migration, the saved amount is absent from the Select's
- * options and MUI renders the control as an empty dropdown.
- */
-function normalizeStartingCash(scenario: ScenarioType): ScenarioType {
-  const options = startingCashOptions(scenario.startingYear);
-  if (options.includes(scenario.cash)) {
-    return scenario;
-  }
-  const legacyIndex = STARTING_CASH.indexOf(scenario.cash);
-  const index =
-    legacyIndex === -1 ? nearestIndex(options, scenario.cash) : legacyIndex;
-  return { ...scenario, cash: options[index] };
-}
-
 interface TechnologyType {
   name: string;
   storage: boolean;
@@ -232,9 +212,7 @@ function facilitiesForStartingCustomers(
 export default function CustomGame(props: Props): React.JSX.Element {
   const { game, onBack, onDelta, onStart } = props;
   const units = useUnits();
-  const [scenario, setScenario] = React.useState<ScenarioType>(() =>
-    normalizeStartingCash(props.scenario),
-  );
+  const [scenario, setScenario] = React.useState<ScenarioType>(props.scenario);
   const [victoryDialogOpen, setVictoryDialogOpen] = React.useState(false);
   const [feeDialogOpen, setFeeDialogOpen] = React.useState(false);
   const [addName, setAddName] = React.useState("");
@@ -253,7 +231,10 @@ export default function CustomGame(props: Props): React.JSX.Element {
   // which is why changing that year has to re-quote whatever was already chosen rather than
   // leaving a 2020 amount on a 2080 game -- see changeStartingYear below.
   const cashOptions = React.useMemo(
-    () => startingCashOptions(scenario.startingYear),
+    () =>
+      STARTING_CASH.map((cash: number) =>
+        inEraMoney(cash, scenario.startingYear),
+      ),
     [scenario.startingYear],
   );
   const rateOptions = React.useMemo(

--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -223,18 +223,6 @@ describe("the Finances chart selectors", () => {
     expect(periodSelect()).toHaveTextContent("Current year");
   });
 
-  // The sentinels the dropdown used to store its two non-year options as. They aren't options
-  // any more, and a returning player has one of them sitting in storage
-  it("falls back when storage holds either old range sentinel", () => {
-    ["-1", "0"].forEach((stored) => {
-      localStorage.setItem("financesChartYear", stored);
-
-      renderFinances(game, "PAUSED");
-      expect(periodSelect()).toHaveTextContent("Current year");
-      cleanup();
-    });
-  });
-
   it("plots further than the game has reached when a forward range is chosen", async () => {
     renderFinances(game, "PAUSED");
     const thisYear = summarised("Revenue");

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -38,7 +38,7 @@ import { getDb, login } from "../../Globals";
 import { getScenario } from "../../data/Scenarios";
 import { getScenarioLocation } from "../../helpers/Locations";
 import { prefetchScenarioData } from "../../helpers/OfflineData";
-import { decodeReplay, replayVersionError } from "../../Replay";
+import { decodeReplay } from "../../Replay";
 import {
   DifficultyType,
   GameType,
@@ -244,9 +244,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
       if (replay) {
         this.props.onWatchReplay(replay);
       } else {
-        this.props.onReplayError(
-          replayVersionError(data) || "Sorry, that replay couldn't be loaded.",
-        );
+        this.props.onReplayError("Sorry, that replay couldn't be loaded.");
       }
     } catch (err) {
       console.warn("Couldn't load the replay: ", err);

--- a/src/helpers/Commitment.test.tsx
+++ b/src/helpers/Commitment.test.tsx
@@ -6,9 +6,11 @@ import {
 import { TickPresentFutureType } from "../Types";
 
 function tick(target: number | undefined): TickPresentFutureType {
-  return (
-    target === undefined ? {} : { dispatchTargetWByFacility: { 7: target } }
-  ) as TickPresentFutureType;
+  const result = {} as TickPresentFutureType;
+  if (target !== undefined) {
+    recordDispatchTarget(result, 7, target);
+  }
+  return result;
 }
 
 describe("generator commitment optimization", () => {

--- a/src/helpers/Commitment.tsx
+++ b/src/helpers/Commitment.tsx
@@ -55,13 +55,7 @@ function dispatchTarget(
   tick: TickPresentFutureType,
   facilityId: number,
 ): number | undefined {
-  return (
-    // Compatibility with timelines loaded from saves written before forecast metadata became
-    // transient. Prefer it when present so an old save (or focused simulation fixture) remains
-    // authoritative rather than being shadowed by metadata from an earlier forecast.
-    tick.dispatchTargetWByFacility?.[facilityId] ??
-    metadata(tick)?.dispatchTargets[facilityId]
-  );
+  return metadata(tick)?.dispatchTargets[facilityId];
 }
 
 /** Copies transient metadata when a forecast pass clones a tick with object spread. */
@@ -138,9 +132,9 @@ export function shouldKeepGeneratorCommitted({
     return false;
   }
 
-  const preparedCost = forecast[fromIndex].dispatchTargetWByFacility
-    ? undefined
-    : metadata(forecast[fromIndex])?.runningCostToNextDispatch[facilityId];
+  const preparedCost = metadata(forecast[fromIndex])?.runningCostToNextDispatch[
+    facilityId
+  ];
   if (preparedCost !== undefined) {
     return preparedCost < startCost;
   }

--- a/src/reducers/GeneratorCommitment.test.tsx
+++ b/src/reducers/GeneratorCommitment.test.tsx
@@ -1,4 +1,8 @@
 import { TICK_MINUTES } from "../Constants";
+import {
+  prepareGeneratorCommitment,
+  recordDispatchTarget,
+} from "../helpers/Commitment";
 import { getTimeFromTimeline } from "../helpers/DateTime";
 import { createGame } from "../testing/Simulator";
 import { GeneratorOperatingType, GameType } from "../Types";
@@ -25,7 +29,7 @@ function isolatedOnlineCoal(): {
   );
   for (let i = nextIndex; i < state.timeline.length; i++) {
     state.timeline[i].demandW = 0;
-    state.timeline[i].dispatchTargetWByFacility = { [coal.id]: 0 };
+    recordDispatchTarget(state.timeline[i], coal.id, 0);
   }
   return { state, coal, nextIndex };
 }
@@ -34,7 +38,12 @@ describe("minimum stable generator dispatch", () => {
   it("holds an online plant at its minimum when avoiding the next start is cheaper", () => {
     const { state, coal, nextIndex } = isolatedOnlineCoal();
     coal.costPerStart = 1000000000;
-    state.timeline[nextIndex + 2].dispatchTargetWByFacility![coal.id] = 1;
+    recordDispatchTarget(state.timeline[nextIndex + 2], coal.id, 1);
+    prepareGeneratorCommitment({
+      facilityId: coal.id,
+      forecast: state.timeline,
+      minimumOperatingCost: () => 1,
+    });
 
     tickState(state);
 
@@ -52,7 +61,12 @@ describe("minimum stable generator dispatch", () => {
     const { state, coal, nextIndex } = isolatedOnlineCoal();
     coal.costPerStart = 1;
     coal.variableOperatingCostPerMWh = 1000000000;
-    state.timeline[nextIndex + 3].dispatchTargetWByFacility![coal.id] = 1;
+    recordDispatchTarget(state.timeline[nextIndex + 3], coal.id, 1);
+    prepareGeneratorCommitment({
+      facilityId: coal.id,
+      forecast: state.timeline,
+      minimumOperatingCost: () => 1000000000,
+    });
     const minimumW = coal.currentW;
 
     tickState(state);

--- a/src/reducers/User.test.tsx
+++ b/src/reducers/User.test.tsx
@@ -58,9 +58,7 @@ function aReplay(overrides: Partial<ReplayType> = {}): ReplayType {
     scenarioId: 101,
     difficulty: "Employee",
     seed: 12345,
-    startingYear: 2020,
     location: LOCATIONS.SF,
-    durationMinutes: 43200,
     actions: [{ minute: 1440, type: "sellFacility", payload: 3 }],
     ...overrides,
   };


### PR DESCRIPTION
## Summary
- reset the unreleased save and replay schemas to their initial public version and remove version-direction error plumbing
- remove pre-release save repair, custom-settings migration, enumerable forecast compatibility, unused replay metadata, and obsolete tests
- require current save/replay envelope metadata and reject impossible save history instead of mutating imported data
- remove pre-standard Web Audio aliases and stabilize the expensive generator UI test under coverage load

## Validation
- npm run check
- npm run build

The full check passed 883 Jest tests and every headless scenario invariant.