### PR TITLE
Show upcoming scenario events on insight graphs

### DIFF
--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { expect, test, type Page } from "@playwright/test";
 
 const REVIEW_VIEWPORTS = new Set([
@@ -13,6 +14,66 @@ const dismissTutorial = async (page: Page) => {
   await exit.click();
   await expect(exit).not.toBeVisible();
 };
+
+test("upcoming scenario events stay usable across insight viewports", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    !new Set(["desktop-chromium", "mobile-390px", "mobile-320px"]).has(
+      testInfo.project.name,
+    ),
+  );
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem("insightsRange", "next5");
+  });
+  await page.goto("/?scenario=100");
+  await page.getByRole("button", { name: "Start game" }).click();
+
+  const insights = page.locator(".insights:visible");
+  if (!(await insights.isVisible())) {
+    await page.getByRole("button", { name: "Insights", exact: true }).click();
+  }
+  await expect(insights).toBeVisible();
+
+  const eventRail = insights.getByRole("region", {
+    name: "Upcoming scenario events",
+  });
+  await expect(eventRail).toContainText("1 in this range");
+  const eventButton = eventRail.getByRole("button", {
+    name: /Higher pollution fee begins/,
+  });
+  await expect(eventButton).toBeVisible();
+  await expect(eventButton).toHaveAttribute("aria-expanded", "false");
+  await eventButton.click();
+  await expect(eventButton).toHaveAttribute("aria-expanded", "true");
+  await expect(eventRail).toContainText("Polluting plants now pay");
+
+  const pageOverflow = await insights.evaluate((element) =>
+    Math.max(0, element.scrollWidth - element.clientWidth),
+  );
+  expect(pageOverflow).toBeLessThanOrEqual(1);
+  if (testInfo.project.name.startsWith("mobile-")) {
+    const eventBox = await eventButton.boundingBox();
+    expect(eventBox).not.toBeNull();
+    expect(eventBox!.height).toBeGreaterThanOrEqual(44);
+    await expect(eventRail.locator(".insightEventList")).toHaveCSS(
+      "overflow-x",
+      "auto",
+    );
+  }
+
+  const reviewDir = process.env.REVIEW_SCREENSHOT_DIR;
+  if (reviewDir) {
+    await page.screenshot({
+      path: path.join(
+        reviewDir,
+        `upcoming-events-${testInfo.project.name}.png`,
+      ),
+      fullPage: true,
+    });
+  }
+});
 
 test("insights header controls stay aligned in one compact row", async ({
   page,

--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -39,7 +39,8 @@ test("upcoming scenario events stay usable across insight viewports", async ({
   const eventRail = insights.getByRole("region", {
     name: "Upcoming scenario events",
   });
-  await expect(eventRail).toContainText("1 in this range");
+  await expect(eventRail).toContainText("Upcoming");
+  await expect(eventRail).not.toContainText("Higher pollution fee begins");
   const eventButton = eventRail.getByRole("button", {
     name: /Higher pollution fee begins/,
   });
@@ -47,7 +48,9 @@ test("upcoming scenario events stay usable across insight viewports", async ({
   await expect(eventButton).toHaveAttribute("aria-expanded", "false");
   await eventButton.click();
   await expect(eventButton).toHaveAttribute("aria-expanded", "true");
-  await expect(eventRail).toContainText("Polluting plants now pay");
+  await expect(page.getByRole("dialog")).toContainText(
+    "Polluting plants now pay",
+  );
 
   const pageOverflow = await insights.evaluate((element) =>
     Math.max(0, element.scrollWidth - element.clientWidth),
@@ -61,6 +64,9 @@ test("upcoming scenario events stay usable across insight viewports", async ({
       "overflow-x",
       "auto",
     );
+    const railBox = await eventRail.boundingBox();
+    expect(railBox).not.toBeNull();
+    expect(railBox!.height).toBeLessThanOrEqual(52);
   }
 
   const reviewDir = process.env.REVIEW_SCREENSHOT_DIR;

--- a/src/app.scss
+++ b/src/app.scss
@@ -1011,6 +1011,109 @@ $pane_header_height: 40px;
   border-bottom: $border_accent;
 }
 
+.insightEventRail {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 960px;
+  padding: 10px 16px 12px;
+  margin: 0 auto;
+  border-bottom: $border_accent;
+  background: var(--bg-raised);
+}
+
+.insightEventRailHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  color: $interactive_blue;
+
+  .MuiTypography-caption {
+    margin-left: auto;
+  }
+}
+
+.insightEventList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.insightEventChip {
+  display: flex;
+  min-width: 0;
+  min-height: 40px;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px 5px 6px;
+  border: 1px solid var(--border-selected);
+  border-radius: 8px;
+  background: var(--chart-surface);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible,
+  &.active {
+    border-color: $interactive_blue;
+    background: var(--interactive-tint);
+    outline: none;
+  }
+
+  &:focus-visible {
+    box-shadow:
+      0 0 0 2px var(--chart-surface),
+      0 0 0 4px $interactive_blue;
+  }
+}
+
+.insightEventNumber {
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid $interactive_blue;
+  border-radius: 50%;
+  color: $interactive_blue;
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.insightEventChipCopy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  line-height: 1.2;
+
+  strong {
+    max-width: 190px;
+    overflow: hidden;
+    font-size: 0.78rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.insightEventDate {
+  color: $font_color_faded;
+  font-size: 0.68rem;
+}
+
+.insightEventDetails {
+  padding: 10px 12px;
+  margin-top: 8px;
+  border-left: 3px solid $interactive_blue;
+  border-radius: 0 6px 6px 0;
+  background: var(--interactive-tint);
+}
+
 .insightsTracks {
   width: 100%;
   max-width: 960px;
@@ -1122,6 +1225,35 @@ $pane_header_height: 40px;
     .MuiButton-root {
       min-height: 44px;
     }
+  }
+
+  .insightEventRail {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .insightEventRailHeader,
+  .insightEventDetails {
+    margin-right: 16px;
+    margin-left: 16px;
+  }
+
+  .insightEventList {
+    flex-wrap: nowrap;
+    padding: 2px 16px 6px;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scroll-padding-inline: 16px;
+    scroll-snap-type: x proximity;
+
+    > li {
+      flex: 0 0 auto;
+      scroll-snap-align: start;
+    }
+  }
+
+  .insightEventChip {
+    min-height: 44px;
   }
 
   // Keep the planning controls on an explicit four-pixel vertical rhythm. Flex wrapping made

--- a/src/app.scss
+++ b/src/app.scss
@@ -1012,55 +1012,58 @@ $pane_header_height: 40px;
 }
 
 .insightEventRail {
+  display: flex;
   box-sizing: border-box;
   width: 100%;
   max-width: 960px;
-  padding: 10px 16px 12px;
+  min-height: 40px;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 16px;
   margin: 0 auto;
   border-bottom: $border_accent;
-  background: var(--bg-raised);
 }
 
-.insightEventRailHeader {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 8px;
-  color: $interactive_blue;
-
-  .MuiTypography-caption {
-    margin-left: auto;
-  }
+.insightEventRailLabel {
+  flex: 0 0 auto;
+  color: $font_color_faded;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .insightEventList {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  min-width: 0;
+  gap: 4px;
   padding: 0;
   margin: 0;
   list-style: none;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
 }
 
 .insightEventChip {
-  display: flex;
+  display: inline-flex;
   min-width: 0;
-  min-height: 40px;
+  min-height: 30px;
   align-items: center;
-  gap: 8px;
-  padding: 5px 10px 5px 6px;
-  border: 1px solid var(--border-selected);
-  border-radius: 8px;
-  background: var(--chart-surface);
+  gap: 5px;
+  padding: 3px 8px 3px 4px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
   color: inherit;
   font: inherit;
-  text-align: left;
+  white-space: nowrap;
   cursor: pointer;
 
   &:hover,
   &:focus-visible,
   &.active {
-    border-color: $interactive_blue;
+    border-color: var(--border-selected);
     background: var(--interactive-tint);
     outline: none;
   }
@@ -1074,44 +1077,35 @@ $pane_header_height: 40px;
 
 .insightEventNumber {
   display: inline-flex;
-  width: 24px;
-  height: 24px;
-  flex: 0 0 24px;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
   align-items: center;
   justify-content: center;
-  border: 1px solid $interactive_blue;
   border-radius: 50%;
-  color: $interactive_blue;
-  font-size: 0.75rem;
+  background: $interactive_blue;
+  color: white;
+  font-size: 0.68rem;
   font-weight: 800;
-}
-
-.insightEventChipCopy {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  line-height: 1.2;
-
-  strong {
-    max-width: 190px;
-    overflow: hidden;
-    font-size: 0.78rem;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
 }
 
 .insightEventDate {
   color: $font_color_faded;
-  font-size: 0.68rem;
+  font-size: 0.74rem;
 }
 
 .insightEventDetails {
+  width: min(300px, calc(100vw - 32px));
   padding: 10px 12px;
-  margin-top: 8px;
-  border-left: 3px solid $interactive_blue;
-  border-radius: 0 6px 6px 0;
-  background: var(--interactive-tint);
+
+  .MuiTypography-caption {
+    display: block;
+    margin: 1px 0 6px;
+  }
+}
+
+.insightEventPopover {
+  z-index: 1300;
 }
 
 .insightsTracks {
@@ -1228,21 +1222,13 @@ $pane_header_height: 40px;
   }
 
   .insightEventRail {
-    padding-right: 0;
-    padding-left: 0;
-  }
-
-  .insightEventRailHeader,
-  .insightEventDetails {
-    margin-right: 16px;
-    margin-left: 16px;
+    min-height: 52px;
+    gap: 6px;
+    padding: 3px 0 3px 16px;
   }
 
   .insightEventList {
-    flex-wrap: nowrap;
-    padding: 2px 16px 6px;
-    overflow-x: auto;
-    overscroll-behavior-x: contain;
+    padding-right: 16px;
     scroll-padding-inline: 16px;
     scroll-snap-type: x proximity;
 
@@ -1254,6 +1240,7 @@ $pane_header_height: 40px;
 
   .insightEventChip {
     min-height: 44px;
+    padding-right: 9px;
   }
 
   // Keep the planning controls on an explicit four-pixel vertical rhythm. Flex wrapping made

--- a/src/components/base/ChartAnnotationsContext.tsx
+++ b/src/components/base/ChartAnnotationsContext.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+export interface ChartEventMarker {
+  key: string;
+  x: number;
+  number: number;
+}
+
+export interface ChartAnnotationsValue {
+  events: ChartEventMarker[];
+  activeEventKey?: string;
+}
+
+export const ChartAnnotationsContext =
+  React.createContext<ChartAnnotationsValue>({ events: [] });

--- a/src/components/base/InsightEventRail.tsx
+++ b/src/components/base/InsightEventRail.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import { Collapse, Typography } from "@mui/material";
+import EventIcon from "@mui/icons-material/Event";
+import { UpcomingStoryEventType } from "../views/StoryEventSelectors";
+
+interface Props {
+  events: UpcomingStoryEventType[];
+  activeKey?: string;
+  onActiveChange: (key?: string) => void;
+}
+
+export default function InsightEventRail(props: Props): React.JSX.Element {
+  const { events, activeKey, onActiveChange } = props;
+  const selected = events.find((event) => event.key === activeKey);
+
+  return (
+    <section
+      className="insightEventRail"
+      aria-labelledby="insight-event-rail-title"
+    >
+      <div className="insightEventRailHeader">
+        <EventIcon aria-hidden="true" fontSize="small" />
+        <Typography id="insight-event-rail-title" variant="subtitle2">
+          Upcoming scenario events
+        </Typography>
+        <Typography variant="caption" color="textSecondary">
+          {events.length} in this range
+        </Typography>
+      </div>
+      <ol className="insightEventList">
+        {events.map((event, index) => {
+          const open = event.key === activeKey;
+          const title = event.title || "Scenario event";
+          const detailsId = `insight-event-details-${index + 1}`;
+          return (
+            <li key={event.key}>
+              <button
+                type="button"
+                className={`insightEventChip${open ? " active" : ""}`}
+                aria-label={`${event.label}: ${title}`}
+                aria-expanded={open}
+                aria-controls={detailsId}
+                onClick={() => onActiveChange(open ? undefined : event.key)}
+              >
+                <span className="insightEventNumber" aria-hidden="true">
+                  {index + 1}
+                </span>
+                <span className="insightEventChipCopy">
+                  <span className="insightEventDate">{event.label}</span>
+                  <strong>{title}</strong>
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+      <Collapse in={!!selected} unmountOnExit>
+        {selected && (
+          <div
+            id={`insight-event-details-${events.indexOf(selected) + 1}`}
+            className="insightEventDetails"
+            role="status"
+          >
+            <Typography variant="caption" color="textSecondary">
+              {selected.label}
+            </Typography>
+            <Typography variant="body2">
+              <strong>{selected.title || "Scenario event"}</strong>
+              {" — "}
+              {selected.message}
+            </Typography>
+          </div>
+        )}
+      </Collapse>
+    </section>
+  );
+}

--- a/src/components/base/InsightEventRail.tsx
+++ b/src/components/base/InsightEventRail.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
-import { Collapse, Typography } from "@mui/material";
-import EventIcon from "@mui/icons-material/Event";
+import { ClickAwayListener, Paper, Popper, Typography } from "@mui/material";
 import { UpcomingStoryEventType } from "../views/StoryEventSelectors";
 
 interface Props {
@@ -12,26 +11,37 @@ interface Props {
 export default function InsightEventRail(props: Props): React.JSX.Element {
   const { events, activeKey, onActiveChange } = props;
   const selected = events.find((event) => event.key === activeKey);
+  const [anchor, setAnchor] = React.useState<HTMLElement | null>(null);
+
+  const closeDetails = () => {
+    setAnchor(null);
+    onActiveChange(undefined);
+  };
 
   return (
     <section
       className="insightEventRail"
-      aria-labelledby="insight-event-rail-title"
+      aria-label="Upcoming scenario events"
+      onKeyDown={(keyEvent) => {
+        if (keyEvent.key === "Escape" && selected) {
+          keyEvent.preventDefault();
+          closeDetails();
+        }
+      }}
     >
-      <div className="insightEventRailHeader">
-        <EventIcon aria-hidden="true" fontSize="small" />
-        <Typography id="insight-event-rail-title" variant="subtitle2">
-          Upcoming scenario events
-        </Typography>
-        <Typography variant="caption" color="textSecondary">
-          {events.length} in this range
-        </Typography>
-      </div>
+      <span className="insightEventRailLabel" aria-hidden="true">
+        Upcoming
+      </span>
+      <span className="srOnly">
+        {events.length} {events.length === 1 ? "event" : "events"} in this
+        range. Select an event to show details.
+      </span>
       <ol className="insightEventList">
         {events.map((event, index) => {
           const open = event.key === activeKey;
           const title = event.title || "Scenario event";
           const detailsId = `insight-event-details-${index + 1}`;
+          const conciseDate = event.label.replace(/^Expected\s+/i, "");
           return (
             <li key={event.key}>
               <button
@@ -39,39 +49,56 @@ export default function InsightEventRail(props: Props): React.JSX.Element {
                 className={`insightEventChip${open ? " active" : ""}`}
                 aria-label={`${event.label}: ${title}`}
                 aria-expanded={open}
-                aria-controls={detailsId}
-                onClick={() => onActiveChange(open ? undefined : event.key)}
+                aria-controls={open ? detailsId : undefined}
+                aria-haspopup="dialog"
+                title={`${event.label}: ${title}`}
+                onClick={(clickEvent) => {
+                  if (open) {
+                    closeDetails();
+                    return;
+                  }
+                  setAnchor(clickEvent.currentTarget);
+                  onActiveChange(event.key);
+                }}
               >
                 <span className="insightEventNumber" aria-hidden="true">
                   {index + 1}
                 </span>
-                <span className="insightEventChipCopy">
-                  <span className="insightEventDate">{event.label}</span>
-                  <strong>{title}</strong>
+                <span className="insightEventDate" aria-hidden="true">
+                  {conciseDate}
                 </span>
               </button>
             </li>
           );
         })}
       </ol>
-      <Collapse in={!!selected} unmountOnExit>
+      <Popper
+        open={!!selected && !!anchor}
+        anchorEl={anchor}
+        placement="bottom-start"
+        className="insightEventPopover"
+      >
         {selected && (
-          <div
-            id={`insight-event-details-${events.indexOf(selected) + 1}`}
-            className="insightEventDetails"
-            role="status"
-          >
-            <Typography variant="caption" color="textSecondary">
-              {selected.label}
-            </Typography>
-            <Typography variant="body2">
-              <strong>{selected.title || "Scenario event"}</strong>
-              {" — "}
-              {selected.message}
-            </Typography>
-          </div>
+          <ClickAwayListener onClickAway={closeDetails}>
+            <Paper elevation={6}>
+              <div
+                id={`insight-event-details-${events.indexOf(selected) + 1}`}
+                className="insightEventDetails"
+                role="dialog"
+                aria-label={selected.title || "Scenario event"}
+              >
+                <Typography variant="subtitle2">
+                  {selected.title || "Scenario event"}
+                </Typography>
+                <Typography variant="caption" color="textSecondary">
+                  {selected.label}
+                </Typography>
+                <Typography variant="body2">{selected.message}</Typography>
+              </div>
+            </Paper>
+          </ClickAwayListener>
         )}
-      </Collapse>
+      </Popper>
     </section>
   );
 }

--- a/src/components/base/UPlotChart.test.tsx
+++ b/src/components/base/UPlotChart.test.tsx
@@ -14,6 +14,7 @@ jest.mock("uplot", () => {
 
 jest.mock("./UPlotHelpers", () => ({
   chartScale: (width: number) => Math.min(width / 350, 1.4),
+  eventMarkersPlugin: () => ({ hooks: {} }),
 }));
 
 describe("UPlotChart resizing", () => {

--- a/src/components/base/UPlotChart.tsx
+++ b/src/components/base/UPlotChart.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import uPlot from "uplot";
 import "uplot/dist/uPlot.min.css";
-import { chartScale } from "./UPlotHelpers";
+import { chartScale, eventMarkersPlugin } from "./UPlotHelpers";
 import { getThemeVersion, subscribeThemeMode } from "../../Theme";
+import { ChartAnnotationsContext } from "./ChartAnnotationsContext";
 
 /**
  * The React shell every chart in the game sits in.
@@ -116,6 +117,7 @@ export default function UPlotChart<S>(
   props: UPlotChartProps<S>,
 ): React.JSX.Element {
   const { ariaLabel, id, height, state, data, structureKey, syncKey } = props;
+  const annotations = React.useContext(ChartAnnotationsContext);
   const rootRef = React.useRef<HTMLDivElement>(null);
   const plotRef = React.useRef<uPlot | null>(null);
   const drawnRef = React.useRef<uPlot.AlignedData | null>(null);
@@ -182,6 +184,8 @@ export default function UPlotChart<S>(
   buildRef.current = props.buildOptions;
   const tooltipRef = React.useRef(props.tooltip);
   tooltipRef.current = props.tooltip;
+  const annotationsRef = React.useRef(annotations);
+  annotationsRef.current = annotations;
 
   // A plot's options are built once and then only fed data, so the colours in them are the
   // ones that were in force when it was built. Switching palette therefore has to rebuild --
@@ -280,6 +284,10 @@ export default function UPlotChart<S>(
           : built.cursor,
         plugins: [
           ...(built.plugins || []),
+          eventMarkersPlugin(
+            () => annotationsRef.current.events,
+            () => annotationsRef.current.activeEventKey,
+          ),
           tooltipPlugin(getState, () => tooltipRef.current, !!syncKey),
         ],
       },
@@ -303,6 +311,10 @@ export default function UPlotChart<S>(
       drawnRef.current = data;
     }
   });
+
+  React.useLayoutEffect(() => {
+    plotRef.current?.redraw();
+  }, [annotations]);
 
   return (
     <div className="accessibleChart">

--- a/src/components/base/UPlotHelpers.test.ts
+++ b/src/components/base/UPlotHelpers.test.ts
@@ -1,0 +1,48 @@
+import uPlot from "uplot";
+import { eventMarkersPlugin } from "./UPlotHelpers";
+
+describe("eventMarkersPlugin", () => {
+  it("draws numbered in-domain event markers and skips events outside the plot", () => {
+    const ctx = {
+      arc: jest.fn(),
+      beginPath: jest.fn(),
+      clip: jest.fn(),
+      fill: jest.fn(),
+      fillText: jest.fn(),
+      moveTo: jest.fn(),
+      rect: jest.fn(),
+      restore: jest.fn(),
+      save: jest.fn(),
+      setLineDash: jest.fn(),
+      stroke: jest.fn(),
+      lineTo: jest.fn(),
+    } as unknown as CanvasRenderingContext2D;
+    const plot = {
+      bbox: { left: 0, top: 0, width: 100, height: 80 },
+      ctx,
+      scales: { x: { min: 0, max: 10 } },
+      valToPos: (value: number) => value * 10,
+      width: 350,
+    } as unknown as uPlot;
+    const plugin = eventMarkersPlugin(
+      () => [
+        { key: "inside", x: 5, number: 1 },
+        { key: "outside", x: 15, number: 2 },
+      ],
+      () => "inside",
+    );
+
+    (plugin.hooks!.draw as (plot: uPlot) => void)(plot);
+
+    expect(ctx.moveTo).toHaveBeenCalledWith(50.5, 0);
+    expect(ctx.moveTo).toHaveBeenCalledTimes(1);
+    expect(ctx.fillText).toHaveBeenCalledWith("1", 50.5, 10);
+    expect(ctx.fillText).not.toHaveBeenCalledWith(
+      "2",
+      expect.any(Number),
+      expect.any(Number),
+    );
+    expect(ctx.save).toHaveBeenCalledTimes(1);
+    expect(ctx.restore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/base/UPlotHelpers.ts
+++ b/src/components/base/UPlotHelpers.ts
@@ -1,5 +1,6 @@
 import uPlot from "uplot";
 import { chartPalette, withAlpha } from "../../Theme";
+import { ChartEventMarker } from "./ChartAnnotationsContext";
 
 /**
  * Shared pieces for the game's uPlot charts: axis styling that matches what the charts looked
@@ -324,6 +325,67 @@ export function verticalLinePlugin(
         u.ctx.moveTo(x, u.bbox.top);
         u.ctx.lineTo(x, u.bbox.top + u.bbox.height);
         u.ctx.stroke();
+        u.ctx.restore();
+      },
+    },
+  };
+}
+
+/** Scenario-event onset markers shared by the stacked Insight charts. */
+export function eventMarkersPlugin(
+  getMarkers: () => ChartEventMarker[],
+  getActiveKey: () => string | undefined,
+): uPlot.Plugin {
+  return {
+    hooks: {
+      draw: (u: uPlot) => {
+        const domainMin = u.scales.x.min;
+        const domainMax = u.scales.x.max;
+        const markers = getMarkers().filter(
+          (marker) =>
+            domainMin != null &&
+            domainMax != null &&
+            marker.x >= domainMin &&
+            marker.x <= domainMax,
+        );
+        if (!markers.length) {
+          return;
+        }
+        const scale = canvasScale(u);
+        const palette = chartPalette();
+        const activeKey = getActiveKey();
+        u.ctx.save();
+        clipToPlot(u);
+        u.ctx.setLineDash([4 * scale, 3 * scale]);
+        u.ctx.strokeStyle = palette.interactive;
+        for (const marker of markers) {
+          const active = marker.key === activeKey;
+          const x = Math.round(u.valToPos(marker.x, "x", true)) + 0.5;
+          u.ctx.globalAlpha = active ? 0.95 : 0.5;
+          u.ctx.lineWidth = (active ? 2 : 1) * uPlot.pxRatio;
+          u.ctx.beginPath();
+          u.ctx.moveTo(x, u.bbox.top);
+          u.ctx.lineTo(x, u.bbox.top + u.bbox.height);
+          u.ctx.stroke();
+
+          const radius = 8 * scale;
+          const badgeY = u.bbox.top + radius + 2 * scale;
+          u.ctx.globalAlpha = 1;
+          u.ctx.setLineDash([]);
+          u.ctx.fillStyle = palette.background;
+          u.ctx.strokeStyle = palette.interactive;
+          u.ctx.lineWidth = (active ? 2 : 1) * uPlot.pxRatio;
+          u.ctx.beginPath();
+          u.ctx.arc(x, badgeY, radius, 0, Math.PI * 2);
+          u.ctx.fill();
+          u.ctx.stroke();
+          u.ctx.fillStyle = palette.interactive;
+          u.ctx.font = chartFont(scale, 10);
+          u.ctx.textAlign = "center";
+          u.ctx.textBaseline = "middle";
+          u.ctx.fillText(String(marker.number), x, badgeY);
+          u.ctx.setLineDash([4 * scale, 3 * scale]);
+        }
         u.ctx.restore();
       },
     },

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -13,12 +13,12 @@ import FilterListIcon from "@mui/icons-material/FilterList";
 import GameCard from "../base/GameCard";
 import {
   ConceptNameType,
-  GameEventImportanceType,
   GameEventKindType,
   GameEventType,
   StoryActionTargetType,
 } from "../../Types";
 import ConceptIcon from "../base/ConceptIcon";
+import { UpcomingStoryEventType } from "./StoryEventSelectors";
 
 /**
  * What has happened to the company, in the order it happened.
@@ -76,16 +76,6 @@ const EVENT_HISTORY_FILTERS: {
     kinds: ["FUEL_PRICE", "FUEL_CROSSOVER", "LOAN"],
   },
 ];
-
-export interface UpcomingStoryEventType {
-  key: string;
-  label: string;
-  title?: string;
-  message: string;
-  concept?: ConceptNameType;
-  importance?: GameEventImportanceType;
-  actionTarget?: StoryActionTargetType;
-}
 
 export interface StateProps {
   events: GameEventType[];

--- a/src/components/views/EventLogContainer.test.tsx
+++ b/src/components/views/EventLogContainer.test.tsx
@@ -2,6 +2,7 @@ import { navigationForStoryTarget, selectOngoing } from "./EventLogContainer";
 import { createGame } from "../../testing/Simulator";
 import { AppStateType } from "../../Types";
 import { getDateFromMinute, MINUTES_PER_MONTH } from "../../helpers/DateTime";
+import { selectUpcomingStoryEvents } from "./StoryEventSelectors";
 
 describe("story action targets", () => {
   it("routes a generator target to the quote screen and preserves its fuel", () => {
@@ -59,5 +60,30 @@ describe("ongoing story events", () => {
         label: "Through Feb 2025",
       }),
     ]);
+  });
+});
+
+describe("upcoming story events", () => {
+  it("preserves graph timing while excluding unpreviewed announcements", () => {
+    const game = createGame({ scenarioId: 100 });
+    const upcoming = selectUpcomingStoryEvents({ game } as AppStateType);
+
+    expect(upcoming).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "story:100:carbon-fee-ratchet:ratchet-onset",
+          startsMinute: 48 * MINUTES_PER_MONTH,
+          label: `Expected Jan ${game.startingYear + 4}`,
+        }),
+      ]),
+    );
+    expect(
+      upcoming.some((event) => event.key.endsWith(":published-ratchet")),
+    ).toBe(false);
+    expect(upcoming.map((event) => event.startsMinute)).toEqual(
+      [...upcoming]
+        .map((event) => event.startsMinute)
+        .sort((a, b) => (a || 0) - (b || 0)),
+    );
   });
 });

--- a/src/components/views/EventLogContainer.tsx
+++ b/src/components/views/EventLogContainer.tsx
@@ -8,13 +8,11 @@ import EventLog, { DispatchProps, StateProps } from "./EventLog";
 import type { AppDispatch } from "../../Store";
 import { markEventsRead } from "../../reducers/Game";
 import { navigate } from "../../reducers/Card";
-import {
-  STORY_ARC_DEFINITIONS,
-  upcomingStoryPhases,
-} from "../../data/WorldEvents";
-import { buildStorySnapshot } from "../../helpers/Story";
 import { getDateFromMinute } from "../../helpers/DateTime";
-import { UpcomingStoryEventType } from "./EventLog";
+import {
+  selectUpcomingStoryEvents,
+  UpcomingStoryEventType,
+} from "./StoryEventSelectors";
 
 export function navigationForStoryTarget(
   target: StoryActionTargetType,
@@ -28,86 +26,7 @@ export function navigationForStoryTarget(
   };
 }
 
-let upcomingCache:
-  { key: string; events: UpcomingStoryEventType[] } | undefined;
-const NO_UPCOMING: UpcomingStoryEventType[] = [];
 const NO_ONGOING: UpcomingStoryEventType[] = [];
-
-function selectUpcoming(state: AppStateType): UpcomingStoryEventType[] {
-  const game = state.game;
-  if (
-    !STORY_ARC_DEFINITIONS.some((arc) => arc.scenarioId === game.scenarioId)
-  ) {
-    return NO_UPCOMING;
-  }
-  const fleetKey = game.facilities
-    .map((facility) =>
-      [
-        facility.id,
-        facility.name,
-        facility.fuel,
-        facility.peakW,
-        facility.yearsToBuildLeft > 0,
-        facility.paused,
-        facility.minuteOperational,
-      ].join(":"),
-    )
-    .join("|");
-  const historyKey = game.monthlyHistory
-    .slice(0, 12)
-    .map((month) =>
-      [
-        month.year,
-        month.month,
-        month.demandWh,
-        month.supplyWh,
-        month.revenue,
-        month.expensesFuel,
-        month.expensesOM,
-        month.expensesCarbonFee,
-        month.expensesInterest,
-        month.peakDemandW,
-        Object.entries(month.deliveredWhByFuel)
-          .sort(([a], [b]) => a.localeCompare(b))
-          .map(([fuel, wh]) => `${fuel}:${wh}`)
-          .join(","),
-      ].join(":"),
-    )
-    .join("|");
-  const key = [
-    game.seed,
-    game.scenarioId,
-    game.difficulty,
-    game.date.monthsElapsed,
-    game.startingYear,
-    game.location.id,
-    historyKey,
-    fleetKey,
-  ].join("|");
-  if (upcomingCache?.key === key) {
-    return upcomingCache.events;
-  }
-  const events = upcomingStoryPhases({
-    seed: game.seed,
-    scenarioId: game.scenarioId,
-    difficulty: game.difficulty,
-    date: game.date,
-    location: game.location,
-    snapshot: buildStorySnapshot(
-      game.monthlyHistory,
-      game.facilities,
-      game.date.minute,
-    ),
-  }).map((event) => {
-    const date = getDateFromMinute(event.startsMinute, game.startingYear);
-    return {
-      ...event,
-      label: `Expected ${date.month} ${date.year}`,
-    };
-  });
-  upcomingCache = { key, events };
-  return events;
-}
 
 export function selectOngoing(state: AppStateType): UpcomingStoryEventType[] {
   const game = state.game;
@@ -123,6 +42,8 @@ export function selectOngoing(state: AppStateType): UpcomingStoryEventType[] {
       );
       return {
         key: event.key,
+        startsMinute: event.startsMinute,
+        endsMinute: event.endsMinute,
         label: `Through ${through.month} ${through.year}`,
         title: event.title,
         message: event.message!,
@@ -144,7 +65,7 @@ const mapStateToProps = (state: AppStateType): StateProps => {
       (event) => !event.storyPhaseKey || !ongoingKeys.has(event.storyPhaseKey),
     ),
     ongoing,
-    upcoming: selectUpcoming(state),
+    upcoming: selectUpcomingStoryEvents(state),
   };
 };
 

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { EMPTY_HISTORY } from "../../helpers/DateTime";
+import { EMPTY_HISTORY, MINUTES_PER_MONTH } from "../../helpers/DateTime";
 import { createGame } from "../../testing/Simulator";
 import { GameType } from "../../Types";
 import Insights, {
@@ -11,6 +11,7 @@ import Insights, {
   presetForLayers,
   withRequiredLayers,
 } from "./Insights";
+import { UpcomingStoryEventType } from "./StoryEventSelectors";
 
 jest.mock("../base/GameCard", () => ({
   __esModule: true,
@@ -127,12 +128,17 @@ const user = userEvent.setup({ delay: null });
 // and clicking several portal-backed controls can legitimately exceed Jest's 5 second default.
 jest.setTimeout(15_000);
 
-function renderInsights(scenarioId = 100, suppliedGame?: GameType) {
+function renderInsights(
+  scenarioId = 100,
+  suppliedGame?: GameType,
+  upcomingEvents?: UpcomingStoryEventType[],
+) {
   return render(
     <Insights
       game={suppliedGame || createGame({ scenarioId })}
       selectedFacilityId={null}
       facilityDragActive={false}
+      upcomingEvents={upcomingEvents}
       onDelta={() => undefined}
     />,
   );
@@ -275,6 +281,61 @@ describe("Insights layers", () => {
     const levers = screen.getByRole("region", { name: "Planning controls" });
     expect(levers).toHaveTextContent(/customer growth \+1.5%\/yr/i);
     expect(levers).not.toHaveTextContent(/market/i);
+  });
+
+  it("shows in-range scenario events and reveals their forecast details", async () => {
+    localStorage.setItem("insightsRange", "next1");
+    renderInsights(100, undefined, [
+      {
+        key: "fee-onset",
+        startsMinute: 6 * MINUTES_PER_MONTH,
+        endsMinute: 7 * MINUTES_PER_MONTH,
+        label: "Expected Jul 2023",
+        title: "Higher pollution fee begins",
+        message: "Polluting plants become more expensive to run.",
+      },
+      {
+        key: "later-event",
+        startsMinute: 18 * MINUTES_PER_MONTH,
+        endsMinute: 19 * MINUTES_PER_MONTH,
+        label: "Expected Jul 2024",
+        title: "Outside range",
+        message: "This should not be shown.",
+      },
+    ]);
+
+    const region = screen.getByRole("region", {
+      name: "Upcoming scenario events",
+    });
+    expect(region).toHaveTextContent("1 in this range");
+    const event = within(region).getByRole("button", {
+      name: "Expected Jul 2023: Higher pollution fee begins",
+    });
+    expect(event).toHaveAttribute("aria-expanded", "false");
+    await user.click(event);
+    expect(event).toHaveAttribute("aria-expanded", "true");
+    expect(region).toHaveTextContent(
+      "Polluting plants become more expensive to run.",
+    );
+    expect(region).not.toHaveTextContent("Outside range");
+  });
+
+  it("does not show forecast event annotations in historical views", async () => {
+    localStorage.setItem("insightsRange", "all");
+    renderInsights(100, gameWithHistory(), [
+      {
+        key: "future",
+        startsMinute: 48 * MINUTES_PER_MONTH,
+        endsMinute: 49 * MINUTES_PER_MONTH,
+        label: "Expected Jan 2027",
+        title: "Future event",
+        message: "Forecast only.",
+      },
+    ]);
+
+    expect(
+      screen.queryByRole("region", { name: "Upcoming scenario events" }),
+    ).toBeNull();
   });
 
   it("offers one rolling 12-month range instead of separate calendar years", async () => {

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -307,16 +307,21 @@ describe("Insights layers", () => {
     const region = screen.getByRole("region", {
       name: "Upcoming scenario events",
     });
-    expect(region).toHaveTextContent("1 in this range");
+    expect(region).toHaveTextContent("Upcoming");
+    expect(region).toHaveTextContent("Jul 2023");
+    expect(region).not.toHaveTextContent("Higher pollution fee begins");
     const event = within(region).getByRole("button", {
       name: "Expected Jul 2023: Higher pollution fee begins",
     });
     expect(event).toHaveAttribute("aria-expanded", "false");
     await user.click(event);
     expect(event).toHaveAttribute("aria-expanded", "true");
-    expect(region).toHaveTextContent(
+    expect(screen.getByRole("dialog")).toHaveTextContent(
       "Polluting plants become more expensive to run.",
     );
+    await user.keyboard("{Escape}");
+    expect(event).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("dialog")).toBeNull();
     expect(region).not.toHaveTextContent("Outside range");
   });
 

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -107,6 +107,9 @@ import GameCard from "../base/GameCard";
 import { UnitsContext } from "../base/UnitsContext";
 import { formatCustomerChange } from "./Finances";
 import { sampleForecastTimeline } from "../../helpers/ForecastSampling";
+import { ChartAnnotationsContext } from "../base/ChartAnnotationsContext";
+import InsightEventRail from "../base/InsightEventRail";
+import { UpcomingStoryEventType } from "./StoryEventSelectors";
 
 export type InsightRange =
   "all" | "next1" | "next5" | "next10" | "next20" | `year:${number}`;
@@ -280,6 +283,7 @@ export interface StateProps {
   selectedFacilityId: number | null;
   facilityDragActive: boolean;
   focusLayer?: InsightLayerId;
+  upcomingEvents?: UpcomingStoryEventType[];
 }
 
 export interface DispatchProps {
@@ -300,6 +304,7 @@ interface State {
   presetNameError: string;
   layersOpen: boolean;
   leversOpen: boolean;
+  activeEventKey?: string;
 }
 
 function sameLayers(left: InsightLayerId[], right: InsightLayerId[]): boolean {
@@ -603,6 +608,7 @@ export default class Insights extends React.Component<Props, State> {
       presetNameError: "",
       layersOpen: false,
       leversOpen: true,
+      activeEventKey: undefined,
     };
   }
 
@@ -625,6 +631,7 @@ export default class Insights extends React.Component<Props, State> {
       nextProps.game.feePerKgCO2e !== this.props.game.feePerKgCO2e ||
       nextProps.selectedFacilityId !== this.props.selectedFacilityId ||
       nextProps.focusLayer !== this.props.focusLayer ||
+      nextProps.upcomingEvents !== this.props.upcomingEvents ||
       facilitySignature(nextProps.game) !== facilitySignature(this.props.game)
     );
   }
@@ -1666,6 +1673,22 @@ export default class Insights extends React.Component<Props, State> {
       !!selectedDefault &&
       !!this.state.presetLibrary.defaults[selectedDefault] &&
       !this.state.presetDirty;
+    const upcomingEvents = projection.historical
+      ? []
+      : (this.props.upcomingEvents || []).filter(
+          (event) =>
+            event.startsMinute !== undefined &&
+            event.startsMinute >= projection.domain.x[0] &&
+            event.startsMinute <= projection.domain.x[1],
+        );
+    const annotations = {
+      events: upcomingEvents.map((event, index) => ({
+        key: event.key,
+        x: event.startsMinute!,
+        number: index + 1,
+      })),
+      activeEventKey: this.state.activeEventKey,
+    };
 
     return (
       <GameCard className="insights" id="insightsPane">
@@ -1881,16 +1904,27 @@ export default class Insights extends React.Component<Props, State> {
           ) : (
             this.renderLevers(now)
           )}
-          <div className="insightsTracks">
-            {visible.map((id, index) =>
-              this.renderTrack(id, index, visible, projection),
-            )}
-            {!visible.length && (
-              <Typography className="insightsEmpty" color="textSecondary">
-                Choose Layers to build this view.
-              </Typography>
-            )}
-          </div>
+          {!!upcomingEvents.length && (
+            <InsightEventRail
+              events={upcomingEvents}
+              activeKey={this.state.activeEventKey}
+              onActiveChange={(activeEventKey) =>
+                this.setState({ activeEventKey })
+              }
+            />
+          )}
+          <ChartAnnotationsContext.Provider value={annotations}>
+            <div className="insightsTracks">
+              {visible.map((id, index) =>
+                this.renderTrack(id, index, visible, projection),
+              )}
+              {!visible.length && (
+                <Typography className="insightsEmpty" color="textSecondary">
+                  Choose Layers to build this view.
+                </Typography>
+              )}
+            </div>
+          </ChartAnnotationsContext.Provider>
         </div>
         {this.renderPresetDialogs()}
       </GameCard>

--- a/src/components/views/InsightsContainer.tsx
+++ b/src/components/views/InsightsContainer.tsx
@@ -7,6 +7,7 @@ import Insights, {
   InsightLayerId,
   StateProps,
 } from "./Insights";
+import { selectUpcomingStoryEvents } from "./StoryEventSelectors";
 
 const STORY_INSIGHT_LAYERS: Record<string, InsightLayerId> = {
   FINANCES: "financeDetails",
@@ -18,6 +19,7 @@ const mapStateToProps = (state: AppStateType): StateProps => ({
   game: state.game,
   selectedFacilityId: state.ui.selectedFacilityId,
   facilityDragActive: state.ui.facilityDragActive,
+  upcomingEvents: selectUpcomingStoryEvents(state),
   focusLayer:
     state.card.storyTarget?.card === "INSIGHTS" && state.card.storyTarget.layer
       ? STORY_INSIGHT_LAYERS[state.card.storyTarget.layer]

--- a/src/components/views/StoryEventSelectors.ts
+++ b/src/components/views/StoryEventSelectors.ts
@@ -1,0 +1,107 @@
+import {
+  AppStateType,
+  ConceptNameType,
+  GameEventImportanceType,
+  StoryActionTargetType,
+} from "../../Types";
+import {
+  STORY_ARC_DEFINITIONS,
+  upcomingStoryPhases,
+} from "../../data/WorldEvents";
+import { getDateFromMinute } from "../../helpers/DateTime";
+import { buildStorySnapshot } from "../../helpers/Story";
+
+export interface UpcomingStoryEventType {
+  key: string;
+  startsMinute?: number;
+  endsMinute?: number;
+  label: string;
+  title?: string;
+  message: string;
+  concept?: ConceptNameType;
+  importance?: GameEventImportanceType;
+  actionTarget?: StoryActionTargetType;
+}
+
+let upcomingCache:
+  { key: string; events: UpcomingStoryEventType[] } | undefined;
+const NO_UPCOMING: UpcomingStoryEventType[] = [];
+
+/** The one presentation-ready source shared by Events and forecast Insights. */
+export function selectUpcomingStoryEvents(
+  state: AppStateType,
+): UpcomingStoryEventType[] {
+  const game = state.game;
+  if (
+    !STORY_ARC_DEFINITIONS.some((arc) => arc.scenarioId === game.scenarioId)
+  ) {
+    return NO_UPCOMING;
+  }
+  const fleetKey = game.facilities
+    .map((facility) =>
+      [
+        facility.id,
+        facility.name,
+        facility.fuel,
+        facility.peakW,
+        facility.yearsToBuildLeft > 0,
+        facility.paused,
+        facility.minuteOperational,
+      ].join(":"),
+    )
+    .join("|");
+  const historyKey = game.monthlyHistory
+    .slice(0, 12)
+    .map((month) =>
+      [
+        month.year,
+        month.month,
+        month.demandWh,
+        month.supplyWh,
+        month.revenue,
+        month.expensesFuel,
+        month.expensesOM,
+        month.expensesCarbonFee,
+        month.expensesInterest,
+        month.peakDemandW,
+        Object.entries(month.deliveredWhByFuel)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([fuel, wh]) => `${fuel}:${wh}`)
+          .join(","),
+      ].join(":"),
+    )
+    .join("|");
+  const key = [
+    game.seed,
+    game.scenarioId,
+    game.difficulty,
+    game.date.monthsElapsed,
+    game.startingYear,
+    game.location.id,
+    historyKey,
+    fleetKey,
+  ].join("|");
+  if (upcomingCache?.key === key) {
+    return upcomingCache.events;
+  }
+  const events = upcomingStoryPhases({
+    seed: game.seed,
+    scenarioId: game.scenarioId,
+    difficulty: game.difficulty,
+    date: game.date,
+    location: game.location,
+    snapshot: buildStorySnapshot(
+      game.monthlyHistory,
+      game.facilities,
+      game.date.minute,
+    ),
+  }).map((event) => {
+    const date = getDateFromMinute(event.startsMinute, game.startingYear);
+    return {
+      ...event,
+      label: `Expected ${date.month} ${date.year}`,
+    };
+  });
+  upcomingCache = { key, events };
+  return events;
+}


### PR DESCRIPTION
## Summary

- adds a compact, accessible upcoming-event key to forecast Insight graphs
- aligns numbered event markers across every visible chart
- keeps full event copy on demand in a dismissible overlay, without moving the graphs
- filters events to the selected forecast range and excludes surprises and historical views

## Verification

- `npm run check` (915 tests and every simulation scenario)
- `npm run build`
- Playwright at desktop Chromium, 390px mobile, and 320px mobile
- independent desktop and mobile QA passes

## Screenshots

![Compact upcoming-event key and graph markers on desktop](https://github.com/user-attachments/assets/ac5cc1f3-b27b-42cd-b81e-b58d9e1b21b3)

![Compact upcoming-event key and graph markers on mobile](https://github.com/user-attachments/assets/ad742613-40ea-49da-aa41-e797f4e19e03)
