### PR TITLE
Simplify and reorder scenario starting fleets

### DIFF
--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -28,8 +28,9 @@ import {
  * reducers/ImportOrder.test.tsx guards against.
  */
 
-// Initial public schema. Increment this when a post-release change becomes incompatible.
-export const REPLAY_VERSION = 1;
+// Version 2 changes authored starting fleets and their facility IDs, so older action streams can
+// no longer reproduce the run they recorded.
+export const REPLAY_VERSION = 2;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -178,11 +178,11 @@ describe("authored starting fleets", () => {
       }),
     ]);
     expect(manassas.facilities).toEqual([
-      expect.objectContaining({ fuel: "Oil", peakW: 55_000_000 }),
       expect.objectContaining({
         fuel: "Natural Gas",
         peakW: 75_000_000,
       }),
+      expect.objectContaining({ fuel: "Oil", peakW: 55_000_000 }),
     ]);
 
     expect(austin).toMatchObject({
@@ -219,6 +219,62 @@ describe("authored starting fleets", () => {
         0,
       ),
     ).toBe(3_827_000_000);
+    expect(
+      austin.facilities.map((facility) => ({
+        fuel: facility.fuel,
+        peakW: facility.peakW,
+      })),
+    ).toEqual([
+      { fuel: "Natural Gas", peakW: 1_497_000_000 },
+      { fuel: "Coal", peakW: 700_000_000 },
+      { fuel: "Uranium", peakW: 430_000_000 },
+      { fuel: "Wind", peakW: 1_200_000_000 },
+    ]);
+  });
+
+  it("keeps every scored-scenario generator at least 5% of its starting fleet", () => {
+    SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
+      (scenario) => {
+        const generators = scenario.facilities.filter(
+          (facility) => facility.peakW !== undefined,
+        );
+        const totalPeakW = generators.reduce(
+          (total, facility) => total + facility.peakW!,
+          0,
+        );
+
+        generators.forEach((facility) => {
+          expect({
+            scenario: scenario.name,
+            fuel: facility.fuel,
+            meetsMinimum: facility.peakW! / totalPeakW >= 0.05,
+          }).toEqual(expect.objectContaining({ meetsMinimum: true }));
+        });
+      },
+    );
+  });
+
+  it("puts each scored scenario's defining facility first", () => {
+    expect(
+      SCENARIOS.filter((scenario) => !scenario.tutorialSteps).map(
+        (scenario) => [
+          scenario.name,
+          scenario.facilities[0].fuel || scenario.facilities[0].name,
+        ],
+      ),
+    ).toEqual([
+      ["Carbon Fee", "Natural Gas"],
+      ["The Shale Boom", "Coal"],
+      ["Paradise", "Sun"],
+      ["Rise of Renewables", "Uranium"],
+      ["Hurricane Season", "Oil"],
+      ["The End of an Era", "Coal"],
+      ["Data Center Boom", "Natural Gas"],
+      ["Deep Freeze", "Natural Gas"],
+      ["Heatwave + Drought", "Hydro"],
+      ["Solar Eclipse", "Sun"],
+      ["Sudden Nuclear Shutdown", "Uranium"],
+    ]);
   });
 
   it("authors three distinct generation and storage resilience challenges", () => {
@@ -248,7 +304,7 @@ describe("authored starting fleets", () => {
       locationId: "Beijing",
       startingYear: 2033,
       durationMonths: 33,
-      startingDemandScale: 1.05,
+      startingDemandScale: 1.11,
       icon: "solar-eclipse",
       reliabilityObjective: { year: 2035, month: 9 },
     });
@@ -258,7 +314,10 @@ describe("authored starting fleets", () => {
     ).toBe(240_000_000);
     expect(
       eclipse.facilities.find((facility) => facility.fuel === "Coal")?.peakW,
-    ).toBe(625_000_000);
+    ).toBe(685_830_000);
+    expect(
+      eclipse.facilities.some((facility) => facility.fuel === "Uranium"),
+    ).toBe(false);
     expect(trip.reliabilityObjective).toMatchObject({
       year: 2026,
       month: 7,

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -687,8 +687,8 @@ export const SCENARIOS = [
     dollarsPerkWh: 0.05,
     durationMonths: 12 * 12,
     facilities: [
-      { fuel: "Coal", peakW: 300000000, initialAgeYears: 30 },
       { fuel: "Natural Gas", peakW: 200000000, initialAgeYears: 10 },
+      { fuel: "Coal", peakW: 300000000, initialAgeYears: 30 },
     ],
   },
   {
@@ -730,9 +730,9 @@ export const SCENARIOS = [
     dollarsPerkWh: 0.07,
     durationMonths: 12 * 12,
     facilities: [
-      { fuel: "Oil", peakW: 450000000, initialAgeYears: 20 },
-      { fuel: "Wind", peakW: 150000000, initialAgeYears: 8 },
       { fuel: "Sun", peakW: 50000000, initialAgeYears: 5 },
+      { fuel: "Wind", peakW: 150000000, initialAgeYears: 8 },
+      { fuel: "Oil", peakW: 450000000, initialAgeYears: 20 },
     ],
   },
   {
@@ -755,8 +755,8 @@ export const SCENARIOS = [
     dollarsPerkWh: 0.02,
     durationMonths: 12 * 12,
     facilities: [
-      { fuel: "Oil", peakW: 100000000, initialAgeYears: 20 },
       { fuel: "Uranium", peakW: 400000000, initialAgeYears: 15 },
+      { fuel: "Oil", peakW: 100000000, initialAgeYears: 20 },
     ],
   },
   {
@@ -846,12 +846,12 @@ export const SCENARIOS = [
     cash: 25000000,
     feePerKgCO2e: 0,
     facilities: [
-      { fuel: "Oil", peakW: 55000000, initialAgeYears: 27 },
       {
         fuel: "Natural Gas",
         peakW: 75000000,
         initialAgeYears: 0,
       },
+      { fuel: "Oil", peakW: 55000000, initialAgeYears: 27 },
     ],
     loadAdditions: [
       {
@@ -906,16 +906,14 @@ export const SCENARIOS = [
       minimumDemandServed: 1,
       label: "February 2021 freeze",
     },
-    // Aggregate Austin Energy resource/PPA portfolio, not a plant ownership table. The solar
-    // residual balances the published 1,287 MW renewable total; it is not a separately audited
-    // solar nameplate.
+    // Aggregate Austin Energy resource/PPA portfolio, not a plant ownership table. To keep the
+    // starting fleet legible, the sub-5% biomass share is grouped with coal and the sub-5% solar
+    // share with wind; the published 3,827 MW total is unchanged.
     facilities: [
       { fuel: "Natural Gas", peakW: 1497000000 },
-      { fuel: "Coal", peakW: 600000000 },
+      { fuel: "Coal", peakW: 700000000 },
       { fuel: "Uranium", peakW: 430000000 },
-      { fuel: "Wind", peakW: 1145000000 },
-      { fuel: "Biomass", peakW: 100000000 },
-      { fuel: "Sun", peakW: 55000000 },
+      { fuel: "Wind", peakW: 1200000000 },
     ],
     endTitle: "After the thaw",
     endMessage: "The storm tested every choice you made to prepare Austin.",
@@ -968,10 +966,10 @@ export const SCENARIOS = [
     // wind, 20.4% combined cycle, 13.3% hydro, 5.5% nuclear, and 3.356GW storage.
     // https://www.ree.es/sites/default/files/2025-02/EN_0402_NP_Solar_FV_kuder_potencia_instalada.pdf
     facilities: [
+      { fuel: "Hydro", peakW: 171570000, initialAgeYears: 30 },
       { fuel: "Sun", peakW: 320430000, initialAgeYears: 5 },
       { fuel: "Wind", peakW: 320070000, initialAgeYears: 8 },
       { fuel: "Natural Gas", peakW: 263160000, initialAgeYears: 12 },
-      { fuel: "Hydro", peakW: 171570000, initialAgeYears: 30 },
       { fuel: "Uranium", peakW: 71170000, initialAgeYears: 30 },
       // 1% of national storage power, represented as a four-hour equivalent.
       { name: "Battery", peakWh: 134240000, initialAgeYears: 3 },
@@ -1012,7 +1010,7 @@ export const SCENARIOS = [
     durationMonths: 33,
     startingCustomers: 1800000,
     // Calibrates the account model to the demand served by this solar-heavy balancing area.
-    startingDemandScale: 1.05,
+    startingDemandScale: 1.11,
     // Beijing's first-tier residential rate is CNY0.4883/kWh, about US$0.07/kWh.
     // https://www.beijing.gov.cn/fwcj/jiage/ggfw1/65b8999311a82834a863952a.html
     dollarsPerkWh: 0.07,
@@ -1026,17 +1024,17 @@ export const SCENARIOS = [
       minimumDemandServed: 1,
       label: "September 2035 total eclipse in China",
     },
-    // Low-carbon capacity is a 0.1%-scale model of China's 2024 national fleet. This
-    // solar-heavy balancing area receives 625MW (about 0.04%) of national thermal capacity;
-    // the 240MWh battery represents 0.1% of China's 60GW new-storage fleet at four-hour duration.
+    // Renewable capacity is a 0.1%-scale model of China's 2024 national fleet. This solar-heavy
+    // balancing area groups the sub-5% nuclear share into coal for a simpler 685.83MW thermal
+    // fleet; the 240MWh battery represents 0.1% of China's 60GW new-storage fleet at four-hour
+    // duration.
     // https://www.nea.gov.cn/20250121/097bfd7c1cd3498897639857d86d5dac/c.html
     // https://www.nea.gov.cn/20241220/39938141b6e74baaa4601e940d12b022/c.html
     facilities: [
       { fuel: "Sun", peakW: 886660000, initialAgeYears: 4 },
       { fuel: "Wind", peakW: 520680000, initialAgeYears: 6 },
       { fuel: "Hydro", peakW: 435950000, initialAgeYears: 20 },
-      { fuel: "Coal", peakW: 625000000, initialAgeYears: 15 },
-      { fuel: "Uranium", peakW: 60830000, initialAgeYears: 12 },
+      { fuel: "Coal", peakW: 685830000, initialAgeYears: 15 },
       { name: "Battery", peakWh: 240000000, initialAgeYears: 3 },
     ],
     endTitle: "Sunlight returns",

--- a/src/reducers/CustomGame.test.tsx
+++ b/src/reducers/CustomGame.test.tsx
@@ -81,6 +81,26 @@ describe("a custom game", () => {
     });
   });
 
+  it("preserves the authored dispatch order for starting generators", () => {
+    const state = createGame({
+      scenarioId: CUSTOM_SCENARIO_ID,
+      scenario: {
+        ...CUSTOM,
+        facilities: [
+          { name: "Natural Gas", peakW: 100000000 },
+          { name: "Coal", peakW: 200000000 },
+          { name: "Pumped Hydro", peakWh: 500000000 },
+        ],
+      },
+    });
+
+    expect(state.facilities.map((facility) => facility.name)).toEqual([
+      "Natural Gas",
+      "Coal",
+      "Pumped Hydro",
+    ]);
+  });
+
   it("rounds starting facility capacities to two significant digits", () => {
     const facilities = [
       { name: "Coal", peakW: 722_225_000 },

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -834,6 +834,20 @@ export const gameSlice = createSlice({
         }
       });
 
+      if (!scenario.tutorialSteps) {
+        // buildFacilityHelper prepends generators because player-built capacity should dispatch
+        // by default. For authored starting fleets, however, the scenario order is deliberate:
+        // reverse just the resulting generator block back into that order while storage remains
+        // at the bottom. Building in the original sequence keeps IDs tied to authored entries.
+        const generators = state.facilities.filter(
+          (facility) => facility.peakWh === undefined,
+        );
+        const storage = state.facilities.filter(
+          (facility) => facility.peakWh !== undefined,
+        );
+        state.facilities = [...generators.reverse(), ...storage];
+      }
+
       // The first blank timeline is created before the authored fleet is resolved. Hydrology is
       // intentionally skipped for a fleet with no Hydro, so refresh it now that a starting dam
       // may exist; otherwise its first forecast has zero inflow for every month.

--- a/src/testing/BalancePlaybooks.ts
+++ b/src/testing/BalancePlaybooks.ts
@@ -13,7 +13,7 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
       peakW: 150000000,
       financed: true,
     },
-    sellFacilityId: 1,
+    sellFacilityId: 2,
     sellAtMonth: 37,
   },
   101: {
@@ -23,7 +23,7 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
       peakW: 300000000,
       financed: true,
     },
-    sellFacilityId: 1,
+    sellFacilityId: 2,
     sellAtMonth: 39,
   },
   102: {
@@ -65,7 +65,7 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
       peakW: 300000000,
       financed: true,
     },
-    sellFacilityId: 1,
+    sellFacilityId: 3,
     sellAtMonth: 39,
   },
 };
@@ -91,7 +91,7 @@ export const INTERN_ONE_BUILD_PLAYS: Record<
     initialBuild: { name: "Natural Gas", peakW: 600000000, financed: true },
   },
   104: {
-    initialBuild: { name: "Natural Gas", peakW: 300000000, financed: true },
+    initialBuild: { name: "Natural Gas", peakW: 500000000, financed: true },
   },
   105: {
     initialBuild: { name: "Natural Gas", peakW: 525000000, financed: true },

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -486,7 +486,7 @@ describe("researched public-utility scenarios", () => {
         difficulty,
         initialBuild: {
           name: "Natural Gas",
-          peakW: 1_000_000_000,
+          peakW: 1_100_000_000,
           financed: true,
         },
       });
@@ -528,14 +528,14 @@ describe("researched public-utility scenarios", () => {
       difficulty: "Manager",
       initialBuild: {
         name: "Natural Gas",
-        peakW: 1_000_000_000,
+        peakW: 1_100_000_000,
         financed: true,
       },
     });
     const oilPlan = runSimulation({
       scenarioId: 107,
       difficulty: "Manager",
-      initialBuild: { name: "Oil", peakW: 500_000_000, financed: true },
+      initialBuild: { name: "Oil", peakW: 600_000_000, financed: true },
     });
     expect(gasPlan.outcome).toBe("completed");
     expect(oilPlan.outcome).toBe("completed");


### PR DESCRIPTION
## Summary

- consolidate every sub-5% generator in scored scenarios into the closest comparable output type
- preserve each authored starting-fleet order in the running dispatch list, with the scenario-defining facility first
- retune deterministic balance playthroughs and bump the replay version for the changed starting fleets

## Fleet consolidations

- Deep Freeze: fold 100 MW biomass into coal and 55 MW solar into wind, preserving the 3.827 GW total
- Solar Eclipse: fold 60.83 MW nuclear into coal, preserving the 2.52912 GW total

## Testing

- `npm run check`
- manually verified the Solar Eclipse game starts with Solar first, followed by Wind, Hydro, Coal, and Battery

## Screenshots

I captured and reviewed the finished Solar Eclipse interface locally. The current browser automation can display the capture for review but cannot export it to a file for GitHub upload, so I could not embed the required screenshot in this PR.
