### PR TITLE
Add challenge sorting and polish scenario events

### DIFF
--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -51,6 +51,10 @@ test("upcoming scenario events stay usable across insight viewports", async ({
   await expect(page.getByRole("dialog")).toContainText(
     "Polluting plants now pay",
   );
+  await eventButton.click();
+  await expect(eventButton).toHaveAttribute("aria-expanded", "false");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await eventButton.click();
 
   const pageOverflow = await insights.evaluate((element) =>
     Math.max(0, element.scrollWidth - element.clientWidth),

--- a/e2e/new-game-responsive.spec.ts
+++ b/e2e/new-game-responsive.spec.ts
@@ -67,4 +67,12 @@ test("game picker prioritizes one lesson and filters the challenge catalog", asy
   await expect(page.getByLabel("Deep Freeze themes")).toContainText(
     "Extreme weather",
   );
+
+  const sortButton = page.getByRole("button", { name: "Newest first" });
+  await expect(sortButton).toBeVisible();
+  await sortButton.click();
+  await page.getByRole("menuitem", { name: "Shortest first" }).click();
+  await expect(
+    page.getByRole("button", { name: "Shortest first" }),
+  ).toBeVisible();
 });

--- a/public/images/wildfire emergency.svg
+++ b/public/images/wildfire emergency.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eebd93316bdd6eb38cebb8722d946301de2f78926b55ff5778d849014e42fa3f
-size 868
+oid sha256:29f117c9ab032f7685461f1b627bd44741bab7da16d20775498278dc8a5eda24
+size 1179

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -319,6 +319,10 @@ describe("Insights layers", () => {
     expect(screen.getByRole("dialog")).toHaveTextContent(
       "Polluting plants become more expensive to run.",
     );
+    await user.click(event);
+    expect(event).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await user.click(event);
     await user.keyboard("{Escape}");
     expect(event).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("dialog")).toBeNull();

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -119,6 +119,43 @@ describe("NewGame", () => {
     expect(screen.queryByLabelText("Deep Freeze themes")).toBeNull();
   });
 
+  it("sorts challenges by play history, timeframe, and duration", () => {
+    const wildfire = SCENARIOS.find(
+      (scenario) => scenario.name === "Wildfire Emergency",
+    )!;
+    recordPlayed(wildfire.id);
+    render(<NewGame {...props()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "All challenges" }));
+    fireEvent.click(screen.getByRole("button", { name: "Newest first" }));
+    expect(screen.getByRole("menu", { name: "Sort challenges" })).toBeVisible();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Unplayed first" }));
+    expect(challengeRows().at(-1)).toHaveTextContent("Wildfire Emergency");
+
+    fireEvent.click(screen.getByRole("button", { name: "Unplayed first" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Newest first" }));
+    expect(challengeRows()[0]).toHaveTextContent("Sudden Nuclear Shutdown");
+
+    fireEvent.click(screen.getByRole("button", { name: "Newest first" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Shortest first" }));
+    const shortestDuration = Math.min(
+      ...SCENARIOS.filter((scenario) => !scenario.tutorialSteps).map(
+        (scenario) => scenario.durationMonths,
+      ),
+    );
+    const firstScenarioId = Number(
+      challengeRows()[0].dataset.testid!.replace("mission-row-", ""),
+    );
+    expect(
+      SCENARIOS.find((scenario) => scenario.id === firstScenarioId),
+    ).toMatchObject({ durationMonths: shortestDuration });
+
+    fireEvent.click(screen.getByRole("button", { name: "Shortest first" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Oldest first" }));
+    expect(challengeRows()[0]).toHaveTextContent("The End of an Era");
+  });
+
   it("moves completed recommendations behind unplayed challenges", () => {
     recordPlayed(107);
     render(<NewGame {...props()} />);

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -11,6 +11,8 @@ import {
   LinearProgress,
   List,
   ListSubheader,
+  Menu,
+  MenuItem,
   Toolbar,
   ToggleButton,
   ToggleButtonGroup,
@@ -22,6 +24,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutlineOutlined";
+import SortIcon from "@mui/icons-material/Sort";
 import { getScenarioPlayCounts } from "../../LocalStorage";
 import { getScenarioLocation } from "../../helpers/Locations";
 import {
@@ -47,11 +50,24 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 type ChallengeFilterType = "For you" | "All challenges" | ScenarioThemeType;
+type ChallengeSortType =
+  "RECOMMENDED" | "UNPLAYED" | "NEWEST" | "SHORTEST" | "OLDEST";
 
 const CHALLENGE_THEMES: ScenarioThemeType[] = [
   "Extreme weather",
   "Energy transition",
   "Rapid growth",
+];
+
+const CHALLENGE_SORTS: Array<{
+  value: ChallengeSortType;
+  label: string;
+}> = [
+  { value: "RECOMMENDED", label: "Recommended" },
+  { value: "UNPLAYED", label: "Unplayed first" },
+  { value: "NEWEST", label: "Newest first" },
+  { value: "SHORTEST", label: "Shortest first" },
+  { value: "OLDEST", label: "Oldest first" },
 ];
 
 function scenarioEndYear(scenario: ScenarioType): number {
@@ -218,6 +234,10 @@ export default function NewGame(props: Props): React.JSX.Element {
   const [showAllTutorials, setShowAllTutorials] = React.useState(false);
   const [challengeFilter, setChallengeFilter] =
     React.useState<ChallengeFilterType>("For you");
+  const [challengeSort, setChallengeSort] =
+    React.useState<ChallengeSortType | null>(null);
+  const [challengeSortAnchor, setChallengeSortAnchor] =
+    React.useState<HTMLElement | null>(null);
   const playCounts = getScenarioPlayCounts();
   const ids = Object.keys(playCounts).map(Number);
   const completedTutorials = TUTORIALS.filter((s) => ids.includes(s.id)).length;
@@ -241,7 +261,7 @@ export default function NewGame(props: Props): React.JSX.Element {
       );
     })
     .slice(0, 3);
-  const visibleScenarios =
+  const filteredScenarios =
     challengeFilter === "For you"
       ? recommendedScenarios
       : challengeFilter === "All challenges"
@@ -249,6 +269,50 @@ export default function NewGame(props: Props): React.JSX.Element {
         : scenarios.filter((scenario) =>
             scenario.themes?.includes(challengeFilter),
           );
+  const effectiveChallengeSort =
+    challengeSort ?? (challengeFilter === "For you" ? "RECOMMENDED" : "NEWEST");
+  const visibleScenarios = [...filteredScenarios].sort((a, b) => {
+    const aPlays = playCounts[a.id] ?? 0;
+    const bPlays = playCounts[b.id] ?? 0;
+    const recommended =
+      Number(aPlays > 0) - Number(bPlays > 0) ||
+      (aPlays > 0 && bPlays > 0 ? bPlays - aPlays : 0) ||
+      recommendationRank(a) - recommendationRank(b) ||
+      a.name.localeCompare(b.name);
+    if (effectiveChallengeSort === "RECOMMENDED") {
+      return recommended;
+    }
+    if (effectiveChallengeSort === "UNPLAYED") {
+      return (
+        Number((playCounts[a.id] ?? 0) > 0) -
+          Number((playCounts[b.id] ?? 0) > 0) ||
+        b.startingYear - a.startingYear ||
+        recommended
+      );
+    }
+    if (effectiveChallengeSort === "SHORTEST") {
+      return (
+        a.durationMonths - b.durationMonths ||
+        b.startingYear - a.startingYear ||
+        recommended
+      );
+    }
+    if (effectiveChallengeSort === "OLDEST") {
+      return (
+        a.startingYear - b.startingYear ||
+        scenarioEndYear(a) - scenarioEndYear(b) ||
+        recommended
+      );
+    }
+    return (
+      b.startingYear - a.startingYear ||
+      scenarioEndYear(b) - scenarioEndYear(a) ||
+      recommended
+    );
+  });
+  const challengeSortLabel = CHALLENGE_SORTS.find(
+    (sort) => sort.value === effectiveChallengeSort,
+  )!.label;
 
   return (
     <div id="listCard" className="flexContainer">
@@ -343,7 +407,45 @@ export default function NewGame(props: Props): React.JSX.Element {
             ))}
           </div>
         )}
-        <MissionSectionHeader>Challenges</MissionSectionHeader>
+        <MissionSectionHeader
+          action={
+            <Button
+              size="small"
+              startIcon={<SortIcon />}
+              endIcon={<ExpandMoreIcon />}
+              onClick={(event) => setChallengeSortAnchor(event.currentTarget)}
+              aria-haspopup="menu"
+              aria-controls={
+                challengeSortAnchor ? "challenge-sort-menu" : undefined
+              }
+              aria-expanded={!!challengeSortAnchor}
+            >
+              {challengeSortLabel}
+            </Button>
+          }
+        >
+          Challenges
+        </MissionSectionHeader>
+        <Menu
+          id="challenge-sort-menu"
+          anchorEl={challengeSortAnchor}
+          open={!!challengeSortAnchor}
+          onClose={() => setChallengeSortAnchor(null)}
+          slotProps={{ list: { "aria-label": "Sort challenges" } }}
+        >
+          {CHALLENGE_SORTS.map((sort) => (
+            <MenuItem
+              key={sort.value}
+              selected={sort.value === effectiveChallengeSort}
+              onClick={() => {
+                setChallengeSort(sort.value);
+                setChallengeSortAnchor(null);
+              }}
+            >
+              {sort.label}
+            </MenuItem>
+          ))}
+        </Menu>
         <ToggleButtonGroup
           className="challengeFilters"
           value={challengeFilter}


### PR DESCRIPTION
## Summary

- show forecastable scenario events above Insights charts, with matching numbered chart markers and details that close when the active event is tapped again
- add a tutorial-styled challenge sort menu with Recommended, Unplayed first, Newest first, Shortest first, and Oldest first choices
- polish the Wildfire Emergency icon with a clearer layered flame encroaching on the power line

## Screenshots

Desktop and mobile challenge sorting, followed by the upcoming-event detail in Insights:

## Testing

- `npm run check`
- `npm run test:e2e -- new-game-responsive.spec.ts insights-responsive.spec.ts wildfire-scenario.spec.ts`

![challenge-sort-desktop-chromium](https://github.com/user-attachments/assets/1fade2fd-7b3d-411b-a1cb-5fe9d3abf3fb)

![challenge-sort-mobile-390px](https://github.com/user-attachments/assets/c28c4ced-4881-42dd-b963-50a04a04218d)

![upcoming-events-desktop-chromium](https://github.com/user-attachments/assets/6497b144-c267-4d12-8ed9-af40e0028828)