### PR TITLE
Fix PostCSS path traversal vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17685,32 +17685,20 @@
       }
     },
     "node_modules/resolve-url-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz",
-      "integrity": "sha512-05VEMczVREcbtT7Bz+C+96eUO5HDNvdthIiMB34t7FcF8ehcu4wC0sSgPUubs3XW2Q3CNLJk/BJrCU9wVRymiA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "adjust-sourcemap-loader": "^4.0.0",
         "convert-source-map": "^1.7.0",
         "loader-utils": "^2.0.0",
-        "postcss": "^7.0.35",
+        "postcss": "^8.2.14",
         "source-map": "0.6.1"
       },
       "engines": {
-        "node": ">=8.9"
-      },
-      "peerDependencies": {
-        "rework": "1.0.1",
-        "rework-visit": "1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rework": {
-          "optional": true
-        },
-        "rework-visit": {
-          "optional": true
-        }
+        "node": ">=12"
       }
     },
     "node_modules/resolve-url-loader/node_modules/convert-source-map": {
@@ -17719,31 +17707,6 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/resolve-url-loader/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/resolve-url-loader/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
     },
     "node_modules/resolve-url-loader/node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
       "svgo": "^2.8.3"
     },
     "react-scripts": {
+      "resolve-url-loader": "5.0.0",
       "typescript": "$typescript"
     }
   }


### PR DESCRIPTION
## Summary

- override Create React App's transitive `resolve-url-loader` dependency to 5.0.0
- remove the legacy nested `postcss@7.0.39` installation
- deduplicate all PostCSS consumers onto patched `postcss@8.5.26`
- resolve [Dependabot alert 324](https://github.com/toddmedema/electrify/security/dependabot/324) / CVE-2026-45623

## Validation

- `npm ci`
- `npm run check` (93 suites, 888 tests, and all simulation scenarios passed)
- `npm run build`
- `npm audit --json` confirms PostCSS is no longer reported as vulnerable
