### PR TITLE
Polish mobile UI spacing, controls, and mission results

### DIFF
--- a/e2e/app-spacing.spec.ts
+++ b/e2e/app-spacing.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+const isPhoneProject = (projectName: string) =>
+  projectName === "mobile-390px" || projectName === "mobile-320px";
+
+async function expectNoHorizontalOverflow(
+  locator: import("@playwright/test").Locator,
+) {
+  const overflow = await locator.evaluate((element) =>
+    Math.max(0, element.scrollWidth - element.clientWidth),
+  );
+  expect(overflow).toBeLessThanOrEqual(1);
+}
+
+test("phone surfaces share stable gutters and compact chrome", async ({
+  page,
+}, testInfo) => {
+  test.skip(!isPhoneProject(testInfo.project.name));
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "How to play" }).click();
+  await page.waitForTimeout(400);
+  const manualEntries = page.locator(".manual-entry");
+  const firstManualEntry = await manualEntries.nth(1).boundingBox();
+  const secondManualEntry = await manualEntries.nth(2).boundingBox();
+  expect(firstManualEntry).not.toBeNull();
+  expect(secondManualEntry).not.toBeNull();
+  expect(firstManualEntry!.x).toBeCloseTo(8, 0);
+  expect(
+    secondManualEntry!.y - (firstManualEntry!.y + firstManualEntry!.height),
+  ).toBeCloseTo(8, 0);
+  await expectNoHorizontalOverflow(page.locator("#manual"));
+
+  await page.goto("/?scenario=103");
+  await page.getByRole("button", { name: "Start game", exact: true }).click();
+  await page.getByRole("button", { name: "Events", exact: true }).click();
+  await page.waitForTimeout(400);
+  const eventItems = page.locator(".upcomingEvents .eventLogItem");
+  const firstEvent = await eventItems.nth(0).boundingBox();
+  const secondEvent = await eventItems.nth(1).boundingBox();
+  expect(firstEvent).not.toBeNull();
+  expect(secondEvent).not.toBeNull();
+  expect(firstEvent!.x).toBeCloseTo(8, 0);
+  expect(secondEvent!.y - (firstEvent!.y + firstEvent!.height)).toBeCloseTo(
+    8,
+    0,
+  );
+
+  await page.getByRole("button", { name: "Facilities", exact: true }).click();
+  await page.getByRole("button", { name: "Storage" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Build Storage" }),
+  ).toBeVisible();
+  await page.waitForTimeout(400);
+  await expectNoHorizontalOverflow(page.locator(".constructionHeader"));
+
+  const closeButton = await page
+    .getByRole("button", { name: "close" })
+    .boundingBox();
+  expect(closeButton).not.toBeNull();
+  expect(closeButton!.x + closeButton!.width).toBeLessThanOrEqual(
+    page.viewportSize()!.width,
+  );
+
+  const firstBuildCard = await page
+    .locator(".cardList > .build-list-item")
+    .first()
+    .boundingBox();
+  expect(firstBuildCard).not.toBeNull();
+  expect(firstBuildCard!.x).toBeCloseTo(8, 0);
+  expect(firstBuildCard!.width).toBeCloseTo(page.viewportSize()!.width - 16, 0);
+
+  const buildAction = page
+    .locator(".cardList > .build-list-item .MuiCardHeader-action")
+    .first();
+  const buyButton = await buildAction.getByRole("button").boundingBox();
+  const buildTiming = await buildAction.locator("p").boundingBox();
+  expect(buyButton).not.toBeNull();
+  expect(buildTiming).not.toBeNull();
+  expect(
+    buildTiming!.x - (buyButton!.x + buyButton!.width),
+  ).toBeGreaterThanOrEqual(7);
+  await expectNoHorizontalOverflow(page.locator("#topbar"));
+});

--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -1,10 +1,18 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 const REVIEW_VIEWPORTS = new Set([
   "mobile-320px",
+  "mobile-390px",
   "tablet-768px",
   "desktop-chromium",
 ]);
+
+const dismissTutorial = async (page: Page) => {
+  const exit = page.getByRole("button", { name: "Exit", exact: true });
+  await expect(exit).toBeVisible();
+  await exit.click();
+  await expect(exit).not.toBeVisible();
+};
 
 test("insights header controls stay aligned in one compact row", async ({
   page,
@@ -47,12 +55,14 @@ test("insights header controls stay aligned in one compact row", async ({
   await page
     .getByRole("button", { name: "Start playing", exact: true })
     .click();
+  await dismissTutorial(page);
 
   const insights = page.locator(".insights");
   if (!(await insights.isVisible())) {
     await page.getByRole("button", { name: "Insights", exact: true }).click();
   }
   await expect(insights).toBeVisible();
+  await page.evaluate(() => document.fonts.ready);
 
   const controls = [
     page.locator(".insightsRange"),
@@ -76,6 +86,60 @@ test("insights header controls stay aligned in one compact row", async ({
       Math.max(0, element.scrollWidth - element.clientWidth),
     );
   expect(headerOverflow).toBeLessThanOrEqual(1);
+
+  if (testInfo.project.name.startsWith("mobile-")) {
+    const header = await page.locator(".insightsHeader").boundingBox();
+    expect(header).not.toBeNull();
+    expect(header!.height).toBeGreaterThanOrEqual(52);
+    expect(header!.height).toBeLessThanOrEqual(54);
+
+    const levers = page.locator(".insightsLevers");
+    await expect(levers).toHaveCSS("display", "grid");
+    await expect(levers).toHaveCSS("row-gap", "4px");
+    const [rateButton, rateSummary, rateSlider, trackTitle] = await Promise.all(
+      [
+        levers.getByRole("button", { name: "Rate controls" }).boundingBox(),
+        levers.locator(":scope > .MuiTypography-root").boundingBox(),
+        levers.locator(".budgetSlider").boundingBox(),
+        page
+          .locator('.insightsTrack[data-layer="supplyDemand"] h6')
+          .boundingBox(),
+      ],
+    );
+    expect(rateButton).not.toBeNull();
+    expect(rateSummary).not.toBeNull();
+    expect(rateSlider).not.toBeNull();
+    expect(trackTitle).not.toBeNull();
+    expect(rateSummary!.y - (rateButton!.y + rateButton!.height)).toBeCloseTo(
+      4,
+      1,
+    );
+    expect(rateSlider!.y - (rateSummary!.y + rateSummary!.height)).toBeCloseTo(
+      4,
+      1,
+    );
+    expect(rateSummary!.x).toBeCloseTo(trackTitle!.x, 1);
+    expect(rateSlider!.x).toBeCloseTo(trackTitle!.x, 1);
+    expect(rateSlider!.x + rateSlider!.width).toBeLessThanOrEqual(
+      (page.viewportSize()?.width || 0) - trackTitle!.x + 0.5,
+    );
+
+    if (testInfo.project.name === "mobile-320px") {
+      const trackHeader = page.locator(
+        '.insightsTrack[data-layer="supplyDemand"] .insightsTrackHeader',
+      );
+      const [trackHeaderBox, trackActions] = await Promise.all([
+        trackHeader.boundingBox(),
+        trackHeader.locator(".insightsTrackActions").boundingBox(),
+      ]);
+      expect(trackHeaderBox).not.toBeNull();
+      expect(trackActions).not.toBeNull();
+      expect(trackHeaderBox!.height).toBeLessThanOrEqual(45);
+      expect(trackTitle!.x + trackTitle!.width).toBeLessThanOrEqual(
+        trackActions!.x + 0.5,
+      );
+    }
+  }
 
   const presetName = page.locator(".insightsPresetName");
   await expect(presetName).toHaveCSS("text-overflow", "ellipsis");
@@ -105,16 +169,17 @@ test("compact facility build buttons stay above the chart", async ({
   await page
     .getByRole("button", { name: "Start playing", exact: true })
     .click();
+  await dismissTutorial(page);
 
   const facilities = page.locator(".facilities");
   if (!(await facilities.isVisible())) {
     await page.getByRole("button", { name: "Facilities", exact: true }).click();
   }
   const buildButtons = [
-    page.getByRole("button", { name: "Generator" }),
-    page.getByRole("button", { name: "Storage" }),
+    facilities.getByRole("button", { name: "Generator" }),
+    facilities.getByRole("button", { name: "Storage" }),
   ];
-  const chart = page.locator("#chartSupplyDemand");
+  const chart = facilities.locator("#chartSupplyDemand");
   await expect(chart).toBeVisible();
   const chartBox = await chart.boundingBox();
   const buttonBoxes = await Promise.all(
@@ -126,11 +191,9 @@ test("compact facility build buttons stay above the chart", async ({
     expect(box!.height).toBeLessThanOrEqual(32);
     expect(box!.y + box!.height).toBeLessThanOrEqual(chartBox!.y + 0.5);
   });
-  if (testInfo.project.name === "mobile-390px") {
-    expect(
-      (await facilities.locator(".paneHeader").boundingBox())!.height,
-    ).toBeLessThanOrEqual(41); // 40px content plus the divider
-  }
+  expect(
+    (await facilities.locator(".paneHeader").boundingBox())!.height,
+  ).toBeLessThanOrEqual(41); // 40px content plus the divider
 });
 
 test("main-menu account actions follow the sound action", async ({

--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -57,15 +57,17 @@ test("insights header controls stay aligned in one compact row", async ({
   const controls = [
     page.locator(".insightsRange"),
     page.locator(".insightsPreset"),
-    page.getByRole("button", { name: "Save" }),
     page.getByRole("button", { name: "Preset actions" }),
     page.getByRole("button", { name: /^Layers \(/ }),
   ];
+  if (!testInfo.project.name.startsWith("mobile-")) {
+    controls.splice(2, 0, page.getByRole("button", { name: "Save" }));
+  }
   const boxes = await Promise.all(
     controls.map((control) => control.boundingBox()),
   );
   expect(boxes.every(Boolean)).toBe(true);
-  expect(boxes.map((box) => box!.height)).toEqual([36, 36, 36, 36, 36]);
+  expect(boxes.every((box) => box!.height >= 36)).toBe(true);
   expect(new Set(boxes.map((box) => box!.y)).size).toBe(1);
 
   const headerOverflow = await page
@@ -78,12 +80,51 @@ test("insights header controls stay aligned in one compact row", async ({
   const presetName = page.locator(".insightsPresetName");
   await expect(presetName).toHaveCSS("text-overflow", "ellipsis");
   if (testInfo.project.name === "mobile-320px") {
+    await expect(page.getByRole("button", { name: "Save" })).not.toBeVisible();
+    await expect(page.locator(".insightsRange")).toContainText(
+      "Next 12 months",
+    );
+    await page.getByRole("button", { name: "Preset actions" }).click();
+    await expect(
+      page.getByRole("menuitem", { name: "Save preset changes" }),
+    ).toBeVisible();
     expect(
       await presetName.evaluate(
         (element) => element.scrollWidth > element.clientWidth,
       ),
     ).toBe(true);
   }
+});
+
+test("touch-sized facility build buttons stay above the chart", async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.startsWith("mobile-"));
+  await page.addInitScript(() => window.localStorage.clear());
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: "Start playing", exact: true })
+    .click();
+
+  const facilities = page.locator(".facilities");
+  if (!(await facilities.isVisible())) {
+    await page.getByRole("button", { name: "Facilities", exact: true }).click();
+  }
+  const buildButtons = [
+    page.getByRole("button", { name: "Generator" }),
+    page.getByRole("button", { name: "Storage" }),
+  ];
+  const chart = page.locator("#chartSupplyDemand");
+  await expect(chart).toBeVisible();
+  const chartBox = await chart.boundingBox();
+  const buttonBoxes = await Promise.all(
+    buildButtons.map((button) => button.boundingBox()),
+  );
+  expect(chartBox).not.toBeNull();
+  expect(buttonBoxes.every(Boolean)).toBe(true);
+  buttonBoxes.forEach((box) => {
+    expect(box!.y + box!.height).toBeLessThanOrEqual(chartBox!.y);
+  });
 });
 
 test("main-menu account actions follow the sound action", async ({

--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -96,7 +96,7 @@ test("insights header controls stay aligned in one compact row", async ({
   }
 });
 
-test("touch-sized facility build buttons stay above the chart", async ({
+test("compact facility build buttons stay above the chart", async ({
   page,
 }, testInfo) => {
   test.skip(!testInfo.project.name.startsWith("mobile-"));
@@ -123,8 +123,14 @@ test("touch-sized facility build buttons stay above the chart", async ({
   expect(chartBox).not.toBeNull();
   expect(buttonBoxes.every(Boolean)).toBe(true);
   buttonBoxes.forEach((box) => {
-    expect(box!.y + box!.height).toBeLessThanOrEqual(chartBox!.y);
+    expect(box!.height).toBeLessThanOrEqual(32);
+    expect(box!.y + box!.height).toBeLessThanOrEqual(chartBox!.y + 0.5);
   });
+  if (testInfo.project.name === "mobile-390px") {
+    expect(
+      (await facilities.locator(".paneHeader").boundingBox())!.height,
+    ).toBeLessThanOrEqual(41); // 40px content plus the divider
+  }
 });
 
 test("main-menu account actions follow the sound action", async ({

--- a/public/images/icon/maskable-512x512.png
+++ b/public/images/icon/maskable-512x512.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28f6ce62dd051e0f41729bedb2cb6ba71fea4937ba980a1500d0272351f63509
-size 13187
+oid sha256:98075eddd6aecec79b71196363b60a819e6bcaa3fe13797716059c417b413810
+size 14286

--- a/src/app.scss
+++ b/src/app.scss
@@ -205,6 +205,14 @@ $sizemap: (
   @return null;
 }
 
+// Interface chrome follows a fixed 4px rhythm. The legacy size() scale remains useful for
+// responsive illustration and chart spacing, but vmin-based gutters made otherwise identical
+// cards drift between 4px and 8px as a phone rotated or changed size.
+$space-1: 4px;
+$space-2: 8px;
+$space-3: 12px;
+$space-4: 16px;
+
 // ===============================================
 // Base/General Styles
 // ===============================================
@@ -497,6 +505,11 @@ $topbar_height: 56px;
   padding-right: max(16px, env(safe-area-inset-right)) !important;
 }
 
+#topbar .constructionTitleBar.MuiToolbar-root {
+  padding-left: max($space-2, env(safe-area-inset-left)) !important;
+  padding-right: max($space-2, env(safe-area-inset-right)) !important;
+}
+
 .constructionHeader {
   flex: 0 0 auto;
   background: var(--bg-primary);
@@ -504,37 +517,45 @@ $topbar_height: 56px;
 
 .constructionTitle {
   display: flex;
+  flex: 1 1 auto;
   align-items: center;
   min-width: 0;
-  gap: 12px;
+  gap: $space-3;
 
   .iconLabel {
     min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
   }
 }
 
 .constructionCash {
   flex: 0 0 auto;
+  margin-left: auto;
   font-size: 0.875rem;
   white-space: nowrap;
+}
+
+.constructionTitleBar #close-button {
+  flex: 0 0 auto;
 }
 
 .constructionControls {
   display: grid;
   grid-template-columns: max-content minmax(80px, 1fr) auto;
   align-items: center;
-  gap: 8px;
+  gap: $space-2;
   min-height: 50px;
-  padding: 0 max(8px, env(safe-area-inset-right)) 0
-    max(8px, env(safe-area-inset-left));
+  padding: 0 max($space-2, env(safe-area-inset-right)) 0
+    max($space-2, env(safe-area-inset-left));
   border-bottom: $border_accent;
 }
 
 .constructionCapacity {
   display: flex;
   align-items: baseline;
-  gap: 4px;
+  gap: $space-1;
   white-space: nowrap;
 }
 
@@ -557,15 +578,15 @@ $topbar_height: 56px;
 
 @media screen and (min-width: 600px) {
   .constructionControls {
-    gap: 16px;
-    padding-left: max(16px, env(safe-area-inset-left));
-    padding-right: max(16px, env(safe-area-inset-right));
+    gap: $space-4;
+    padding-left: max($space-4, env(safe-area-inset-left));
+    padding-right: max($space-4, env(safe-area-inset-right));
   }
 }
 
 @media screen and (max-width: 359px) {
   .constructionTitle {
-    gap: 6px;
+    gap: $space-1;
     font-size: 1.05rem !important;
   }
 
@@ -574,9 +595,9 @@ $topbar_height: 56px;
   }
 
   .constructionControls {
-    gap: 4px;
-    padding-left: max(4px, env(safe-area-inset-left));
-    padding-right: max(4px, env(safe-area-inset-right));
+    gap: $space-1;
+    padding-left: max($space-2, env(safe-area-inset-left));
+    padding-right: max($space-2, env(safe-area-inset-right));
   }
 
   .constructionCapacity {
@@ -1327,6 +1348,8 @@ $pane_header_height: 40px;
       .MuiStack-root {
         display: flex;
         flex-wrap: wrap;
+        gap: $space-2;
+        align-items: flex-start;
         justify-content: flex-end;
       }
     }
@@ -1850,15 +1873,15 @@ html[data-theme="dark"] .uplot {
   .conceptLegend {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: size(small);
-    margin-top: size(base);
+    gap: $space-2;
+    margin-top: $space-4;
   }
 
   .conceptLegendItem {
     display: flex;
     align-items: center;
-    gap: size(small);
-    padding: size(small);
+    gap: $space-2;
+    padding: $space-2;
     border: 1px solid var(--border-subtle);
     border-radius: 4px;
     background: var(--bg-raised);
@@ -1872,17 +1895,17 @@ html[data-theme="dark"] .uplot {
   }
 
   .MuiCard-root {
-    margin: 0 size(small) size(base) size(small);
+    margin: 0 $space-2 $space-2;
     border-radius: 0;
     position: relative;
 
     .MuiCardHeader-root {
       align-items: flex-start;
-      padding: size(base);
+      padding: $space-4;
     }
 
     .MuiCardHeader-avatar {
-      margin-right: size(base);
+      margin-right: $space-3;
     }
 
     .MuiCardHeader-action {
@@ -1892,14 +1915,14 @@ html[data-theme="dark"] .uplot {
       text-align: right;
 
       p.MuiTypography-colorTextSecondary {
-        margin-top: size(small);
+        margin-top: $space-1;
       }
     }
   }
 
   .expand-details.MuiButton-root {
     width: calc(100% - 32px);
-    margin: 0 16px size(small);
+    margin: 0 $space-4 $space-2;
     border-top: 1px solid var(--border-subtle);
     border-radius: 0;
   }
@@ -1954,7 +1977,7 @@ html[data-theme="dark"] .uplot {
 
       .gameSubtitle {
         max-width: 380px;
-        margin: 0 auto 20px;
+        margin: 0 auto $space-4;
         color: $font_color_faded;
         font-size: 1.05rem;
         line-height: 1.5;
@@ -1962,7 +1985,7 @@ html[data-theme="dark"] .uplot {
 
       .mainActions {
         align-items: center;
-        margin-bottom: 10px;
+        margin-bottom: $space-2;
 
         .MuiButton-root {
           width: min(100%, 260px);
@@ -1976,7 +1999,7 @@ html[data-theme="dark"] .uplot {
 
       .accountActions {
         align-items: center;
-        margin-top: 6px;
+        margin-top: $space-2;
 
         .MuiTypography-caption {
           font-size: 0.8125rem;
@@ -1985,7 +2008,7 @@ html[data-theme="dark"] .uplot {
       }
 
       .discoveryActions {
-        margin-top: 14px;
+        margin-top: $space-4;
       }
 
       button {
@@ -2051,7 +2074,7 @@ html[data-theme="dark"] .uplot {
 
   #manual {
     figure {
-      margin: size(base) 0;
+      margin: $space-4 0;
     }
 
     img {
@@ -2065,11 +2088,11 @@ html[data-theme="dark"] .uplot {
     figcaption {
       font-size: 0.75rem;
       opacity: 0.7;
-      margin-top: size(small);
+      margin-top: $space-1;
     }
 
     .manual-empty {
-      padding: size(base) size(base) size(base) size(base);
+      padding: $space-4;
       text-align: center;
     }
 
@@ -2092,7 +2115,7 @@ html[data-theme="dark"] .uplot {
   // Manual entries are Accordions rather than clickable Cards, which is what gets them
   // keyboard focus, aria-expanded and a real heading for free
   .manual-entry {
-    margin: 0 size(small) size(base) size(small);
+    margin: 0 $space-2 $space-2;
 
     // MUI zeroes the radius on a square Accordion but keeps the before-pseudo divider that
     // stacked accordions use; these are separate cards, so it isn't wanted
@@ -2101,7 +2124,7 @@ html[data-theme="dark"] .uplot {
     }
 
     .MuiAccordionSummary-root {
-      padding: 0 size(base);
+      padding: 0 $space-4;
 
       &:hover {
         background: var(--bg-raised);
@@ -2116,7 +2139,7 @@ html[data-theme="dark"] .uplot {
     }
 
     .MuiAccordionDetails-root {
-      padding: 0 size(base) size(base) size(base);
+      padding: 0 $space-4 $space-4;
     }
   }
 
@@ -2826,14 +2849,14 @@ html[data-theme="dark"] .uplot {
   // and the only column they share is when they happened
   .eventLogList {
     display: grid;
-    gap: size(small);
+    gap: $space-2;
     margin: 0;
-    padding: 0 size(small) size(small);
+    padding: 0 $space-2 $space-2;
     list-style: none;
   }
 
   .eventLogSection {
-    padding-top: size(small);
+    padding-top: $space-2;
   }
 
   .eventLogSectionHeader {
@@ -2841,7 +2864,7 @@ html[data-theme="dark"] .uplot {
     grid-template-columns: 1fr auto;
     gap: 1px;
     align-items: center;
-    padding: 0 size(base) size(small);
+    padding: 0 $space-4 $space-2;
   }
 
   .eventHistoryFilterButton {
@@ -2931,7 +2954,7 @@ html[data-theme="dark"] .uplot {
   // column would take a third of it to say something the eye only occasionally asks for
   .eventLogWhen {
     grid-column: 2;
-    margin-top: size(tiny);
+    margin-top: $space-1;
     font-size: 0.75rem;
   }
 
@@ -2946,7 +2969,7 @@ html[data-theme="dark"] .uplot {
 
   .eventLogEmpty {
     display: block;
-    padding: size(base);
+    padding: $space-4;
   }
 
   // The change column, and the facility figures that use the same two colours
@@ -3125,6 +3148,8 @@ html[data-theme="dark"] .uplot {
       .MuiStack-root {
         display: flex;
         flex-wrap: wrap;
+        gap: $space-2;
+        align-items: flex-start;
         justify-content: flex-end;
       }
     }

--- a/src/app.scss
+++ b/src/app.scss
@@ -800,6 +800,21 @@ $pane_header_height: 40px;
   }
 }
 
+// Touch targets grow to 44px on coarse pointers. Give the Facilities toolbar the same room so
+// its build controls cannot spill over the supply/demand chart immediately below it.
+@media (pointer: coarse) {
+  .base_main .facilities .MuiToolbar-root.paneHeader {
+    min-height: 48px !important;
+  }
+}
+
+@media (pointer: coarse) and (max-width: 359px) {
+  .base_main .facilities .MuiToolbar-root.paneHeader {
+    row-gap: 8px;
+    padding-bottom: 18px;
+  }
+}
+
 // A control living in a paneHeader alongside the title, pushed to the toolbar's trailing edge --
 // the flex equivalent of .manual-search, for headers with a dropdown instead of a search box
 .headerControl {
@@ -919,6 +934,14 @@ $pane_header_height: 40px;
   }
 }
 
+.insightsPresetSaveMenuItem {
+  display: none !important;
+
+  > svg {
+    margin-right: 12px;
+  }
+}
+
 .insightsLayerPanel {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
@@ -1002,7 +1025,7 @@ $pane_header_height: 40px;
 
   .insightsHeaderControls {
     display: grid;
-    grid-template-columns: 96px minmax(0, 1fr) 36px;
+    grid-template-columns: minmax(128px, 1fr) minmax(88px, 1fr) 36px;
     width: 100%;
     gap: 4px;
     margin-left: 0;
@@ -1020,12 +1043,26 @@ $pane_header_height: 40px;
         width: 100%;
         min-width: 0;
       }
+
+      .insightsPresetSave {
+        display: none;
+      }
     }
 
     .insightsLayerControls {
       width: 36px;
       height: 36px;
     }
+  }
+
+  .insightsPresetSaveMenuItem {
+    display: flex !important;
+  }
+
+  // The custom state already uses the same "Save as new preset" action above. Keep one clear
+  // save action in the compact mobile menu instead of repeating it on adjacent rows.
+  .insightsPresetSaveMenuItem + .insightsPresetSaveAsMenuItem {
+    display: none;
   }
 
   .insightsPresetEdited,
@@ -1661,83 +1698,18 @@ html[data-theme="dark"] .uplot {
 
 .victoryDebrief {
   display: grid;
-  gap: 10px;
-  margin: 10px 0 14px;
-  padding: 12px;
-  border: 1px solid var(--border-tile);
-  border-radius: 10px;
-  background: var(--bg-raised);
-
-  & > h3 {
-    font-weight: 800;
-  }
-}
-
-.victoryFleetComparison {
-  display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: 8px 16px;
+  margin: 16px 0 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-subtle);
 }
 
-.victoryFleetMix h4 {
-  font-weight: 800;
-  line-height: 1.3;
-}
-
-.victoryFleetBar {
-  display: flex;
-  height: 18px;
-  overflow: hidden;
-  border: 1px solid var(--border-strong);
-  border-radius: 9px;
-  background: var(--bg-sunken);
-
-  span {
-    min-width: 3px;
-  }
-
-  .empty {
-    width: 100%;
-    background: var(--border-tile);
-  }
-}
-
-.victoryFleetLegend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2px 8px;
-  margin-top: 4px;
-  color: $font_color_faded;
-  font-size: 0.72rem;
-
-  span {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-  }
-
-  i {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-  }
-}
-
-.victoryDebriefStats {
+.victoryMetric {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 7px;
-
-  & > div {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
-    align-items: center;
-    gap: 2px 6px;
-    padding: 7px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 7px;
-    background: var(--bg-primary);
-  }
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0 7px;
 
   .conceptIcon {
     grid-row: 1 / span 2;
@@ -1748,54 +1720,42 @@ html[data-theme="dark"] .uplot {
     line-height: 1.25;
     overflow-wrap: anywhere;
   }
+
+  > span {
+    color: $font_color_faded;
+    font-size: 0.75rem;
+    line-height: 1.2;
+  }
 }
 
-.victoryHighlights {
-  display: grid;
-  gap: 6px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+.victoryScore,
+.victoryScoreBreakdown,
+.victoryStanding {
+  text-align: center;
+}
 
-  li {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    align-items: start;
-    gap: 7px;
-  }
+.victoryScore {
+  margin: 8px 0 0 !important;
+}
 
-  li span span {
-    display: block;
-  }
+.victoryScoreBreakdown {
+  margin-top: 2px !important;
+}
+
+.victoryStanding {
+  margin-top: 12px !important;
 }
 
 @media (max-width: 520px) {
   .victoryDebrief {
-    padding: 10px;
-  }
-
-  .victoryFleetComparison {
-    grid-template-columns: 1fr;
-  }
-
-  .victoryDebriefStats {
-    grid-template-columns: 1fr;
-
-    & > div {
-      min-height: 48px;
-      padding: 8px 10px;
-    }
+    gap: 8px 12px;
   }
 
   .victoryDialogActions {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 4px;
+    justify-content: center;
 
     & > .MuiButton-root {
-      width: 100%;
       min-height: 40px;
-      margin: 0;
     }
   }
 }

--- a/src/app.scss
+++ b/src/app.scss
@@ -812,6 +812,21 @@ $pane_header_height: 40px;
   }
 }
 
+@media (pointer: coarse) and (max-width: 359px) {
+  .facilities .paneHeader {
+    flex-flow: row nowrap !important;
+    gap: 4px;
+    padding-right: 8px;
+    padding-left: 8px;
+
+    > h6 {
+      min-width: 0;
+      font-size: 1.125rem;
+      white-space: nowrap;
+    }
+  }
+}
+
 // A control living in a paneHeader alongside the title, pushed to the toolbar's trailing edge --
 // the flex equivalent of .manual-search, for headers with a dropdown instead of a search box
 .headerControl {
@@ -1012,7 +1027,9 @@ $pane_header_height: 40px;
 
 @media screen and (max-width: 700px) {
   .base_main .MuiToolbar-root.insightsHeader {
-    min-height: 52px !important;
+    // Toolbar min-height is content height; the 8px padding is added around it. Match the
+    // 36px controls instead of accidentally adding another 16px of empty height.
+    min-height: 36px !important;
     padding: 8px !important;
   }
 
@@ -1083,6 +1100,47 @@ $pane_header_height: 40px;
 
     .MuiButton-root {
       min-height: 44px;
+    }
+  }
+
+  // Keep the planning controls on an explicit four-pixel vertical rhythm. Flex wrapping made
+  // the title and description share a row only at a few in-between widths, and left their
+  // horizontal edges out of step with the track headings below.
+  .insightsLevers {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 4px;
+    padding: 4px 16px 8px;
+
+    > .MuiButton-root {
+      justify-self: start;
+      padding-left: 0;
+
+      .MuiButton-startIcon {
+        margin-left: 0;
+      }
+    }
+
+    .budgetSlider {
+      box-sizing: border-box;
+      width: 100%;
+      min-width: 0;
+    }
+  }
+
+  @media screen and (max-width: 359px) {
+    .base_main .MuiToolbar-root.insightsTrackHeader {
+      flex-flow: row nowrap !important;
+      padding-right: 8px;
+      padding-left: 8px;
+
+      > h6 {
+        min-width: 0;
+        overflow: hidden;
+        font-size: 1.125rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 }

--- a/src/app.scss
+++ b/src/app.scss
@@ -800,18 +800,15 @@ $pane_header_height: 40px;
   }
 }
 
-// Touch targets grow to 44px on coarse pointers. Give the Facilities toolbar the same room so
-// its build controls cannot spill over the supply/demand chart immediately below it.
+// Keep the compact pane-header height on phones while preventing the global coarse-pointer
+// target size from making these two labeled controls spill into the chart below.
 @media (pointer: coarse) {
-  .base_main .facilities .MuiToolbar-root.paneHeader {
-    min-height: 48px !important;
-  }
-}
-
-@media (pointer: coarse) and (max-width: 359px) {
-  .base_main .facilities .MuiToolbar-root.paneHeader {
-    row-gap: 8px;
-    padding-bottom: 18px;
+  .facilities .paneHeader {
+    .button-buildGenerator,
+    .button-buildStorage {
+      height: 32px;
+      min-height: 32px !important;
+    }
   }
 }
 

--- a/src/components/base/VictoryDialog.test.tsx
+++ b/src/components/base/VictoryDialog.test.tsx
@@ -67,22 +67,19 @@ describe("VictoryDialog", () => {
    */
   it("shows the breakdown before any of the async data lands", () => {
     renderDialog();
-    expect(screen.getByText(/812/)).toBeInTheDocument();
-    expect(
-      screen.getByText(/800 pts from electricity supplied/),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/-18 pts from blackouts/)).toBeInTheDocument();
-    expect(screen.queryByText("What you accomplished")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Final score 812 points")).toBeInTheDocument();
+    expect(screen.getByText(/800 electricity supplied/)).toBeInTheDocument();
+    expect(screen.getByText(/-18 blackouts/)).toBeInTheDocument();
   });
 
-  it("uses the scenario name instead of repeating a generic completion title", () => {
+  it("shows one generic completion title", () => {
     renderDialog({ victory: aVictory({ endTitle: "Mission complete!" }) });
 
-    expect(screen.getByText("Deregulation")).toBeInTheDocument();
     expect(screen.getAllByText(/Mission complete/i)).toHaveLength(1);
+    expect(screen.queryByText("Deregulation")).not.toBeInTheDocument();
   });
 
-  it("shows how the fleet and company changed over the run", () => {
+  it("summarizes mission results without replaying the run", () => {
     renderDialog({
       victory: aVictory({
         debrief: {
@@ -118,30 +115,23 @@ describe("VictoryDialog", () => {
       }),
     });
 
-    expect(screen.getByText("The story of your grid")).toBeInTheDocument();
     expect(
-      screen.getByRole("img", { name: /Coal 300MW, Natural Gas 200MW/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("img", { name: /Sun 400MW, Natural Gas 200MW/ }),
-    ).toBeInTheDocument();
+      screen.getByRole("region", { name: "Mission results" }),
+    ).toBeVisible();
     expect(screen.getByText("99.8%")).toBeInTheDocument();
+    expect(screen.getByText("$510M")).toBeInTheDocument();
+    expect(screen.queryByText("$330M")).not.toBeInTheDocument();
     expect(
       screen.getByText("Demand not met during Winter Storm Uri · Feb 2021"),
     ).toBeInTheDocument();
     expect(screen.getByText("12GWh")).toBeInTheDocument();
-    expect(
-      screen.getByText("Construction complete: Solar"),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Construction complete: Solar")).toBeNull();
   });
 
   it("fills in the global rank once it resolves", async () => {
     mockFetchGlobalRank.mockResolvedValue(4);
     renderDialog();
-    expect(
-      await screen.findByText(/on the global leaderboard/),
-    ).toBeInTheDocument();
-    expect(screen.getByText("#4")).toBeInTheDocument();
+    expect(await screen.findByText(/#4 globally/)).toBeInTheDocument();
     expect(mockFetchGlobalRank).toHaveBeenCalledWith(101, 812);
   });
 
@@ -153,14 +143,9 @@ describe("VictoryDialog", () => {
     renderDialog();
 
     await waitFor(() =>
-      expect(
-        screen.queryByLabelText("Working out your rank"),
-      ).not.toBeInTheDocument(),
+      expect(screen.queryByText(/globally/)).not.toBeInTheDocument(),
     );
-    expect(
-      screen.getByText(/800 pts from electricity supplied/),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/global leaderboard/)).not.toBeInTheDocument();
+    expect(screen.getByText(/800 electricity supplied/)).toBeInTheDocument();
     warn.mockRestore();
   });
 
@@ -169,12 +154,11 @@ describe("VictoryDialog", () => {
   it("celebrates a personal best against the previous one", () => {
     renderDialog({ victory: aVictory({ previousBest: 640 }) });
     expect(screen.getByText(/New personal best/)).toBeInTheDocument();
-    expect(screen.getByText(/was 640/)).toBeInTheDocument();
   });
 
   it("reports the best that still stands when the run didn't beat it", () => {
     renderDialog({ victory: aVictory({ score: 500, previousBest: 640 }) });
-    expect(screen.getByText(/Your best: 640/)).toBeInTheDocument();
+    expect(screen.getByText(/Personal best 640/)).toBeInTheDocument();
     expect(screen.queryByText(/New personal best/)).not.toBeInTheDocument();
   });
 
@@ -183,7 +167,7 @@ describe("VictoryDialog", () => {
   it("offers a login rather than a personal best when logged out", () => {
     renderDialog({ loggedIn: false });
     expect(screen.queryByText(/personal best/)).not.toBeInTheDocument();
-    expect(screen.getByText(/under your name/)).toBeInTheDocument();
+    expect(screen.getByText(/join the leaderboard/)).toBeInTheDocument();
   });
 
   // A custom game shares its scenario id with every other custom game, and a replay is someone
@@ -200,7 +184,7 @@ describe("VictoryDialog", () => {
     mockShareText.mockResolvedValue("clipboard");
     renderDialog({ onShared });
 
-    await userEvent.click(screen.getByText("Share"));
+    await userEvent.click(screen.getByRole("button", { name: "Share score" }));
     await waitFor(() => expect(onShared).toHaveBeenCalled());
     expect(onShared.mock.calls[0][1]).toBe("clipboard");
   });
@@ -212,7 +196,7 @@ describe("VictoryDialog", () => {
     mockShareText.mockResolvedValue("cancelled");
     renderDialog({ onShared, onShareFailed });
 
-    await userEvent.click(screen.getByText("Share"));
+    await userEvent.click(screen.getByRole("button", { name: "Share score" }));
     await waitFor(() => expect(mockShareText).toHaveBeenCalled());
     expect(onShared).not.toHaveBeenCalled();
     expect(onShareFailed).not.toHaveBeenCalled();
@@ -237,10 +221,11 @@ describe("VictoryDialog", () => {
       const onClose = jest.fn();
       renderDialog({ victory: aVictory({ outcome }), onClose });
 
-      expect(screen.getByText("Run ended")).toBeInTheDocument();
       expect(screen.getByText(title)).toBeInTheDocument();
       expect(screen.queryByText("How you scored")).not.toBeInTheDocument();
-      expect(screen.getByText(/Final score/)).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Final score 812 points"),
+      ).toBeInTheDocument();
       expect(screen.queryByText("Review grid")).not.toBeInTheDocument();
       await userEvent.keyboard("{Escape}");
       expect(onClose).not.toHaveBeenCalled();
@@ -257,9 +242,7 @@ describe("VictoryDialog", () => {
     });
     expect(screen.getByText("The lights stayed on")).toBeInTheDocument();
     expect(screen.getByText("Your city never noticed.")).toBeInTheDocument();
-    // The breakdown is still there: the override replaces the flavour text, not the score
-    expect(
-      screen.getByText(/800 pts from electricity supplied/),
-    ).toBeInTheDocument();
+    // The compact breakdown remains: the override replaces the flavour text, not the score.
+    expect(screen.getByText(/800 electricity supplied/)).toBeInTheDocument();
   });
 });

--- a/src/components/base/VictoryDialog.tsx
+++ b/src/components/base/VictoryDialog.tsx
@@ -5,8 +5,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
-  Skeleton,
+  IconButton,
   Stack,
   Typography,
 } from "@mui/material";
@@ -14,25 +13,15 @@ import ShareIcon from "@mui/icons-material/Share";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import numbro from "numbro";
-import {
-  GameEventKindType,
-  VictoryDebriefType,
-  VictoryFleetCapacityType,
-  VictoryType,
-} from "../../Types";
+import { VictoryDebriefType, VictoryType } from "../../Types";
 import { fetchGlobalRank } from "../../reducers/User";
 import {
   buildScoreShareContent,
   canShare,
   shareText,
 } from "../../helpers/Share";
-import ConceptIcon, { ConceptNameType } from "./ConceptIcon";
-import { fuelColors } from "../../Theme";
-import {
-  formatMoneyConcise,
-  formatWattHours,
-  formatWatts,
-} from "../../helpers/Format";
+import ConceptIcon from "./ConceptIcon";
+import { formatMoneyConcise } from "../../helpers/Format";
 import { formatLargeMass } from "../../helpers/Units";
 import { useUnits } from "./UnitsContext";
 
@@ -46,15 +35,6 @@ export const SCORE_LABELS: { [key: string]: string } = {
   rate: "electric rates",
   emissions: "emissions",
   blackouts: "blackouts",
-};
-
-const SCORE_CONCEPTS: { [key: string]: ConceptNameType | undefined } = {
-  supply: "supply",
-  netWorth: "money",
-  customers: "customers",
-  rate: "money",
-  emissions: "danger",
-  blackouts: "blackout",
 };
 
 export interface StateProps {
@@ -78,60 +58,6 @@ export function formatScore(score: number): string {
   return numbro(score).format({ thousandSeparated: true, mantissa: 0 });
 }
 
-const EVENT_CONCEPTS: Record<GameEventKindType, ConceptNameType> = {
-  BLACKOUT: "blackout",
-  BLACKOUT_OVER: "supply",
-  CONSTRUCTION: "construction",
-  BUILD: "build",
-  SELL: "money",
-  LOAN: "finances",
-  FUEL_PRICE: "fuel",
-  FUEL_CROSSOVER: "fuel",
-  WORLD_EVENT: "forecast",
-};
-
-function FleetMix(props: {
-  title: string;
-  fleet: VictoryFleetCapacityType[];
-}): React.JSX.Element {
-  const total = props.fleet.reduce((sum, item) => sum + item.watts, 0);
-  const label =
-    props.fleet.length > 0
-      ? props.fleet
-          .map((item) => `${item.fuel} ${formatWatts(item.watts)}`)
-          .join(", ")
-      : "No operational generation";
-  const colors = fuelColors();
-  return (
-    <div className="victoryFleetMix">
-      <Typography variant="overline" component="h4">
-        {props.title}
-      </Typography>
-      <div className="victoryFleetBar" role="img" aria-label={label}>
-        {props.fleet.map((item) => (
-          <span
-            key={item.fuel}
-            style={{
-              flexGrow: item.watts,
-              backgroundColor: colors[item.fuel],
-            }}
-          />
-        ))}
-        {total === 0 && <span className="empty" />}
-      </div>
-      <div className="victoryFleetLegend">
-        {props.fleet.map((item) => (
-          <span key={item.fuel}>
-            <i style={{ backgroundColor: colors[item.fuel] }} />
-            {item.fuel} {formatWatts(item.watts)}
-          </span>
-        ))}
-        {props.fleet.length === 0 && <span>No operational generation</span>}
-      </div>
-    </div>
-  );
-}
-
 function RunDebrief({
   debrief,
 }: {
@@ -141,92 +67,38 @@ function RunDebrief({
   const reliability = `${(debrief.reliability * 100).toFixed(
     debrief.reliability >= 0.999 ? 2 : 1,
   )}%`;
+  const metrics = [
+    { concept: "supply" as const, label: "served", value: reliability },
+    {
+      concept: "money" as const,
+      label: "cash",
+      value: formatMoneyConcise(debrief.finalCash),
+    },
+    {
+      concept: "customers" as const,
+      label: "customers",
+      value: numbro(debrief.finalCustomers).format({ average: true }),
+    },
+    {
+      concept: "danger" as const,
+      label: "emissions",
+      value: formatLargeMass(debrief.kgco2e, units),
+    },
+    ...(debrief.scenarioMetrics || []).map((metric) => ({
+      concept: metric.concept,
+      label: metric.label,
+      value: metric.value,
+    })),
+  ];
   return (
-    <section className="victoryDebrief" aria-labelledby="debrief-title">
-      <Typography id="debrief-title" variant="h6" component="h3">
-        The story of your grid
-      </Typography>
-      <div className="victoryFleetComparison">
-        <FleetMix
-          title="Then · starting capacity"
-          fleet={debrief.startingFleet}
-        />
-        <FleetMix
-          title="Now · operational capacity"
-          fleet={debrief.finalFleet}
-        />
-      </div>
-      <div className="victoryDebriefStats">
-        <div>
-          <ConceptIcon concept="supply" fontSize="small" />
-          <Typography variant="caption">Demand served</Typography>
-          <strong>{reliability}</strong>
+    <section className="victoryDebrief" aria-label="Mission results">
+      {metrics.map((metric) => (
+        <div key={metric.label} className="victoryMetric">
+          <ConceptIcon concept={metric.concept} fontSize="small" />
+          <strong>{metric.value}</strong>
+          <span>{metric.label}</span>
         </div>
-        <div>
-          <ConceptIcon concept="money" fontSize="small" />
-          <Typography variant="caption">Cash</Typography>
-          <strong>
-            {formatMoneyConcise(debrief.startingCash)} →{" "}
-            {formatMoneyConcise(debrief.finalCash)}
-          </strong>
-        </div>
-        <div>
-          <ConceptIcon concept="customers" fontSize="small" />
-          <Typography variant="caption">Customers</Typography>
-          <strong>
-            {numbro(debrief.finalCustomers).format({ average: true })}
-          </strong>
-        </div>
-        <div>
-          <ConceptIcon concept="danger" fontSize="small" />
-          <Typography variant="caption">Emissions</Typography>
-          <strong>{formatLargeMass(debrief.kgco2e, units)}</strong>
-        </div>
-        {debrief.unservedWh > 0 && (
-          <div>
-            <ConceptIcon concept="blackout" fontSize="small" />
-            <Typography variant="caption">Customer demand not met</Typography>
-            <strong>{formatWattHours(debrief.unservedWh)}</strong>
-          </div>
-        )}
-        {debrief.scenarioMetrics?.map((metric) => (
-          <div key={metric.label}>
-            <ConceptIcon concept={metric.concept} fontSize="small" />
-            <Typography variant="caption">{metric.label}</Typography>
-            <strong>{metric.value}</strong>
-          </div>
-        ))}
-      </div>
-      {debrief.highlights.length > 0 && (
-        <>
-          <Divider />
-          <Typography variant="overline" component="h4">
-            Turning points
-          </Typography>
-          <ol className="victoryHighlights">
-            {debrief.highlights.map((event, index) => (
-              <li key={`${event.label}-${index}`}>
-                <ConceptIcon
-                  concept={EVENT_CONCEPTS[event.kind]}
-                  fontSize="small"
-                />
-                <span>
-                  <Typography variant="body2" component="span">
-                    {event.message}
-                  </Typography>
-                  <Typography
-                    variant="caption"
-                    color="textSecondary"
-                    component="span"
-                  >
-                    {event.label}
-                  </Typography>
-                </span>
-              </li>
-            ))}
-          </ol>
-        </>
-      )}
+      ))}
     </section>
   );
 }
@@ -284,16 +156,17 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
   const failed = victory.outcome === "bankrupt" || victory.outcome === "fired";
   const isPersonalBest =
     previousBest === undefined || victory.score > previousBest;
-  let displayTitle =
-    endTitle ||
-    (victory.outcome === "bankrupt"
-      ? "Bankrupt!"
-      : victory.outcome === "fired"
-        ? "Fired!"
-        : `You've retired!`);
-  if (!failed && endTitle && /^mission complete!?$/i.test(endTitle.trim())) {
-    displayTitle = victory.scenarioName;
-  }
+  const displayTitle = failed
+    ? endTitle || (victory.outcome === "bankrupt" ? "Bankrupt!" : "Fired!")
+    : !endTitle || /^mission complete!?$/i.test(endTitle.trim())
+      ? "Mission complete"
+      : endTitle;
+  const breakdownSummary = Object.keys(breakdown)
+    .map(
+      (category) =>
+        `${formatScore(breakdown[category])} ${SCORE_LABELS[category] || category}`,
+    )
+    .join(" · ");
 
   const onShare = () => {
     const content = buildScoreShareContent({
@@ -339,23 +212,16 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
           {failed ? (
             <ReportProblemOutlinedIcon
               color="error"
-              sx={{ fontSize: 52 }}
+              sx={{ fontSize: 44 }}
               aria-hidden
             />
           ) : (
             <EmojiEventsIcon
               color="warning"
-              sx={{ fontSize: 52 }}
+              sx={{ fontSize: 44 }}
               aria-hidden
             />
           )}
-          <Typography
-            variant="overline"
-            color={failed ? "error.main" : "warning.main"}
-            sx={{ fontWeight: 800, letterSpacing: "0.14em" }}
-          >
-            {failed ? "Run ended" : "Mission complete"}
-          </Typography>
           <Typography variant="h5" component="span" sx={{ fontWeight: 800 }}>
             {displayTitle}
           </Typography>
@@ -367,58 +233,49 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
             {endMessage}
           </Typography>
         )}
-        {victory.debrief && <RunDebrief debrief={victory.debrief} />}
-        {victory.debrief && <Divider sx={{ my: 1.5 }} />}
-        <Typography variant="body1" sx={{ fontWeight: 600 }}>
-          Final score: <strong>{formatScore(victory.score)}</strong>
+        <Typography
+          className="victoryScore"
+          variant="h4"
+          component="p"
+          aria-label={`Final score ${formatScore(victory.score)} points`}
+        >
+          <strong>{formatScore(victory.score)}</strong> points
         </Typography>
-        <div style={{ margin: "8px 0" }}>
-          {Object.keys(breakdown).map((category: string) => {
-            const concept = SCORE_CONCEPTS[category];
-            return (
-              <div key={category} className="scoreBreakdownRow">
-                {concept && <ConceptIcon concept={concept} fontSize="small" />}
-                {breakdown[category]} pts from{" "}
-                {SCORE_LABELS[category] || category}
-              </div>
-            );
-          })}
-        </div>
+        <Typography
+          className="victoryScoreBreakdown"
+          variant="body2"
+          color="textSecondary"
+        >
+          {breakdownSummary}
+        </Typography>
+        {victory.debrief && <RunDebrief debrief={victory.debrief} />}
         {ranked && loggedIn && (
-          <Typography variant="body1" style={{ marginTop: 12 }}>
+          <Typography
+            className="victoryStanding"
+            variant="body2"
+            color="textSecondary"
+          >
             {isPersonalBest ? (
-              <strong>
-                New personal best
-                {previousBest !== undefined
-                  ? ` - was ${formatScore(previousBest)}`
-                  : ""}
-              </strong>
+              <span>New personal best</span>
             ) : (
-              <span>Your best: {formatScore(previousBest as number)}</span>
+              <span>Personal best {formatScore(previousBest as number)}</span>
             )}
-          </Typography>
-        )}
-        {ranked && !rankFailed && (
-          <Typography variant="body1" component="div">
-            {rank === undefined ? (
-              <Skeleton width={200} aria-label="Working out your rank" />
-            ) : (
-              <span>
-                <strong>#{formatScore(rank)}</strong> on the global leaderboard
-              </span>
+            {!rankFailed && rank !== undefined && (
+              <span> · #{formatScore(rank)} globally</span>
             )}
           </Typography>
         )}
         {ranked && !loggedIn && (
-          <Typography variant="body2" color="textSecondary" component="div">
-            <Button
-              color="primary"
-              onClick={onLogin}
-              style={{ paddingLeft: 0 }}
-            >
+          <Typography
+            className="victoryStanding"
+            variant="body2"
+            color="textSecondary"
+            component="div"
+          >
+            <Button color="primary" onClick={onLogin} size="small">
               Log in
             </Button>
-            to put this score on the board under your name
+            to join the leaderboard
           </Typography>
         )}
       </DialogContent>
@@ -433,9 +290,13 @@ export default function VictoryDialog(props: Props): React.JSX.Element {
         }}
       >
         {canShare() && (
-          <Button color="primary" onClick={onShare} startIcon={<ShareIcon />}>
-            Share
-          </Button>
+          <IconButton
+            color="primary"
+            onClick={onShare}
+            aria-label="Share score"
+          >
+            <ShareIcon />
+          </IconButton>
         )}
         {!failed && (
           <Button color="primary" onClick={onClose}>

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -1831,6 +1831,25 @@ export default class Insights extends React.Component<Props, State> {
               onClose={() => this.setState({ presetMenuAnchor: null })}
             >
               <MenuItem
+                className="insightsPresetSaveMenuItem"
+                disabled={
+                  !this.state.layers.length ||
+                  (this.state.preset !== "custom" && !this.state.presetDirty) ||
+                  (this.state.preset === "custom" && customLimitReached)
+                }
+                onClick={() => {
+                  this.setState({ presetMenuAnchor: null }, () =>
+                    this.savePresetChanges(),
+                  );
+                }}
+              >
+                <SaveIcon fontSize="small" />
+                {this.state.preset === "custom"
+                  ? "Save as new preset"
+                  : "Save preset changes"}
+              </MenuItem>
+              <MenuItem
+                className="insightsPresetSaveAsMenuItem"
                 disabled={customLimitReached || !this.state.layers.length}
                 onClick={() => this.openPresetDialog("saveAs")}
               >

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -280,6 +280,26 @@ describe("The Shale Boom pilot arc", () => {
       "story:103:shale-boom:freeze-recovery",
       "story:103:shale-boom:normalization",
     ]);
+    expect(upcoming.map(({ title, message }) => ({ title, message }))).toEqual([
+      {
+        title: "Gas prices will fall",
+        message: "Natural gas prices will drop 25% through Feb 2016.",
+      },
+      {
+        title: "Winter freeze will hit",
+        message:
+          "Gas costs will spike and gas plants will be limited to 70% output for three months.",
+      },
+      {
+        title: "Gas output will recover",
+        message:
+          "Plant limits will lift and lower boom-era prices will resume.",
+      },
+      {
+        title: "Gas boom will end",
+        message: "Natural gas prices will return to normal.",
+      },
+    ]);
     expect(resolveStoryAtDate(shaleContext(47)).effects).toEqual({});
   });
 

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -183,6 +183,10 @@ const SHALE_BOOM_ARC: StoryArcDefinitionType = {
       id: "regional-glut",
       schedule: { atMonth: 48 },
       durationMonths: 74,
+      preview: ({ difficulty }) => ({
+        title: "Gas prices will fall",
+        message: `Natural gas prices will drop ${Math.round((1 - SHALE_BOOM_BALANCE[difficulty].boomGasMultiplier) * 100)}% through Feb 2016.`,
+      }),
       describe: ({ difficulty }) => {
         const { boomGasMultiplier } = SHALE_BOOM_BALANCE[difficulty];
         return {
@@ -219,6 +223,13 @@ const SHALE_BOOM_ARC: StoryArcDefinitionType = {
       id: "freeze",
       schedule: { atMonth: 96 },
       durationMonths: 3,
+      preview: ({ difficulty }) => {
+        const balance = SHALE_BOOM_BALANCE[difficulty];
+        return {
+          title: "Winter freeze will hit",
+          message: `Gas costs will spike and gas plants will be limited to ${Math.round(balance.freezeGasOutput * 100)}% output for three months.`,
+        };
+      },
       describe: ({ difficulty }) => {
         const balance = SHALE_BOOM_BALANCE[difficulty];
         const effectiveMultiplier =
@@ -249,6 +260,10 @@ const SHALE_BOOM_ARC: StoryArcDefinitionType = {
     {
       id: "normalization",
       schedule: { atMonth: 122 },
+      preview: () => ({
+        title: "Gas boom will end",
+        message: "Natural gas prices will return to normal.",
+      }),
       describe: ({ snapshot }) => {
         const gasShare = share(
           snapshot.deliveredWhByFuel12m["Natural Gas"] || 0,
@@ -276,6 +291,11 @@ const SHALE_BOOM_ARC: StoryArcDefinitionType = {
     {
       id: "freeze-recovery",
       schedule: { atMonth: 99 },
+      preview: () => ({
+        title: "Gas output will recover",
+        message:
+          "Plant limits will lift and lower boom-era prices will resume.",
+      }),
       describe: ({ difficulty }) => ({
         title: "Winter freeze ends",
         message: `Gas output is fully restored, and prices return to the ${Math.round((1 - SHALE_BOOM_BALANCE[difficulty].boomGasMultiplier) * 100)}% reduction caused by the shale gas boom.`,


### PR DESCRIPTION
## Summary
- move mobile insight-preset saving into the preset menu so forecast ranges have room for their full labels
- normalize mobile Insights spacing with a compact selector bar, consistent Rate controls rhythm, aligned content edges, and one-row narrow track headers
- extend that spacing audit across every major app surface with a fixed 4px rhythm: 8px list/card gutters and sibling gaps, 16px content padding, and predictable menu-group spacing
- keep compact construction chrome and card actions inside 320px, including visible cash/close controls and separated purchase metadata
- keep the original Facilities toolbar height while shortening its mobile build buttons so they stay clear of the supply/demand chart
- replace the maskable PWA icon background with white to match the loading screen
- simplify mission-end results to one headline, one score breakdown, and a compact results grid
- rewrite Shale Boom upcoming events as short future-tense warnings while preserving live event copy

## Validation
- `npm run check`
- `npm run build`
- `npm run test:e2e` (59 passed, 36 intentionally skipped by viewport)
- new 320px and 390px geometry coverage for manual cards, event cards, construction chrome, build cards, action spacing, and horizontal overflow

![Mobile Insights showing the full Next 5 years label and polished spacing through Rate controls](https://github.com/user-attachments/assets/00fa0a14-0eea-465b-9190-6fa0a763fb0f)

![Build Storage at phone width showing the shared card rhythm and compact overflow-free construction controls](https://github.com/user-attachments/assets/e626ef6f-808e-4db2-9fe1-142fc2d97ce5)

![Simplified mobile mission-end results card](https://github.com/user-attachments/assets/054d94b5-dd2e-4ff0-abde-a7c0d186730d)
