### PR TITLE
Smooth chart-heavy pointer interactions

### DIFF
--- a/.github/pr-screenshots/ui-smoothness-under-load/desktop.png
+++ b/.github/pr-screenshots/ui-smoothness-under-load/desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2876583fc2b1f652a9221d0f6b128c2d441760fddedcfd981ef5b7f8dd072b2
+size 102541

--- a/.github/pr-screenshots/ui-smoothness-under-load/mobile.png
+++ b/.github/pr-screenshots/ui-smoothness-under-load/mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3766a5038367d4973fa65120cf1518a6acd832ac7be6f5bc59823138436c718b
+size 43498

--- a/e2e/performance-responsive.spec.ts
+++ b/e2e/performance-responsive.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+test("chart-heavy controls remain responsive during pointer gestures", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop-1440px");
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "plays",
+      JSON.stringify({
+        plays: [{ scenarioId: 0, date: new Date().toString() }],
+      }),
+    );
+  });
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: "Start playing", exact: true })
+    .click();
+  await page.getByRole("button", { name: "View Custom Game details" }).click();
+  await page.getByRole("button", { name: "Play", exact: true }).click();
+
+  // A divider drag used to destroy and reconstruct every visible uPlot on every pointer step.
+  // Count actual plot nodes added during a gesture so that regression is deterministic and does
+  // not depend on CI machine timing.
+  await page.evaluate(() => {
+    (window as Window & { plotsAdded?: number }).plotsAdded = 0;
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        for (const node of record.addedNodes) {
+          if (!(node instanceof Element)) continue;
+          const total =
+            (node.matches(".uplot") ? 1 : 0) +
+            node.querySelectorAll(".uplot").length;
+          const target = window as Window & { plotsAdded?: number };
+          target.plotsAdded = (target.plotsAdded || 0) + total;
+        }
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+  const splitter = page.getByRole("separator").first();
+  const splitterBox = await splitter.boundingBox();
+  expect(splitterBox).not.toBeNull();
+  await page.mouse.move(
+    splitterBox!.x + splitterBox!.width / 2,
+    splitterBox!.y + splitterBox!.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(splitterBox!.x + 220, splitterBox!.y, { steps: 40 });
+  await page.mouse.up();
+  await page.waitForTimeout(200);
+  expect(
+    await page.evaluate(
+      () => (window as Window & { plotsAdded?: number }).plotsAdded,
+    ),
+  ).toBeLessThanOrEqual(8);
+
+  // The expensive 20-year projection should retain its current preview during the drag and
+  // commit exactly where the player releases, keeping the pointer path free of projection work.
+  await page.getByRole("combobox", { name: "Insight range" }).click();
+  await page.getByRole("option", { name: "Next 20 years" }).click();
+  const controls = page.getByRole("region", { name: "Planning controls" });
+  const slider = controls.getByRole("slider");
+  const sliderBox = await slider.boundingBox();
+  expect(sliderBox).not.toBeNull();
+  const before = await controls.innerText();
+  await page.mouse.move(sliderBox!.x + sliderBox!.width * 0.25, sliderBox!.y);
+  await page.mouse.down();
+  await page.mouse.move(sliderBox!.x + sliderBox!.width * 0.75, sliderBox!.y, {
+    steps: 20,
+  });
+  expect(await controls.innerText()).toBe(before);
+  await page.mouse.up();
+  await expect(controls).not.toHaveText(before);
+});

--- a/src/components/base/UPlotChart.test.tsx
+++ b/src/components/base/UPlotChart.test.tsx
@@ -1,0 +1,107 @@
+import { act, render } from "@testing-library/react";
+import uPlot from "uplot";
+import UPlotChart from "./UPlotChart";
+
+jest.mock("uplot", () => {
+  const MockUPlot = jest.fn();
+  MockUPlot.prototype.over = global.document.createElement("div");
+  MockUPlot.prototype.cursor = {};
+  MockUPlot.prototype.setData = jest.fn();
+  MockUPlot.prototype.setSize = jest.fn();
+  MockUPlot.prototype.destroy = jest.fn();
+  return { __esModule: true, default: MockUPlot };
+});
+
+jest.mock("./UPlotHelpers", () => ({
+  chartScale: (width: number) => Math.min(width / 350, 1.4),
+}));
+
+describe("UPlotChart resizing", () => {
+  const uPlotPrototype = (
+    uPlot as unknown as {
+      prototype: { setSize: jest.Mock; destroy: jest.Mock };
+    }
+  ).prototype;
+  let width = 400;
+  let resize: ResizeObserverCallback;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    width = 400;
+    jest.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      () =>
+        ({
+          width,
+          height: 200,
+          top: 0,
+          right: width,
+          bottom: 200,
+          left: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => undefined,
+        }) as DOMRect,
+    );
+    window.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resize = callback;
+      }
+      public observe() {
+        return undefined;
+      }
+      public unobserve() {
+        return undefined;
+      }
+      public disconnect() {
+        return undefined;
+      }
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("resizes the live canvas and rebuilds scaled options only after resizing settles", () => {
+    render(
+      <UPlotChart
+        ariaLabel="Test chart"
+        state={{}}
+        data={[
+          [0, 1],
+          [2, 3],
+        ]}
+        buildOptions={() => ({ width: 0, height: 0, series: [{}, {}] })}
+      />,
+    );
+
+    expect(uPlot).toHaveBeenCalledTimes(1);
+
+    const resizeTo = (nextWidth: number) => {
+      width = nextWidth;
+      act(() => {
+        resize([], {} as ResizeObserver);
+        jest.advanceTimersByTime(16);
+      });
+    };
+    resizeTo(440);
+    resizeTo(480);
+    resizeTo(520);
+
+    expect(uPlotPrototype.setSize).toHaveBeenCalledTimes(3);
+    expect(uPlotPrototype.setSize).toHaveBeenLastCalledWith({
+      width: 520,
+      height: 420,
+    });
+    expect(uPlot).toHaveBeenCalledTimes(1);
+
+    act(() => jest.advanceTimersByTime(103));
+    expect(uPlot).toHaveBeenCalledTimes(1);
+
+    act(() => jest.advanceTimersByTime(1));
+    expect(uPlotPrototype.destroy).toHaveBeenCalledTimes(1);
+    expect(uPlot).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/base/UPlotChart.tsx
+++ b/src/components/base/UPlotChart.tsx
@@ -55,6 +55,10 @@ export interface UPlotChartProps<S> {
 }
 
 const TOOLTIP_OFFSET = 8;
+// During a live pane or window resize, changing this state rebuilds the complete plot so axes,
+// fonts and decorations can be rescaled. Do that once after the gesture instead of once per
+// pointer move; uPlot can resize its existing canvas cheaply in the meantime.
+const RESIZE_SETTLE_MS = 120;
 
 function tooltipPlugin<S>(
   getState: () => S,
@@ -116,6 +120,9 @@ export default function UPlotChart<S>(
   const plotRef = React.useRef<uPlot | null>(null);
   const drawnRef = React.useRef<uPlot.AlignedData | null>(null);
   const [width, setWidth] = React.useState(0);
+  const measuredWidthRef = React.useRef(0);
+  const heightRef = React.useRef(height);
+  heightRef.current = height;
   const number = React.useMemo(
     () => new Intl.NumberFormat(undefined, { maximumSignificantDigits: 4 }),
     [],
@@ -187,18 +194,64 @@ export default function UPlotChart<S>(
 
   React.useLayoutEffect(() => {
     const root = rootRef.current!;
+    let resizeFrame: number | undefined;
+    let settleTimer: ReturnType<typeof setTimeout> | undefined;
+    let nextWidth = 0;
+
+    const resizeExistingPlot = () => {
+      resizeFrame = undefined;
+      const plot = plotRef.current;
+      if (!plot || nextWidth <= 0) {
+        return;
+      }
+      plot.setSize({
+        width: nextWidth,
+        height: Math.max(
+          1,
+          Math.round((heightRef.current || 300) * chartScale(nextWidth)),
+        ),
+      });
+    };
+
     const measure = () => {
       // Floor fractional flex widths so uPlot's explicit canvas width can never
       // round a pixel wider than the pane that owns it.
-      const nextWidth = Math.floor(root.getBoundingClientRect().width);
-      setWidth((currentWidth) =>
-        currentWidth === nextWidth ? currentWidth : nextWidth,
+      nextWidth = Math.floor(root.getBoundingClientRect().width);
+      if (nextWidth <= 0 || nextWidth === measuredWidthRef.current) {
+        return;
+      }
+      measuredWidthRef.current = nextWidth;
+
+      // There is no canvas to resize on first layout, so build it immediately. Once it exists,
+      // coalesce ResizeObserver bursts into one cheap setSize per animation frame and reserve
+      // the full options rebuild for the end of the resize gesture.
+      if (!plotRef.current) {
+        setWidth(nextWidth);
+        return;
+      }
+      if (resizeFrame === undefined) {
+        resizeFrame = requestAnimationFrame(resizeExistingPlot);
+      }
+      if (settleTimer) {
+        clearTimeout(settleTimer);
+      }
+      settleTimer = setTimeout(
+        () => setWidth(measuredWidthRef.current),
+        RESIZE_SETTLE_MS,
       );
     };
     measure();
     const observer = new ResizeObserver(measure);
     observer.observe(root);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (resizeFrame !== undefined) {
+        cancelAnimationFrame(resizeFrame);
+      }
+      if (settleTimer) {
+        clearTimeout(settleTimer);
+      }
+    };
   }, []);
 
   React.useLayoutEffect(() => {

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -1147,9 +1147,14 @@ export default class Insights extends React.Component<Props, State> {
         {this.state.leversOpen && (
           <div className="budgetSlider flex-newline">
             <Slider
+              // Keep the thumb local while it is moving. Dispatching every pointer step makes
+              // the entire workbench reconcile and regenerate its long-range projection before
+              // the browser can paint the next thumb position. The committed rate remounts this
+              // uncontrolled slider through its key, so external changes still stay in sync.
+              key={game.dollarsPerkWh}
               id="rateSlider"
               disabled={!!game.replayPlayback}
-              value={game.dollarsPerkWh}
+              defaultValue={game.dollarsPerkWh}
               aria-label="The rate you charge for electricity generation"
               valueLabelDisplay="auto"
               valueLabelFormat={(rate) => `${formatMoneyConcise(rate)}/kWh`}
@@ -1157,7 +1162,7 @@ export default class Insights extends React.Component<Props, State> {
               min={0}
               step={scenario.ownership === "Investor" ? 0.001 : 0.01}
               max={max}
-              onChange={(_event, value) =>
+              onChangeCommitted={(_event, value) =>
                 onDelta({
                   dollarsPerkWh: Array.isArray(value) ? value[0] : value,
                 })


### PR DESCRIPTION
## Summary

- resize existing uPlot canvases once per animation frame while a pane or window is moving, then rebuild scaled chart options once after the gesture settles
- keep the rate slider local during a drag and commit the selected rate on release, avoiding repeated long-range forecast regeneration in the pointer path
- add unit and browser regressions for live chart resizing and deferred 20-year forecast updates

## Performance validation

Representative 1440×900 Chromium traces on the custom scenario:

| Stress path | Before | After |
| --- | ---: | ---: |
| 80-step desktop pane-divider drag | 480 uPlot constructions | 6 (one per visible chart) |
| 20-year rate-slider drag | 3 long tasks (115–129 ms) during the gesture | 1 final 117 ms calculation after release |
| FAST simulation, 2.5-second steady sample | — | 0 frames over 34 ms; 16.8 ms worst frame |

The browser regression uses plot-node construction counts instead of timing thresholds, so it remains deterministic across CI hardware. The full responsive suite also exercises the game at 320 px, 390 px, 768 px, 1280 px, and 1440 px.

## Screenshots

### Desktop — resized chart workbench with a 20-year forecast

![Desktop chart workbench](https://github.com/toddmedema/electrify/blob/codex/ui-smoothness-under-load/.github/pr-screenshots/ui-smoothness-under-load/desktop.png?raw=true)

### Mobile — the same long-range controls and charts at 390 px

![Mobile chart workbench](https://github.com/toddmedema/electrify/blob/codex/ui-smoothness-under-load/.github/pr-screenshots/ui-smoothness-under-load/mobile.png?raw=true)

## Validation

- `npm run check` — 93 suites / 884 tests, plus all 17 simulation scenarios and invariants
- `npm run test:e2e` — 35 passed / 20 intentionally skipped across five viewport projects
- `npm run build`
