### PR TITLE
Add California wildfire emergency scenario

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,25 @@ files are large, so broad rewrites create expensive review diffs.
 - Reducer changes should have a reducer/helper test and should run `npm run sim -- --all`. UI flow,
   responsive layout, or tutorial changes may also need a Playwright spec.
 
+## Icon design
+
+- Match the existing scenario and facility icon system: use a `0 0 500 500` SVG view box, a bold
+  circular silhouette where appropriate, flat fills, black outlines, and no text, gradients,
+  filters, or decorative detail that disappears at small sizes.
+- Use the shared stroke hierarchy exactly: `40` for the outer boundary, `20` for primary interior
+  shapes, and `10` for secondary detail. Do not introduce in-between stroke widths to compensate
+  for imprecise geometry.
+- Prefer the fewest shapes and anchor points that communicate the concept. Build on clean circles,
+  straight segments, and simple curves; keep repeated elements equal in size and spacing.
+- Align geometry to deliberate centers, baselines, and axes. Use whole-number coordinates, mirror
+  symmetric elements from a shared axis, and account for stroke extents so forms do not crowd or
+  clip the 500 px canvas.
+- Preserve legibility at the icon's actual UI size. Review both the full-size SVG and a rasterized
+  small-size preview, checking silhouette, contrast, optical centering, and separation between
+  overlapping forms before choosing an option.
+- Include concise SVG `<title>` and `<desc>` elements for scenario icons. Reuse the established
+  palette and visual language from nearby icons instead of adding a one-off illustration style.
+
 ## Guardrails
 
 - Keep seeded simulation paths deterministic. Use the seed helpers in `src/helpers/Math.tsx`, not

--- a/e2e/new-game-responsive.spec.ts
+++ b/e2e/new-game-responsive.spec.ts
@@ -53,6 +53,9 @@ test("game picker prioritizes one lesson and filters the challenge catalog", asy
     page.getByRole("button", { name: "View Heatwave + Drought details" }),
   ).toBeVisible();
   await expect(
+    page.getByRole("button", { name: "View Wildfire Emergency details" }),
+  ).toBeVisible();
+  await expect(
     page.getByRole("button", { name: "View Deep Freeze details" }),
   ).toBeVisible();
   await expect(

--- a/e2e/wildfire-scenario.spec.ts
+++ b/e2e/wildfire-scenario.spec.ts
@@ -1,0 +1,58 @@
+import path from "path";
+import { expect, test } from "@playwright/test";
+
+const REVIEW_PROJECTS = new Set(["desktop-chromium", "mobile-390px"]);
+
+test("wildfire briefing and ongoing emergency stay usable", async ({
+  page,
+}, testInfo) => {
+  test.skip(!REVIEW_PROJECTS.has(testInfo.project.name));
+  await page.addInitScript(() => window.localStorage.clear());
+  await page.goto("/?scenario=111");
+
+  await expect(
+    page.getByRole("heading", { name: "Wildfire Emergency" }),
+  ).toBeVisible();
+  await expect(page.getByText("LOS ANGELES, CA")).toBeVisible();
+  await expect(page.getByText(/Safety shutoffs will cut sales/)).toBeVisible();
+
+  const reviewDir = process.env.REVIEW_SCREENSHOT_DIR;
+  if (reviewDir && testInfo.project.name === "desktop-chromium") {
+    // Let the incoming details card finish sliding over the main menu before capturing the frame.
+    await page.waitForTimeout(400);
+    await page.screenshot({
+      path: path.join(reviewDir, "wildfire-briefing-desktop.png"),
+    });
+  }
+
+  await page.getByRole("button", { name: "Start game" }).click();
+  await page.getByRole("button", { name: "Events", exact: true }).click();
+  await page
+    .locator("#appbar:visible")
+    .getByRole("button", { name: "fast speed" })
+    .first()
+    .click();
+
+  await expect(
+    page.getByRole("heading", { name: "Ongoing events" }),
+  ).toBeVisible({ timeout: 25000 });
+  await expect(page.getByText("Wildfire emergency")).toBeVisible();
+  await expect(page.getByText("Through Feb 2025")).toBeVisible();
+  await expect(page.getByText(/restoration costs \$1\.5M/)).toBeVisible();
+  await expect(page.getByText("Red-flag warning")).toBeVisible();
+
+  const horizontalOverflow = await page
+    .locator(".eventLog:visible")
+    .last()
+    .evaluate((element) =>
+      Math.max(0, element.scrollWidth - element.clientWidth),
+    );
+  expect(horizontalOverflow).toBeLessThanOrEqual(1);
+
+  if (reviewDir) {
+    await page.screenshot({
+      path: path.join(reviewDir, `wildfire-event-${testInfo.project.name}.png`),
+      fullPage: true,
+    });
+  }
+});

--- a/public/images/wildfire emergency.svg
+++ b/public/images/wildfire emergency.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2f345737dde6f9f5f10e5744afd19bc361d0e607bdad89c653dc73f05cdeee2
-size 861
+oid sha256:aa32af1f43e669acabb8dea2deda490097824378fe5597e9cfbb0ed97a4d96c8
+size 863

--- a/public/images/wildfire emergency.svg
+++ b/public/images/wildfire emergency.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa32af1f43e669acabb8dea2deda490097824378fe5597e9cfbb0ed97a4d96c8
-size 863
+oid sha256:eebd93316bdd6eb38cebb8722d946301de2f78926b55ff5778d849014e42fa3f
+size 868

--- a/public/images/wildfire emergency.svg
+++ b/public/images/wildfire emergency.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f345737dde6f9f5f10e5744afd19bc361d0e607bdad89c653dc73f05cdeee2
+size 861

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -700,6 +700,8 @@ export interface WorldEventEffectsType {
   carbonFeePerKgCO2e?: number;
   buildCostMultipliersByFuel?: Partial<Record<FuelNameType, number>>;
   operatingCostMultipliersByFuel?: Partial<Record<FuelNameType, number>>;
+  /** Fixed company-wide operating expense charged once per active story month. */
+  operatingExpensePerMonth?: number;
   facilityOutputMultipliersByFuel?: Partial<Record<FuelNameType, number>>;
   facilityOutputMultipliersById?: Record<string, number>;
 }
@@ -744,6 +746,13 @@ export interface ActiveWorldEventType {
   effects: WorldEventEffectsType;
   /** False for surprises that must not appear in the event list or forward forecasts. */
   forecastable?: boolean;
+  // Presentation travels with a persisted occurrence so the Events pane can continue to explain
+  // an ongoing effect after a save/load without re-resolving authored content.
+  title?: string;
+  message?: string;
+  concept?: ConceptNameType;
+  importance?: GameEventImportanceType;
+  actionTarget?: StoryActionTargetType;
 }
 
 export interface WorldEventStateType {

--- a/src/app.scss
+++ b/src/app.scss
@@ -2881,6 +2881,17 @@ html[data-theme="dark"] .uplot {
     width: 24px;
   }
 
+  // Active scenario effects stay pinned above the historical feed for their whole duration, so
+  // a player can always answer "what is changing the grid right now?" after dismissing the alert.
+  .ongoingEvents {
+    border-bottom: 1px solid var(--border-strong);
+    background: var(--blackout-tint);
+
+    .eventLogIcon {
+      color: $blackout_red;
+    }
+  }
+
   // Forecasts are grouped on a sunken surface and deliberately stay neutral: a future critical
   // event should not look like a red, active emergency before it has happened.
   .upcomingEvents {

--- a/src/components/views/EventLog.test.tsx
+++ b/src/components/views/EventLog.test.tsx
@@ -61,6 +61,47 @@ describe("EventLog", () => {
     expect(screen.queryByText("Critical")).not.toBeInTheDocument();
   });
 
+  it("pins an ongoing emergency above upcoming events and history", () => {
+    render(
+      <EventLog
+        events={[
+          {
+            id: 1,
+            kind: "BUILD",
+            label: "Dec 2024",
+            message: "Battery project completed.",
+          },
+        ]}
+        ongoing={[
+          {
+            key: "story:111:california-wildfire-2025:firestorm",
+            label: "Through Feb 2025",
+            title: "Wildfire emergency",
+            message: "Safety shutoffs and restoration work remain active.",
+            concept: "danger",
+            importance: "CRITICAL",
+            actionTarget: { card: "FACILITIES", view: "FLEET" },
+          },
+        ]}
+        upcoming={[
+          {
+            key: "next",
+            label: "Expected Mar 2025",
+            message: "Restoration review.",
+          },
+        ]}
+        onOpen={jest.fn()}
+        onSelect={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Ongoing events")).toBeVisible();
+    expect(screen.getByText("Wildfire emergency")).toBeVisible();
+    expect(screen.getByText("Through Feb 2025")).toBeVisible();
+    expect(screen.getByText("Upcoming events")).toBeVisible();
+    expect(screen.getByText("Event history")).toBeVisible();
+  });
+
   it("keeps upcoming and past events in labeled sections", () => {
     render(
       <EventLog

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -90,6 +90,7 @@ export interface UpcomingStoryEventType {
 export interface StateProps {
   events: GameEventType[];
   upcoming?: UpcomingStoryEventType[];
+  ongoing?: UpcomingStoryEventType[];
 }
 
 export interface DispatchProps {
@@ -100,7 +101,7 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 export default function EventLog(props: Props): React.JSX.Element {
-  const { events, onOpen, onSelect, upcoming = [] } = props;
+  const { events, onOpen, onSelect, upcoming = [], ongoing = [] } = props;
   const [historyFilter, setHistoryFilter] =
     React.useState<EventHistoryFilterType>("ALL");
   const [filterAnchor, setFilterAnchor] = React.useState<HTMLElement | null>(
@@ -121,6 +122,65 @@ export default function EventLog(props: Props): React.JSX.Element {
   return (
     <GameCard className="eventLog" title="Events" id="eventsPane">
       <div className="scrollable">
+        {ongoing.length > 0 && (
+          <section
+            className="eventLogSection ongoingEvents"
+            aria-labelledby="ongoingEventsTitle"
+          >
+            <header className="eventLogSectionHeader">
+              <Typography id="ongoingEventsTitle" variant="subtitle2">
+                Ongoing events
+              </Typography>
+            </header>
+            <ul className="eventLogList">
+              {ongoing.map((event) => (
+                <li
+                  className={`eventLogItem ongoing importance-${event.importance || "ROUTINE"}${event.actionTarget ? " actionable" : ""}`}
+                  key={event.key}
+                  onClick={() => onSelect(event.actionTarget)}
+                  onKeyDown={(e: React.KeyboardEvent<HTMLLIElement>) => {
+                    if (
+                      event.actionTarget &&
+                      (e.key === "Enter" || e.key === " ")
+                    ) {
+                      e.preventDefault();
+                      onSelect(event.actionTarget);
+                    }
+                  }}
+                  role={event.actionTarget ? "button" : undefined}
+                  tabIndex={event.actionTarget ? 0 : undefined}
+                >
+                  <span className="eventLogIcon">
+                    <ConceptIcon
+                      concept={event.concept || "forecast"}
+                      fontSize="small"
+                    />
+                  </span>
+                  <span>
+                    {event.title && <strong>{event.title}</strong>}
+                    <span className="eventLogCopy">
+                      <Typography
+                        variant="body2"
+                        component="span"
+                        sx={{ display: "block" }}
+                      >
+                        {event.message}
+                      </Typography>
+                    </span>
+                  </span>
+                  <Typography
+                    className="eventLogWhen"
+                    variant="body2"
+                    color="textSecondary"
+                    component="span"
+                  >
+                    {event.label}
+                  </Typography>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
         {upcoming.length > 0 && (
           <section
             className="eventLogSection upcomingEvents"

--- a/src/components/views/EventLogContainer.test.tsx
+++ b/src/components/views/EventLogContainer.test.tsx
@@ -1,4 +1,7 @@
-import { navigationForStoryTarget } from "./EventLogContainer";
+import { navigationForStoryTarget, selectOngoing } from "./EventLogContainer";
+import { createGame } from "../../testing/Simulator";
+import { AppStateType } from "../../Types";
+import { getDateFromMinute, MINUTES_PER_MONTH } from "../../helpers/DateTime";
 
 describe("story action targets", () => {
   it("routes a generator target to the quote screen and preserves its fuel", () => {
@@ -26,5 +29,35 @@ describe("story action targets", () => {
       name: "EVENTS",
       storyTarget: { card: "EVENTS" },
     });
+  });
+});
+
+describe("ongoing story events", () => {
+  it("keeps persisted presentation and formats the inclusive end month", () => {
+    const game = createGame({ scenarioId: 111 });
+    game.date = getDateFromMinute(12 * MINUTES_PER_MONTH, game.startingYear);
+    game.worldEvents.active = [
+      {
+        key: "story:111:california-wildfire-2025:firestorm",
+        definitionId: "california-wildfire-2025:firestorm",
+        startsMinute: 12 * MINUTES_PER_MONTH,
+        endsMinute: 14 * MINUTES_PER_MONTH,
+        attributes: {},
+        effects: { demandMultiplier: 0.94 },
+        title: "Wildfire emergency",
+        message: "Safety shutoffs are active.",
+        concept: "danger",
+        importance: "CRITICAL",
+        actionTarget: { card: "FACILITIES", view: "FLEET" },
+      },
+    ];
+
+    expect(selectOngoing({ game } as AppStateType)).toEqual([
+      expect.objectContaining({
+        key: "story:111:california-wildfire-2025:firestorm",
+        title: "Wildfire emergency",
+        label: "Through Feb 2025",
+      }),
+    ]);
   });
 });

--- a/src/components/views/EventLogContainer.tsx
+++ b/src/components/views/EventLogContainer.tsx
@@ -31,6 +31,7 @@ export function navigationForStoryTarget(
 let upcomingCache:
   { key: string; events: UpcomingStoryEventType[] } | undefined;
 const NO_UPCOMING: UpcomingStoryEventType[] = [];
+const NO_ONGOING: UpcomingStoryEventType[] = [];
 
 function selectUpcoming(state: AppStateType): UpcomingStoryEventType[] {
   const game = state.game;
@@ -108,9 +109,41 @@ function selectUpcoming(state: AppStateType): UpcomingStoryEventType[] {
   return events;
 }
 
+export function selectOngoing(state: AppStateType): UpcomingStoryEventType[] {
+  const game = state.game;
+  const ongoing = game.worldEvents.active
+    .filter(
+      (event) =>
+        event.endsMinute > game.date.minute && event.message !== undefined,
+    )
+    .map((event) => {
+      const through = getDateFromMinute(
+        event.endsMinute - 1,
+        game.startingYear,
+      );
+      return {
+        key: event.key,
+        label: `Through ${through.month} ${through.year}`,
+        title: event.title,
+        message: event.message!,
+        concept: event.concept,
+        importance: event.importance,
+        actionTarget: event.actionTarget,
+      };
+    });
+  return ongoing.length > 0 ? ongoing : NO_ONGOING;
+}
+
 const mapStateToProps = (state: AppStateType): StateProps => {
+  const ongoing = selectOngoing(state);
+  const ongoingKeys = new Set(ongoing.map((event) => event.key));
   return {
-    events: state.game.eventLog,
+    // An active story belongs in the status section; its original log row returns to history as
+    // soon as the effect expires.
+    events: state.game.eventLog.filter(
+      (event) => !event.storyPhaseKey || !ongoingKeys.has(event.storyPhaseKey),
+    ),
+    ongoing,
     upcoming: selectUpcoming(state),
   };
 };

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -102,6 +102,7 @@ describe("NewGame", () => {
     fireEvent.click(screen.getByRole("button", { name: "Extreme weather" }));
     expect(challengeRows().map((row) => row.textContent)).toEqual([
       expect.stringContaining("Heatwave + Drought"),
+      expect.stringContaining("Wildfire Emergency"),
       expect.stringContaining("Deep Freeze"),
       expect.stringContaining("Hurricane Season"),
     ]);

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "./Scenarios";
 import { AppStateType, ScenarioType } from "../Types";
 import { render, screen } from "@testing-library/react";
+import { getScenarioLocation } from "../helpers/Locations";
 
 describe("getScenario", () => {
   it("finds an authored scenario by id", () => {
@@ -290,6 +291,7 @@ describe("authored starting fleets", () => {
       ["Deep Freeze", "Natural Gas"],
       ["Heatwave + Drought", "Hydro"],
       ["Sudden Nuclear Shutdown", "Uranium"],
+      ["Wildfire Emergency", "Natural Gas"],
     ]);
   });
 
@@ -332,15 +334,44 @@ describe("authored starting fleets", () => {
 
   it("keeps locations in scenario metadata rather than scenario names", () => {
     expect(
-      [107, 108, 110].map((id) => ({
+      [107, 108, 110, 111].map((id) => ({
         name: getScenario(id)!.name,
-        location: getScenario(id)!.location?.name,
+        location: getScenarioLocation(getScenario(id))?.name,
       })),
     ).toEqual([
       { name: "Deep Freeze", location: "Austin, TX" },
       { name: "Heatwave + Drought", location: "Madrid, Spain" },
       { name: "Sudden Nuclear Shutdown", location: "Paris, France" },
+      { name: "Wildfire Emergency", location: "Los Angeles, CA" },
     ]);
+  });
+
+  it("authors a Los Angeles-only January 2025 wildfire challenge", () => {
+    const wildfire = getScenario(111)!;
+
+    expect(wildfire).toMatchObject({
+      name: "Wildfire Emergency",
+      icon: "wildfire emergency",
+      locationId: "LA",
+      startingYear: 2024,
+      durationMonths: 36,
+      startingCustomers: 16_000,
+      reliabilityObjective: {
+        year: 2025,
+        month: 1,
+        durationMonths: 2,
+        minimumDemandServed: 1,
+      },
+    });
+    expect(wildfire.briefing?.threat).toMatch(
+      /safety shutoffs.*sales.*restoration costs/i,
+    );
+    expect(
+      wildfire.facilities.reduce(
+        (total, facility) => total + (facility.peakW || 0),
+        0,
+      ),
+    ).toBe(80_810_000);
   });
 
   it("makes every plant in the aging coal fleet at least 20 years old", () => {

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -1048,6 +1048,61 @@ export const SCENARIOS = [
     endMessage:
       "The sudden shutdown tested the backup capacity your normal plan rarely needed.",
   },
+  {
+    id: 111, // Scenario IDs are persisted and shared; append rather than renumbering.
+    name: "Wildfire Emergency",
+    icon: "wildfire emergency",
+    locationId: "LA",
+    summary: "Prepare Los Angeles for the January 2025 firestorm.",
+    themes: ["Extreme weather"],
+    briefing: {
+      tone: "storm",
+      fantasy:
+        "Guide Los Angeles through extreme fire weather and a long restoration effort.",
+      objective:
+        "Keep all connected customers supplied during the January and February 2025 wildfire emergency.",
+      threat:
+        "Safety shutoffs will cut sales, constrain part of the fleet, and raise restoration costs.",
+    },
+    ownership: "Public",
+    startingYear: 2024,
+    durationMonths: 36,
+    // A 1%-scale model of LADWP's roughly 1.6 million electric customers and 20,749 GWh of
+    // FY2023-24 retail sales. The demand scale reconciles the account-based load model to that
+    // annual energy total. https://www.ladwp.com/who-we-are/power-system
+    startingCustomers: 16000,
+    startingDemandScale: 3.55,
+    dollarsPerkWh: 0.17,
+    cash: 50000000,
+    feePerKgCO2e: 50 / 1000,
+    reliabilityObjective: {
+      year: 2025,
+      month: 1,
+      durationMonths: 2,
+      minimumDemandServed: 1,
+      label: "January and February 2025 wildfire emergency",
+    },
+    // One percent of LADWP's 8,081 MW net dependable capacity, grouped into six readable
+    // resources using its 2024 power-content mix as the portfolio anchor.
+    // https://www.ladwp.com/who-we-are/power-system/power-content-label
+    facilities: [
+      {
+        fuel: "Natural Gas",
+        peakW: 24240000,
+        initialAgeYears: 18,
+        label: "Harbor Gas Portfolio",
+      },
+      { fuel: "Sun", peakW: 17000000, initialAgeYears: 6 },
+      { fuel: "Uranium", peakW: 12120000, initialAgeYears: 30 },
+      { fuel: "Wind", peakW: 10500000, initialAgeYears: 8 },
+      { fuel: "Coal", peakW: 8890000, initialAgeYears: 35 },
+      { fuel: "Geothermal", peakW: 8060000, initialAgeYears: 20 },
+      { name: "Battery", peakWh: 20000000, initialAgeYears: 4 },
+    ],
+    endTitle: "After the firestorm",
+    endMessage:
+      "The emergency tested whether backup power and financial reserves could carry Los Angeles through shutoffs and restoration.",
+  },
 ] as ScenarioType[];
 
 // The opening missions, in the order a new player should work through them

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -2,6 +2,7 @@ import { LOCATIONS } from "../Constants";
 import { getDateFromMinute, MINUTES_PER_MONTH } from "../helpers/DateTime";
 import { StorySnapshotType } from "../Types";
 import {
+  CALIFORNIA_WILDFIRE_BALANCE,
   combineStoryEffects,
   CARBON_FEE_BALANCE,
   END_OF_ERA_BALANCE,
@@ -169,6 +170,7 @@ describe("story effect composition", () => {
             temperatureOffsetC: -4,
             fuelPriceMultipliers: { "Natural Gas": 0.75 },
             carbonFeePerKgCO2e: 0.1,
+            operatingExpensePerMonth: 1000,
           },
         },
         {
@@ -177,6 +179,7 @@ describe("story effect composition", () => {
             temperatureOffsetC: 2,
             fuelPriceMultipliers: { "Natural Gas": 1.8 },
             carbonFeePerKgCO2e: 0.1,
+            operatingExpensePerMonth: 2500,
           },
         },
       ]),
@@ -185,6 +188,7 @@ describe("story effect composition", () => {
       temperatureOffsetC: -2,
       fuelPriceMultipliers: { "Natural Gas": 1.35 },
       carbonFeePerKgCO2e: 0.1,
+      operatingExpensePerMonth: 3500,
     });
   });
 
@@ -306,7 +310,7 @@ describe("The Shale Boom pilot arc", () => {
   it("authors every scenario with deterministic story events and no custom game", () => {
     expect(
       [...new Set(STORY_ARC_DEFINITIONS.map((arc) => arc.scenarioId))].sort(),
-    ).toEqual([100, 101, 102, 103, 104, 105, 107, 108, 110]);
+    ).toEqual([100, 101, 102, 103, 104, 105, 107, 108, 110, 111]);
     expect(resolveStoryAtDate(context(48, 999)).occurrences).toEqual([]);
   });
 
@@ -325,6 +329,8 @@ describe("The Shale Boom pilot arc", () => {
       "seasonal-warning",
       "advance-warning",
       "contingency-review",
+      "red-flag-warning",
+      "restoration-complete",
     ]);
 
     STORY_ARC_DEFINITIONS.forEach((arc) => {
@@ -494,6 +500,102 @@ describe("generation and storage reliability scenarios", () => {
     expect(trip.attributes.selectedFacilityNames).toEqual([
       "Grand Nuclear Unit",
     ]);
+  });
+});
+
+describe("California wildfire emergency", () => {
+  const wildfireContext = (month: number) => ({
+    ...context(month, 111, 2468),
+    location: LOCATIONS.LA,
+    snapshot: {
+      ...EMPTY_SNAPSHOT,
+      facilities: [
+        {
+          id: 10,
+          name: "Harbor Gas Portfolio",
+          fuel: "Natural Gas" as const,
+          ageYears: 18,
+          peakW: 60,
+          operational: true,
+        },
+        {
+          id: 11,
+          name: "Solar Portfolio",
+          fuel: "Sun" as const,
+          ageYears: 6,
+          peakW: 40,
+          operational: true,
+        },
+        {
+          id: 12,
+          name: "Battery",
+          ageYears: 4,
+          peakW: 100,
+          operational: true,
+        },
+      ],
+    },
+  });
+
+  it("applies the fixed January 2025 emergency only to scenario 111", () => {
+    const january = resolveStoryAtDate(wildfireContext(12));
+    const february = resolveStoryAtDate(wildfireContext(13));
+
+    expect(january.occurrences[0]).toMatchObject({
+      key: "story:111:california-wildfire-2025:firestorm",
+      title: "Wildfire emergency",
+      importance: "CRITICAL",
+      effects: { demandMultiplier: 0.94 },
+    });
+    expect(january.effects.facilityOutputMultipliersById).toBeDefined();
+    expect(january.effects.operatingExpensePerMonth).toBe(2_000_000);
+    expect(february.effects).toEqual(january.effects);
+    expect(resolveStoryAtDate(wildfireContext(14)).effects).toEqual({});
+    expect(
+      resolveStoryAtDate({ ...wildfireContext(12), scenarioId: 999 })
+        .occurrences,
+    ).toEqual([]);
+    expect(
+      resolveStoryAtDate({ ...wildfireContext(12), scenarioId: 0 }).occurrences,
+    ).toEqual([]);
+  });
+
+  it("previews one emergency and reports the recorded restoration result", () => {
+    const upcoming = upcomingStoryPhases(wildfireContext(0));
+    expect(upcoming.map((phase) => phase.key)).toEqual([
+      "story:111:california-wildfire-2025:firestorm",
+    ]);
+    expect(upcoming[0].message).toMatch(/safety shutoffs/i);
+
+    const onset = resolveStoryAtDate(wildfireContext(12)).occurrences[0];
+    const restoration = resolveStoryAtDate({
+      ...wildfireContext(14),
+      periodSnapshots: {
+        2: {
+          deliveredWhByFuel: {},
+          demandWh: 100,
+          unservedWh: 1,
+          netIncome: -10,
+          peakDemandW: 10,
+        },
+      },
+      occurrences: [onset],
+    }).occurrences[0];
+    expect(restoration).toMatchObject({
+      key: "story:111:california-wildfire-2025:restoration-complete",
+      attributes: { reliability: 0.99 },
+    });
+    expect(restoration.message).toMatch(/met 99% of connected demand/i);
+  });
+
+  it("checks in the Manager balance values", () => {
+    expect(CALIFORNIA_WILDFIRE_BALANCE.Manager).toEqual({
+      disconnectedDemand: 0.06,
+      targetCapacityShare: 0.5,
+      outputMultiplier: 0.45,
+      restorationCostPerMonth: 2_000_000,
+    });
+    expect(validateStoryDifficultyMonotonicity()).toEqual([]);
   });
 });
 

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -1266,6 +1266,164 @@ const HEATWAVE_DROUGHT_ARC: StoryArcDefinitionType = {
   ],
 };
 
+export interface CaliforniaWildfireBalanceType {
+  disconnectedDemand: number;
+  targetCapacityShare: number;
+  outputMultiplier: number;
+  restorationCostPerMonth: number;
+}
+
+export const CALIFORNIA_WILDFIRE_BALANCE: Record<
+  DifficultyType,
+  CaliforniaWildfireBalanceType
+> = {
+  Intern: {
+    disconnectedDemand: 0.02,
+    targetCapacityShare: 0.3,
+    outputMultiplier: 0.65,
+    restorationCostPerMonth: 1000000,
+  },
+  Employee: {
+    disconnectedDemand: 0.04,
+    targetCapacityShare: 0.4,
+    outputMultiplier: 0.55,
+    restorationCostPerMonth: 1500000,
+  },
+  Manager: {
+    disconnectedDemand: 0.06,
+    targetCapacityShare: 0.5,
+    outputMultiplier: 0.45,
+    restorationCostPerMonth: 2000000,
+  },
+  VP: {
+    disconnectedDemand: 0.08,
+    targetCapacityShare: 0.6,
+    outputMultiplier: 0.35,
+    restorationCostPerMonth: 2750000,
+  },
+  CEO: {
+    disconnectedDemand: 0.1,
+    targetCapacityShare: 0.7,
+    outputMultiplier: 0.25,
+    restorationCostPerMonth: 3500000,
+  },
+};
+
+const CALIFORNIA_WILDFIRE_ARC: StoryArcDefinitionType = {
+  id: "california-wildfire-2025",
+  scenarioId: 111,
+  phases: [
+    {
+      id: "red-flag-warning",
+      schedule: { atMonth: 11 },
+      preview: () => null,
+      describe: () => ({
+        title: "Red-flag warning",
+        message:
+          "After an exceptionally dry fall, extreme Santa Ana winds are forecast for January, so prepare backup power for possible safety shutoffs.",
+        concept: "forecast",
+        kind: "WORLD_EVENT",
+        importance: "NOTABLE",
+        actionTarget: FLEET_TARGET,
+      }),
+    },
+    {
+      id: "firestorm",
+      schedule: { atMonth: 12 },
+      durationMonths: 2,
+      preview: () => ({
+        title: "January wildfire emergency",
+        message:
+          "Extreme fire weather may force two months of safety shutoffs, lost sales, constrained generation, and restoration work.",
+      }),
+      describe: (context, random) => {
+        const balance = CALIFORNIA_WILDFIRE_BALANCE[context.difficulty];
+        const candidates = context.snapshot.facilities
+          .filter((facility) => facility.operational && !!facility.fuel)
+          .map((facility) => ({
+            ...facility,
+            score: random(`facility|${facility.id}`),
+          }))
+          .sort((a, b) => a.score - b.score || a.id - b.id);
+        const totalPeakW = candidates.reduce(
+          (total, facility) => total + facility.peakW,
+          0,
+        );
+        const targetPeakW = totalPeakW * balance.targetCapacityShare;
+        const selected: typeof candidates = [];
+        let selectedPeakW = 0;
+        for (const candidate of candidates) {
+          if (selectedPeakW >= targetPeakW) {
+            break;
+          }
+          selected.push(candidate);
+          selectedPeakW += candidate.peakW;
+        }
+        const outputMultipliers = Object.fromEntries(
+          selected.map((facility) => [
+            String(facility.id),
+            balance.outputMultiplier,
+          ]),
+        );
+        const selectedNames = selected.map((facility) => facility.name);
+        const affectedFacilities = selectedNames.length
+          ? selectedNames.join(", ")
+          : "No operating generators";
+        return {
+          title: "Wildfire emergency",
+          message: `${Math.round(balance.disconnectedDemand * 100)}% of customer load is disconnected by safety shutoffs while ${affectedFacilities} ${selectedNames.length === 1 ? "is" : "are"} limited to ${percent(balance.outputMultiplier)} output and restoration costs $${(balance.restorationCostPerMonth / 1000000).toFixed(1)}M per month through February.`,
+          concept: "danger",
+          kind: "WORLD_EVENT",
+          importance: "CRITICAL",
+          actionTarget: FLEET_TARGET,
+          attributes: {
+            disconnectedDemand: balance.disconnectedDemand,
+            targetCapacityShare: balance.targetCapacityShare,
+            selectedCapacityShare: share(selectedPeakW, totalPeakW),
+            selectedFacilityIds: selected.map((facility) => facility.id),
+            selectedFacilityNames: selectedNames,
+            outputMultiplier: balance.outputMultiplier,
+            restorationCostPerMonth: balance.restorationCostPerMonth,
+          },
+          effects: {
+            demandMultiplier: 1 - balance.disconnectedDemand,
+            facilityOutputMultipliersById: outputMultipliers,
+            operatingExpensePerMonth: balance.restorationCostPerMonth,
+          },
+          turningPointPriority: 120,
+        };
+      },
+    },
+    {
+      id: "restoration-complete",
+      schedule: { atMonth: 14 },
+      preview: () => null,
+      describe: (context) => {
+        const period = context.periodSnapshots?.[2];
+        const demandWh = period?.demandWh || context.snapshot.demandWh12m;
+        const unservedWh = period?.unservedWh || context.snapshot.unservedWh12m;
+        const reliability = reliabilityOf(demandWh, unservedWh);
+        const onset = context.occurrences?.find(
+          (event) =>
+            event.key === "story:111:california-wildfire-2025:firestorm",
+        );
+        const selectedNames = (onset?.attributes.selectedFacilityNames ||
+          []) as string[];
+        return {
+          title: "Wildfire restoration complete",
+          message: `Safety shutoffs are lifted, ${selectedNames.length ? selectedNames.join(", ") : "affected generators"} return to normal, and the grid met ${percent(reliability)} of connected demand during the emergency.`,
+          concept: "supply",
+          kind: "WORLD_EVENT",
+          importance: unservedWh > demandWh * 0.001 ? "NOTABLE" : "ROUTINE",
+          actionTarget: SUPPLY_DEMAND_TARGET,
+          attributes: { demandWh, unservedWh, reliability },
+          turningPointPriority: 110,
+        };
+      },
+    },
+  ],
+};
+
 const NUCLEAR_TRIP_ARC: StoryArcDefinitionType = {
   id: "nuclear-trip",
   scenarioId: 110,
@@ -1329,6 +1487,7 @@ export const STORY_ARC_DEFINITIONS: StoryArcDefinitionType[] = [
   TEXAS_DEEP_FREEZE_ARC,
   HEATWAVE_DROUGHT_ARC,
   NUCLEAR_TRIP_ARC,
+  CALIFORNIA_WILDFIRE_ARC,
 ];
 
 /** Content-level difficulty scaling is centralized and mechanically checkable. */
@@ -1474,6 +1633,33 @@ export function validateStoryDifficultyMonotonicity(): string[] {
       (difficulty) => END_OF_ERA_BALANCE[difficulty].complianceCoalOutput,
     ),
   );
+  ascending(
+    "California wildfire disconnected demand",
+    DIFFICULTY_ORDER.map(
+      (difficulty) =>
+        CALIFORNIA_WILDFIRE_BALANCE[difficulty].disconnectedDemand,
+    ),
+  );
+  ascending(
+    "California wildfire affected capacity",
+    DIFFICULTY_ORDER.map(
+      (difficulty) =>
+        CALIFORNIA_WILDFIRE_BALANCE[difficulty].targetCapacityShare,
+    ),
+  );
+  descending(
+    "California wildfire output",
+    DIFFICULTY_ORDER.map(
+      (difficulty) => CALIFORNIA_WILDFIRE_BALANCE[difficulty].outputMultiplier,
+    ),
+  );
+  ascending(
+    "California wildfire restoration cost",
+    DIFFICULTY_ORDER.map(
+      (difficulty) =>
+        CALIFORNIA_WILDFIRE_BALANCE[difficulty].restorationCostPerMonth,
+    ),
+  );
   return problems;
 }
 
@@ -1574,6 +1760,14 @@ export function combineStoryEffects(
     );
     if (operatingCostMultipliersByFuel !== undefined) {
       combined.operatingCostMultipliersByFuel = operatingCostMultipliersByFuel;
+    }
+    if (
+      combined.operatingExpensePerMonth !== undefined ||
+      effects.operatingExpensePerMonth !== undefined
+    ) {
+      combined.operatingExpensePerMonth =
+        (combined.operatingExpensePerMonth || 0) +
+        (effects.operatingExpensePerMonth || 0);
     }
     const facilityOutputMultipliersByFuel = multiplyEffects(
       combined.facilityOutputMultipliersByFuel,

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -504,6 +504,7 @@ const storyEffectsCache = new Map<string, WorldEventEffectsType>();
 function scheduledStoryCacheKey(date: DateType, state: GameType): string {
   const fleetSensitive =
     state.scenarioId === 104 ||
+    state.scenarioId === 111 ||
     (state.scenarioId === 102 &&
       date.monthsElapsed >= 72 &&
       date.monthsElapsed < 96);
@@ -2206,7 +2207,10 @@ function updateSupplyFacilitiesFinances(
 
   // Facilities expenses
   let kgco2e = 0;
-  let expensesOM = 0;
+  // Some authored emergencies carry company-level response costs that do not belong to a single
+  // plant, such as field crews and rebuilding damaged distribution equipment.
+  let expensesOM =
+    (tickStoryEffects.operatingExpensePerMonth || 0) / ticksPerMonth;
   let expensesFuel = 0;
   let expensesInterest = 0;
   let principalRepayment = 0;


### PR DESCRIPTION
## Summary

- add a 2024–2026 Los Angeles **Wildfire Emergency** scenario centered on the January 2025 fires
- tell a deterministic, authored arc: a December red-flag warning, January–February emergency conditions, and a March restoration report
- model public-safety shutoffs through reduced connected demand and revenue, derate a seeded subset of generators, and charge difficulty-scaled restoration costs
- pin active multi-month effects in an **Ongoing events** section and cover the flow at desktop and 390 px mobile widths
- use a 10/20/40-stroke scenario icon with a clearly separated short power-line span and flame

## Scope

This is intentionally scoped to scenario 111. It does **not** add a global wildfire probability model, location-driven wildfire behavior, or a generalized maintenance-budget system. Other scenarios and custom games do not trigger the wildfire arc.

Addresses #62.

## Research and design inputs

- [NOAA Climate.gov: weather and climate influences on the January 2025 Los Angeles fires](https://prod-01-asg-www-climate.woc.noaa.gov/news-features/event-tracker/weather-and-climate-influences-january-2025-fires-around-los-angeles)
- [NOAA NESDIS: satellite monitoring of the California wildfires](https://www.nesdis.noaa.gov/news/noaa-satellites-monitor-raging-wildfires-california)
- [LADWP power system overview](https://www.ladwp.com/who-we-are/power-system)
- [LADWP power content label](https://www.ladwp.com/who-we-are/power-system/power-content-label)

## Testing

- `npm run check` — 94 suites and 911 tests passed; all scenarios satisfy every invariant
- `npm run build`
- `npm run test:e2e -- e2e/wildfire-scenario.spec.ts --project=desktop-chromium --project=mobile-390px`

## Screenshots

### Scenario briefing

![Wildfire Emergency scenario briefing with selected C2 icon](https://github.com/user-attachments/assets/abef4902-e593-4260-9b76-619d1e5101c2)

### Active emergency — desktop

![Wildfire Emergency active event and affected facilities on desktop](https://github.com/user-attachments/assets/c013f166-3cfe-4a67-9aa6-8df752885624)

### Active emergency — mobile

![Wildfire Emergency active event at 390 px mobile width](https://github.com/user-attachments/assets/e1cd58e8-8631-4a35-ab78-4cdd39ca23e4)
