### PR TITLE
Use refined wildfire scenario icon

### DIFF
--- a/public/images/wildfire emergency.svg
+++ b/public/images/wildfire emergency.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29f117c9ab032f7685461f1b627bd44741bab7da16d20775498278dc8a5eda24
-size 1179
+oid sha256:cbf4bebe9ecf3bcd0a7bf3ceb6410de69f3160275a5064818493f940b0f952a5
+size 1144

--- a/public/images/wildfire emergency.svg
+++ b/public/images/wildfire emergency.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbf4bebe9ecf3bcd0a7bf3ceb6410de69f3160275a5064818493f940b0f952a5
-size 1144
+oid sha256:94ab2145a8d71080b919d28eaa56ee844ab7375327afbb3f041b90d6432bdc0f
+size 1053


### PR DESCRIPTION
## Summary

- redraw the Wildfire Emergency icon around the supplied flame silhouette
- use a two-tone orange outer flame and yellow inner flame on the established deep-red badge
- preserve the 500 × 500 view box, 40/20 stroke hierarchy, flat palette, and accessible title and description

## Validation

- `npm run check` — 97 test suites and 929 tests passed; all scenario simulations satisfy their invariants
- `npm run build` — compiled successfully
- visually reviewed at 500 px and at the actual 40–48 px UI size on light and dark backgrounds
- inspected the finished Wildfire Emergency details screen in dark mode

## Screenshots

The finished interface was reviewed in the local browser, but this environment blocked exporting the captured screenshot to a file for upload. The screenshot is therefore omitted rather than silently excluded.