### PR TITLE
Streamline game selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@ files are large, so broad rewrites create expensive review diffs.
 - When opening a pull request with user-visible UI changes, capture 1-3 screenshots of the
   finished interface and embed them in the pull request description. Choose views that clearly
   show the change, including both desktop and mobile layouts when responsive behavior is relevant.
+- Keep review screenshots in a temporary location and upload them with GitHub CLI 2.99 or newer
+  using `gh pr create --attach`, `gh pr edit --attach`, or `gh pr comment --attach`. Do not commit
+  screenshots that exist only to illustrate a pull request; GitHub-hosted attachments keep them
+  out of the repository and its Git LFS history. Remove the temporary files after a successful
+  upload.
 - Review screenshots before uploading them: exclude sensitive or user-specific data, transient
   errors, debug UI, and unrelated windows or overlays. Non-UI changes do not need screenshots.
 - If the current environment cannot capture or upload images, say so in the pull request

--- a/e2e/new-game-responsive.spec.ts
+++ b/e2e/new-game-responsive.spec.ts
@@ -62,6 +62,6 @@ test("game picker prioritizes one lesson and filters the challenge catalog", asy
     page.getByRole("button", { name: "View Data Center Boom details" }),
   ).toHaveCount(0);
   await expect(page.getByLabel("Deep Freeze themes")).toContainText(
-    "Sudden disruption",
+    "Extreme weather",
   );
 });

--- a/e2e/new-game-responsive.spec.ts
+++ b/e2e/new-game-responsive.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+
+const REVIEW_VIEWPORTS = new Set([
+  "desktop-chromium",
+  "mobile-390px",
+  "mobile-320px",
+]);
+
+test("game picker prioritizes one lesson and filters the challenge catalog", async ({
+  page,
+}, testInfo) => {
+  test.skip(!REVIEW_VIEWPORTS.has(testInfo.project.name));
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem(
+      "plays",
+      JSON.stringify({
+        plays: [{ scenarioId: 0, date: new Date().toString() }],
+      }),
+    );
+  });
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: "Start playing", exact: true })
+    .click();
+
+  await expect(
+    page.getByRole("heading", { name: "Choose a game" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Start Generators" }),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("challenge-list").getByRole("button"),
+  ).toHaveCount(3);
+  await expect(page.getByText("Recommended for you")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "View Solar Eclipse details" }),
+  ).toHaveCount(0);
+
+  const pageOverflow = await page
+    .locator(".missionList")
+    .evaluate((element) =>
+      Math.max(0, element.scrollWidth - element.clientWidth),
+    );
+  expect(pageOverflow).toBeLessThanOrEqual(1);
+
+  await page.getByRole("button", { name: "View all 11" }).click();
+  await page.getByRole("button", { name: "Extreme weather" }).click();
+  await expect(
+    page.getByRole("button", { name: "View Heatwave + Drought details" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "View Deep Freeze details" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "View Hurricane Season details" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "View Data Center Boom details" }),
+  ).toHaveCount(0);
+});

--- a/e2e/new-game-responsive.spec.ts
+++ b/e2e/new-game-responsive.spec.ts
@@ -33,7 +33,10 @@ test("game picker prioritizes one lesson and filters the challenge catalog", asy
   await expect(
     page.getByTestId("challenge-list").getByRole("button"),
   ).toHaveCount(3);
-  await expect(page.getByText("Recommended for you")).toBeVisible();
+  await expect(page.getByRole("button", { name: "For you" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
   await expect(
     page.getByRole("button", { name: "View Solar Eclipse details" }),
   ).toHaveCount(0);
@@ -45,7 +48,6 @@ test("game picker prioritizes one lesson and filters the challenge catalog", asy
     );
   expect(pageOverflow).toBeLessThanOrEqual(1);
 
-  await page.getByRole("button", { name: "View all 11" }).click();
   await page.getByRole("button", { name: "Extreme weather" }).click();
   await expect(
     page.getByRole("button", { name: "View Heatwave + Drought details" }),
@@ -59,4 +61,7 @@ test("game picker prioritizes one lesson and filters the challenge catalog", asy
   await expect(
     page.getByRole("button", { name: "View Data Center Boom details" }),
   ).toHaveCount(0);
+  await expect(page.getByLabel("Deep Freeze themes")).toContainText(
+    "Sudden disruption",
+  );
 });

--- a/src/LocalStorage.test.tsx
+++ b/src/LocalStorage.test.tsx
@@ -1,4 +1,10 @@
-import { getStorageChoice, setStorageKeyValue } from "./LocalStorage";
+import {
+  getPlayedScenarioIds,
+  getScenarioPlayCounts,
+  getStorageChoice,
+  recordScenarioPlayed,
+  setStorageKeyValue,
+} from "./LocalStorage";
 import { getLocalStorage } from "./Globals";
 
 const KEY = "testChoice";
@@ -31,5 +37,37 @@ describe("getStorageChoice", () => {
   it("keeps negative and zero choices distinct from the fallback", () => {
     setStorageKeyValue(KEY, 0);
     expect(getStorageChoice(KEY, [0, -1, 2020], -1)).toBe(0);
+  });
+});
+
+describe("scenario play history", () => {
+  beforeEach(() => {
+    getLocalStorage().removeItem("plays");
+  });
+
+  it("treats legacy records without counts as one play", () => {
+    setStorageKeyValue("plays", {
+      plays: [
+        { scenarioId: 100, date: "2026-08-27" },
+        { scenarioId: 101, date: "2026-08-28", timesPlayed: 3 },
+      ],
+    });
+
+    expect(getScenarioPlayCounts()).toEqual({ 100: 1, 101: 3 });
+    expect(getPlayedScenarioIds()).toEqual([100, 101]);
+
+    recordScenarioPlayed(100);
+    expect(getScenarioPlayCounts()).toEqual({ 100: 2, 101: 3 });
+  });
+
+  it("increments a compact count instead of appending repeat plays", () => {
+    recordScenarioPlayed(100);
+    recordScenarioPlayed(100);
+    recordScenarioPlayed(100);
+
+    expect(getScenarioPlayCounts()).toEqual({ 100: 3 });
+    expect(
+      JSON.parse(getLocalStorage().getItem("plays") as string).plays,
+    ).toEqual([expect.objectContaining({ scenarioId: 100, timesPlayed: 3 })]);
   });
 });

--- a/src/LocalStorage.tsx
+++ b/src/LocalStorage.tsx
@@ -90,20 +90,40 @@ function getPlays(): LocalStoragePlayedType[] {
 // The scenarios (tutorials included) the player has finished, used for the completion
 // markers and progress in the scenario list
 export function getPlayedScenarioIds(): number[] {
-  return getPlays().map((p) => p.scenarioId);
+  return Object.keys(getScenarioPlayCounts()).map(Number);
 }
 
-// Only recorded the first time: nothing reads the repeats, so appending one entry per
-// replay would grow this list forever
+// Counts completed plays without appending one entry per replay, which would grow this list
+// forever. Records written before counts were introduced represent one completed play.
+export function getScenarioPlayCounts(): Record<number, number> {
+  return getPlays().reduce<Record<number, number>>((counts, play) => {
+    counts[play.scenarioId] =
+      (counts[play.scenarioId] ?? 0) + (play.timesPlayed ?? 1);
+    return counts;
+  }, {});
+}
+
 export function recordScenarioPlayed(scenarioId: number) {
   const plays = getPlays();
-  if (plays.some((p) => p.scenarioId === scenarioId)) {
+  const existingIndex = plays.findIndex((p) => p.scenarioId === scenarioId);
+  if (existingIndex !== -1) {
+    const existing = plays[existingIndex];
+    const updated = [...plays];
+    updated[existingIndex] = {
+      ...existing,
+      timesPlayed: (existing.timesPlayed ?? 1) + 1,
+    };
+    setStorageKeyValue("plays", { plays: updated });
     return;
   }
   setStorageKeyValue("plays", {
     plays: [
       ...plays,
-      { scenarioId, date: new Date().toString() } as LocalStoragePlayedType,
+      {
+        scenarioId,
+        date: new Date().toString(),
+        timesPlayed: 1,
+      } as LocalStoragePlayedType,
     ],
   });
 }

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -249,6 +249,8 @@ export interface ReplayPlaybackType {
 export interface LocalStoragePlayedType {
   scenarioId: number;
   date: string; // Stringified new Date()
+  // Missing from older saves, where the presence of this record means one completed play.
+  timesPlayed?: number;
 }
 
 export interface DateType {
@@ -562,11 +564,7 @@ export type ScenarioBriefingToneType =
   "transition" | "boom" | "island" | "innovation" | "storm" | "legacy";
 
 export type ScenarioThemeType =
-  | "Extreme weather"
-  | "Energy transition"
-  | "Rapid growth"
-  | "Island grids"
-  | "Sudden disruption";
+  "Extreme weather" | "Energy transition" | "Rapid growth" | "Island grids";
 
 /**
  * The authored promise of a scenario, kept beside its simulation setup so the mission list and

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -564,7 +564,7 @@ export type ScenarioBriefingToneType =
   "transition" | "boom" | "island" | "innovation" | "storm" | "legacy";
 
 export type ScenarioThemeType =
-  "Extreme weather" | "Energy transition" | "Rapid growth" | "Island grids";
+  "Extreme weather" | "Energy transition" | "Rapid growth";
 
 /**
  * The authored promise of a scenario, kept beside its simulation setup so the mission list and

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -561,6 +561,13 @@ export interface TutorialStepChangeType {
 export type ScenarioBriefingToneType =
   "transition" | "boom" | "island" | "innovation" | "storm" | "legacy";
 
+export type ScenarioThemeType =
+  | "Extreme weather"
+  | "Energy transition"
+  | "Rapid growth"
+  | "Island grids"
+  | "Sudden disruption";
+
 /**
  * The authored promise of a scenario, kept beside its simulation setup so the mission list and
  * briefing screen tell the same story. Each scenario's dedicated icon supplies the visual tone.
@@ -583,6 +590,10 @@ export interface ScenarioType {
   location?: LocationType;
   summary?: string;
   briefing?: ScenarioBriefingType;
+  // Player-facing browse categories. A challenge may appear in more than one theme.
+  themes?: ScenarioThemeType[];
+  // Lower numbers appear first in the compact recommendations; omitted challenges follow.
+  recommendationOrder?: number;
   ownership: "Investor" | "Public";
   tutorialSteps?: TutorialStepType[];
   // Pins the run's RNG so it plays out identically every time. Every authored scenario leaves

--- a/src/app.scss
+++ b/src/app.scss
@@ -2348,22 +2348,27 @@ html[data-theme="dark"] .uplot {
     padding-top: 4px;
   }
 
-  .challengeBrowseCaption {
-    margin: 0 16px 8px;
-    color: $font_color_faded;
-  }
-
   .challengeFilters {
     display: flex !important;
+    gap: 6px;
     width: calc(100% - 24px);
     margin: 0 12px 10px;
     overflow-x: auto;
+    padding-bottom: 2px;
 
     .MuiToggleButton-root {
       flex: 0 0 auto;
       padding: 5px 10px;
+      border: 1px solid var(--border-tile) !important;
+      border-radius: 999px !important;
       font-size: 0.75rem;
       text-transform: none;
+
+      &.Mui-selected {
+        border-color: $interactive_blue !important;
+        color: $interactive_blue;
+        font-weight: 700;
+      }
     }
   }
 
@@ -2416,6 +2421,23 @@ html[data-theme="dark"] .uplot {
       display: block;
       margin-top: 2px;
       color: $font_color_faded;
+    }
+
+    .missionThemes {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      margin-top: 6px;
+    }
+
+    .missionThemeTag {
+      height: 20px;
+      color: $font_color_faded;
+      font-size: 0.68rem;
+
+      .MuiChip-label {
+        padding: 0 7px;
+      }
     }
   }
 

--- a/src/app.scss
+++ b/src/app.scss
@@ -1319,23 +1319,6 @@ html[data-theme="dark"] .uplot {
   margin-bottom: 100%;
 }
 
-// Completion state of each tutorial in the scenario list
-.tutorialIncomplete {
-  color: var(--font-color-disabled);
-}
-
-// How far through the 101-106 sequence the player is
-.tutorialProgressBar {
-  margin: 0 16px 12px 8px;
-  height: 4px !important;
-  border-radius: 2px;
-}
-
-// The next tutorial to play, so the sequence has one obvious entry point
-.tutorialNext {
-  border-left: 4px solid var(--interactive-blue);
-}
-
 .scenarioDossier {
   display: flex;
   flex-direction: column;
@@ -2271,6 +2254,135 @@ html[data-theme="dark"] .uplot {
 
       &:first-child {
         padding-top: 12px;
+      }
+    }
+
+    .missionSectionHeader {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      background: transparent;
+      color: $font_color_primary;
+
+      .MuiButton-root {
+        flex: 0 0 auto;
+        margin-right: -8px;
+        text-transform: none;
+      }
+    }
+  }
+
+  .tutorialSpotlight {
+    margin: 0 12px 8px;
+    border: 1px solid $interactive_blue;
+    border-radius: 10px;
+    background: var(--bg-raised);
+    box-shadow: none;
+
+    .MuiCardHeader-root {
+      padding: 12px 14px 8px;
+    }
+
+    .MuiCardHeader-action {
+      align-self: center;
+      margin: 0 0 0 12px;
+    }
+  }
+
+  .tutorialSpotlightEyebrow,
+  .tutorialSpotlightTitle {
+    display: block;
+  }
+
+  .tutorialSpotlightEyebrow {
+    margin-bottom: 2px;
+    color: $interactive_blue;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.055em;
+    text-transform: uppercase;
+  }
+
+  .tutorialSpotlightTitle {
+    color: $font_color_primary;
+    font-weight: 700;
+  }
+
+  .tutorialSpotlightAction {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    padding: 6px 8px;
+    border-radius: 6px;
+    background: $interactive_blue;
+    color: $bg_primary;
+    font-size: 0.8rem;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+
+  .tutorialSpotlightProgress {
+    height: 4px !important;
+    margin: 0 14px 12px;
+    border-radius: 2px;
+  }
+
+  .tutorialCompleteSummary {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 0 12px 8px;
+    padding: 12px 14px;
+    border: 1px solid var(--border-tile);
+    border-radius: 10px;
+    background: var(--bg-raised);
+
+    & > span {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+
+  .tutorialCatalog {
+    padding-top: 4px;
+  }
+
+  .challengeBrowseCaption {
+    margin: 0 16px 8px;
+    color: $font_color_faded;
+  }
+
+  .challengeFilters {
+    display: flex !important;
+    width: calc(100% - 24px);
+    margin: 0 12px 10px;
+    overflow-x: auto;
+
+    .MuiToggleButton-root {
+      flex: 0 0 auto;
+      padding: 5px 10px;
+      font-size: 0.75rem;
+      text-transform: none;
+    }
+  }
+
+  @media (max-width: 520px) {
+    .tutorialSpotlight {
+      .MuiCardHeader-root {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr);
+      }
+
+      .MuiCardHeader-content {
+        min-width: 0;
+      }
+
+      .MuiCardHeader-action {
+        grid-row: 2;
+        grid-column: 2;
+        justify-self: start;
+        margin: 8px 0 0 !important;
       }
     }
   }

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -106,7 +106,7 @@ describe("NewGame", () => {
       expect.stringContaining("Hurricane Season"),
     ]);
     expect(screen.getByLabelText("Deep Freeze themes")).toHaveTextContent(
-      "Extreme weatherSudden disruption",
+      "Extreme weather",
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Island grids" }));
@@ -128,6 +128,50 @@ describe("NewGame", () => {
       expect.stringContaining("Data Center Boom"),
       expect.stringContaining("Carbon Fee"),
       expect.stringContaining("Solar Eclipse"),
+    ]);
+  });
+
+  it("fills fewer than three unplayed recommendations with the most-played challenge", () => {
+    const challenges = SCENARIOS.filter((scenario) => !scenario.tutorialSteps);
+    const unplayedNames = new Set(["Deep Freeze", "Data Center Boom"]);
+    const playedIds = challenges
+      .filter((scenario) => !unplayedNames.has(scenario.name))
+      .map((scenario) => scenario.id);
+    const paradiseId = challenges.find(
+      (scenario) => scenario.name === "Paradise",
+    )!.id;
+    recordPlayed(...playedIds, paradiseId, paradiseId, paradiseId);
+
+    render(<NewGame {...props()} />);
+
+    expect(challengeRows().map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Deep Freeze"),
+      expect.stringContaining("Data Center Boom"),
+      expect.stringContaining("Paradise"),
+    ]);
+  });
+
+  it("recommends the most-played challenges after every challenge has been played", () => {
+    const challenges = SCENARIOS.filter((scenario) => !scenario.tutorialSteps);
+    const dataCenterId = challenges.find(
+      (scenario) => scenario.name === "Data Center Boom",
+    )!.id;
+    const deepFreezeId = challenges.find(
+      (scenario) => scenario.name === "Deep Freeze",
+    )!.id;
+    recordPlayed(
+      ...challenges.map((scenario) => scenario.id),
+      dataCenterId,
+      dataCenterId,
+      deepFreezeId,
+    );
+
+    render(<NewGame {...props()} />);
+
+    expect(challengeRows().map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Data Center Boom"),
+      expect.stringContaining("Deep Freeze"),
+      expect.stringContaining("Carbon Fee"),
     ]);
   });
 

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -109,11 +109,9 @@ describe("NewGame", () => {
       "Extreme weather",
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Island grids" }));
-    expect(challengeRows().map((row) => row.textContent)).toEqual([
-      expect.stringContaining("Paradise"),
-      expect.stringContaining("Hurricane Season"),
-    ]);
+    fireEvent.click(screen.getByRole("button", { name: "Energy transition" }));
+    expect(screen.getByTestId("mission-row-105")).toHaveTextContent("Paradise");
+    expect(screen.queryByTestId("mission-row-104")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "For you" }));
     expect(challengeRows()).toHaveLength(3);

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -49,12 +49,12 @@ describe("NewGame", () => {
       expect.stringContaining("Data Center Boom"),
       expect.stringContaining("Carbon Fee"),
     ]);
-    expect(screen.getByText("Recommended for you")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "View all 6" })).toHaveAttribute(
-      "aria-expanded",
-      "false",
+    expect(screen.getByRole("button", { name: "For you" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
     );
-    expect(screen.getByRole("button", { name: "View all 11" })).toHaveAttribute(
+    expect(screen.queryByLabelText("Deep Freeze themes")).toBeNull();
+    expect(screen.getByRole("button", { name: "View all 6" })).toHaveAttribute(
       "aria-expanded",
       "false",
     );
@@ -63,7 +63,7 @@ describe("NewGame", () => {
     ).toHaveTextContent("Custom Game");
   });
 
-  it("expands tutorials in authored order and challenges by latest timeframe", () => {
+  it("expands tutorials in authored order and shows all challenges by latest timeframe", () => {
     render(<NewGame {...props()} />);
 
     fireEvent.click(screen.getByRole("button", { name: "View all 6" }));
@@ -78,7 +78,7 @@ describe("NewGame", () => {
       ),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "View all 11" }));
+    fireEvent.click(screen.getByRole("button", { name: "All challenges" }));
     const scenariosNewestFirst = SCENARIOS.filter(
       (scenario) => !scenario.tutorialSteps,
     ).sort(
@@ -98,7 +98,6 @@ describe("NewGame", () => {
 
   it("filters the full challenge catalog by player-facing themes", () => {
     render(<NewGame {...props()} />);
-    fireEvent.click(screen.getByRole("button", { name: "View all 11" }));
 
     fireEvent.click(screen.getByRole("button", { name: "Extreme weather" }));
     expect(challengeRows().map((row) => row.textContent)).toEqual([
@@ -106,12 +105,19 @@ describe("NewGame", () => {
       expect.stringContaining("Deep Freeze"),
       expect.stringContaining("Hurricane Season"),
     ]);
+    expect(screen.getByLabelText("Deep Freeze themes")).toHaveTextContent(
+      "Extreme weatherSudden disruption",
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Island grids" }));
     expect(challengeRows().map((row) => row.textContent)).toEqual([
       expect.stringContaining("Paradise"),
       expect.stringContaining("Hurricane Season"),
     ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "For you" }));
+    expect(challengeRows()).toHaveLength(3);
+    expect(screen.queryByLabelText("Deep Freeze themes")).toBeNull();
   });
 
   it("moves completed recommendations behind unplayed challenges", () => {
@@ -183,7 +189,7 @@ describe("NewGame", () => {
     render(<NewGame {...props()} />);
 
     fireEvent.click(screen.getByRole("button", { name: "View all 6" }));
-    fireEvent.click(screen.getByRole("button", { name: "View all 11" }));
+    fireEvent.click(screen.getByRole("button", { name: "All challenges" }));
     expect(
       screen.getByTestId(`mission-complete-${TUTORIALS[0].id}`),
     ).toBeInTheDocument();

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -28,14 +28,57 @@ function recordPlayed(...scenarioIds: number[]) {
   );
 }
 
+function challengeRows(): HTMLElement[] {
+  return within(screen.getByTestId("challenge-list")).getAllByTestId(
+    /^mission-row-/,
+  );
+}
+
 describe("NewGame", () => {
   beforeEach(() => localStorage.clear());
 
-  it("shows training in its authored order and scenarios by latest timeframe", () => {
+  it("starts with one next lesson and three varied challenge recommendations", () => {
     render(<NewGame {...props()} />);
 
-    const rows = screen.getAllByTestId(/^mission-row-/);
-    expect(rows).toHaveLength(SCENARIOS.length + 1);
+    expect(
+      screen.getByTestId(`tutorial-spotlight-${TUTORIALS[0].id}`),
+    ).toHaveTextContent("Continue learning · 0 of 6 complete");
+    expect(screen.queryByTestId(`mission-row-${TUTORIALS[0].id}`)).toBeNull();
+    expect(challengeRows().map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Deep Freeze"),
+      expect.stringContaining("Data Center Boom"),
+      expect.stringContaining("Carbon Fee"),
+    ]);
+    expect(screen.getByText("Recommended for you")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View all 6" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "View all 11" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(
+      screen.getByTestId(`mission-row-${CUSTOM_SCENARIO_ID}`),
+    ).toHaveTextContent("Custom Game");
+  });
+
+  it("expands tutorials in authored order and challenges by latest timeframe", () => {
+    render(<NewGame {...props()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "View all 6" }));
+    const tutorialCatalog = screen.getByRole("group", {
+      name: "All tutorials",
+    });
+    const tutorialRows =
+      within(tutorialCatalog).getAllByTestId(/^mission-row-/);
+    TUTORIALS.forEach((tutorial, index) =>
+      expect(tutorialRows[index]).toHaveTextContent(
+        tutorial.name.replace(/^Mission \d+:\s*/, ""),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "View all 11" }));
     const scenariosNewestFirst = SCENARIOS.filter(
       (scenario) => !scenario.tutorialSteps,
     ).sort(
@@ -46,30 +89,43 @@ describe("NewGame", () => {
           1 -
           (a.startingYear + Math.ceil(a.durationMonths / 12) - 1),
     );
-    [...TUTORIALS, ...scenariosNewestFirst].forEach((scenario, index) =>
-      expect(rows[index]).toHaveTextContent(
-        scenario.name.replace(/^Mission \d+:\s*/, ""),
-      ),
+    const rows = challengeRows();
+    expect(rows).toHaveLength(scenariosNewestFirst.length);
+    scenariosNewestFirst.forEach((scenario, index) =>
+      expect(rows[index]).toHaveTextContent(scenario.name),
     );
-    const scenarioYears = scenariosNewestFirst.map(
-      (scenario) => scenario.startingYear,
-    );
-    expect(scenarioYears).toEqual([...scenarioYears].sort((a, b) => b - a));
-    expect(
-      scenariosNewestFirst
-        .filter((scenario) => scenario.startingYear === 2020)
-        .map((scenario) => scenario.name),
-    ).toEqual(["Data Center Boom", "Carbon Fee"]);
-    expect(rows[rows.length - 1]).toHaveTextContent("Custom Game");
-    expect(screen.getByText("Learn the basics")).toBeInTheDocument();
-    expect(screen.getByText("Challenges")).toBeInTheDocument();
-    expect(screen.getByText("Custom game")).toBeInTheDocument();
-    expect(
-      screen.getByRole("list", { name: "Available games" }),
-    ).toContainElement(rows[0]);
   });
 
-  it("uses each scenario's dedicated icon", () => {
+  it("filters the full challenge catalog by player-facing themes", () => {
+    render(<NewGame {...props()} />);
+    fireEvent.click(screen.getByRole("button", { name: "View all 11" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Extreme weather" }));
+    expect(challengeRows().map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Heatwave + Drought"),
+      expect.stringContaining("Deep Freeze"),
+      expect.stringContaining("Hurricane Season"),
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Island grids" }));
+    expect(challengeRows().map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Paradise"),
+      expect.stringContaining("Hurricane Season"),
+    ]);
+  });
+
+  it("moves completed recommendations behind unplayed challenges", () => {
+    recordPlayed(107);
+    render(<NewGame {...props()} />);
+
+    expect(challengeRows().map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Data Center Boom"),
+      expect.stringContaining("Carbon Fee"),
+      expect.stringContaining("Solar Eclipse"),
+    ]);
+  });
+
+  it("uses each recommended scenario's dedicated icon", () => {
     render(<NewGame {...props()} />);
     expect(
       screen.getByRole("img", { name: "Carbon Fee icon" }),
@@ -82,7 +138,7 @@ describe("NewGame", () => {
     ).toHaveAttribute("src", "/images/texas deep freeze.svg");
   });
 
-  it("shows the inclusive final calendar year for each scenario", () => {
+  it("shows the inclusive final calendar year for recommendations", () => {
     render(<NewGame {...props()} />);
 
     expect(screen.getByTestId("mission-row-107")).toHaveTextContent(
@@ -93,62 +149,66 @@ describe("NewGame", () => {
     );
   });
 
-  it("highlights the first incomplete tutorial without replacing its subtitle", () => {
+  it("turns the first incomplete tutorial into an explicit continuation", () => {
     recordPlayed(TUTORIALS[0].id);
     render(<NewGame {...props()} />);
 
-    const next = screen.getByTestId(`mission-row-${TUTORIALS[1].id}`);
-    expect(TUTORIALS[1].summary).toBeDefined();
+    const next = screen.getByTestId(`tutorial-spotlight-${TUTORIALS[1].id}`);
+    expect(next).toHaveTextContent("Continue learning · 1 of 6 complete");
     expect(next).toHaveTextContent(TUTORIALS[1].summary as string);
-    expect(next).not.toHaveTextContent("Start here");
-    expect(next).not.toHaveTextContent("Recommended next");
-    expect(next).toHaveTextContent(
-      TUTORIALS[1].name.replace(/^Mission \d+:\s*/, ""),
-    );
-    expect(next).toHaveClass("tutorialNext");
     expect(within(next).getByRole("button")).toHaveAccessibleName(
       `Start ${TUTORIALS[1].name.replace(/^Mission \d+:\s*/, "")}`,
     );
   });
 
-  it("shows completion badges for tutorials and regular missions", () => {
+  it("shows a completion summary when every tutorial is finished", () => {
+    recordPlayed(...TUTORIALS.map((tutorial) => tutorial.id));
+    render(<NewGame {...props()} />);
+
+    expect(screen.getByText("Tutorials complete")).toBeInTheDocument();
+    expect(screen.queryByTestId(/^tutorial-spotlight-/)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "View all 6" }));
+    expect(
+      within(
+        screen.getByRole("group", { name: "All tutorials" }),
+      ).getAllByTestId(/^mission-complete-/),
+    ).toHaveLength(TUTORIALS.length);
+  });
+
+  it("shows completion badges in the expanded catalogs", () => {
     const regular = SCENARIOS.find(
       (scenario: ScenarioType) => !scenario.tutorialSteps,
     ) as ScenarioType;
     recordPlayed(TUTORIALS[0].id, regular.id);
     render(<NewGame {...props()} />);
 
+    fireEvent.click(screen.getByRole("button", { name: "View all 6" }));
+    fireEvent.click(screen.getByRole("button", { name: "View all 11" }));
     expect(
       screen.getByTestId(`mission-complete-${TUTORIALS[0].id}`),
     ).toBeInTheDocument();
     expect(
       screen.getByTestId(`mission-complete-${regular.id}`),
     ).toBeInTheDocument();
-    expect(screen.queryByText("Completed")).toBeNull();
   });
 
-  it("starts tutorials directly and opens details for regular missions", () => {
+  it("starts the recommended tutorial and opens challenge and custom details", () => {
     const onTutorial = jest.fn();
     const onDetails = jest.fn();
     const onCustomGame = jest.fn();
-    const regular = SCENARIOS.find(
-      (scenario: ScenarioType) => !scenario.tutorialSteps,
-    ) as ScenarioType;
     render(<NewGame {...props({ onTutorial, onDetails, onCustomGame })} />);
 
     fireEvent.click(
-      within(screen.getByTestId(`mission-row-${TUTORIALS[0].id}`)).getByRole(
-        "button",
-      ),
+      within(
+        screen.getByTestId(`tutorial-spotlight-${TUTORIALS[0].id}`),
+      ).getByRole("button"),
     );
     expect(onTutorial).toHaveBeenCalledWith(TUTORIALS[0].id);
 
     fireEvent.click(
-      within(screen.getByTestId(`mission-row-${regular.id}`)).getByRole(
-        "button",
-      ),
+      within(screen.getByTestId("mission-row-107")).getByRole("button"),
     );
-    expect(onDetails).toHaveBeenCalledWith({ scenarioId: regular.id });
+    expect(onDetails).toHaveBeenCalledWith({ scenarioId: 107 });
 
     fireEvent.click(
       within(screen.getByTestId(`mission-row-${CUSTOM_SCENARIO_ID}`)).getByRole(

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -6,6 +6,7 @@ import {
   Card,
   CardActionArea,
   CardHeader,
+  Chip,
   IconButton,
   LinearProgress,
   List,
@@ -45,7 +46,7 @@ export interface DispatchProps {
 
 export interface Props extends StateProps, DispatchProps {}
 
-type ChallengeFilterType = "All" | ScenarioThemeType;
+type ChallengeFilterType = "For you" | "All challenges" | ScenarioThemeType;
 
 const CHALLENGE_THEMES: ScenarioThemeType[] = [
   "Extreme weather",
@@ -63,6 +64,7 @@ interface MissionListItemProps {
   s: ScenarioType;
   completed: boolean;
   onSelect: () => void;
+  showThemes?: boolean;
 }
 
 function displayName(s: ScenarioType): string {
@@ -90,7 +92,7 @@ function MissionSectionHeader(
 // One row for everything: tutorial missions, scenarios, and the custom game all share the
 // list now - the only differences are the action control and what the subheader shows
 function MissionListItem(props: MissionListItemProps): React.JSX.Element {
-  const { s, completed, onSelect } = props;
+  const { s, completed, onSelect, showThemes = false } = props;
   const isTutorial = !!s.tutorialSteps;
   const name = displayName(s);
   const location = getScenarioLocation(s) || { name: "UNKNOWN" };
@@ -104,6 +106,20 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
         <span className="missionMeta">
           {location.name} · {s.startingYear}–{scenarioEndYear(s)}
         </span>
+        {showThemes && s.themes && (
+          <span className="missionThemes" aria-label={`${name} themes`}>
+            {s.themes.map((theme) => (
+              <Chip
+                component="span"
+                className="missionThemeTag"
+                key={theme}
+                label={theme}
+                size="small"
+                variant="outlined"
+              />
+            ))}
+          </span>
+        )}
       </span>
     );
   return (
@@ -202,9 +218,8 @@ function TutorialSpotlight(props: TutorialSpotlightProps): React.JSX.Element {
 
 export default function NewGame(props: Props): React.JSX.Element {
   const [showAllTutorials, setShowAllTutorials] = React.useState(false);
-  const [showAllChallenges, setShowAllChallenges] = React.useState(false);
   const [challengeFilter, setChallengeFilter] =
-    React.useState<ChallengeFilterType>("All");
+    React.useState<ChallengeFilterType>("For you");
   const ids = getPlayedScenarioIds();
   const completedTutorials = TUTORIALS.filter((s) => ids.includes(s.id)).length;
   const nextTutorial = TUTORIALS.find((s) => ids.indexOf(s.id) === -1);
@@ -223,13 +238,14 @@ export default function NewGame(props: Props): React.JSX.Element {
         recommendationRank(a) - recommendationRank(b),
     )
     .slice(0, 3);
-  const visibleScenarios = showAllChallenges
-    ? scenarios.filter(
-        (scenario) =>
-          challengeFilter === "All" ||
-          scenario.themes?.includes(challengeFilter),
-      )
-    : recommendedScenarios;
+  const visibleScenarios =
+    challengeFilter === "For you"
+      ? recommendedScenarios
+      : challengeFilter === "All challenges"
+        ? scenarios
+        : scenarios.filter((scenario) =>
+            scenario.themes?.includes(challengeFilter),
+          );
 
   return (
     <div id="listCard" className="flexContainer">
@@ -324,53 +340,30 @@ export default function NewGame(props: Props): React.JSX.Element {
             ))}
           </div>
         )}
-        <MissionSectionHeader
-          action={
-            <Button
-              size="small"
-              onClick={() => {
-                setShowAllChallenges(!showAllChallenges);
-                setChallengeFilter("All");
-              }}
-              aria-expanded={showAllChallenges}
-              aria-controls="challenge-catalog"
-              endIcon={
-                showAllChallenges ? <ExpandLessIcon /> : <ExpandMoreIcon />
-              }
-            >
-              {showAllChallenges
-                ? "Show recommendations"
-                : `View all ${scenarios.length}`}
-            </Button>
-          }
+        <MissionSectionHeader>Challenges</MissionSectionHeader>
+        <ToggleButtonGroup
+          className="challengeFilters"
+          value={challengeFilter}
+          exclusive
+          onChange={(
+            _event: React.MouseEvent<HTMLElement>,
+            value: ChallengeFilterType | null,
+          ) => value && setChallengeFilter(value)}
+          aria-label="Browse challenges"
+          size="small"
         >
-          Challenges
-        </MissionSectionHeader>
-        {showAllChallenges ? (
-          <ToggleButtonGroup
-            className="challengeFilters"
-            value={challengeFilter}
-            exclusive
-            onChange={(
-              _event: React.MouseEvent<HTMLElement>,
-              value: ChallengeFilterType | null,
-            ) => value && setChallengeFilter(value)}
-            aria-label="Filter challenges by theme"
-            size="small"
-          >
-            {(["All", ...CHALLENGE_THEMES] as ChallengeFilterType[]).map(
-              (theme) => (
-                <ToggleButton key={theme} value={theme} aria-label={theme}>
-                  {theme}
-                </ToggleButton>
-              ),
-            )}
-          </ToggleButtonGroup>
-        ) : (
-          <Typography className="challengeBrowseCaption" variant="body2">
-            Recommended for you
-          </Typography>
-        )}
+          {(
+            [
+              "For you",
+              ...CHALLENGE_THEMES,
+              "All challenges",
+            ] as ChallengeFilterType[]
+          ).map((filter) => (
+            <ToggleButton key={filter} value={filter} aria-label={filter}>
+              {filter}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
         <div id="challenge-catalog" data-testid="challenge-list">
           {visibleScenarios.map((s) => (
             <MissionListItem
@@ -378,6 +371,7 @@ export default function NewGame(props: Props): React.JSX.Element {
               s={s}
               completed={ids.indexOf(s.id) !== -1}
               onSelect={() => props.onDetails({ scenarioId: s.id })}
+              showThemes={challengeFilter !== "For you"}
             />
           ))}
         </div>

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -52,7 +52,6 @@ const CHALLENGE_THEMES: ScenarioThemeType[] = [
   "Extreme weather",
   "Energy transition",
   "Rapid growth",
-  "Island grids",
 ];
 
 function scenarioEndYear(scenario: ScenarioType): number {

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -22,7 +22,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutlineOutlined";
-import { getPlayedScenarioIds } from "../../LocalStorage";
+import { getScenarioPlayCounts } from "../../LocalStorage";
 import { getScenarioLocation } from "../../helpers/Locations";
 import {
   CUSTOM_SCENARIO_ID,
@@ -53,7 +53,6 @@ const CHALLENGE_THEMES: ScenarioThemeType[] = [
   "Energy transition",
   "Rapid growth",
   "Island grids",
-  "Sudden disruption",
 ];
 
 function scenarioEndYear(scenario: ScenarioType): number {
@@ -220,7 +219,8 @@ export default function NewGame(props: Props): React.JSX.Element {
   const [showAllTutorials, setShowAllTutorials] = React.useState(false);
   const [challengeFilter, setChallengeFilter] =
     React.useState<ChallengeFilterType>("For you");
-  const ids = getPlayedScenarioIds();
+  const playCounts = getScenarioPlayCounts();
+  const ids = Object.keys(playCounts).map(Number);
   const completedTutorials = TUTORIALS.filter((s) => ids.includes(s.id)).length;
   const nextTutorial = TUTORIALS.find((s) => ids.indexOf(s.id) === -1);
   const scenarios = SCENARIOS.filter((s) => !s.tutorialSteps).sort(
@@ -232,11 +232,15 @@ export default function NewGame(props: Props): React.JSX.Element {
     return scenario.recommendationOrder ?? Number.MAX_SAFE_INTEGER;
   };
   const recommendedScenarios = [...scenarios]
-    .sort(
-      (a, b) =>
-        Number(ids.includes(a.id)) - Number(ids.includes(b.id)) ||
-        recommendationRank(a) - recommendationRank(b),
-    )
+    .sort((a, b) => {
+      const aPlays = playCounts[a.id] ?? 0;
+      const bPlays = playCounts[b.id] ?? 0;
+      return (
+        Number(aPlays > 0) - Number(bPlays > 0) ||
+        (aPlays > 0 && bPlays > 0 ? bPlays - aPlays : 0) ||
+        recommendationRank(a) - recommendationRank(b)
+      );
+    })
     .slice(0, 3);
   const visibleScenarios =
     challengeFilter === "For you"

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -2,18 +2,24 @@ import * as React from "react";
 import {
   Avatar,
   Badge,
+  Button,
   Card,
   CardActionArea,
   CardHeader,
   IconButton,
+  LinearProgress,
   List,
   ListSubheader,
   Toolbar,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from "@mui/material";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutlineOutlined";
 import { getPlayedScenarioIds } from "../../LocalStorage";
 import { getScenarioLocation } from "../../helpers/Locations";
@@ -23,7 +29,7 @@ import {
   SCENARIOS,
   TUTORIALS,
 } from "../../data/Scenarios";
-import { GameType, ScenarioType } from "../../Types";
+import { GameType, ScenarioThemeType, ScenarioType } from "../../Types";
 
 export interface StateProps {
   game: GameType;
@@ -39,6 +45,16 @@ export interface DispatchProps {
 
 export interface Props extends StateProps, DispatchProps {}
 
+type ChallengeFilterType = "All" | ScenarioThemeType;
+
+const CHALLENGE_THEMES: ScenarioThemeType[] = [
+  "Extreme weather",
+  "Energy transition",
+  "Rapid growth",
+  "Island grids",
+  "Sudden disruption",
+];
+
 function scenarioEndYear(scenario: ScenarioType): number {
   return scenario.startingYear + Math.ceil(scenario.durationMonths / 12) - 1;
 }
@@ -46,9 +62,6 @@ function scenarioEndYear(scenario: ScenarioType): number {
 interface MissionListItemProps {
   s: ScenarioType;
   completed: boolean;
-  // The first mission the player hasn't done yet, called out so the single list has an
-  // obvious entry point instead of a dozen equal-looking rows
-  next: boolean;
   onSelect: () => void;
 }
 
@@ -56,10 +69,28 @@ function displayName(s: ScenarioType): string {
   return s.name.replace(/^Mission \d+:\s*/, "");
 }
 
+interface MissionSectionHeaderProps {
+  children: React.ReactNode;
+  action?: React.ReactNode;
+}
+
+function MissionSectionHeader(
+  props: MissionSectionHeaderProps,
+): React.JSX.Element {
+  return (
+    <ListSubheader disableSticky className="missionSectionHeader">
+      <Typography component="h2" variant="subtitle2" sx={{ fontWeight: 700 }}>
+        {props.children}
+      </Typography>
+      {props.action}
+    </ListSubheader>
+  );
+}
+
 // One row for everything: tutorial missions, scenarios, and the custom game all share the
 // list now - the only differences are the action control and what the subheader shows
 function MissionListItem(props: MissionListItemProps): React.JSX.Element {
-  const { s, completed, next, onSelect } = props;
+  const { s, completed, onSelect } = props;
   const isTutorial = !!s.tutorialSteps;
   const name = displayName(s);
   const location = getScenarioLocation(s) || { name: "UNKNOWN" };
@@ -78,11 +109,10 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
   return (
     <Card
       data-testid={`mission-row-${s.id}`}
-      className={`build-list-item missionItem${next ? " tutorialNext" : ""}`}
+      className="build-list-item missionItem"
     >
       <CardActionArea
         onClick={onSelect}
-        autoFocus={next}
         aria-label={
           isTutorial
             ? `${completed ? "Review" : "Start"} ${name}`
@@ -121,14 +151,85 @@ function MissionListItem(props: MissionListItemProps): React.JSX.Element {
   );
 }
 
+interface TutorialSpotlightProps {
+  completedTutorials: number;
+  onSelect: () => void;
+  tutorial: ScenarioType;
+}
+
+function TutorialSpotlight(props: TutorialSpotlightProps): React.JSX.Element {
+  const { completedTutorials, onSelect, tutorial } = props;
+  const name = displayName(tutorial);
+  return (
+    <Card
+      data-testid={`tutorial-spotlight-${tutorial.id}`}
+      className="tutorialSpotlight"
+    >
+      <CardActionArea onClick={onSelect} autoFocus aria-label={`Start ${name}`}>
+        <CardHeader
+          avatar={
+            <Avatar
+              src={`/images/${tutorial.icon.toLowerCase()}.svg`}
+              alt={`${name} icon`}
+            />
+          }
+          title={
+            <span>
+              <span className="tutorialSpotlightEyebrow">
+                Continue learning · {completedTutorials} of {TUTORIALS.length}{" "}
+                complete
+              </span>
+              <span className="tutorialSpotlightTitle">{name}</span>
+            </span>
+          }
+          subheader={tutorial.summary}
+          action={
+            <span className="tutorialSpotlightAction" aria-hidden>
+              Start lesson <ArrowRightIcon fontSize="small" />
+            </span>
+          }
+        />
+        <LinearProgress
+          variant="determinate"
+          value={(completedTutorials / TUTORIALS.length) * 100}
+          className="tutorialSpotlightProgress"
+          aria-label={`Tutorials: ${completedTutorials} of ${TUTORIALS.length} complete`}
+        />
+      </CardActionArea>
+    </Card>
+  );
+}
+
 export default function NewGame(props: Props): React.JSX.Element {
+  const [showAllTutorials, setShowAllTutorials] = React.useState(false);
+  const [showAllChallenges, setShowAllChallenges] = React.useState(false);
+  const [challengeFilter, setChallengeFilter] =
+    React.useState<ChallengeFilterType>("All");
   const ids = getPlayedScenarioIds();
+  const completedTutorials = TUTORIALS.filter((s) => ids.includes(s.id)).length;
   const nextTutorial = TUTORIALS.find((s) => ids.indexOf(s.id) === -1);
   const scenarios = SCENARIOS.filter((s) => !s.tutorialSteps).sort(
     (a, b) =>
       b.startingYear - a.startingYear ||
       scenarioEndYear(b) - scenarioEndYear(a),
   );
+  const recommendationRank = (scenario: ScenarioType): number => {
+    return scenario.recommendationOrder ?? Number.MAX_SAFE_INTEGER;
+  };
+  const recommendedScenarios = [...scenarios]
+    .sort(
+      (a, b) =>
+        Number(ids.includes(a.id)) - Number(ids.includes(b.id)) ||
+        recommendationRank(a) - recommendationRank(b),
+    )
+    .slice(0, 3);
+  const visibleScenarios = showAllChallenges
+    ? scenarios.filter(
+        (scenario) =>
+          challengeFilter === "All" ||
+          scenario.themes?.includes(challengeFilter),
+      )
+    : recommendedScenarios;
 
   return (
     <div id="listCard" className="flexContainer">
@@ -166,77 +267,125 @@ export default function NewGame(props: Props): React.JSX.Element {
         className="scrollable cardList missionList"
         aria-label="Available games"
       >
-        <ListSubheader
-          disableSticky
-          sx={{
-            bgcolor: "transparent",
-            color: "text.primary",
-            fontWeight: 700,
-          }}
+        <MissionSectionHeader
+          action={
+            <Button
+              size="small"
+              onClick={() => setShowAllTutorials(!showAllTutorials)}
+              aria-expanded={showAllTutorials}
+              aria-controls="tutorial-catalog"
+              endIcon={
+                showAllTutorials ? <ExpandLessIcon /> : <ExpandMoreIcon />
+              }
+            >
+              {showAllTutorials
+                ? "Hide lessons"
+                : `View all ${TUTORIALS.length}`}
+            </Button>
+          }
         >
-          <Typography
-            component="h2"
-            variant="subtitle2"
-            sx={{ fontWeight: 700 }}
-          >
-            Learn the basics
-          </Typography>
-        </ListSubheader>
-        {TUTORIALS.map((s) => (
-          <MissionListItem
-            key={s.id}
-            s={s}
-            completed={ids.indexOf(s.id) !== -1}
-            next={nextTutorial !== undefined && s.id === nextTutorial.id}
-            onSelect={() => props.onTutorial(s.id)}
+          Learn the basics
+        </MissionSectionHeader>
+        {nextTutorial ? (
+          <TutorialSpotlight
+            tutorial={nextTutorial}
+            completedTutorials={completedTutorials}
+            onSelect={() => props.onTutorial(nextTutorial.id)}
           />
-        ))}
-        <ListSubheader
-          disableSticky
-          sx={{
-            bgcolor: "transparent",
-            color: "text.primary",
-            fontWeight: 700,
-          }}
-        >
-          <Typography
-            component="h2"
-            variant="subtitle2"
-            sx={{ fontWeight: 700 }}
+        ) : (
+          <div className="tutorialCompleteSummary">
+            <CheckCircleIcon color="primary" />
+            <span>
+              <strong>Tutorials complete</strong>
+              <Typography
+                component="span"
+                variant="body2"
+                color="textSecondary"
+              >
+                You can replay any lesson whenever you want.
+              </Typography>
+            </span>
+          </div>
+        )}
+        {showAllTutorials && (
+          <div
+            id="tutorial-catalog"
+            className="tutorialCatalog"
+            role="group"
+            aria-label="All tutorials"
           >
-            Challenges
-          </Typography>
-        </ListSubheader>
-        {scenarios.map((s) => (
-          <MissionListItem
-            key={s.id}
-            s={s}
-            completed={ids.indexOf(s.id) !== -1}
-            next={false}
-            onSelect={() => props.onDetails({ scenarioId: s.id })}
-          />
-        ))}
-        <ListSubheader
-          disableSticky
-          sx={{
-            bgcolor: "transparent",
-            color: "text.primary",
-            fontWeight: 700,
-          }}
+            {TUTORIALS.map((s) => (
+              <MissionListItem
+                key={s.id}
+                s={s}
+                completed={ids.indexOf(s.id) !== -1}
+                onSelect={() => props.onTutorial(s.id)}
+              />
+            ))}
+          </div>
+        )}
+        <MissionSectionHeader
+          action={
+            <Button
+              size="small"
+              onClick={() => {
+                setShowAllChallenges(!showAllChallenges);
+                setChallengeFilter("All");
+              }}
+              aria-expanded={showAllChallenges}
+              aria-controls="challenge-catalog"
+              endIcon={
+                showAllChallenges ? <ExpandLessIcon /> : <ExpandMoreIcon />
+              }
+            >
+              {showAllChallenges
+                ? "Show recommendations"
+                : `View all ${scenarios.length}`}
+            </Button>
+          }
         >
-          <Typography
-            component="h2"
-            variant="subtitle2"
-            sx={{ fontWeight: 700 }}
+          Challenges
+        </MissionSectionHeader>
+        {showAllChallenges ? (
+          <ToggleButtonGroup
+            className="challengeFilters"
+            value={challengeFilter}
+            exclusive
+            onChange={(
+              _event: React.MouseEvent<HTMLElement>,
+              value: ChallengeFilterType | null,
+            ) => value && setChallengeFilter(value)}
+            aria-label="Filter challenges by theme"
+            size="small"
           >
-            Custom game
+            {(["All", ...CHALLENGE_THEMES] as ChallengeFilterType[]).map(
+              (theme) => (
+                <ToggleButton key={theme} value={theme} aria-label={theme}>
+                  {theme}
+                </ToggleButton>
+              ),
+            )}
+          </ToggleButtonGroup>
+        ) : (
+          <Typography className="challengeBrowseCaption" variant="body2">
+            Recommended for you
           </Typography>
-        </ListSubheader>
+        )}
+        <div id="challenge-catalog" data-testid="challenge-list">
+          {visibleScenarios.map((s) => (
+            <MissionListItem
+              key={s.id}
+              s={s}
+              completed={ids.indexOf(s.id) !== -1}
+              onSelect={() => props.onDetails({ scenarioId: s.id })}
+            />
+          ))}
+        </div>
+        <MissionSectionHeader>Custom game</MissionSectionHeader>
         <MissionListItem
           key={CUSTOM_SCENARIO_ID}
           s={DEFAULT_CUSTOM_SCENARIO}
           completed={false}
-          next={false}
           onSelect={props.onCustomGame}
         />
       </List>

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -141,6 +141,22 @@ describe("authored scenario briefings", () => {
       (scenario) => expect(scenario.themes?.length).toBeGreaterThan(0),
     );
   });
+
+  it("uses the four player-facing challenge themes", () => {
+    const themes = new Set(
+      SCENARIOS.filter((scenario) => !scenario.tutorialSteps).flatMap(
+        (scenario) => scenario.themes ?? [],
+      ),
+    );
+    expect(themes).toEqual(
+      new Set([
+        "Extreme weather",
+        "Energy transition",
+        "Rapid growth",
+        "Island grids",
+      ]),
+    );
+  });
 });
 
 describe("authored starting fleets", () => {

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -142,19 +142,14 @@ describe("authored scenario briefings", () => {
     );
   });
 
-  it("uses the four player-facing challenge themes", () => {
+  it("uses the three player-facing challenge themes", () => {
     const themes = new Set(
       SCENARIOS.filter((scenario) => !scenario.tutorialSteps).flatMap(
         (scenario) => scenario.themes ?? [],
       ),
     );
     expect(themes).toEqual(
-      new Set([
-        "Extreme weather",
-        "Energy transition",
-        "Rapid growth",
-        "Island grids",
-      ]),
+      new Set(["Extreme weather", "Energy transition", "Rapid growth"]),
     );
   });
 });

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -135,6 +135,12 @@ describe("authored scenario briefings", () => {
       },
     );
   });
+
+  it("gives every challenge at least one player-facing browse theme", () => {
+    SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
+      (scenario) => expect(scenario.themes?.length).toBeGreaterThan(0),
+    );
+  });
 });
 
 describe("authored starting fleets", () => {

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -674,6 +674,8 @@ export const SCENARIOS = [
     icon: "carbon fee",
     locationId: "SF",
     summary: "Pollution now costs money. Can you replace your aging plants?",
+    themes: ["Energy transition"],
+    recommendationOrder: 3,
     briefing: {
       tone: "transition",
       fantasy: "Modernize an aging grid as pollution gets more expensive.",
@@ -697,6 +699,7 @@ export const SCENARIOS = [
     icon: "the shale boom",
     locationId: "PIT",
     summary: "Local gas is suddenly cheap—but the boom may not last.",
+    themes: ["Rapid growth"],
     briefing: {
       tone: "boom",
       fantasy: "Turn a cheap-gas boom into lasting success.",
@@ -717,6 +720,7 @@ export const SCENARIOS = [
     icon: "paradise",
     locationId: "HNL",
     summary: "Power an island where every shipment and outage matters.",
+    themes: ["Island grids"],
     briefing: {
       tone: "island",
       fantasy: "Keep an island paradise bright without outside backup.",
@@ -741,6 +745,7 @@ export const SCENARIOS = [
     icon: "rise of renewables",
     locationId: "SF",
     summary: "New clean technologies are arriving fast. Choose when to invest.",
+    themes: ["Energy transition"],
     briefing: {
       tone: "innovation",
       fantasy: "Build the next generation of clean power.",
@@ -765,6 +770,7 @@ export const SCENARIOS = [
     icon: "hurricane season",
     locationId: "SJU",
     summary: "Prepare an island grid for storms and costly fuel.",
+    themes: ["Extreme weather", "Island grids", "Sudden disruption"],
     briefing: {
       tone: "storm",
       fantasy: "Protect an island grid through years of fierce storms.",
@@ -790,6 +796,7 @@ export const SCENARIOS = [
     icon: "the end of an era",
     locationId: "PIT",
     summary: "Your coal company must adapt to a changing power market.",
+    themes: ["Energy transition"],
     briefing: {
       tone: "legacy",
       fantasy: "Decide what comes after a century of coal.",
@@ -825,6 +832,8 @@ export const SCENARIOS = [
       timeZone: "America/New_York",
     },
     summary: "Prepare for data-center growth without pricing out residents.",
+    themes: ["Rapid growth"],
+    recommendationOrder: 2,
     briefing: {
       tone: "boom",
       fantasy: "Guide a small city grid through explosive growth.",
@@ -883,6 +892,8 @@ export const SCENARIOS = [
       timeZone: "America/Chicago",
     },
     summary: "Prepare Austin's grid for a historic winter emergency.",
+    themes: ["Extreme weather", "Sudden disruption"],
+    recommendationOrder: 1,
     briefing: {
       tone: "storm",
       fantasy: "Keep Austin powered through a brutal winter storm.",
@@ -938,6 +949,7 @@ export const SCENARIOS = [
       resources: { hydro: true },
     },
     summary: "Keep Spain powered through a worsening heatwave and drought.",
+    themes: ["Extreme weather", "Sudden disruption"],
     briefing: {
       tone: "storm",
       fantasy:
@@ -996,6 +1008,7 @@ export const SCENARIOS = [
       resources: { hydro: true },
     },
     summary: "Prepare China's solar-heavy grid for a total eclipse.",
+    themes: ["Energy transition", "Sudden disruption"],
     briefing: {
       tone: "innovation",
       fantasy:
@@ -1059,6 +1072,7 @@ export const SCENARIOS = [
       resources: { hydro: false },
     },
     summary: "Cover an unexpected nuclear shutdown in France.",
+    themes: ["Sudden disruption"],
     briefing: {
       tone: "legacy",
       fantasy:

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -770,7 +770,7 @@ export const SCENARIOS = [
     icon: "hurricane season",
     locationId: "SJU",
     summary: "Prepare an island grid for storms and costly fuel.",
-    themes: ["Extreme weather", "Island grids", "Sudden disruption"],
+    themes: ["Extreme weather", "Island grids"],
     briefing: {
       tone: "storm",
       fantasy: "Protect an island grid through years of fierce storms.",
@@ -892,7 +892,7 @@ export const SCENARIOS = [
       timeZone: "America/Chicago",
     },
     summary: "Prepare Austin's grid for a historic winter emergency.",
-    themes: ["Extreme weather", "Sudden disruption"],
+    themes: ["Extreme weather"],
     recommendationOrder: 1,
     briefing: {
       tone: "storm",
@@ -947,7 +947,7 @@ export const SCENARIOS = [
       resources: { hydro: true },
     },
     summary: "Keep Spain powered through a worsening heatwave and drought.",
-    themes: ["Extreme weather", "Sudden disruption"],
+    themes: ["Extreme weather"],
     briefing: {
       tone: "storm",
       fantasy:
@@ -1006,7 +1006,7 @@ export const SCENARIOS = [
       resources: { hydro: true },
     },
     summary: "Prepare China's solar-heavy grid for a total eclipse.",
-    themes: ["Energy transition", "Sudden disruption"],
+    themes: ["Energy transition"],
     briefing: {
       tone: "innovation",
       fantasy:
@@ -1070,7 +1070,7 @@ export const SCENARIOS = [
       resources: { hydro: false },
     },
     summary: "Cover an unexpected nuclear shutdown in France.",
-    themes: ["Sudden disruption"],
+    themes: ["Energy transition"],
     briefing: {
       tone: "legacy",
       fantasy:

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -720,7 +720,7 @@ export const SCENARIOS = [
     icon: "paradise",
     locationId: "HNL",
     summary: "Power an island where every shipment and outage matters.",
-    themes: ["Island grids"],
+    themes: ["Energy transition"],
     briefing: {
       tone: "island",
       fantasy: "Keep an island paradise bright without outside backup.",
@@ -770,7 +770,7 @@ export const SCENARIOS = [
     icon: "hurricane season",
     locationId: "SJU",
     summary: "Prepare an island grid for storms and costly fuel.",
-    themes: ["Extreme weather", "Island grids"],
+    themes: ["Extreme weather"],
     briefing: {
       tone: "storm",
       fantasy: "Protect an island grid through years of fierce storms.",


### PR DESCRIPTION
## Summary

- replace the six-row tutorial block with one explicit next-lesson card, progress, and an expandable lesson catalog
- show three challenge recommendations under a default **For you** chip, prioritizing unplayed challenges and then the player's most-played challenges
- store repeat completions as a compact, backward-compatible play count for recommendation ranking
- provide persistent theme chips for extreme weather, energy transition, and rapid growth, plus the complete catalog
- display each challenge's authored theme tags while browsing the full catalog
- preserve completion badges, scenario details, chronological full-catalog ordering, and custom games
- cover the compact, themed, recommendation fallback, and responsive states with focused tests
- document native GitHub-hosted PR attachments so review screenshots never enter the repository or Git LFS history

## Screenshots

### Default desktop

![Choose a game page on desktop with the next tutorial, challenge filters, and three recommendations](https://github.com/user-attachments/assets/651fede8-8c19-427d-9cb1-d6d99df4fc14)

### Mobile

![Choose a game page at 390 pixels wide with horizontally scrollable challenge filters](https://github.com/user-attachments/assets/e4699457-ddea-4b50-87ae-94e88b6d00e1)

### Filtered with player-facing tags

![Challenge catalog filtered to extreme weather with theme tags on each result](https://github.com/user-attachments/assets/d6d74f0c-c018-4262-9f8f-7bae33e8544b)

## Testing

- `npm run check` (93 suites and 898 tests passed; all scenarios hold every invariant)
- `npx playwright test --config e2e/playwright.config.ts e2e/new-game-responsive.spec.ts` (3 passed, 2 skipped by viewport scope)
- `npm run build`
