### PR TITLE
Add zoom and pan to insight charts

### DIFF
--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -56,6 +56,90 @@ test("upcoming scenario events stay usable across insight viewports", async ({
   await expect(page.getByRole("dialog")).toHaveCount(0);
   await eventButton.click();
 
+  const charts = insights.locator(".accessibleChart [role=img]");
+  const fullMin = Number(
+    await charts.first().getAttribute("data-viewport-min"),
+  );
+  const fullMax = Number(
+    await charts.first().getAttribute("data-viewport-max"),
+  );
+  await page.getByRole("button", { name: "Zoom to event" }).click();
+  await expect
+    .poll(async () => {
+      const min = Number(
+        await charts.first().getAttribute("data-viewport-min"),
+      );
+      const max = Number(
+        await charts.first().getAttribute("data-viewport-max"),
+      );
+      return max - min;
+    })
+    .toBeLessThan(fullMax - fullMin);
+  const zoomedMin = Number(
+    await charts.first().getAttribute("data-viewport-min"),
+  );
+  const zoomedMax = Number(
+    await charts.first().getAttribute("data-viewport-max"),
+  );
+  expect(zoomedMax - zoomedMin).toBeLessThan(fullMax - fullMin);
+  const chartRanges = await charts.evaluateAll((elements) =>
+    elements.map((element) => [
+      element.getAttribute("data-viewport-min"),
+      element.getAttribute("data-viewport-max"),
+    ]),
+  );
+  expect(new Set(chartRanges.map((range) => range.join(":"))).size).toBe(1);
+
+  const viewportToolbar = insights.getByRole("region", {
+    name: "Chart time navigation",
+  });
+  await expect(viewportToolbar).toContainText(/20\d{2}/);
+  const horizon = viewportToolbar.getByRole("combobox", {
+    name: "Time horizon",
+  });
+  await expect(insights.locator(".insightsHeader .insightsRange")).toHaveCount(
+    0,
+  );
+  const viewportButtons = viewportToolbar.getByRole("button");
+  const viewportControls = [horizon, ...(await viewportButtons.all())];
+  const viewportControlBoxes = await Promise.all(
+    viewportControls.map((control) => control.boundingBox()),
+  );
+  expect(viewportControlBoxes.every(Boolean)).toBe(true);
+  const viewportControlCenters = viewportControlBoxes.map(
+    (box) => box!.y + box!.height / 2,
+  );
+  expect(
+    Math.max(...viewportControlCenters) - Math.min(...viewportControlCenters),
+  ).toBeLessThanOrEqual(1);
+  const toolbarBox = await viewportToolbar.boundingBox();
+  expect(toolbarBox).not.toBeNull();
+  expect(toolbarBox!.height).toBeLessThanOrEqual(53);
+  const toolbarOverflow = await viewportToolbar.evaluate((element) =>
+    Math.max(0, element.scrollWidth - element.clientWidth),
+  );
+  expect(toolbarOverflow).toBeLessThanOrEqual(1);
+  const viewportButtonBoxes = viewportControlBoxes.slice(1);
+  expect(
+    viewportButtonBoxes.every((box) =>
+      testInfo.project.name.startsWith("mobile-")
+        ? box!.height >= 44
+        : box!.height >= 40,
+    ),
+  ).toBe(true);
+  if (testInfo.project.name.startsWith("mobile-")) {
+    expect(viewportControlBoxes[0]!.width).toBeCloseTo(80, 0);
+    viewportButtonBoxes.forEach((box) => expect(box!.width).toBeCloseTo(44, 0));
+  } else {
+    const longHorizonLabel = horizon.locator(".insightsHorizonLong");
+    await expect(longHorizonLabel).toContainText("Next 5 years");
+    expect(
+      await longHorizonLabel.evaluate(
+        (element) => element.scrollWidth - element.clientWidth,
+      ),
+    ).toBeLessThanOrEqual(0);
+  }
+
   const pageOverflow = await insights.evaluate((element) =>
     Math.max(0, element.scrollWidth - element.clientWidth),
   );
@@ -75,6 +159,8 @@ test("upcoming scenario events stay usable across insight viewports", async ({
 
   const reviewDir = process.env.REVIEW_SCREENSHOT_DIR;
   if (reviewDir) {
+    await eventButton.click();
+    await viewportToolbar.scrollIntoViewIfNeeded();
     await page.screenshot({
       path: path.join(
         reviewDir,
@@ -136,13 +222,12 @@ test("insights header controls stay aligned in one compact row", async ({
   await page.evaluate(() => document.fonts.ready);
 
   const controls = [
-    page.locator(".insightsRange"),
     page.locator(".insightsPreset"),
     page.getByRole("button", { name: "Preset actions" }),
     page.getByRole("button", { name: /^Layers \(/ }),
   ];
   if (!testInfo.project.name.startsWith("mobile-")) {
-    controls.splice(2, 0, page.getByRole("button", { name: "Save" }));
+    controls.splice(1, 0, page.getByRole("button", { name: "Save" }));
   }
   const boxes = await Promise.all(
     controls.map((control) => control.boundingBox()),
@@ -166,34 +251,52 @@ test("insights header controls stay aligned in one compact row", async ({
 
     const levers = page.locator(".insightsLevers");
     await expect(levers).toHaveCSS("display", "grid");
-    await expect(levers).toHaveCSS("row-gap", "4px");
-    const [rateButton, rateSummary, rateSlider, trackTitle] = await Promise.all(
-      [
-        levers.getByRole("button", { name: "Rate controls" }).boundingBox(),
-        levers.locator(":scope > .MuiTypography-root").boundingBox(),
-        levers.locator(".budgetSlider").boundingBox(),
-        page
-          .locator('.insightsTrack[data-layer="supplyDemand"] h6')
-          .boundingBox(),
-      ],
-    );
-    expect(rateButton).not.toBeNull();
-    expect(rateSummary).not.toBeNull();
+    await expect(levers).toHaveCSS("row-gap", "0px");
+    const rateToggle = levers.locator(".insightsRateToggle");
+    const rateMetrics = levers.locator(".insightsRateMetrics");
+    await expect(rateToggle).not.toBeVisible();
+    const [leversBox, metricsBox, rateSlider, trackTitle] = await Promise.all([
+      levers.boundingBox(),
+      rateMetrics.boundingBox(),
+      levers.locator(".budgetSlider").boundingBox(),
+      page
+        .locator('.insightsTrack[data-layer="supplyDemand"] h6')
+        .boundingBox(),
+    ]);
+    expect(leversBox).not.toBeNull();
+    expect(metricsBox).not.toBeNull();
     expect(rateSlider).not.toBeNull();
     expect(trackTitle).not.toBeNull();
-    expect(rateSummary!.y - (rateButton!.y + rateButton!.height)).toBeCloseTo(
-      4,
-      1,
+    expect(leversBox!.height).toBeLessThanOrEqual(110);
+    expect(metricsBox!.height).toBeGreaterThanOrEqual(44);
+    expect(metricsBox!.x - leversBox!.x).toBeCloseTo(12, 1);
+    expect(
+      await levers.evaluate(
+        (element) => element.scrollWidth - element.clientWidth,
+      ),
+    ).toBeLessThanOrEqual(0);
+    expect(
+      await rateMetrics.evaluate(
+        (element) => element.scrollWidth - element.clientWidth,
+      ),
+    ).toBeLessThanOrEqual(0);
+    await expect(rateMetrics).toContainText(/RATE/i);
+    await expect(rateMetrics).toContainText(/MARKET/i);
+    await expect(rateMetrics).toContainText(/CUSTOMERS \/ MO/i);
+    await expect(rateMetrics).toContainText(/\+.*\(\+.*%\)/);
+    const visibleRateMarks = levers.locator(".insightsRateMarkMobile:visible");
+    await expect(visibleRateMarks).toHaveCount(3);
+    await expect(visibleRateMarks.nth(1)).toContainText(/market/i);
+    const markBoxes = await Promise.all(
+      (await visibleRateMarks.all()).map((mark) => mark.boundingBox()),
     );
-    expect(rateSlider!.y - (rateSummary!.y + rateSummary!.height)).toBeCloseTo(
-      4,
-      1,
+    expect(markBoxes.every(Boolean)).toBe(true);
+    const marksBottom = Math.max(
+      ...markBoxes.map((box) => box!.y + box!.height),
     );
-    expect(rateSummary!.x).toBeCloseTo(trackTitle!.x, 1);
-    expect(rateSlider!.x).toBeCloseTo(trackTitle!.x, 1);
-    expect(rateSlider!.x + rateSlider!.width).toBeLessThanOrEqual(
-      (page.viewportSize()?.width || 0) - trackTitle!.x + 0.5,
-    );
+    expect(
+      leversBox!.y + leversBox!.height - marksBottom,
+    ).toBeGreaterThanOrEqual(4);
 
     if (testInfo.project.name === "mobile-320px") {
       const trackHeader = page.locator(
@@ -212,13 +315,29 @@ test("insights header controls stay aligned in one compact row", async ({
     }
   }
 
+  const reviewDir = process.env.REVIEW_SCREENSHOT_DIR;
+  if (reviewDir) {
+    await page.screenshot({
+      path: path.join(
+        reviewDir,
+        `compact-rate-controls-${testInfo.project.name}.png`,
+      ),
+      fullPage: true,
+    });
+  }
+
   const presetName = page.locator(".insightsPresetName");
   await expect(presetName).toHaveCSS("text-overflow", "ellipsis");
   if (testInfo.project.name === "mobile-320px") {
     await expect(page.getByRole("button", { name: "Save" })).not.toBeVisible();
-    await expect(page.locator(".insightsRange")).toContainText(
-      "Next 12 months",
-    );
+    const horizon = page.getByRole("combobox", { name: "Time horizon" });
+    await expect(horizon.locator(".insightsHorizonCompact")).toHaveText("1y");
+    await horizon.click();
+    await page.getByRole("option", { name: "Next 5 years" }).click();
+    await expect(horizon.locator(".insightsHorizonCompact")).toHaveText("5y");
+    await expect(
+      page.getByRole("button", { name: "Fit 5-year horizon" }),
+    ).toBeDisabled();
     await page.getByRole("button", { name: "Preset actions" }).click();
     await expect(
       page.getByRole("menuitem", { name: "Save preset changes" }),

--- a/src/app.scss
+++ b/src/app.scss
@@ -1006,9 +1006,90 @@ $pane_header_height: 40px;
   }
 }
 
+.insightsRateMetrics,
+.insightsRateMarkMobile {
+  display: none;
+}
+
+.insightsRateSliderCollapsed {
+  display: none;
+}
+
 .insightsHistoryNotice {
   padding: 8px 16px;
   border-bottom: $border_accent;
+}
+
+.insightsViewportToolbar {
+  display: flex;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 960px;
+  height: 52px;
+  min-height: 52px;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 8px;
+  padding: 4px 16px;
+  margin: 0 auto;
+  overflow: hidden;
+  border-bottom: $border_accent;
+  background: var(--bg-raised);
+}
+
+.insightsHorizon {
+  width: 152px;
+  height: 40px;
+  min-width: 0;
+  flex: 0 0 152px;
+}
+
+.insightsHorizonValue {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.insightsHorizonCompact {
+  display: none;
+}
+
+.insightsViewportButtons {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 2px;
+
+  .insightsViewportButton,
+  .MuiIconButton-root {
+    width: 40px;
+    height: 40px;
+    flex: 0 0 40px;
+  }
+
+  .MuiIconButton-root {
+    color: $interactive_blue;
+  }
+}
+
+.insightsViewportText {
+  min-width: 0;
+  flex: 1 1 auto;
+
+  .MuiTypography-root {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.insights .u-over {
+  cursor: grab;
+
+  &:active {
+    cursor: grabbing;
+  }
 }
 
 .insightEventRail {
@@ -1102,6 +1183,11 @@ $pane_header_height: 40px;
     display: block;
     margin: 1px 0 6px;
   }
+
+  .MuiButton-root {
+    min-height: 36px;
+    margin-top: 10px;
+  }
 }
 
 .insightEventPopover {
@@ -1157,7 +1243,7 @@ $pane_header_height: 40px;
 
   .insightsHeaderControls {
     display: grid;
-    grid-template-columns: minmax(128px, 1fr) minmax(88px, 1fr) 36px;
+    grid-template-columns: minmax(0, 1fr) 36px;
     width: 100%;
     gap: 4px;
     margin-left: 0;
@@ -1227,6 +1313,43 @@ $pane_header_height: 40px;
     padding: 3px 0 3px 16px;
   }
 
+  .insightsViewportToolbar {
+    height: 52px;
+    min-height: 52px;
+    gap: 4px;
+    padding: 4px 8px;
+  }
+
+  .insightsHorizon {
+    width: 80px;
+    height: 44px;
+    flex-basis: 80px;
+  }
+
+  .insightsHorizonLong {
+    display: none;
+  }
+
+  .insightsHorizonCompact {
+    display: inline;
+  }
+
+  .insightsViewportButtons {
+    flex-basis: 220px;
+    gap: 0;
+
+    .insightsViewportButton,
+    .MuiIconButton-root {
+      width: 44px;
+      height: 44px;
+      flex-basis: 44px;
+    }
+  }
+
+  .insightsViewportText {
+    display: none;
+  }
+
   .insightEventList {
     padding-right: 16px;
     scroll-padding-inline: 16px;
@@ -1243,28 +1366,101 @@ $pane_header_height: 40px;
     padding-right: 9px;
   }
 
-  // Keep the planning controls on an explicit four-pixel vertical rhythm. Flex wrapping made
-  // the title and description share a row only at a few in-between widths, and left their
-  // horizontal edges out of step with the track headings below.
   .insightsLevers {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-    row-gap: 4px;
-    padding: 4px 16px 8px;
+    gap: 0;
+    padding: 4px 12px 12px;
 
-    > .MuiButton-root {
-      justify-self: start;
-      padding-left: 0;
+    > .insightsRateToggle {
+      display: none;
+    }
 
-      .MuiButton-startIcon {
-        margin-left: 0;
+    .insightsRateToggleLabel,
+    .insightsRateSummaryDesktop {
+      display: none;
+    }
+
+    .insightsRateMetrics {
+      display: grid;
+      min-width: 0;
+      height: 44px;
+      grid-column: 1;
+      grid-template-columns: minmax(68px, 0.8fr) minmax(60px, 0.75fr) minmax(
+          112px,
+          1.25fr
+        );
+      gap: 4px;
+      align-items: stretch;
+
+      &.insightsRateMetricsPublic {
+        grid-template-columns: 72px minmax(0, 1fr);
       }
+    }
+
+    .insightsRateMetric {
+      display: flex;
+      min-width: 0;
+      flex-direction: column;
+      justify-content: center;
+      padding-left: 4px;
+      border-left: 1px solid var(--border-subtle);
+    }
+
+    .insightsRateMetric:first-child {
+      padding-left: 0;
+      border-left: 0;
+    }
+
+    .insightsRateMetricGrowth {
+      grid-column: 2;
+    }
+
+    .insightsRateMetricLabel,
+    .insightsRateMetricValue {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .insightsRateMetricLabel {
+      color: var(--text-secondary);
+      font-size: 0.6rem;
+      line-height: 1.15;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+
+    .insightsRateMetricValue {
+      font-size: 0.78rem;
+      line-height: 1.35;
     }
 
     .budgetSlider {
       box-sizing: border-box;
       width: 100%;
+      min-height: 48px;
       min-width: 0;
+      grid-column: 1;
+      padding: 0 20px;
+
+      .MuiSlider-root {
+        margin-bottom: 0;
+      }
+    }
+
+    .insightsRateSliderCollapsed {
+      display: block;
+    }
+
+    .insightsRateMarkDesktop {
+      display: none;
+    }
+
+    .insightsRateMarkMobile {
+      display: inline;
+      font-size: 0.65rem;
+      white-space: nowrap;
     }
   }
 

--- a/src/components/base/ChartViewportContext.test.tsx
+++ b/src/components/base/ChartViewportContext.test.tsx
@@ -1,0 +1,34 @@
+import {
+  clampChartViewport,
+  eventChartViewport,
+  panChartViewport,
+  zoomChartViewport,
+} from "./ChartViewportContext";
+
+describe("chart viewport math", () => {
+  const bounds: [number, number] = [0, 100];
+
+  it("zooms around an arbitrary anchor and observes the minimum span", () => {
+    expect(zoomChartViewport(bounds, bounds, 10, 0.5, 0.25)).toEqual([
+      12.5, 62.5,
+    ]);
+    expect(zoomChartViewport(bounds, [20, 30], 10, 0.1, 0.5)).toEqual([20, 30]);
+  });
+
+  it("pans to either boundary without shrinking", () => {
+    expect(panChartViewport(bounds, [20, 40], 10, -50)).toEqual([0, 20]);
+    expect(panChartViewport(bounds, [20, 40], 10, 100)).toEqual([80, 100]);
+  });
+
+  it("fits invalid and over-wide ranges to the full horizon", () => {
+    expect(clampChartViewport(bounds, [Number.NaN, 20], 10)).toEqual(bounds);
+    expect(clampChartViewport(bounds, [-10, 120], 10)).toEqual(bounds);
+  });
+
+  it("frames point and duration events with context", () => {
+    expect(eventChartViewport(bounds, 50, undefined, 10)).toEqual([40, 60]);
+    expect(eventChartViewport(bounds, 40, 60, 10)).toEqual([38, 62]);
+    expect(eventChartViewport(bounds, 2, undefined, 10)).toEqual([0, 20]);
+    expect(eventChartViewport([0, 1000], 400, 900, 10)).toEqual([394, 454]);
+  });
+});

--- a/src/components/base/ChartViewportContext.tsx
+++ b/src/components/base/ChartViewportContext.tsx
@@ -1,0 +1,135 @@
+import * as React from "react";
+
+export type ChartViewportRange = [number, number];
+
+export interface ChartViewportValue {
+  bounds: ChartViewportRange;
+  range: ChartViewportRange;
+  minSpan: number;
+  onRangeChange: (range: ChartViewportRange, announce?: boolean) => void;
+  onReset: (announce?: boolean) => void;
+}
+
+export const ChartViewportContext =
+  React.createContext<ChartViewportValue | null>(null);
+
+const EPSILON = 1e-7;
+
+export function rangesEqual(
+  left: ChartViewportRange,
+  right: ChartViewportRange,
+): boolean {
+  return (
+    Math.abs(left[0] - right[0]) <= EPSILON &&
+    Math.abs(left[1] - right[1]) <= EPSILON
+  );
+}
+
+/** Keep a finite viewport inside its data horizon without changing its requested span. */
+export function clampChartViewport(
+  bounds: ChartViewportRange,
+  candidate: ChartViewportRange,
+  minSpan: number,
+): ChartViewportRange {
+  const [boundMin, boundMax] = bounds;
+  const fullSpan = boundMax - boundMin;
+  if (
+    !Number.isFinite(boundMin) ||
+    !Number.isFinite(boundMax) ||
+    fullSpan <= 0
+  ) {
+    return bounds;
+  }
+  if (!Number.isFinite(candidate[0]) || !Number.isFinite(candidate[1])) {
+    return bounds;
+  }
+  const span = Math.min(
+    fullSpan,
+    Math.max(Math.min(minSpan, fullSpan), candidate[1] - candidate[0]),
+  );
+  if (span >= fullSpan - EPSILON) {
+    return bounds;
+  }
+  let min = candidate[0];
+  let max = min + span;
+  if (min < boundMin) {
+    min = boundMin;
+    max = min + span;
+  }
+  if (max > boundMax) {
+    max = boundMax;
+    min = max - span;
+  }
+  return [min, max];
+}
+
+/** factor below one zooms in; factor above one zooms out around the supplied anchor. */
+export function zoomChartViewport(
+  bounds: ChartViewportRange,
+  range: ChartViewportRange,
+  minSpan: number,
+  factor: number,
+  anchor = 0.5,
+): ChartViewportRange {
+  if (!Number.isFinite(factor) || factor <= 0) {
+    return clampChartViewport(bounds, range, minSpan);
+  }
+  const current = clampChartViewport(bounds, range, minSpan);
+  const clampedAnchor = Math.min(1, Math.max(0, anchor));
+  const span = Math.max(
+    Math.min(minSpan, bounds[1] - bounds[0]),
+    (current[1] - current[0]) * factor,
+  );
+  const anchorValue = current[0] + (current[1] - current[0]) * clampedAnchor;
+  return clampChartViewport(
+    bounds,
+    [
+      anchorValue - span * clampedAnchor,
+      anchorValue + span * (1 - clampedAnchor),
+    ],
+    minSpan,
+  );
+}
+
+export function panChartViewport(
+  bounds: ChartViewportRange,
+  range: ChartViewportRange,
+  minSpan: number,
+  delta: number,
+): ChartViewportRange {
+  if (!Number.isFinite(delta)) {
+    return clampChartViewport(bounds, range, minSpan);
+  }
+  return clampChartViewport(
+    bounds,
+    [range[0] + delta, range[1] + delta],
+    minSpan,
+  );
+}
+
+export function eventChartViewport(
+  bounds: ChartViewportRange,
+  start: number,
+  end: number | undefined,
+  minSpan: number,
+): ChartViewportRange {
+  const eventEnd = Number.isFinite(end) ? (end as number) : start;
+  const duration = Math.max(0, eventEnd - start);
+  const naturalSpan = duration
+    ? Math.max(minSpan, duration * 1.2)
+    : Math.max(minSpan, minSpan * 2);
+  const span = Math.min(naturalSpan, minSpan * 6);
+  if (naturalSpan > span) {
+    return clampChartViewport(
+      bounds,
+      [start - span * 0.1, start + span * 0.9],
+      minSpan,
+    );
+  }
+  const center = start + duration / 2;
+  return clampChartViewport(
+    bounds,
+    [center - span / 2, center + span / 2],
+    minSpan,
+  );
+}

--- a/src/components/base/InsightEventRail.tsx
+++ b/src/components/base/InsightEventRail.tsx
@@ -1,15 +1,22 @@
 import * as React from "react";
-import { ClickAwayListener, Paper, Popper, Typography } from "@mui/material";
+import {
+  Button,
+  ClickAwayListener,
+  Paper,
+  Popper,
+  Typography,
+} from "@mui/material";
 import { UpcomingStoryEventType } from "../views/StoryEventSelectors";
 
 interface Props {
   events: UpcomingStoryEventType[];
   activeKey?: string;
   onActiveChange: (key?: string) => void;
+  onZoom: (event: UpcomingStoryEventType) => void;
 }
 
 export default function InsightEventRail(props: Props): React.JSX.Element {
-  const { events, activeKey, onActiveChange } = props;
+  const { events, activeKey, onActiveChange, onZoom } = props;
   const selected = events.find((event) => event.key === activeKey);
   const [anchor, setAnchor] = React.useState<HTMLElement | null>(null);
 
@@ -94,6 +101,13 @@ export default function InsightEventRail(props: Props): React.JSX.Element {
                   {selected.label}
                 </Typography>
                 <Typography variant="body2">{selected.message}</Typography>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={() => onZoom(selected)}
+                >
+                  Zoom to event
+                </Button>
               </div>
             </Paper>
           </ClickAwayListener>

--- a/src/components/base/UPlotChart.test.tsx
+++ b/src/components/base/UPlotChart.test.tsx
@@ -1,6 +1,7 @@
 import { act, render } from "@testing-library/react";
 import uPlot from "uplot";
 import UPlotChart from "./UPlotChart";
+import { ChartViewportContext } from "./ChartViewportContext";
 
 jest.mock("uplot", () => {
   const MockUPlot = jest.fn();
@@ -8,6 +9,8 @@ jest.mock("uplot", () => {
   MockUPlot.prototype.cursor = {};
   MockUPlot.prototype.setData = jest.fn();
   MockUPlot.prototype.setSize = jest.fn();
+  MockUPlot.prototype.setScale = jest.fn();
+  MockUPlot.prototype.redraw = jest.fn();
   MockUPlot.prototype.destroy = jest.fn();
   return { __esModule: true, default: MockUPlot };
 });
@@ -20,7 +23,12 @@ jest.mock("./UPlotHelpers", () => ({
 describe("UPlotChart resizing", () => {
   const uPlotPrototype = (
     uPlot as unknown as {
-      prototype: { setSize: jest.Mock; destroy: jest.Mock };
+      prototype: {
+        over: HTMLDivElement;
+        setSize: jest.Mock;
+        setScale: jest.Mock;
+        destroy: jest.Mock;
+      };
     }
   ).prototype;
   let width = 400;
@@ -104,5 +112,140 @@ describe("UPlotChart resizing", () => {
     act(() => jest.advanceTimersByTime(1));
     expect(uPlotPrototype.destroy).toHaveBeenCalledTimes(1);
     expect(uPlot).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies a shared viewport and reserves Ctrl-wheel for anchored zoom", () => {
+    const onRangeChange = jest.fn();
+    render(
+      <ChartViewportContext.Provider
+        value={{
+          bounds: [0, 100],
+          range: [0, 100],
+          minSpan: 10,
+          onRangeChange,
+          onReset: jest.fn(),
+        }}
+      >
+        <UPlotChart
+          ariaLabel="Interactive chart"
+          state={{}}
+          data={[
+            [0, 100],
+            [2, 3],
+          ]}
+          buildOptions={() => ({ width: 0, height: 0, series: [{}, {}] })}
+        />
+      </ChartViewportContext.Provider>,
+    );
+
+    expect(uPlotPrototype.setScale).toHaveBeenCalledWith("x", {
+      min: 0,
+      max: 100,
+    });
+    const ordinaryWheel = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 100,
+    });
+    uPlotPrototype.over.dispatchEvent(ordinaryWheel);
+    expect(ordinaryWheel.defaultPrevented).toBe(false);
+
+    const zoomWheel = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+      clientX: 200,
+      deltaY: -120,
+    });
+    act(() => {
+      uPlotPrototype.over.dispatchEvent(zoomWheel);
+      jest.advanceTimersByTime(200);
+    });
+    expect(zoomWheel.defaultPrevented).toBe(true);
+    expect(onRangeChange).toHaveBeenCalled();
+    const zoomed = onRangeChange.mock.calls.at(-1)?.[0];
+    expect(zoomed[1] - zoomed[0]).toBeLessThan(100);
+  });
+
+  it("pans with a pointer drag and zooms with a touch pinch", () => {
+    const onRangeChange = jest.fn();
+    const pointer = (type: string, values: Record<string, string | number>) => {
+      const event = new Event(type, { bubbles: true, cancelable: true });
+      Object.assign(event, values);
+      uPlotPrototype.over.dispatchEvent(event);
+    };
+    render(
+      <ChartViewportContext.Provider
+        value={{
+          bounds: [0, 100],
+          range: [25, 75],
+          minSpan: 10,
+          onRangeChange,
+          onReset: jest.fn(),
+        }}
+      >
+        <UPlotChart
+          ariaLabel="Gesture chart"
+          state={{}}
+          data={[
+            [0, 100],
+            [2, 3],
+          ]}
+          buildOptions={() => ({ width: 0, height: 0, series: [{}, {}] })}
+        />
+      </ChartViewportContext.Provider>,
+    );
+
+    pointer("pointerdown", {
+      pointerId: 1,
+      pointerType: "mouse",
+      button: 0,
+      clientX: 100,
+      clientY: 10,
+    });
+    pointer("pointermove", {
+      pointerId: 1,
+      pointerType: "mouse",
+      clientX: 80,
+      clientY: 10,
+    });
+    pointer("pointerup", {
+      pointerId: 1,
+      pointerType: "mouse",
+      clientX: 80,
+      clientY: 10,
+    });
+    expect(onRangeChange).toHaveBeenCalled();
+    expect(onRangeChange.mock.calls.at(-1)?.[0]).toEqual([50, 100]);
+
+    onRangeChange.mockClear();
+    pointer("pointerdown", {
+      pointerId: 2,
+      pointerType: "touch",
+      button: 0,
+      clientX: 100,
+      clientY: 10,
+    });
+    pointer("pointerdown", {
+      pointerId: 3,
+      pointerType: "touch",
+      button: 0,
+      clientX: 200,
+      clientY: 10,
+    });
+    pointer("pointermove", {
+      pointerId: 3,
+      pointerType: "touch",
+      clientX: 250,
+      clientY: 10,
+    });
+    pointer("pointerup", {
+      pointerId: 3,
+      pointerType: "touch",
+      clientX: 250,
+      clientY: 10,
+    });
+    const pinched = onRangeChange.mock.calls.at(-1)?.[0];
+    expect(pinched[1] - pinched[0]).toBeLessThan(50);
   });
 });

--- a/src/components/base/UPlotChart.tsx
+++ b/src/components/base/UPlotChart.tsx
@@ -4,6 +4,13 @@ import "uplot/dist/uPlot.min.css";
 import { chartScale, eventMarkersPlugin } from "./UPlotHelpers";
 import { getThemeVersion, subscribeThemeMode } from "../../Theme";
 import { ChartAnnotationsContext } from "./ChartAnnotationsContext";
+import {
+  ChartViewportContext,
+  ChartViewportRange,
+  panChartViewport,
+  rangesEqual,
+  zoomChartViewport,
+} from "./ChartViewportContext";
 
 /**
  * The React shell every chart in the game sits in.
@@ -118,6 +125,7 @@ export default function UPlotChart<S>(
 ): React.JSX.Element {
   const { ariaLabel, id, height, state, data, structureKey, syncKey } = props;
   const annotations = React.useContext(ChartAnnotationsContext);
+  const viewport = React.useContext(ChartViewportContext);
   const rootRef = React.useRef<HTMLDivElement>(null);
   const plotRef = React.useRef<uPlot | null>(null);
   const drawnRef = React.useRef<uPlot.AlignedData | null>(null);
@@ -186,6 +194,9 @@ export default function UPlotChart<S>(
   tooltipRef.current = props.tooltip;
   const annotationsRef = React.useRef(annotations);
   annotationsRef.current = annotations;
+  const viewportRef = React.useRef(viewport);
+  viewportRef.current = viewport;
+  const viewportEnabled = !!viewport;
 
   // A plot's options are built once and then only fed data, so the colours in them are the
   // ones that were in force when it was built. Switching palette therefore has to rebuild --
@@ -313,6 +324,206 @@ export default function UPlotChart<S>(
   });
 
   React.useLayoutEffect(() => {
+    if (plotRef.current && viewport) {
+      plotRef.current.setScale("x", {
+        min: viewport.range[0],
+        max: viewport.range[1],
+      });
+    }
+  }, [viewport, width]);
+
+  React.useLayoutEffect(() => {
+    const plot = plotRef.current;
+    const currentViewport = viewportRef.current;
+    if (!plot || !currentViewport) {
+      return;
+    }
+    const over = plot.over;
+    over.style.touchAction = "pan-y";
+    let liveRange = currentViewport.range;
+    let frame: number | undefined;
+    let pending: ChartViewportRange | undefined;
+    let wheelTimer: ReturnType<typeof setTimeout> | undefined;
+    const pointers = new Map<number, { x: number; y: number }>();
+    let drag:
+      | { id: number; x: number; y: number; active: boolean; touch: boolean }
+      | undefined;
+    let pinchDistance: number | undefined;
+
+    const schedule = (range: ChartViewportRange) => {
+      liveRange = range;
+      pending = range;
+      if (frame === undefined) {
+        frame = requestAnimationFrame(() => {
+          frame = undefined;
+          if (pending) {
+            viewportRef.current?.onRangeChange(pending);
+            pending = undefined;
+          }
+        });
+      }
+    };
+    const commit = () => {
+      if (frame !== undefined) {
+        cancelAnimationFrame(frame);
+        frame = undefined;
+      }
+      if (pending) {
+        liveRange = pending;
+        pending = undefined;
+      }
+      viewportRef.current?.onRangeChange(liveRange, true);
+    };
+    const point = (clientX: number) => {
+      const rect = over.getBoundingClientRect();
+      return Math.min(
+        1,
+        Math.max(0, (clientX - rect.left) / Math.max(1, rect.width)),
+      );
+    };
+    const onWheel = (event: WheelEvent) => {
+      const value = viewportRef.current;
+      if (!value) return;
+      if (!wheelTimer) liveRange = value.range;
+      const horizontal =
+        Math.abs(event.deltaX) > Math.abs(event.deltaY) || event.shiftKey;
+      if (event.ctrlKey || event.metaKey) {
+        event.preventDefault();
+        const factor = Math.exp(Math.max(-1, Math.min(1, event.deltaY / 240)));
+        schedule(
+          zoomChartViewport(
+            value.bounds,
+            liveRange,
+            value.minSpan,
+            factor,
+            point(event.clientX),
+          ),
+        );
+      } else if (horizontal && !rangesEqual(value.bounds, liveRange)) {
+        event.preventDefault();
+        const delta = event.shiftKey ? event.deltaY : event.deltaX;
+        schedule(
+          panChartViewport(
+            value.bounds,
+            liveRange,
+            value.minSpan,
+            (delta / Math.max(1, over.clientWidth)) *
+              (liveRange[1] - liveRange[0]),
+          ),
+        );
+      } else {
+        return;
+      }
+      if (wheelTimer) clearTimeout(wheelTimer);
+      wheelTimer = setTimeout(() => {
+        wheelTimer = undefined;
+        commit();
+      }, 160);
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.button !== 0) return;
+      if (viewportRef.current) liveRange = viewportRef.current.range;
+      pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+      if (pointers.size >= 2) {
+        const [a, b] = [...pointers.values()];
+        pinchDistance = Math.hypot(a.x - b.x, a.y - b.y);
+        drag = undefined;
+        pointers.forEach((_pointer, id) => over.setPointerCapture?.(id));
+        event.preventDefault();
+        return;
+      }
+      drag = {
+        id: event.pointerId,
+        x: event.clientX,
+        y: event.clientY,
+        active: event.pointerType !== "touch",
+        touch: event.pointerType === "touch",
+      };
+      if (!drag.touch) over.setPointerCapture?.(event.pointerId);
+    };
+    const onPointerMove = (event: PointerEvent) => {
+      if (pointers.has(event.pointerId)) {
+        pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+      }
+      const value = viewportRef.current;
+      if (!value) return;
+      if (pinchDistance !== undefined && pointers.size >= 2) {
+        const [a, b] = [...pointers.values()];
+        const distance = Math.hypot(a.x - b.x, a.y - b.y);
+        if (distance > 0) {
+          event.preventDefault();
+          schedule(
+            zoomChartViewport(
+              value.bounds,
+              liveRange,
+              value.minSpan,
+              pinchDistance / distance,
+              point((a.x + b.x) / 2),
+            ),
+          );
+          pinchDistance = distance;
+        }
+        return;
+      }
+      if (!drag || drag.id !== event.pointerId) return;
+      const deltaX = event.clientX - drag.x;
+      const deltaY = event.clientY - drag.y;
+      if (!drag.active) {
+        if (Math.abs(deltaY) >= Math.abs(deltaX) || Math.abs(deltaX) < 8) {
+          return;
+        }
+        drag.active = true;
+        over.setPointerCapture?.(event.pointerId);
+      }
+      if (rangesEqual(value.bounds, liveRange)) return;
+      event.preventDefault();
+      drag.x = event.clientX;
+      drag.y = event.clientY;
+      schedule(
+        panChartViewport(
+          value.bounds,
+          liveRange,
+          value.minSpan,
+          (-deltaX / Math.max(1, over.clientWidth)) *
+            (liveRange[1] - liveRange[0]),
+        ),
+      );
+    };
+    const onPointerEnd = (event: PointerEvent) => {
+      const interacted = pinchDistance !== undefined || !!drag?.active;
+      pointers.delete(event.pointerId);
+      if (pointers.size < 2) pinchDistance = undefined;
+      if (drag?.id === event.pointerId) drag = undefined;
+      if (over.hasPointerCapture?.(event.pointerId)) {
+        over.releasePointerCapture(event.pointerId);
+      }
+      if (interacted) commit();
+    };
+    const onDoubleClick = (event: MouseEvent) => {
+      event.preventDefault();
+      viewportRef.current?.onReset(true);
+    };
+
+    over.addEventListener("wheel", onWheel, { passive: false });
+    over.addEventListener("pointerdown", onPointerDown);
+    over.addEventListener("pointermove", onPointerMove);
+    over.addEventListener("pointerup", onPointerEnd);
+    over.addEventListener("pointercancel", onPointerEnd);
+    over.addEventListener("dblclick", onDoubleClick);
+    return () => {
+      over.style.touchAction = "";
+      over.removeEventListener("wheel", onWheel);
+      over.removeEventListener("pointerdown", onPointerDown);
+      over.removeEventListener("pointermove", onPointerMove);
+      over.removeEventListener("pointerup", onPointerEnd);
+      over.removeEventListener("pointercancel", onPointerEnd);
+      over.removeEventListener("dblclick", onDoubleClick);
+      if (frame !== undefined) cancelAnimationFrame(frame);
+      if (wheelTimer) clearTimeout(wheelTimer);
+    };
+  }, [width, viewportEnabled]);
+
+  React.useLayoutEffect(() => {
     plotRef.current?.redraw();
   }, [annotations]);
 
@@ -323,6 +534,8 @@ export default function UPlotChart<S>(
         ref={rootRef}
         role="img"
         aria-label={accessibleLabel}
+        data-viewport-min={viewport?.range[0]}
+        data-viewport-max={viewport?.range[1]}
         style={{
           width: "100%",
           minWidth: 0,

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -24,19 +24,24 @@ interface ChartMockProps {
   id?: string;
   syncKey?: string;
   timeline?: unknown[];
+  domain?: [number, number] | { x: [number, number] };
 }
+
+const domainValue = (domain?: ChartMockProps["domain"]) =>
+  JSON.stringify(Array.isArray(domain) ? domain : domain?.x);
 
 let mockSupplyDemandPaints = 0;
 
 jest.mock("../base/ChartFinances", () => ({
   __esModule: true,
-  default: ({ id, syncKey, timeline }: ChartMockProps) => (
+  default: ({ id, syncKey, timeline, domain }: ChartMockProps) => (
     <div
       role="img"
       id={id}
       data-testid={id}
       data-sync-key={syncKey}
       data-points={timeline?.length}
+      data-domain={domainValue(domain)}
     />
   ),
 }));
@@ -70,7 +75,7 @@ jest.mock("../base/ChartForecastSupplyByFuel", () => ({
 }));
 jest.mock("../base/ChartForecastSupplyDemand", () => ({
   __esModule: true,
-  default: ({ syncKey, timeline }: ChartMockProps) => {
+  default: ({ syncKey, timeline, domain }: ChartMockProps) => {
     mockSupplyDemandPaints++;
     return (
       <div
@@ -79,6 +84,7 @@ jest.mock("../base/ChartForecastSupplyDemand", () => ({
         data-testid="supply-demand-chart"
         data-sync-key={syncKey}
         data-points={timeline?.length}
+        data-domain={domainValue(domain)}
       />
     );
   },
@@ -272,7 +278,39 @@ describe("Insights layers", () => {
 
     const levers = screen.getByRole("region", { name: "Planning controls" });
     expect(levers).toHaveTextContent(/Rate .*\/kWh/);
-    expect(levers.textContent).not.toMatch(/market [^·]*\/kWh/);
+    expect(
+      within(levers).getByText(/market \$/, {
+        selector: ".insightsRateSummaryDesktop",
+      }).textContent,
+    ).not.toMatch(/market [^·]*\/kWh/);
+    expect(within(levers).getByText("Market")).toBeInTheDocument();
+    expect(within(levers).getByText("Customers / mo")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Hide rate slider" }),
+    ).toHaveAccessibleDescription(/projected customers .* next month/i);
+  });
+
+  it("keeps the compact rate metrics visible when the slider is collapsed", async () => {
+    renderInsights();
+
+    const toggle = screen.getByRole("button", { name: "Hide rate slider" });
+    const sliderControl = screen.getByTestId("rate-slider-control");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(sliderControl).not.toHaveClass("insightsRateSliderCollapsed");
+    expect(screen.getByRole("slider")).toBeVisible();
+
+    await user.click(toggle);
+
+    expect(
+      screen.getByRole("button", { name: "Show rate slider" }),
+    ).toHaveAttribute("aria-expanded", "false");
+    expect(sliderControl).toHaveClass("insightsRateSliderCollapsed");
+    expect(screen.getByRole("slider")).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByRole("region", { name: "Planning controls" }),
+      ).getByText("Customers / mo"),
+    ).toBeInTheDocument();
   });
 
   it("keeps the customer growth rate visible for public utilities", () => {
@@ -281,6 +319,12 @@ describe("Insights layers", () => {
     const levers = screen.getByRole("region", { name: "Planning controls" });
     expect(levers).toHaveTextContent(/customer growth \+1.5%\/yr/i);
     expect(levers).not.toHaveTextContent(/market/i);
+    expect(
+      within(levers).getByText("Customer growth / yr"),
+    ).toBeInTheDocument();
+    expect(
+      within(levers).getByText("+1.5%", { selector: "strong" }),
+    ).toBeVisible();
   });
 
   it("shows in-range scenario events and reveals their forecast details", async () => {
@@ -323,6 +367,11 @@ describe("Insights layers", () => {
     expect(event).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("dialog")).toBeNull();
     await user.click(event);
+    await user.click(screen.getByRole("button", { name: "Zoom to event" }));
+    expect(screen.getByTestId("supply-demand-chart")).toHaveAttribute(
+      "data-domain",
+      JSON.stringify([5.9 * MINUTES_PER_MONTH, 7.1 * MINUTES_PER_MONTH]),
+    );
     await user.keyboard("{Escape}");
     expect(event).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("dialog")).toBeNull();
@@ -351,7 +400,7 @@ describe("Insights layers", () => {
     localStorage.setItem("insightsRange", "current");
     renderInsights();
 
-    const range = screen.getByRole("combobox", { name: "Insight range" });
+    const range = screen.getByRole("combobox", { name: "Time horizon" });
     expect(range).toHaveTextContent("Next 12 months");
     await user.click(range);
 
@@ -359,6 +408,31 @@ describe("Insights layers", () => {
     expect(options.getByText("Next 12 months")).toBeVisible();
     expect(options.queryByText("Current year")).toBeNull();
     expect(options.queryByText("Next year")).toBeNull();
+  });
+
+  it("zooms and pans every insight chart on one shared time viewport", async () => {
+    renderInsights();
+
+    const supply = screen.getByTestId("supply-demand-chart");
+    const cash = screen.getByTestId("chartInsightsCashPlot");
+    const full = JSON.parse(supply.getAttribute("data-domain") || "[]");
+    expect(cash).toHaveAttribute("data-domain", JSON.stringify(full));
+    expect(screen.getByRole("button", { name: "Pan earlier" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Zoom in" }));
+    const zoomed = JSON.parse(supply.getAttribute("data-domain") || "[]");
+    expect(zoomed[1] - zoomed[0]).toBeCloseTo((full[1] - full[0]) / 2);
+    expect(cash).toHaveAttribute("data-domain", JSON.stringify(zoomed));
+    expect(screen.getByRole("button", { name: "Pan earlier" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Pan later" })).toBeEnabled();
+
+    await user.click(screen.getByRole("button", { name: "Pan later" }));
+    expect(supply.getAttribute("data-domain")).not.toBe(JSON.stringify(zoomed));
+    await user.click(
+      screen.getByRole("button", { name: "Fit 1-year horizon" }),
+    );
+    expect(supply).toHaveAttribute("data-domain", JSON.stringify(full));
   });
 
   it.each([
@@ -571,7 +645,7 @@ describe("Insights layers", () => {
     const game = gameWithHistory();
     renderInsights(100, game);
 
-    await user.click(screen.getByRole("combobox", { name: "Insight range" }));
+    await user.click(screen.getByRole("combobox", { name: "Time horizon" }));
     const ranges = within(await screen.findByRole("listbox"));
     expect(ranges.getByText(String(game.startingYear))).toBeVisible();
     await user.click(ranges.getByText("All recorded"));
@@ -599,7 +673,7 @@ describe("Insights layers", () => {
     );
     expect(screen.getByText(/Energy not served:/)).toBeVisible();
 
-    await user.click(screen.getByRole("combobox", { name: "Insight range" }));
+    await user.click(screen.getByRole("combobox", { name: "Time horizon" }));
     await user.click(
       within(await screen.findByRole("listbox")).getByText(
         String(game.startingYear),

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -26,11 +26,16 @@ import {
 } from "@mui/material";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import CloseIcon from "@mui/icons-material/Close";
 import LayersIcon from "@mui/icons-material/Layers";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
+import FitScreenIcon from "@mui/icons-material/FitScreen";
 import SaveIcon from "@mui/icons-material/Save";
 import TuneIcon from "@mui/icons-material/Tune";
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import ZoomOutIcon from "@mui/icons-material/ZoomOut";
 import {
   GAME_TO_REAL_YEARS,
   ORGANIC_GROWTH_MAX_ANNUAL,
@@ -110,6 +115,15 @@ import { sampleForecastTimeline } from "../../helpers/ForecastSampling";
 import { ChartAnnotationsContext } from "../base/ChartAnnotationsContext";
 import InsightEventRail from "../base/InsightEventRail";
 import { UpcomingStoryEventType } from "./StoryEventSelectors";
+import {
+  ChartViewportContext,
+  ChartViewportRange,
+  clampChartViewport,
+  eventChartViewport,
+  panChartViewport,
+  rangesEqual,
+  zoomChartViewport,
+} from "../base/ChartViewportContext";
 
 export type InsightRange =
   "all" | "next1" | "next5" | "next10" | "next20" | `year:${number}`;
@@ -254,9 +268,30 @@ const HISTORICAL_LAYER_IDS = new Set<InsightLayerId>([
 ]);
 const HOURS_PER_RECORDED_MONTH = 24 * GAME_TO_REAL_YEARS;
 
+function formatRateCompact(rate: number): string {
+  return `${Number((rate * 100).toFixed(1))}¢`;
+}
+
+function rateMarkLabel(
+  rate: number,
+  desktopLabel = formatMoneyConcise(rate),
+  mobileLabel = "",
+) {
+  return (
+    <>
+      <span className="insightsRateMarkDesktop">{desktopLabel}</span>
+      <span className="insightsRateMarkMobile">{mobileLabel}</span>
+    </>
+  );
+}
+
 const RATE_MARKS = [0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3].map((rate) => ({
   value: rate,
-  label: formatMoneyConcise(rate),
+  label: rateMarkLabel(
+    rate,
+    formatMoneyConcise(rate),
+    [0, 0.15, 0.3].includes(rate) ? formatRateCompact(rate) : "",
+  ),
 }));
 
 interface BlackoutEdges {
@@ -276,6 +311,7 @@ interface ProjectionView {
   hasHydro: boolean;
   financePast: MonthlyHistoryType[];
   financeProjected: MonthlyHistoryType[];
+  projectionStepMinutes: number;
 }
 
 export interface StateProps {
@@ -305,6 +341,89 @@ interface State {
   layersOpen: boolean;
   leversOpen: boolean;
   activeEventKey?: string;
+  viewport?: ChartViewportRange;
+  viewportAnnouncement: string;
+}
+
+const VIEWPORT_ZOOM_FACTOR = 0.5;
+const VIEWPORT_PAN_FRACTION = 0.25;
+
+function viewportLabel(
+  range: ChartViewportRange,
+  bounds: ChartViewportRange,
+  startingYear: number,
+): string {
+  if (rangesEqual(range, bounds)) {
+    return "Full selected range";
+  }
+  const start = getDateFromMinute(range[0], startingYear);
+  const end = getDateFromMinute(range[1], startingYear);
+  const left = `${start.month} ${start.year}`;
+  const right = `${end.month} ${end.year}`;
+  return left === right ? left : `${left} – ${right}`;
+}
+
+function horizonLabels(range: InsightRange): {
+  compact: string;
+  full: string;
+  description: string;
+} {
+  if (range === "all") {
+    return {
+      compact: "All",
+      full: "All recorded",
+      description: "recorded history",
+    };
+  }
+  const year = historicalYear(range);
+  if (year !== null) {
+    return {
+      compact: String(year),
+      full: String(year),
+      description: String(year),
+    };
+  }
+  const years = rangeYears(range) || 1;
+  return {
+    compact: `${years}y`,
+    full: years === 1 ? "Next 12 months" : `Next ${years} years`,
+    description: `${years}-year horizon`,
+  };
+}
+
+function viewportAnnouncement(
+  range: ChartViewportRange,
+  bounds: ChartViewportRange,
+  startingYear: number,
+  horizon: InsightRange,
+): string {
+  const description = horizonLabels(horizon).description;
+  return rangesEqual(range, bounds)
+    ? `Showing the full ${description}`
+    : `Showing ${viewportLabel(range, bounds, startingYear)} within the ${description}`;
+}
+
+function timelineWithin(
+  timeline: TickPresentFutureType[],
+  range: ChartViewportRange,
+): TickPresentFutureType[] {
+  if (timeline.length <= 2) return timeline;
+  let first = 0;
+  let last = timeline.length;
+  while (first < last) {
+    const middle = Math.floor((first + last) / 2);
+    if (timeline[middle].minute < range[0]) first = middle + 1;
+    else last = middle;
+  }
+  const from = Math.max(0, first - 1);
+  first = from;
+  last = timeline.length;
+  while (first < last) {
+    const middle = Math.floor((first + last) / 2);
+    if (timeline[middle].minute <= range[1]) first = middle + 1;
+    else last = middle;
+  }
+  return timeline.slice(from, Math.min(timeline.length, first + 1));
 }
 
 function sameLayers(left: InsightLayerId[], right: InsightLayerId[]): boolean {
@@ -549,6 +668,8 @@ function financeSeries(
   key: DerivedHistoryKeysType,
   past: MonthlyHistoryType[],
   projected: MonthlyHistoryType[],
+  domain?: ChartViewportRange,
+  startingYear?: number,
 ) {
   const point = (month: MonthlyHistoryType, isProjected: boolean) => {
     const summary = deriveExpandedSummary(month);
@@ -559,10 +680,21 @@ function financeSeries(
       projected: isProjected,
     };
   };
-  return [
+  const points = [
     ...[...past].reverse().map((month) => point(month, false)),
     ...projected.map((month) => point(month, true)),
   ];
+  if (!domain || startingYear === undefined || points.length <= 2)
+    return points;
+  const minutes = points.map(
+    (value) => (value.month - startingYear * 12 - 1) * MINUTES_PER_MONTH,
+  );
+  const firstInside = minutes.findIndex((minute) => minute >= domain[0]);
+  const first =
+    firstInside < 0 ? points.length - 1 : Math.max(0, firstInside - 1);
+  const firstAfter = minutes.findIndex((minute) => minute > domain[1]);
+  const end = firstAfter < 0 ? points.length : firstAfter + 1;
+  return points.slice(first, Math.max(first + 1, Math.min(points.length, end)));
 }
 
 function facilitySignature(game: GameType): string {
@@ -609,6 +741,8 @@ export default class Insights extends React.Component<Props, State> {
       layersOpen: false,
       leversOpen: true,
       activeEventKey: undefined,
+      viewport: undefined,
+      viewportAnnouncement: "",
     };
   }
 
@@ -648,7 +782,11 @@ export default class Insights extends React.Component<Props, State> {
 
   private setRange(range: InsightRange) {
     setStorageKeyValue(RANGE_KEY, range);
-    this.setState({ range });
+    this.setState({
+      range,
+      viewport: undefined,
+      viewportAnnouncement: `Showing the full ${horizonLabels(range).description}`,
+    });
   }
 
   private setLayers(
@@ -942,6 +1080,7 @@ export default class Insights extends React.Component<Props, State> {
       hasHydro: false,
       financePast,
       financeProjected: [],
+      projectionStepMinutes: MINUTES_PER_MONTH,
     };
   }
 
@@ -1058,6 +1197,7 @@ export default class Insights extends React.Component<Props, State> {
       hasHydro: game.facilities.some((facility) => facility.fuel === "Hydro"),
       financePast: [],
       financeProjected: [currentMonth, ...projectedMonths],
+      projectionStepMinutes,
     };
     this.projectionCache = { key, projection };
     return projection;
@@ -1112,33 +1252,58 @@ export default class Insights extends React.Component<Props, State> {
     const marks =
       scenario.ownership === "Investor"
         ? [
-            { value: 0, label: "$0" },
+            { value: 0, label: rateMarkLabel(0, "$0", "0¢") },
             {
               value: marketRate,
-              label: `${formatMoneyConcise(marketRate)} market`,
+              label: rateMarkLabel(
+                marketRate,
+                `${formatMoneyConcise(marketRate)} market`,
+                `market ${formatRateCompact(marketRate)}`,
+              ),
             },
-            { value: max, label: formatMoneyConcise(max) },
+            {
+              value: max,
+              label: rateMarkLabel(
+                max,
+                formatMoneyConcise(max),
+                formatRateCompact(max),
+              ),
+            },
           ]
         : RATE_MARKS;
+    const formattedCustomerChange = formatCustomerChange(
+      customerChange,
+      now.customers,
+    );
+    const rateSummary =
+      scenario.ownership === "Investor"
+        ? `Rate ${formatMoneyConcise(game.dollarsPerkWh)} per kilowatt hour; market rate ${formatMoneyConcise(marketRate)}; projected customers ${formattedCustomerChange} next month.`
+        : `Rate ${formatMoneyConcise(game.dollarsPerkWh)} per kilowatt hour; customer growth plus ${(ORGANIC_GROWTH_MAX_ANNUAL * 100).toFixed(1)} percent per year.`;
     return (
       <section className="insightsLevers" aria-label="Planning controls">
         <Button
+          className="insightsRateToggle"
           startIcon={<TuneIcon />}
           onClick={() => this.setState({ leversOpen: !this.state.leversOpen })}
           aria-expanded={this.state.leversOpen}
+          aria-controls="rateSliderControl"
+          aria-label={`${this.state.leversOpen ? "Hide" : "Show"} rate slider`}
+          aria-describedby="insightsRateSummary"
         >
-          Rate controls
+          <span className="insightsRateToggleLabel">Rate controls</span>
         </Button>
-        <Typography variant="body2" color="textSecondary">
+        <Typography
+          className="insightsRateSummaryDesktop"
+          variant="body2"
+          color="textSecondary"
+          aria-hidden="true"
+        >
           Rate <strong>{formatMoneyConcise(game.dollarsPerkWh)}/kWh</strong>
           {scenario.ownership === "Investor" && (
             <>
               {" "}
               · market {formatMoneyConcise(marketRate)} · projected customers{" "}
-              <strong>
-                {formatCustomerChange(customerChange, now.customers)}
-              </strong>{" "}
-              next month
+              <strong>{formattedCustomerChange}</strong> next month
             </>
           )}
           {scenario.ownership === "Public" && (
@@ -1151,32 +1316,80 @@ export default class Insights extends React.Component<Props, State> {
             </>
           )}
         </Typography>
-        {this.state.leversOpen && (
-          <div className="budgetSlider flex-newline">
-            <Slider
-              // Keep the thumb local while it is moving. Dispatching every pointer step makes
-              // the entire workbench reconcile and regenerate its long-range projection before
-              // the browser can paint the next thumb position. The committed rate remounts this
-              // uncontrolled slider through its key, so external changes still stay in sync.
-              key={game.dollarsPerkWh}
-              id="rateSlider"
-              disabled={!!game.replayPlayback}
-              defaultValue={game.dollarsPerkWh}
-              aria-label="The rate you charge for electricity generation"
-              valueLabelDisplay="auto"
-              valueLabelFormat={(rate) => `${formatMoneyConcise(rate)}/kWh`}
-              marks={marks}
-              min={0}
-              step={scenario.ownership === "Investor" ? 0.001 : 0.01}
-              max={max}
-              onChangeCommitted={(_event, value) =>
-                onDelta({
-                  dollarsPerkWh: Array.isArray(value) ? value[0] : value,
-                })
-              }
-            />
-          </div>
-        )}
+        <div
+          className={`insightsRateMetrics ${
+            scenario.ownership === "Public" ? "insightsRateMetricsPublic" : ""
+          }`}
+          aria-hidden="true"
+        >
+          <span className="insightsRateMetric">
+            <span className="insightsRateMetricLabel">Rate</span>
+            <strong className="insightsRateMetricValue">
+              {formatRateCompact(game.dollarsPerkWh)}/kWh
+            </strong>
+          </span>
+          {scenario.ownership === "Investor" ? (
+            <>
+              <span className="insightsRateMetric">
+                <span className="insightsRateMetricLabel">Market</span>
+                <span className="insightsRateMetricValue">
+                  {formatRateCompact(marketRate)}
+                </span>
+              </span>
+              <span className="insightsRateMetric">
+                <span className="insightsRateMetricLabel">Customers / mo</span>
+                <strong className="insightsRateMetricValue">
+                  {formattedCustomerChange}
+                </strong>
+              </span>
+            </>
+          ) : (
+            <span className="insightsRateMetric insightsRateMetricGrowth">
+              <span className="insightsRateMetricLabel">
+                Customer growth / yr
+              </span>
+              <strong className="insightsRateMetricValue">
+                +{(ORGANIC_GROWTH_MAX_ANNUAL * 100).toFixed(1)}%
+              </strong>
+            </span>
+          )}
+        </div>
+        <span id="insightsRateSummary" className="srOnly">
+          {rateSummary}
+        </span>
+        <div
+          className={`budgetSlider flex-newline ${
+            this.state.leversOpen ? "" : "insightsRateSliderCollapsed"
+          }`}
+          id="rateSliderControl"
+          data-testid="rate-slider-control"
+        >
+          <Slider
+            // Keep the thumb local while it is moving. Dispatching every pointer step makes
+            // the entire workbench reconcile and regenerate its long-range projection before
+            // the browser can paint the next thumb position. The committed rate remounts this
+            // uncontrolled slider through its key, so external changes still stay in sync.
+            key={game.dollarsPerkWh}
+            id="rateSlider"
+            disabled={!!game.replayPlayback}
+            defaultValue={game.dollarsPerkWh}
+            aria-label="The rate you charge for electricity generation"
+            valueLabelDisplay="auto"
+            valueLabelFormat={(rate) => `${formatMoneyConcise(rate)}/kWh`}
+            getAriaValueText={(rate) =>
+              `${formatMoneyConcise(rate)} per kilowatt hour`
+            }
+            marks={marks}
+            min={0}
+            step={scenario.ownership === "Investor" ? 0.001 : 0.01}
+            max={max}
+            onChangeCommitted={(_event, value) =>
+              onDelta({
+                dollarsPerkWh: Array.isArray(value) ? value[0] : value,
+              })
+            }
+          />
+        </div>
       </section>
     );
   }
@@ -1273,6 +1486,165 @@ export default class Insights extends React.Component<Props, State> {
     );
   }
 
+  private setViewport(
+    bounds: ChartViewportRange,
+    minSpan: number,
+    next: ChartViewportRange,
+    announce = true,
+  ) {
+    const clamped = clampChartViewport(bounds, next, minSpan);
+    this.setState({
+      viewport: rangesEqual(clamped, bounds) ? undefined : clamped,
+      viewportAnnouncement: announce
+        ? viewportAnnouncement(
+            clamped,
+            bounds,
+            this.props.game.startingYear,
+            this.state.range,
+          )
+        : this.state.viewportAnnouncement,
+    });
+  }
+
+  private renderViewportControls(
+    bounds: ChartViewportRange,
+    range: ChartViewportRange,
+    minSpan: number,
+    years: number[],
+  ) {
+    const full = rangesEqual(bounds, range);
+    const span = range[1] - range[0];
+    const setRange = (next: ChartViewportRange) =>
+      this.setViewport(bounds, minSpan, next);
+    const iconButton = (
+      label: string,
+      icon: React.ReactNode,
+      disabled: boolean,
+      onClick: () => void,
+    ) => (
+      <Tooltip title={label}>
+        <span className="insightsViewportButton">
+          <IconButton
+            size="small"
+            aria-label={label}
+            disabled={disabled}
+            onClick={onClick}
+          >
+            {icon}
+          </IconButton>
+        </span>
+      </Tooltip>
+    );
+    return (
+      <section
+        className="insightsViewportToolbar"
+        aria-label="Chart time navigation"
+        aria-describedby="insightsViewportHint"
+      >
+        <Select
+          id="insightsRange"
+          value={this.state.range}
+          onChange={(event: SelectChangeEvent<InsightRange>) =>
+            this.setRange(event.target.value as InsightRange)
+          }
+          className="insightsHorizon"
+          aria-label="Time horizon"
+          renderValue={(value) => {
+            const labels = horizonLabels(value as InsightRange);
+            return (
+              <span className="insightsHorizonValue">
+                <span className="srOnly">{labels.full}</span>
+                <span className="insightsHorizonLong" aria-hidden="true">
+                  {labels.full}
+                </span>
+                <span className="insightsHorizonCompact" aria-hidden="true">
+                  {labels.compact}
+                </span>
+              </span>
+            );
+          }}
+        >
+          <MenuItem value="next1">Next 12 months</MenuItem>
+          <MenuItem value="next5">Next 5 years</MenuItem>
+          <MenuItem value="next10">Next 10 years</MenuItem>
+          <MenuItem value="next20">Next 20 years</MenuItem>
+          {!!this.props.game.monthlyHistory.length && (
+            <MenuItem value="all">All recorded</MenuItem>
+          )}
+          {years.map((year) => (
+            <MenuItem value={historyRange(year)} key={year}>
+              {year}
+            </MenuItem>
+          ))}
+        </Select>
+        <div className="insightsViewportButtons">
+          {iconButton(
+            "Pan earlier",
+            <ChevronLeftIcon />,
+            full || range[0] <= bounds[0],
+            () =>
+              setRange(
+                panChartViewport(
+                  bounds,
+                  range,
+                  minSpan,
+                  -span * VIEWPORT_PAN_FRACTION,
+                ),
+              ),
+          )}
+          {iconButton("Zoom out", <ZoomOutIcon />, full, () =>
+            setRange(
+              zoomChartViewport(
+                bounds,
+                range,
+                minSpan,
+                1 / VIEWPORT_ZOOM_FACTOR,
+              ),
+            ),
+          )}
+          {iconButton(
+            `Fit ${horizonLabels(this.state.range).description}`,
+            <FitScreenIcon />,
+            full,
+            () => setRange(bounds),
+          )}
+          {iconButton("Zoom in", <ZoomInIcon />, span <= minSpan, () =>
+            setRange(
+              zoomChartViewport(bounds, range, minSpan, VIEWPORT_ZOOM_FACTOR),
+            ),
+          )}
+          {iconButton(
+            "Pan later",
+            <ChevronRightIcon />,
+            full || range[1] >= bounds[1],
+            () =>
+              setRange(
+                panChartViewport(
+                  bounds,
+                  range,
+                  minSpan,
+                  span * VIEWPORT_PAN_FRACTION,
+                ),
+              ),
+          )}
+        </div>
+        <div className="insightsViewportText">
+          <Typography variant="body2">
+            {viewportLabel(range, bounds, this.props.game.startingYear)} ·
+            Ctrl-scroll or drag
+          </Typography>
+        </div>
+        <span id="insightsViewportHint" className="srOnly">
+          Pinch or use the zoom controls to zoom. Swipe, drag, or use the pan
+          controls to move through time.
+        </span>
+        <span className="srOnly" aria-live="polite">
+          {this.state.viewportAnnouncement}
+        </span>
+      </section>
+    );
+  }
+
   private renderTrack(
     id: InsightLayerId,
     index: number,
@@ -1307,6 +1679,8 @@ export default class Insights extends React.Component<Props, State> {
             finance.key,
             projection.financePast,
             projection.financeProjected,
+            projection.domain.x,
+            game.startingYear,
           )}
           title={finance.label}
           format={finance.format}
@@ -1653,6 +2027,56 @@ export default class Insights extends React.Component<Props, State> {
       return <span />;
     }
     const projection = this.getProjection(now);
+    const viewportBounds = projection.domain.x;
+    const minViewportSpan = Math.min(
+      viewportBounds[1] - viewportBounds[0],
+      MINUTES_PER_MONTH,
+    );
+    const viewportRange = this.state.viewport
+      ? clampChartViewport(viewportBounds, this.state.viewport, minViewportSpan)
+      : viewportBounds;
+    const viewportTimeline = rangesEqual(viewportRange, viewportBounds)
+      ? projection.timeline
+      : timelineWithin(projection.timeline, viewportRange);
+    const viewportSampleInterval = Math.max(
+      projection.projectionStepMinutes,
+      Math.ceil(
+        (viewportRange[1] - viewportRange[0]) /
+          1600 /
+          projection.projectionStepMinutes,
+      ) * projection.projectionStepMinutes,
+    );
+    const viewportProjection: ProjectionView = rangesEqual(
+      viewportRange,
+      viewportBounds,
+    )
+      ? projection
+      : {
+          ...projection,
+          domain: { ...projection.domain, x: viewportRange },
+          timeline: viewportTimeline,
+          sampled: projection.historical
+            ? viewportTimeline
+            : sampleForecastTimeline(
+                viewportTimeline,
+                viewportSampleInterval,
+                projection.projectionStepMinutes,
+              ),
+        };
+    const viewportContext = {
+      bounds: viewportBounds,
+      range: viewportRange,
+      minSpan: minViewportSpan,
+      onRangeChange: (range: ChartViewportRange, announce = false) =>
+        this.setViewport(viewportBounds, minViewportSpan, range, announce),
+      onReset: (announce = false) =>
+        this.setViewport(
+          viewportBounds,
+          minViewportSpan,
+          viewportBounds,
+          announce,
+        ),
+    };
     const years = playedHistoryYears(game);
     const visible = this.state.layers.filter((id) => {
       const definition = INSIGHT_LAYERS.find((layer) => layer.id === id);
@@ -1696,28 +2120,6 @@ export default class Insights extends React.Component<Props, State> {
           <Toolbar className="paneHeader insightsHeader">
             <Typography variant="h6">Insights</Typography>
             <div className="insightsHeaderControls">
-              <Select
-                id="insightsRange"
-                value={this.state.range}
-                onChange={(event: SelectChangeEvent<InsightRange>) =>
-                  this.setRange(event.target.value as InsightRange)
-                }
-                className="headerControl insightsRange"
-                aria-label="Insight range"
-              >
-                <MenuItem value="next1">Next 12 months</MenuItem>
-                <MenuItem value="next5">Next 5 years</MenuItem>
-                <MenuItem value="next10">Next 10 years</MenuItem>
-                <MenuItem value="next20">Next 20 years</MenuItem>
-                {!!game.monthlyHistory.length && (
-                  <MenuItem value="all">All recorded</MenuItem>
-                )}
-                {years.map((year) => (
-                  <MenuItem value={historyRange(year)} key={year}>
-                    {year}
-                  </MenuItem>
-                ))}
-              </Select>
               <div
                 className="insightsPresetControls"
                 role="group"
@@ -1904,6 +2306,12 @@ export default class Insights extends React.Component<Props, State> {
           ) : (
             this.renderLevers(now)
           )}
+          {this.renderViewportControls(
+            viewportBounds,
+            viewportRange,
+            minViewportSpan,
+            years,
+          )}
           {!!upcomingEvents.length && (
             <InsightEventRail
               events={upcomingEvents}
@@ -1911,20 +2319,34 @@ export default class Insights extends React.Component<Props, State> {
               onActiveChange={(activeEventKey) =>
                 this.setState({ activeEventKey })
               }
+              onZoom={(event) =>
+                this.setViewport(
+                  viewportBounds,
+                  minViewportSpan,
+                  eventChartViewport(
+                    viewportBounds,
+                    event.startsMinute!,
+                    event.endsMinute,
+                    minViewportSpan,
+                  ),
+                )
+              }
             />
           )}
-          <ChartAnnotationsContext.Provider value={annotations}>
-            <div className="insightsTracks">
-              {visible.map((id, index) =>
-                this.renderTrack(id, index, visible, projection),
-              )}
-              {!visible.length && (
-                <Typography className="insightsEmpty" color="textSecondary">
-                  Choose Layers to build this view.
-                </Typography>
-              )}
-            </div>
-          </ChartAnnotationsContext.Provider>
+          <ChartViewportContext.Provider value={viewportContext}>
+            <ChartAnnotationsContext.Provider value={annotations}>
+              <div className="insightsTracks">
+                {visible.map((id, index) =>
+                  this.renderTrack(id, index, visible, viewportProjection),
+                )}
+                {!visible.length && (
+                  <Typography className="insightsEmpty" color="textSecondary">
+                    Choose Layers to build this view.
+                  </Typography>
+                )}
+              </div>
+            </ChartAnnotationsContext.Provider>
+          </ChartViewportContext.Provider>
         </div>
         {this.renderPresetDialogs()}
       </GameCard>


### PR DESCRIPTION
## Summary

- add one shared, bounded time viewport across every Insight chart
- support desktop Ctrl/Cmd-wheel zoom, horizontal drag/trackpad pan, double-click fit, and touch pinch/swipe gestures
- consolidate the time horizon and zoom/pan/fit actions into one fixed 52px row, including at 320px mobile width
- compact mobile rate controls into one metric strip plus the slider, preserving rate, market, and projected monthly customer change
- remove the redundant mobile rate-settings button and keep the slider directly available
- use concise cent-based mobile slider labels with at least 4px bottom clearance, while retaining full desktop wording and accessible summaries
- let players zoom directly to an upcoming scenario event without hiding other event chips
- resample only the visible forecast window so deep zoom remains detailed and responsive

## Verification

- `npm run check` — 924 tests and all simulation scenarios pass
- `npm run build`
- Playwright responsive coverage for desktop Chromium, 390px mobile, and 320px mobile
- layout assertions cover the single-row time toolbar, compact rate-section height, absent mobile settings control, zero horizontal overflow, and measured 4px-or-greater clearance below every visible slider label

## Screenshots

Updated desktop and 320px mobile views are attached below.

![upcoming-events-desktop-chromium](https://github.com/user-attachments/assets/36d234c9-852c-41e2-8c56-ce6ce19d94c2)

![compact-rate-controls-mobile-320px](https://github.com/user-attachments/assets/4bb05ed9-fa09-4341-b8de-f529d2d953f5)