### PR TITLE
Refine homepage, Insights controls, and upcoming events

### DIFF
--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+
+const REVIEW_VIEWPORTS = new Set([
+  "mobile-320px",
+  "tablet-768px",
+  "desktop-chromium",
+]);
+
+test("insights header controls stay aligned in one compact row", async ({
+  page,
+}, testInfo) => {
+  test.skip(!REVIEW_VIEWPORTS.has(testInfo.project.name));
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem(
+      "insightsPresetLibrary",
+      JSON.stringify({
+        defaults: {},
+        custom: [
+          {
+            id: "responsive",
+            name: "Very long preset name for narrow screens",
+            layers: [
+              "supplyDemand",
+              "cash",
+              "profit",
+              "customers",
+              "emissions",
+            ],
+          },
+        ],
+      }),
+    );
+    window.localStorage.setItem("insightsActivePreset", "saved:responsive");
+    window.localStorage.setItem(
+      "insightsLayers",
+      JSON.stringify([
+        "supplyDemand",
+        "cash",
+        "profit",
+        "customers",
+        "emissions",
+      ]),
+    );
+  });
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: "Start playing", exact: true })
+    .click();
+
+  const insights = page.locator(".insights");
+  if (!(await insights.isVisible())) {
+    await page.getByRole("button", { name: "Insights", exact: true }).click();
+  }
+  await expect(insights).toBeVisible();
+
+  const controls = [
+    page.locator(".insightsRange"),
+    page.locator(".insightsPreset"),
+    page.getByRole("button", { name: "Save" }),
+    page.getByRole("button", { name: "Preset actions" }),
+    page.getByRole("button", { name: /^Layers \(/ }),
+  ];
+  const boxes = await Promise.all(
+    controls.map((control) => control.boundingBox()),
+  );
+  expect(boxes.every(Boolean)).toBe(true);
+  expect(boxes.map((box) => box!.height)).toEqual([36, 36, 36, 36, 36]);
+  expect(new Set(boxes.map((box) => box!.y)).size).toBe(1);
+
+  const headerOverflow = await page
+    .locator(".insightsHeader")
+    .evaluate((element) =>
+      Math.max(0, element.scrollWidth - element.clientWidth),
+    );
+  expect(headerOverflow).toBeLessThanOrEqual(1);
+
+  const presetName = page.locator(".insightsPresetName");
+  await expect(presetName).toHaveCSS("text-overflow", "ellipsis");
+  if (testInfo.project.name === "mobile-320px") {
+    expect(
+      await presetName.evaluate(
+        (element) => element.scrollWidth > element.clientWidth,
+      ),
+    ).toBe(true);
+  }
+});
+
+test("main-menu account actions follow the sound action", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "mobile-320px");
+  await page.addInitScript(() => window.localStorage.clear());
+  await page.goto("/");
+
+  const sound = page.getByRole("button", { name: "Turn on sound" });
+  const account = page.getByRole("region", { name: "Account actions" });
+  const [soundBox, accountBox] = await Promise.all([
+    sound.boundingBox(),
+    account.boundingBox(),
+  ]);
+  expect(soundBox).not.toBeNull();
+  expect(accountBox).not.toBeNull();
+  expect(accountBox!.y).toBeGreaterThanOrEqual(soundBox!.y + soundBox!.height);
+});

--- a/src/app.scss
+++ b/src/app.scss
@@ -724,21 +724,28 @@ $pane_header_height: 40px;
   margin-left: auto;
 
   .headerControl {
+    width: 180px;
     min-width: 112px;
-    flex: 1 1 132px;
+    height: 36px;
+    flex: 0 1 180px;
     margin-left: 0;
   }
 
   .insightsLayerControls {
-    min-height: 36px;
+    width: 36px;
+    height: 36px;
+    min-width: 36px !important;
+    min-height: 36px !important;
     flex: 0 0 auto;
+    color: $interactive_blue;
   }
 }
 
 .insightsPresetControls {
   display: flex;
-  min-width: 218px;
-  flex: 1.35 1 284px;
+  width: 260px;
+  min-width: 0;
+  flex: 0 1 260px;
   align-items: center;
   gap: 4px;
 
@@ -750,6 +757,10 @@ $pane_header_height: 40px;
 
   .insightsPresetSave,
   .insightsPresetActions {
+    width: 36px;
+    height: 36px;
+    min-width: 36px !important;
+    min-height: 36px !important;
     flex: 0 0 auto;
     color: $interactive_blue;
   }
@@ -882,10 +893,8 @@ $pane_header_height: 40px;
 
 @media screen and (max-width: 700px) {
   .base_main .MuiToolbar-root.insightsHeader {
-    min-height: auto !important;
-    display: block;
-    padding-top: 6px;
-    padding-bottom: 8px;
+    min-height: 52px !important;
+    padding: 8px !important;
   }
 
   .insightsHeader > h6 {
@@ -894,22 +903,17 @@ $pane_header_height: 40px;
 
   .insightsHeaderControls {
     display: grid;
-    grid-template-areas:
-      "range layers"
-      "preset preset";
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: 96px minmax(0, 1fr) 36px;
     width: 100%;
-    gap: 8px;
+    gap: 4px;
     margin-left: 0;
 
     .headerControl {
-      grid-area: range;
       width: 100%;
       min-width: 0;
     }
 
     .insightsPresetControls {
-      grid-area: preset;
       width: 100%;
       min-width: 0;
 
@@ -920,13 +924,22 @@ $pane_header_height: 40px;
     }
 
     .insightsLayerControls {
-      grid-area: layers;
-      min-height: 44px;
+      width: 36px;
+      height: 36px;
     }
   }
 
-  .insightsPresetControls .insightsPreset {
-    min-height: 44px;
+  .insightsPresetEdited,
+  .insightsPresetCustomized {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
   }
 
   .insightsPresetDialog {

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -379,7 +379,7 @@ describe("Insights layers", () => {
 
     await user.click(screen.getByRole("button", { name: "Preset actions" }));
     await user.click(
-      screen.getByRole("menuitem", { name: /Restore original preset/ }),
+      screen.getByRole("menuitem", { name: "Restore original preset" }),
     );
     await user.click(screen.getByRole("button", { name: "Restore" }));
 
@@ -394,7 +394,7 @@ describe("Insights layers", () => {
     renderInsights();
     await user.click(screen.getByRole("button", { name: "Preset actions" }));
     await user.click(
-      screen.getByRole("menuitem", { name: /Save as new preset/ }),
+      screen.getByRole("menuitem", { name: "Save as new preset" }),
     );
     await user.type(
       screen.getByRole("textbox", { name: "Preset name" }),
@@ -474,7 +474,7 @@ describe("Insights layers", () => {
 
     await user.click(screen.getByRole("button", { name: "Preset actions" }));
     expect(
-      screen.getByRole("menuitem", { name: /Save as new preset/ }),
+      screen.getByRole("menuitem", { name: "Save as new preset" }),
     ).toHaveAttribute("aria-disabled", "true");
   });
 

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -1326,7 +1326,7 @@ export default class Insights extends React.Component<Props, State> {
                     </>
                   ) : (
                     <>
-                      Forecast electricity shortfall: ~
+                      Forecasted shortfall: ~
                       {formatWattHours(projection.blackoutTotalWh)} of demand
                       not met · largest shortage{" "}
                       {formatWatts(projection.largestBlackout.peakW)}
@@ -1803,18 +1803,21 @@ export default class Insights extends React.Component<Props, State> {
                   </IconButton>
                 </Tooltip>
               </div>
-              <Button
-                id="insightsLayersButton"
-                className="insightsLayerControls"
-                startIcon={<LayersIcon />}
-                onClick={() =>
-                  this.setState({ layersOpen: !this.state.layersOpen })
-                }
-                aria-expanded={this.state.layersOpen}
-                aria-controls="insightsLayerPanel"
-              >
-                Layers ({visible.length})
-              </Button>
+              <Tooltip title={`Choose layers (${visible.length} shown)`}>
+                <IconButton
+                  id="insightsLayersButton"
+                  className="insightsLayerControls"
+                  size="small"
+                  onClick={() =>
+                    this.setState({ layersOpen: !this.state.layersOpen })
+                  }
+                  aria-label={`Layers (${visible.length} shown)`}
+                  aria-expanded={this.state.layersOpen}
+                  aria-controls="insightsLayerPanel"
+                >
+                  <LayersIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
             </div>
             <Menu
               id="insightsPresetActionsMenu"
@@ -1826,7 +1829,7 @@ export default class Insights extends React.Component<Props, State> {
                 disabled={customLimitReached || !this.state.layers.length}
                 onClick={() => this.openPresetDialog("saveAs")}
               >
-                Save as new preset…
+                Save as new preset
               </MenuItem>
               {selectedCustom && (
                 <MenuItem onClick={() => this.openPresetDialog("rename")}>
@@ -1841,7 +1844,7 @@ export default class Insights extends React.Component<Props, State> {
               {selectedDefault &&
                 this.state.presetLibrary.defaults[selectedDefault] && (
                   <MenuItem onClick={() => this.openPresetDialog("restore")}>
-                    Restore original preset…
+                    Restore original preset
                   </MenuItem>
                 )}
             </Menu>

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -55,7 +55,7 @@ describe("MainMenu", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("places account actions between resources and discovery actions", () => {
+  it("places account actions below the sound and discovery actions", () => {
     render(
       <MainMenu
         {...props({
@@ -74,11 +74,11 @@ describe("MainMenu", () => {
       name: "Discovery actions",
     });
     expect(
-      resources.compareDocumentPosition(account) &
+      resources.compareDocumentPosition(discovery) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      account.compareDocumentPosition(discovery) &
+      discovery.compareDocumentPosition(account) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(within(account).getByText("Free · no sign-up needed")).toBeVisible();

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -110,23 +110,6 @@ const MainMenu = (props: Props): React.JSX.Element => {
             Settings
           </Button>
         </Stack>
-        {!props.uid && (
-          <Stack
-            component="section"
-            aria-label="Account actions"
-            className="accountActions"
-            spacing={0}
-          >
-            <Button variant="text" color="primary" onClick={login}>
-              Sign in
-            </Button>
-            {!props.hasSavedGame && (
-              <Typography variant="caption" color="text.secondary">
-                Free · no sign-up needed
-              </Typography>
-            )}
-          </Stack>
-        )}
         <Stack
           component="section"
           aria-label="Discovery actions"
@@ -151,6 +134,23 @@ const MainMenu = (props: Props): React.JSX.Element => {
             </Button>
           )}
         </Stack>
+        {!props.uid && (
+          <Stack
+            component="section"
+            aria-label="Account actions"
+            className="accountActions"
+            spacing={0}
+          >
+            <Button variant="text" color="primary" onClick={login}>
+              Sign in
+            </Button>
+            {!props.hasSavedGame && (
+              <Typography variant="caption" color="text.secondary">
+                Free · no sign-up needed
+              </Typography>
+            )}
+          </Stack>
+        )}
         <Typography className="srOnly" role="status" aria-live="polite">
           {shareStatus}
         </Typography>

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -278,7 +278,6 @@ describe("The Shale Boom pilot arc", () => {
     const upcoming = upcomingStoryPhases(shaleContext(47));
     expect(upcoming.map((phase) => phase.key)).toEqual([
       "story:103:shale-boom:regional-glut",
-      "story:103:shale-boom:freeze-warning",
       "story:103:shale-boom:freeze",
       "story:103:shale-boom:freeze-recovery",
       "story:103:shale-boom:normalization",
@@ -293,13 +292,39 @@ describe("The Shale Boom pilot arc", () => {
     expect(resolveStoryAtDate(context(48, 999)).occurrences).toEqual([]);
   });
 
+  it("omits warning-only phases from upcoming events in every scenario", () => {
+    const warningIds = new Set([
+      "published-ratchet",
+      "manufacturing-warning",
+      "clean-tech-load-warning",
+      "aging-warning",
+      "compliance-warning",
+      "regional-glut-warning",
+      "freeze-warning",
+      "outlook",
+      "visitor-warning",
+      "cargo-warning",
+      "seasonal-warning",
+      "advance-warning",
+      "contingency-review",
+    ]);
+
+    STORY_ARC_DEFINITIONS.forEach((arc) => {
+      const upcomingIds = upcomingStoryPhases(context(0, arc.scenarioId)).map(
+        (phase) => phase.key.split(":").at(-1),
+      );
+      expect(upcomingIds.filter((id) => id && warningIds.has(id))).toEqual([]);
+    });
+  });
+
   it("keeps every authored event body to one sentence and one text level", () => {
     const entries = STORY_ARC_DEFINITIONS.flatMap((arc) =>
       arc.phases.flatMap((phase) => {
         const storyContext = context(0, arc.scenarioId);
+        const preview = phase.preview?.(storyContext, () => 0.5);
         return [
           phase.describe(storyContext, () => 0.5),
-          ...(phase.preview ? [phase.preview(storyContext, () => 0.5)] : []),
+          ...(preview ? [preview] : []),
         ];
       }),
     );
@@ -468,17 +493,14 @@ describe("generation and storage reliability scenarios", () => {
     ]);
   });
 
-  it("uses short preview copy before the eclipse and precise copy at onset", () => {
+  it("previews the actual eclipse but not its separate warning phase", () => {
     const upcoming = upcomingStoryPhases(context(0, 109));
     const warning = upcoming.find((phase) =>
       phase.key.endsWith(":advance-warning"),
-    )!;
+    );
     const eclipse = upcoming.find((phase) => phase.key.endsWith(":eclipse"))!;
 
-    expect(warning).toMatchObject({
-      title: "Eclipse planning ahead",
-      message: "Grid planners will begin preparing for a total eclipse.",
-    });
+    expect(warning).toBeUndefined();
     expect(eclipse).toMatchObject({
       title: "Total solar eclipse",
       message: "A total eclipse will briefly reduce solar generation.",

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -65,11 +65,11 @@ export interface StoryPhaseDefinitionType {
   /** Allows linked seeded phases (for example landfall/restoration) to share one addressed draw. */
   scheduleAddress?: string;
   scheduleOffsetMonths?: number | ((context: StoryContextType) => number);
-  /** Short, future-tense copy for the Events tab. Live logs continue to use `describe`. */
+  /** Events-tab copy; live logs use `describe`. Return null to omit warning-only phases. */
   preview?: (
     context: StoryContextType,
     random: StoryRandomType,
-  ) => StoryPhasePreviewType;
+  ) => StoryPhasePreviewType | null;
   describe: (
     context: StoryContextType,
     random: StoryRandomType,
@@ -168,6 +168,7 @@ const SHALE_BOOM_ARC: StoryArcDefinitionType = {
     {
       id: "regional-glut-warning",
       schedule: { atMonth: 12 },
+      preview: () => null,
       describe: () => ({
         title: "Cheaper gas forecast",
         message:
@@ -201,6 +202,7 @@ const SHALE_BOOM_ARC: StoryArcDefinitionType = {
     {
       id: "freeze-warning",
       schedule: { atMonth: 95 },
+      preview: () => null,
       describe: ({ difficulty }) => {
         const { freezeGasOutput } = SHALE_BOOM_BALANCE[difficulty];
         return {
@@ -436,6 +438,7 @@ const CARBON_FEE_ARC: StoryArcDefinitionType = {
     {
       id: "published-ratchet",
       schedule: { atMonth: 12 },
+      preview: () => null,
       describe: ({ difficulty }) => {
         const feePerTon = CARBON_FEE_BALANCE[difficulty];
         return {
@@ -515,6 +518,7 @@ const PARADISE_ARC: StoryArcDefinitionType = {
     {
       id: "visitor-warning",
       schedule: { atMonth: 21 },
+      preview: () => null,
       describe: ({ difficulty }) => ({
         title: "Visitor surge forecast",
         message: `Visitors are expected to raise electricity use ${Math.round((PARADISE_BALANCE[difficulty].visitorDemand - 1) * 100)}% from May 2006 through October 2007.`,
@@ -545,6 +549,7 @@ const PARADISE_ARC: StoryArcDefinitionType = {
     {
       id: "cargo-warning",
       schedule: { atMonth: 101 },
+      preview: () => null,
       describe: ({ difficulty }) => ({
         title: "Fuel delivery warning",
         message: `A late fuel shipment could raise oil prices ${Math.round((PARADISE_BALANCE[difficulty].oilShock - 1) * 100)}% this fall, so prepare local generation or stored energy before September.`,
@@ -662,6 +667,7 @@ const RENEWABLES_ARC: StoryArcDefinitionType = {
     {
       id: "manufacturing-warning",
       schedule: { atMonth: 72 },
+      preview: () => null,
       describe: ({ difficulty }) => {
         const balance = RENEWABLES_BALANCE[difficulty];
         return {
@@ -704,6 +710,7 @@ const RENEWABLES_ARC: StoryArcDefinitionType = {
     {
       id: "clean-tech-load-warning",
       schedule: { atMonth: 114 },
+      preview: () => null,
       describe: ({ difficulty }) => ({
         title: "Factory growth forecast",
         message: `New factories are expected to raise electricity use ${Math.round((RENEWABLES_BALANCE[difficulty].demandLoad - 1) * 100)}% from 2012 through 2013.`,
@@ -775,6 +782,7 @@ const HURRICANE_ARC: StoryArcDefinitionType = {
     {
       id: "outlook",
       schedule: { atMonth: 96 },
+      preview: () => null,
       describe: ({ difficulty }) => {
         const balance = HURRICANE_BALANCE[difficulty];
         return {
@@ -896,6 +904,7 @@ const END_OF_ERA_ARC: StoryArcDefinitionType = {
     {
       id: "aging-warning",
       schedule: { atMonth: 48 },
+      preview: () => null,
       describe: ({ snapshot, difficulty }) => {
         const selected = snapshot.facilities.filter(
           (facility) => facility.fuel === "Coal" && facility.ageYears + 2 >= 30,
@@ -951,6 +960,7 @@ const END_OF_ERA_ARC: StoryArcDefinitionType = {
     {
       id: "compliance-warning",
       schedule: { atMonth: 130 },
+      preview: () => null,
       describe: ({ difficulty }) => ({
         title: "New coal rules announced",
         message: `Operating costs for old and new coal plants will rise ${Math.round((END_OF_ERA_BALANCE[difficulty].coalOM - 1) * 100)}% in January 1995.`,
@@ -1181,6 +1191,7 @@ const HEATWAVE_DROUGHT_ARC: StoryArcDefinitionType = {
     {
       id: "seasonal-warning",
       schedule: { atMonth: 24 },
+      preview: () => null,
       describe: () => ({
         title: "A hot, dry summer ahead",
         message:
@@ -1250,10 +1261,7 @@ const SOLAR_ECLIPSE_ARC: StoryArcDefinitionType = {
     {
       id: "advance-warning",
       schedule: { atMonth: 24 },
-      preview: () => ({
-        title: "Eclipse planning ahead",
-        message: "Grid planners will begin preparing for a total eclipse.",
-      }),
+      preview: () => null,
       describe: () => ({
         title: "Eclipse preparations begin",
         message:
@@ -1304,6 +1312,7 @@ const NUCLEAR_TRIP_ARC: StoryArcDefinitionType = {
     {
       id: "contingency-review",
       schedule: { atMonth: 24 },
+      preview: () => null,
       describe: () => ({
         title: "Backup-power review",
         message:
@@ -1760,10 +1769,10 @@ export function upcomingStoryPhases(
     .flatMap((arc) =>
       arc.phases
         .filter((phase) => phase.forecastable !== false)
-        .map((phase) => {
+        .flatMap((phase) => {
           const resolved = resolveStoryPhase(arc, phase, context);
           if (!phase.preview) {
-            return resolved;
+            return [resolved];
           }
           const random = (attribute: string) =>
             randomAt(
@@ -1772,11 +1781,15 @@ export function upcomingStoryPhases(
               storyHash(`${resolved.key}|${attribute}`),
             );
           const preview = phase.preview(context, random);
-          return {
-            ...resolved,
-            title: preview.title,
-            message: preview.message,
-          };
+          return preview
+            ? [
+                {
+                  ...resolved,
+                  title: preview.title,
+                  message: preview.message,
+                },
+              ]
+            : [];
         }),
     )
     .filter(


### PR DESCRIPTION
## Summary

- move the homepage sign-in block below the sound controls
- compact the Insights range, preset, save, actions, and Layers controls into one equal-height responsive row
- shorten the forecast shortfall and preset action copy
- omit warning-only phases from Upcoming events while preserving their live event messages
- add responsive browser coverage for the Insights toolbar and homepage ordering

## Screenshots

### Mobile Insights (320x568)

![Compact Insights controls at 320 pixels](https://github.com/user-attachments/assets/ecaca531-d1db-4078-84ac-10f654702dd1)

### Desktop Insights (1280x800)

![Compact Insights controls at 1280 pixels](https://github.com/user-attachments/assets/98b5d14c-68b3-48a5-9ea9-fb7384da873b)

### Mobile homepage (320x568)

![Sign-in block below the sound control on the mobile homepage](https://github.com/user-attachments/assets/333894d0-2141-4784-8e49-262a55452a64)

## Validation

- `npm run check`
- `npm run build`
- responsive Playwright checks at 320x568, 768x1024, and 1280x800
- low-height homepage Playwright regression at 360x320
