### PR TITLE
Load Roboto from Google Fonts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,14 @@
     />
     <link rel="canonical" href="https://electrifygame.com/" />
 
+    <!-- Load the complete weight range used by the game and MUI typography. -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@100..900&amp;display=swap"
+    />
+
     <!-- Twitter Card data -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@toddmedema" />


### PR DESCRIPTION
## Summary

- load Roboto from the Google Fonts CSS2 API
- request the complete variable weight range used by the game and MUI
- preconnect to the Google Fonts stylesheet and font asset origins

## Verification

- `npm run check`
- browser verification confirmed `document.fonts.check("16px Roboto")`
- reviewed desktop and 390×844 mobile layouts with no visible regressions

## Screenshots

Desktop and mobile screenshots were captured and reviewed locally. This environment cannot upload image attachments through the GitHub CLI, so they are not embedded here.
