### PR TITLE
Add shareable scenario detail URLs

### DIFF
--- a/e2e/new-game-responsive.spec.ts
+++ b/e2e/new-game-responsive.spec.ts
@@ -6,6 +6,51 @@ const REVIEW_VIEWPORTS = new Set([
   "mobile-320px",
 ]);
 
+test("challenge details have a shareable URL and return to the catalog", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop-chromium");
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem(
+      "plays",
+      JSON.stringify({
+        plays: [0, 1, 2, 3, 4, 5, 100, 103].map((scenarioId) => ({
+          scenarioId,
+          date: new Date().toString(),
+        })),
+      }),
+    );
+  });
+
+  await page.goto("/?scenario=111");
+  await expect(
+    page.getByRole("heading", { name: "Wildfire Emergency" }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\?scenario=111$/);
+
+  await page.getByRole("button", { name: "back" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Choose a game" }),
+  ).toBeVisible();
+  await expect(page).not.toHaveURL(/scenario=/);
+
+  await page.getByRole("button", { name: "All challenges" }).click();
+  await page
+    .getByRole("button", { name: "View Wildfire Emergency details" })
+    .click();
+  await expect(page).toHaveURL(/\?scenario=111$/);
+
+  await page.goBack();
+  await expect(
+    page.getByRole("heading", { name: "Choose a game" }),
+  ).toBeVisible();
+  await page.goForward();
+  await expect(
+    page.getByRole("heading", { name: "Wildfire Emergency" }),
+  ).toBeVisible();
+});
+
 test("game picker prioritizes one lesson and filters the challenge catalog", async ({
   page,
 }, testInfo) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,20 @@
 import { ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { User } from "firebase/auth";
 import CompositorContainer from "./components/CompositorContainer";
 import UnitsProvider from "./components/base/UnitsContext";
 import { navigate, navigateBack } from "./reducers/Card";
 import { pauseAudio, resumeAudio } from "./reducers/Settings";
 import { snackbarOpen } from "./reducers/UI";
-import { firebaseAppAuth, getDevicePlatform } from "./Globals";
+import { firebaseAppAuth, getDevicePlatform, getHistoryApi } from "./Globals";
 import { delta, loadProfile, reset } from "./reducers/User";
 import { SCENARIOS } from "./data/Scenarios";
 import { delta as gameDelta } from "./reducers/Game";
+import {
+  scenarioDetailsUrl,
+  scenarioFromSearch,
+  scenarioListUrl,
+} from "./ScenarioUrl";
 import { startAutosave } from "./SaveGame";
 import { store, useAppSelector } from "./Store";
 import {
@@ -134,6 +139,7 @@ function OfflineNotice(): React.JSX.Element | null {
 }
 
 export default function App() {
+  const scenarioRouteInitialized = useRef(false);
   /**
    * All of this used to run in the component body. A function component's body runs on every
    * render, and index.tsx mounts App inside React.StrictMode, which deliberately invokes it twice
@@ -145,21 +151,36 @@ export default function App() {
   useEffect(() => {
     setupStorage(document);
 
-    // Shared score links land on the relevant challenge instead of dropping a new player at an
-    // unexplained title screen. Tutorial ids still use the guided mission list.
-    const sharedScenarioId = Number(
-      new URLSearchParams(window.location.search).get("scenario"),
-    );
-    const sharedScenario = SCENARIOS.find(
-      (scenario) => scenario.id === sharedScenarioId && !scenario.tutorialSteps,
-    );
-    if (sharedScenario) {
-      store.dispatch(gameDelta({ scenarioId: sharedScenario.id }));
-      store.dispatch(navigate("NEW_GAME_DETAILS"));
+    // A direct challenge link needs a real catalog entry behind it, so both the visible Back
+    // button and the browser Back button stay in the app instead of returning to the referring
+    // site. The ref makes this safe under StrictMode's development effect replay.
+    if (!scenarioRouteInitialized.current) {
+      scenarioRouteInitialized.current = true;
+      const sharedScenario = scenarioFromSearch(window.location.search);
+      if (sharedScenario) {
+        const detailsUrl = scenarioDetailsUrl(sharedScenario.id);
+        getHistoryApi().replaceState(null, "", scenarioListUrl());
+        store.dispatch(
+          navigate({ name: "NEW_GAME", skipBrowserHistory: true }),
+        );
+        store.dispatch(gameDelta({ scenarioId: sharedScenario.id }));
+        store.dispatch(navigate({ name: "NEW_GAME_DETAILS", url: detailsUrl }));
+      }
     }
 
     const onPopState = (e: PopStateEvent) => {
-      store.dispatch(navigateBack());
+      const sharedScenario = scenarioFromSearch(window.location.search);
+      if (sharedScenario) {
+        store.dispatch(gameDelta({ scenarioId: sharedScenario.id }));
+        store.dispatch(
+          navigate({
+            name: "NEW_GAME_DETAILS",
+            skipBrowserHistory: true,
+          }),
+        );
+      } else {
+        store.dispatch(navigateBack());
+      }
       e.preventDefault();
     };
     window.addEventListener("popstate", onPopState);

--- a/src/Globals.tsx
+++ b/src/Globals.tsx
@@ -53,6 +53,8 @@ export function logout(): Promise<void> {
 // non-browser hosts) gets a no-op.
 interface HistoryApi {
   pushState: History["pushState"];
+  replaceState: History["replaceState"];
+  back: History["back"];
 }
 
 const refs = {
@@ -60,7 +62,11 @@ const refs = {
   history:
     typeof window !== "undefined" && typeof window.history !== "undefined"
       ? (window.history as HistoryApi)
-      : { pushState: () => undefined },
+      : {
+          pushState: () => undefined,
+          replaceState: () => undefined,
+          back: () => undefined,
+        },
   localStorage: null as Storage | null,
   audioContext: null as AudioContext | null,
 };

--- a/src/ScenarioUrl.test.ts
+++ b/src/ScenarioUrl.test.ts
@@ -1,0 +1,35 @@
+import {
+  scenarioDetailsUrl,
+  scenarioFromSearch,
+  scenarioListUrl,
+} from "./ScenarioUrl";
+
+describe("scenario URLs", () => {
+  it("resolves a public challenge from a shared query", () => {
+    expect(scenarioFromSearch("?scenario=111")?.name).toBe(
+      "Wildfire Emergency",
+    );
+  });
+
+  it("does not route unknown, malformed, or tutorial ids to challenge details", () => {
+    expect(scenarioFromSearch("?scenario=99999")).toBeUndefined();
+    expect(scenarioFromSearch("?scenario=111oops")).toBeUndefined();
+    expect(scenarioFromSearch("?scenario=0")).toBeUndefined();
+  });
+
+  it("adds and removes only the scenario query parameter", () => {
+    const location = {
+      pathname: "/play",
+      search: "?campaign=fall",
+    } as Location;
+    expect(scenarioDetailsUrl(111, location)).toBe(
+      "/play?campaign=fall&scenario=111",
+    );
+    expect(
+      scenarioListUrl({
+        pathname: "/play",
+        search: "?campaign=fall&scenario=111",
+      } as Location),
+    ).toBe("/play?campaign=fall");
+  });
+});

--- a/src/ScenarioUrl.ts
+++ b/src/ScenarioUrl.ts
@@ -1,0 +1,37 @@
+import { SCENARIOS } from "./data/Scenarios";
+import { ScenarioType } from "./Types";
+
+type LocationParts = Pick<Location, "pathname" | "search">;
+
+/** Resolves a public challenge details link without letting tutorial ids bypass the mission flow. */
+export function scenarioFromSearch(search: string): ScenarioType | undefined {
+  const rawId = new URLSearchParams(search).get("scenario");
+  if (rawId === null || !/^\d+$/.test(rawId)) {
+    return undefined;
+  }
+
+  const scenarioId = Number(rawId);
+  return SCENARIOS.find(
+    (scenario) => scenario.id === scenarioId && !scenario.tutorialSteps,
+  );
+}
+
+/** Keeps unrelated query parameters intact while making the selected challenge shareable. */
+export function scenarioDetailsUrl(
+  scenarioId: number,
+  location: LocationParts = window.location,
+): string {
+  const params = new URLSearchParams(location.search);
+  params.set("scenario", String(scenarioId));
+  return `${location.pathname}?${params.toString()}`;
+}
+
+/** The scenario catalog is the parent route of every challenge details link. */
+export function scenarioListUrl(
+  location: LocationParts = window.location,
+): string {
+  const params = new URLSearchParams(location.search);
+  params.delete("scenario");
+  const search = params.toString();
+  return `${location.pathname}${search ? `?${search}` : ""}`;
+}

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -163,6 +163,10 @@ export type StoryActionTargetType =
 export interface NavigateActionType {
   name: CardNameType;
   dontRemember?: boolean;
+  // Most cards use the app's anonymous hash entry. Public routes can supply a meaningful URL,
+  // while a popstate restoration must not write another browser-history entry.
+  url?: string;
+  skipBrowserHistory?: boolean;
   // Manual entry to open and scroll to, for deep links from terms the game shows elsewhere
   entry?: string;
   storyTarget?: StoryActionTargetType;

--- a/src/components/views/NewGameContainer.tsx
+++ b/src/components/views/NewGameContainer.tsx
@@ -2,6 +2,7 @@ import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
 import { delta, start, quit } from "../../reducers/Game";
 import { navigate } from "../../reducers/Card";
+import { scenarioDetailsUrl } from "../../ScenarioUrl";
 import { AppStateType, GameType } from "../../Types";
 import NewGame, { DispatchProps, StateProps } from "./NewGame";
 
@@ -21,7 +22,14 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     },
     onDetails: (d: Partial<GameType>) => {
       dispatch(delta(d));
-      dispatch(navigate("NEW_GAME_DETAILS"));
+      if (d.scenarioId !== undefined) {
+        dispatch(
+          navigate({
+            name: "NEW_GAME_DETAILS",
+            url: scenarioDetailsUrl(d.scenarioId),
+          }),
+        );
+      }
     },
     onManual: () => {
       dispatch(navigate("MANUAL"));

--- a/src/components/views/NewGameDetailsContainer.tsx
+++ b/src/components/views/NewGameDetailsContainer.tsx
@@ -1,7 +1,8 @@
 import type { AppDispatch } from "../../Store";
 import { connect } from "react-redux";
-import { navigateBack } from "../../reducers/Card";
 import { start, delta, startReplay } from "../../reducers/Game";
+import { getHistoryApi } from "../../Globals";
+import { scenarioListUrl } from "../../ScenarioUrl";
 import { snackbarOpen } from "../../reducers/UI";
 import { startWithSaveGuard } from "./StartGame";
 import { AppStateType, GameType, ReplayType } from "../../Types";
@@ -17,17 +18,23 @@ const mapStateToProps = (state: AppStateType): StateProps => {
 const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onBack: () => {
-      dispatch(navigateBack());
+      // Consuming the details entry keeps the address bar and Redux's popstate navigation in
+      // lockstep. Direct links are bootstrapped with a catalog entry immediately behind them.
+      getHistoryApi().back();
     },
     onDelta: (d: Partial<GameType>) => {
       dispatch(delta(d));
     },
     onStart: (scenarioId: number) => {
-      startWithSaveGuard(dispatch, () => dispatch(start(scenarioId)));
+      startWithSaveGuard(dispatch, () => {
+        getHistoryApi().replaceState(null, "", scenarioListUrl());
+        dispatch(start(scenarioId));
+      });
     },
     // Watching a replay simulates a whole game, but never writes one, so unlike onStart it has
     // no autosave to clobber and needs no confirmation
     onWatchReplay: (replay: ReplayType) => {
+      getHistoryApi().replaceState(null, "", scenarioListUrl());
       dispatch(startReplay(replay));
     },
     onReplayError: (message: string) => {

--- a/src/reducers/Card.test.tsx
+++ b/src/reducers/Card.test.tsx
@@ -20,4 +20,22 @@ describe("card reducer", () => {
     // Back from the scenario list should still reach the title screen
     expect(state.history).toEqual(["NEW_GAME", "MAIN_MENU"]);
   });
+
+  it("writes a public URL for routed cards", () => {
+    window.history.replaceState(null, "", "/");
+    cardReducer(
+      undefined,
+      navigate({ name: "NEW_GAME_DETAILS", url: "/?scenario=111" }),
+    );
+    expect(window.location.search).toBe("?scenario=111");
+  });
+
+  it("does not add a browser entry while restoring a route", () => {
+    window.history.replaceState(null, "", "/?scenario=111");
+    cardReducer(
+      undefined,
+      navigate({ name: "NEW_GAME_DETAILS", skipBrowserHistory: true }),
+    );
+    expect(window.location.search).toBe("?scenario=111");
+  });
 });

--- a/src/reducers/Card.tsx
+++ b/src/reducers/Card.tsx
@@ -32,7 +32,9 @@ export const cardSlice = createSlice({
         return state;
       }
       logEvent("card_view", { card: a.name });
-      getHistoryApi().pushState(null, "", "#");
+      if (!a.skipBrowserHistory) {
+        getHistoryApi().pushState(null, "", a.url || "#");
+      }
       // TODO better implementation for don't remember, right now it still makes an entry!
       return {
         ...state,


### PR DESCRIPTION
## Summary

- give every challenge details screen a stable `?scenario=<id>` URL that can be copied and shared
- open valid challenge links directly for signed-out, new, and returning players while keeping tutorials in their guided flow
- keep the in-app Back control and browser Back/Forward navigation synchronized with the challenge catalog
- clear the details route when starting a game or replay

## Test plan

- `npm run check`
- `npm run build`
- `npx playwright test --config e2e/playwright.config.ts e2e/new-game-responsive.spec.ts --project=desktop-chromium`

## Screenshot

Wildfire Emergency opened directly from `/?scenario=111`:

![scenario-share-pr](https://github.com/user-attachments/assets/9b781581-c9f6-4622-863e-65ccd923fb2c)