### PR TITLE
Streamline challenge categories and Wildfire fleet

### DIFF
--- a/e2e/new-game-responsive.spec.ts
+++ b/e2e/new-game-responsive.spec.ts
@@ -64,6 +64,9 @@ test("game picker prioritizes one lesson and filters the challenge catalog", asy
   await expect(
     page.getByRole("button", { name: "View Data Center Boom details" }),
   ).toHaveCount(0);
+  await expect(page.getByLabel("Deep Freeze themes")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "All challenges" }).click();
   await expect(page.getByLabel("Deep Freeze themes")).toContainText(
     "Extreme weather",
   );

--- a/e2e/wildfire-scenario.spec.ts
+++ b/e2e/wildfire-scenario.spec.ts
@@ -26,6 +26,7 @@ test("wildfire briefing and ongoing emergency stay usable", async ({
   }
 
   await page.getByRole("button", { name: "Start game" }).click();
+  await expect(page.getByText("Natural Gas", { exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Events", exact: true }).click();
   await page
     .locator("#appbar:visible")

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -94,6 +94,9 @@ describe("NewGame", () => {
     scenariosNewestFirst.forEach((scenario, index) =>
       expect(rows[index]).toHaveTextContent(scenario.name),
     );
+    expect(screen.getByLabelText("Deep Freeze themes")).toHaveTextContent(
+      "Extreme weather",
+    );
   });
 
   it("filters the full challenge catalog by player-facing themes", () => {
@@ -106,9 +109,7 @@ describe("NewGame", () => {
       expect.stringContaining("Deep Freeze"),
       expect.stringContaining("Hurricane Season"),
     ]);
-    expect(screen.getByLabelText("Deep Freeze themes")).toHaveTextContent(
-      "Extreme weather",
-    );
+    expect(screen.queryByLabelText("Deep Freeze themes")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Energy transition" }));
     expect(screen.getByTestId("mission-row-105")).toHaveTextContent("Paradise");

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -374,7 +374,7 @@ export default function NewGame(props: Props): React.JSX.Element {
               s={s}
               completed={ids.indexOf(s.id) !== -1}
               onSelect={() => props.onDetails({ scenarioId: s.id })}
-              showThemes={challengeFilter !== "For you"}
+              showThemes={challengeFilter === "All challenges"}
             />
           ))}
         </div>

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -422,9 +422,6 @@ export default class NewGameDetails extends React.Component<Props, State> {
               </div>
               <div className="scenarioStartControls">
                 <div className="difficultyPicker">
-                  <Typography variant="caption" component="div">
-                    Difficulty
-                  </Typography>
                   <ToggleButtonGroup
                     exclusive
                     value={game.difficulty}

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -372,6 +372,11 @@ describe("authored starting fleets", () => {
         0,
       ),
     ).toBe(80_810_000);
+    expect(wildfire.facilities[0]).toEqual({
+      fuel: "Natural Gas",
+      peakW: 24_240_000,
+      initialAgeYears: 18,
+    });
   });
 
   it("makes every plant in the aging coal fleet at least 20 years old", () => {

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -1090,7 +1090,6 @@ export const SCENARIOS = [
         fuel: "Natural Gas",
         peakW: 24240000,
         initialAgeYears: 18,
-        label: "Harbor Gas Portfolio",
       },
       { fuel: "Sun", peakW: 17000000, initialAgeYears: 6 },
       { fuel: "Uranium", peakW: 12120000, initialAgeYears: 30 },

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -512,7 +512,7 @@ describe("California wildfire emergency", () => {
       facilities: [
         {
           id: 10,
-          name: "Harbor Gas Portfolio",
+          name: "Natural Gas",
           fuel: "Natural Gas" as const,
           ageYears: 18,
           peakW: 60,


### PR DESCRIPTION
## Summary

- show challenge theme chips only in the **All challenges** view
- remove the redundant **Difficulty** caption above the game-details picker
- use the standard Natural Gas plant in Wildfire Emergency and remove the obsolete portfolio label

## Screenshots

### Extreme weather filter

![Extreme weather challenges without redundant category chips](https://github.com/user-attachments/assets/36ad4754-62fe-4ab8-9861-eab5de04eda6)

### Wildfire game details

![Wildfire game details on mobile with the streamlined difficulty picker](https://github.com/user-attachments/assets/722cda1d-dcbe-41f9-8d97-7a3ed4a7752a)

### Wildfire starting fleet

![Wildfire starting fleet with the standard Natural Gas plant](https://github.com/user-attachments/assets/c04e78cc-b89a-4a17-ba18-9f70d3583df0)

## Validation

- `npm run check`
- `npm run build`
- `npx playwright test --config e2e/playwright.config.ts e2e/new-game-responsive.spec.ts --project=desktop-chromium --project=mobile-390px --project=mobile-320px`
- `npx playwright test --config e2e/playwright.config.ts e2e/wildfire-scenario.spec.ts --project=desktop-chromium --project=mobile-390px`
