### PR TITLE
Make grid reserve status responsive and actionable

### DIFF
--- a/.github/pr-screenshots/grid-status-reserve/desktop-stable.jpg
+++ b/.github/pr-screenshots/grid-status-reserve/desktop-stable.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65b4daba2e8bdfee2266e23377fcf36b9cfffc57e9071e049de21719798cf036
+size 104452

--- a/.github/pr-screenshots/grid-status-reserve/desktop-stable.jpg
+++ b/.github/pr-screenshots/grid-status-reserve/desktop-stable.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65b4daba2e8bdfee2266e23377fcf36b9cfffc57e9071e049de21719798cf036
-size 104452
+oid sha256:b6dbe5455a46a06125ed3a0973e5f914c1dae884102667fc5e2ad7939031d42c
+size 104459

--- a/.github/pr-screenshots/grid-status-reserve/mobile-blackout.jpg
+++ b/.github/pr-screenshots/grid-status-reserve/mobile-blackout.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6802d5ba81c0acfee7231d543806c085630c05ce3d5b1997174a6662cbe578dc
+size 10128

--- a/.github/pr-screenshots/grid-status-reserve/mobile-stable.jpg
+++ b/.github/pr-screenshots/grid-status-reserve/mobile-stable.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a54a67e0e3948718142b9df3fba743488c44427646d52f866595a5285d57caa
+size 8222

--- a/src/app.scss
+++ b/src/app.scss
@@ -699,6 +699,13 @@ $topbar_height: 56px;
   white-space: nowrap;
 }
 
+// Remove the inline SVG's baseline space so its visual center matches the adjacent label.
+.gridHealthIcon {
+  display: flex;
+  align-items: center;
+  line-height: 0;
+}
+
 .gridHealthMetric {
   min-width: 8.5rem;
   text-align: left;

--- a/src/app.scss
+++ b/src/app.scss
@@ -653,22 +653,30 @@ $topbar_height: 56px;
 // Never squeezed by whatever is below it, on either layout
 #appbar {
   flex: 0 0 auto;
+  position: relative;
 }
 
 .gridHealth {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  min-height: 18px;
-  padding: 0 max(12px, env(safe-area-inset-left));
+  gap: 12px;
+  min-height: 32px;
+  padding: 0 max(12px, env(safe-area-inset-right)) 0
+    max(12px, env(safe-area-inset-left));
   border-top: 1px solid var(--border-subtle);
   border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-raised);
   color: $font_color_primary;
-  font-size: 0.7rem;
-  line-height: 18px;
+  font-size: 0.75rem;
+  line-height: 1.25;
   text-align: center;
+
+  &.gridHealth-low-reserve,
+  &.gridHealth-at-limit {
+    border-color: var(--mark-bg);
+    background: var(--mark-bg);
+  }
 
   &.gridHealth-blackout {
     background: var(--blackout-tint);
@@ -676,9 +684,82 @@ $topbar_height: 56px;
   }
 }
 
-@media screen and (max-width: 420px) {
+.gridHealthSummary,
+.gridHealthState {
+  display: flex;
+  align-items: center;
+}
+
+.gridHealthSummary {
+  gap: 8px;
+}
+
+.gridHealthState {
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.gridHealthMetric {
+  min-width: 8.5rem;
+  text-align: left;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.gridHealth-stable .conceptIcon {
+  color: $interactive_blue;
+}
+
+// On a wide layout, the routine state belongs to the toolbar rather than consuming another
+// horizontal strip. Actionable states deliberately break out into a banner below it.
+@media screen and (min-width: $pane_breakpoint) {
+  .gridHealth-stable {
+    position: absolute;
+    top: calc(env(safe-area-inset-top) + 13px);
+    left: 50%;
+    z-index: 1;
+    min-height: 30px;
+    padding: 0 10px;
+    transform: translateX(-50%);
+    border: 1px solid var(--border-selected);
+    border-radius: 999px;
+    background: var(--bg-selected);
+    color: $interactive_blue;
+
+    .gridHealthMetric {
+      min-width: 7.75rem;
+    }
+  }
+}
+
+// Phones and narrow tablets keep the readout in its own intentional row: state on the left,
+// operational cushion on the right. Emergency guidance gets the row to itself.
+@media screen and (max-width: ($pane_breakpoint - 1px)) {
   .gridHealth {
-    justify-content: space-between;
+    flex-direction: column;
+    gap: 3px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+
+    .gridHealthSummary {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      width: 100%;
+    }
+
+    .gridHealthSeparator {
+      display: none;
+    }
+
+    .gridHealthMetric {
+      min-width: 0;
+      text-align: right;
+    }
+
+    .gridHealthAdvice {
+      width: 100%;
+      text-align: left;
+    }
   }
 }
 

--- a/src/components/base/GameAppBar.test.tsx
+++ b/src/components/base/GameAppBar.test.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { createGame } from "../../testing/Simulator";
-import { GameAppBar, Props, reserveCapacityW } from "./GameAppBar";
+import {
+  GameAppBar,
+  getGridHealth,
+  Props,
+  reserveCapacityW,
+} from "./GameAppBar";
 import { getTimeFromTimeline } from "../../helpers/DateTime";
 import { FacilityOperatingType, TickPresentFutureType } from "../../Types";
 
@@ -9,6 +14,13 @@ jest.mock("../../Globals", () => ({
   ...jest.requireActual("../../Globals"),
   isBigScreen: () => true,
 }));
+
+const WEATHER_DRIVEN_TEST_FUELS = [
+  "Sun",
+  "Wind",
+  "Offshore Wind",
+  "Airborne Wind",
+];
 
 function renderAppBar(overrides: Partial<Props> = {}) {
   const game = createGame({ scenarioId: 101 });
@@ -38,7 +50,7 @@ describe("GameAppBar", () => {
     expect(onSpeedChange).toHaveBeenCalledWith("FAST");
   });
 
-  it("reports unused available capacity in MW and grows when a plant is added", () => {
+  it("reports reserve and grows when a plant is added", () => {
     const game = createGame({ scenarioId: 101 });
     const now = getTimeFromTimeline(game.date.minute, game.timeline)!;
     const plant = game.facilities.find(
@@ -51,10 +63,73 @@ describe("GameAppBar", () => {
 
     expect(reserveCapacityW(game, now) - before).toBe(plant.peakW);
     renderAppBar({ game: { ...game, inGame: true } });
+    expect(screen.getByText(/\+.*W reserve/)).toBeInTheDocument();
+    expect(screen.getByText("Stable")).toBeInTheDocument();
+  });
+
+  it("warns when reserve falls to ten percent of demand", () => {
+    const game = createGame({ scenarioId: 101 });
+    const now = getTimeFromTimeline(game.date.minute, game.timeline)!;
+    const plant = game.facilities.find(
+      (facility: FacilityOperatingType) =>
+        facility.fuel &&
+        !facility.peakWh &&
+        !WEATHER_DRIVEN_TEST_FUELS.includes(facility.fuel),
+    )!;
+    const lowReserveGame = {
+      ...game,
+      facilities: [
+        {
+          ...plant,
+          paused: false,
+          yearsToBuildLeft: 0,
+          peakW: now.demandW * 1.05,
+        },
+      ],
+    };
+
+    expect(getGridHealth(lowReserveGame, now)).toMatchObject({
+      state: "low-reserve",
+      label: "Low reserve",
+      metric: expect.stringMatching(/reserve \(5%\)/),
+    });
+  });
+
+  it("distinguishes an exhausted reserve from a blackout", () => {
+    const game = createGame({ scenarioId: 101 });
+    const now = getTimeFromTimeline(game.date.minute, game.timeline)!;
+    const plant = game.facilities.find(
+      (facility: FacilityOperatingType) =>
+        facility.fuel &&
+        !facility.peakWh &&
+        !WEATHER_DRIVEN_TEST_FUELS.includes(facility.fuel),
+    )!;
+    const atLimitGame = {
+      ...game,
+      facilities: [
+        {
+          ...plant,
+          paused: false,
+          yearsToBuildLeft: 0,
+          peakW: now.demandW,
+        },
+      ],
+    };
+
+    expect(getGridHealth(atLimitGame, now)).toMatchObject({
+      state: "at-limit",
+      metric: "0W reserve",
+    });
     expect(
-      screen.getByText(/Grid stable · .*W spare capacity/),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/% reserve/)).not.toBeInTheDocument();
+      getGridHealth(game, {
+        ...now,
+        supplyW: now.demandW - 373000000,
+      } as TickPresentFutureType),
+    ).toMatchObject({
+      state: "blackout",
+      label: "Blackout",
+      metric: "373MW short",
+    });
   });
 
   it("counts only current weather-limited Airborne Wind output as reserve", () => {

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -351,7 +351,7 @@ export function GameAppBar(props: Props) {
       >
         <div className="gridHealthSummary">
           <span className="gridHealthState">
-            <span aria-hidden="true">
+            <span className="gridHealthIcon" aria-hidden="true">
               <ConceptIcon
                 concept={
                   inBlackout

--- a/src/components/base/GameAppBar.tsx
+++ b/src/components/base/GameAppBar.tsx
@@ -77,6 +77,17 @@ const WEATHER_DRIVEN_FUELS = new Set([
   "Airborne Wind",
 ]);
 
+const LOW_RESERVE_RATIO = 0.1;
+
+type GridHealthState = "stable" | "low-reserve" | "at-limit" | "blackout";
+
+interface GridHealth {
+  state: GridHealthState;
+  label: string;
+  metric: string;
+  announcement: string;
+}
+
 /** Capacity that could serve demand now, rather than the deliberately dispatched output. */
 export function reserveCapacityW(
   game: GameType,
@@ -106,6 +117,49 @@ export function reserveCapacityW(
     0,
   );
   return available - now.demandW;
+}
+
+/** Turns the live supply margin into the few states a player can act on at a glance. */
+export function getGridHealth(
+  game: GameType,
+  now: TickPresentFutureType,
+): GridHealth {
+  if (now.supplyW < now.demandW) {
+    return {
+      state: "blackout",
+      label: "Blackout",
+      metric: `${formatWatts(now.demandW - now.supplyW)} short`,
+      announcement: "Blackout. Demand is higher than supply.",
+    };
+  }
+
+  const reserveW = Math.max(0, reserveCapacityW(game, now));
+  if (reserveW === 0) {
+    return {
+      state: "at-limit",
+      label: "At limit",
+      metric: "0W reserve",
+      announcement: "Grid at limit. No reserve remains.",
+    };
+  }
+
+  const reserveRatio = now.demandW > 0 ? reserveW / now.demandW : Infinity;
+  if (reserveRatio <= LOW_RESERVE_RATIO) {
+    const reservePercent = Math.round(reserveRatio * 100);
+    return {
+      state: "low-reserve",
+      label: "Low reserve",
+      metric: `+${formatWatts(reserveW)} reserve (${reservePercent}%)`,
+      announcement: "Low reserve.",
+    };
+  }
+
+  return {
+    state: "stable",
+    label: "Stable",
+    metric: `+${formatWatts(reserveW)} reserve`,
+    announcement: "Grid stable.",
+  };
 }
 
 const SPEED_ARIA_LABELS: { [k in SpeedType]: string } = {
@@ -265,11 +319,8 @@ export function GameAppBar(props: Props) {
     return <span />;
   }
 
-  const inBlackout = now.supplyW < now.demandW;
-  const reserveW = Math.max(0, reserveCapacityW(game, now));
-  const gridHealth = inBlackout
-    ? `Blackout · ${formatWatts(now.demandW - now.supplyW)} short`
-    : `Grid stable · ${formatWatts(reserveW)} spare capacity`;
+  const gridHealth = getGridHealth(game, now);
+  const inBlackout = gridHealth.state === "blackout";
 
   return (
     <div id="appbar">
@@ -295,21 +346,38 @@ export function GameAppBar(props: Props) {
         </Toolbar>
       </div>
       <div
-        className={`gridHealth ${inBlackout ? "gridHealth-blackout" : ""}`}
-        aria-label={`Current grid status: ${gridHealth}`}
+        className={`gridHealth gridHealth-${gridHealth.state}`}
+        aria-label={`Current grid status: ${gridHealth.label}, ${gridHealth.metric}`}
       >
-        <strong>{gridHealth}</strong>
+        <div className="gridHealthSummary">
+          <span className="gridHealthState">
+            <span aria-hidden="true">
+              <ConceptIcon
+                concept={
+                  inBlackout
+                    ? "blackout"
+                    : gridHealth.state === "stable"
+                      ? "supply"
+                      : "danger"
+                }
+                fontSize="small"
+              />
+            </span>
+            <strong>{gridHealth.label}</strong>
+          </span>
+          <span className="gridHealthSeparator" aria-hidden="true">
+            |
+          </span>
+          <strong className="gridHealthMetric">{gridHealth.metric}</strong>
+        </div>
         {inBlackout && (
-          <span>
-            Resume available resources, discharge storage, or plan more
-            capacity.
+          <span className="gridHealthAdvice">
+            Resume generation or discharge storage now.
           </span>
         )}
       </div>
       <span className="srOnly" aria-live="polite">
-        {inBlackout
-          ? "Blackout. Demand is higher than supply."
-          : `Grid stable. Game speed ${speed.toLowerCase()}.`}
+        {gridHealth.announcement}
       </span>
       <div
         id="yearProgressBar"

--- a/src/helpers/Debrief.tsx
+++ b/src/helpers/Debrief.tsx
@@ -153,7 +153,7 @@ function scenarioMetrics(
         concept: "rate",
       },
       {
-        label: "Smallest spare capacity · 2026",
+        label: "Smallest reserve · 2026",
         value:
           minimumMargin === undefined
             ? "Not reached"


### PR DESCRIPTION
## Summary

- move the routine stable reserve readout into a compact, centered desktop toolbar pill while keeping a deliberate two-column row on mobile and narrow tablets
- add scaled low-reserve, at-limit, and blackout states, with immediate recovery guidance during an outage
- announce only grid-state transitions to assistive technology and standardize player-facing terminology on “reserve”

## Screenshots

### Desktop · stable

![Desktop stable reserve](https://github.com/toddmedema/electrify/blob/019c8ed/.github/pr-screenshots/grid-status-reserve/desktop-stable.jpg?raw=1)

### Mobile · stable

![Mobile stable reserve](https://github.com/toddmedema/electrify/blob/019c8ed/.github/pr-screenshots/grid-status-reserve/mobile-stable.jpg?raw=1)

### Mobile · blackout

![Mobile blackout guidance](https://github.com/toddmedema/electrify/blob/019c8ed/.github/pr-screenshots/grid-status-reserve/mobile-blackout.jpg?raw=1)

## Testing

- `npm run check` — 890 tests passed and all scenario invariants held
- `npm run build`
- manual responsive review at 1440×900 and 390×844, including stable, low-reserve, and blackout states
- `npm run test:e2e` — broader run encountered unrelated custom location-picker timeouts across mobile/tablet projects and was stopped after the repeated timeouts; the changed status layouts were reviewed directly at the relevant breakpoints