### PR TITLE
Fix Insights chart ranges and sizing

### DIFF
--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -25,7 +25,6 @@ test("upcoming scenario events stay usable across insight viewports", async ({
   );
   await page.addInitScript(() => {
     window.localStorage.clear();
-    window.localStorage.setItem("insightsRange", "next5");
   });
   await page.goto("/?scenario=100");
   await page.getByRole("button", { name: "Start game" }).click();
@@ -35,6 +34,8 @@ test("upcoming scenario events stay usable across insight viewports", async ({
     await page.getByRole("button", { name: "Insights", exact: true }).click();
   }
   await expect(insights).toBeVisible();
+  await insights.getByRole("button", { name: "Zoom out" }).click();
+  await insights.getByRole("button", { name: "Zoom out" }).click();
 
   const eventRail = insights.getByRole("region", {
     name: "Upcoming scenario events",
@@ -94,14 +95,10 @@ test("upcoming scenario events stay usable across insight viewports", async ({
     name: "Chart time navigation",
   });
   await expect(viewportToolbar).toContainText(/20\d{2}/);
-  const horizon = viewportToolbar.getByRole("combobox", {
-    name: "Time horizon",
-  });
-  await expect(insights.locator(".insightsHeader .insightsRange")).toHaveCount(
-    0,
-  );
-  const viewportButtons = viewportToolbar.getByRole("button");
-  const viewportControls = [horizon, ...(await viewportButtons.all())];
+  await expect(
+    viewportToolbar.getByRole("combobox", { name: "Time horizon" }),
+  ).toHaveCount(0);
+  const viewportControls = await viewportToolbar.getByRole("button").all();
   const viewportControlBoxes = await Promise.all(
     viewportControls.map((control) => control.boundingBox()),
   );
@@ -119,7 +116,7 @@ test("upcoming scenario events stay usable across insight viewports", async ({
     Math.max(0, element.scrollWidth - element.clientWidth),
   );
   expect(toolbarOverflow).toBeLessThanOrEqual(1);
-  const viewportButtonBoxes = viewportControlBoxes.slice(1);
+  const viewportButtonBoxes = viewportControlBoxes;
   expect(
     viewportButtonBoxes.every((box) =>
       testInfo.project.name.startsWith("mobile-")
@@ -128,16 +125,16 @@ test("upcoming scenario events stay usable across insight viewports", async ({
     ),
   ).toBe(true);
   if (testInfo.project.name.startsWith("mobile-")) {
-    expect(viewportControlBoxes[0]!.width).toBeCloseTo(80, 0);
-    viewportButtonBoxes.forEach((box) => expect(box!.width).toBeCloseTo(44, 0));
+    viewportControlBoxes.forEach((box) =>
+      expect(box!.width).toBeCloseTo(44, 0),
+    );
+    await expect(
+      viewportToolbar.locator(".insightsViewportDateCompact"),
+    ).toBeVisible();
   } else {
-    const longHorizonLabel = horizon.locator(".insightsHorizonLong");
-    await expect(longHorizonLabel).toContainText("Next 5 years");
-    expect(
-      await longHorizonLabel.evaluate(
-        (element) => element.scrollWidth - element.clientWidth,
-      ),
-    ).toBeLessThanOrEqual(0);
+    await expect(
+      viewportToolbar.locator(".insightsViewportDateLong"),
+    ).toBeVisible();
   }
 
   const pageOverflow = await insights.evaluate((element) =>
@@ -220,6 +217,19 @@ test("insights header controls stay aligned in one compact row", async ({
   }
   await expect(insights).toBeVisible();
   await page.evaluate(() => document.fonts.ready);
+
+  const [supplyPlot, cashPlot] = await Promise.all([
+    insights
+      .locator('.insightsTrack[data-layer="supplyDemand"] .u-over')
+      .boundingBox(),
+    insights.locator('.insightsTrack[data-layer="cash"] .u-over').boundingBox(),
+  ]);
+  expect(supplyPlot).not.toBeNull();
+  expect(cashPlot).not.toBeNull();
+  expect(supplyPlot!.x + supplyPlot!.width).toBeCloseTo(
+    cashPlot!.x + cashPlot!.width,
+    0,
+  );
 
   const controls = [
     page.locator(".insightsPreset"),
@@ -317,6 +327,17 @@ test("insights header controls stay aligned in one compact row", async ({
 
   const reviewDir = process.env.REVIEW_SCREENSHOT_DIR;
   if (reviewDir) {
+    const notification = page.getByRole("button", {
+      name: "Dismiss notification",
+    });
+    if (await notification.count()) {
+      await notification.click({ timeout: 2_000 }).catch(() => undefined);
+    }
+    await page
+      .getByText(/^Walkthrough closed/)
+      .waitFor({ state: "hidden", timeout: 10_000 })
+      .catch(() => undefined);
+    await page.waitForTimeout(500);
     await page.screenshot({
       path: path.join(
         reviewDir,
@@ -330,14 +351,12 @@ test("insights header controls stay aligned in one compact row", async ({
   await expect(presetName).toHaveCSS("text-overflow", "ellipsis");
   if (testInfo.project.name === "mobile-320px") {
     await expect(page.getByRole("button", { name: "Save" })).not.toBeVisible();
-    const horizon = page.getByRole("combobox", { name: "Time horizon" });
-    await expect(horizon.locator(".insightsHorizonCompact")).toHaveText("1y");
-    await horizon.click();
-    await page.getByRole("option", { name: "Next 5 years" }).click();
-    await expect(horizon.locator(".insightsHorizonCompact")).toHaveText("5y");
+    await expect(page.getByLabel(/Displayed date range:/)).toContainText(
+      /20\d{2}/,
+    );
     await expect(
-      page.getByRole("button", { name: "Fit 5-year horizon" }),
-    ).toBeDisabled();
+      page.getByRole("combobox", { name: "Time horizon" }),
+    ).toHaveCount(0);
     await page.getByRole("button", { name: "Preset actions" }).click();
     await expect(
       page.getByRole("menuitem", { name: "Save preset changes" }),

--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -128,14 +128,10 @@ test("upcoming scenario events stay usable across insight viewports", async ({
     viewportControlBoxes.forEach((box) =>
       expect(box!.width).toBeCloseTo(44, 0),
     );
-    await expect(
-      viewportToolbar.locator(".insightsViewportDateCompact"),
-    ).toBeVisible();
-  } else {
-    await expect(
-      viewportToolbar.locator(".insightsViewportDateLong"),
-    ).toBeVisible();
   }
+  await expect(
+    viewportToolbar.locator(".insightsViewportDate"),
+  ).toBeVisible();
 
   const pageOverflow = await insights.evaluate((element) =>
     Math.max(0, element.scrollWidth - element.clientWidth),
@@ -351,9 +347,22 @@ test("insights header controls stay aligned in one compact row", async ({
   await expect(presetName).toHaveCSS("text-overflow", "ellipsis");
   if (testInfo.project.name === "mobile-320px") {
     await expect(page.getByRole("button", { name: "Save" })).not.toBeVisible();
-    await expect(page.getByLabel(/Displayed date range:/)).toContainText(
-      /20\d{2}/,
+    const dateRange = page.getByLabel(/Displayed date range:/);
+    await expect(dateRange).toHaveAttribute(
+      "aria-label",
+      "Displayed date range: 2019–20",
     );
+    await expect(dateRange).toHaveCSS("font-size", "14px");
+    await page.getByRole("button", { name: "Zoom in" }).click();
+    await expect(dateRange).toHaveAttribute(
+      "aria-label",
+      "Displayed date range: Apr–Oct 2019",
+    );
+    expect(
+      await dateRange.evaluate(
+        (element) => element.scrollWidth - element.clientWidth,
+      ),
+    ).toBeLessThanOrEqual(0);
     await expect(
       page.getByRole("combobox", { name: "Time horizon" }),
     ).toHaveCount(0);

--- a/src/app.scss
+++ b/src/app.scss
@@ -1046,10 +1046,6 @@ $pane_header_height: 40px;
   font-variant-numeric: tabular-nums;
 }
 
-.insightsViewportDateCompact {
-  display: none;
-}
-
 .insightsViewportButtons {
   display: flex;
   flex: 0 0 auto;
@@ -1300,28 +1296,13 @@ $pane_header_height: 40px;
     height: 52px;
     min-height: 52px;
     gap: 4px;
-    padding: 4px 8px;
+    padding: 4px;
   }
 
   .insightsViewportDate {
-    flex: 1 1 80px;
-    font-size: 0.72rem;
-    line-height: 1.2;
-    white-space: normal;
-  }
-
-  .insightsViewportDateLong {
-    display: none;
-  }
-
-  .insightsViewportDateCompact {
-    display: flex;
-    flex-direction: column;
-
-    // Preserve the range relationship when the dates wrap onto separate lines.
-    span + span::before {
-      content: "– ";
-    }
+    flex: 1 1 auto;
+    font-size: 0.875rem;
+    white-space: nowrap;
   }
 
   .insightsViewportButtons {

--- a/src/app.scss
+++ b/src/app.scss
@@ -1037,22 +1037,16 @@ $pane_header_height: 40px;
   background: var(--bg-raised);
 }
 
-.insightsHorizon {
-  width: 152px;
-  height: 40px;
+.insightsViewportDate {
   min-width: 0;
-  flex: 0 0 152px;
-}
-
-.insightsHorizonValue {
-  display: block;
-  min-width: 0;
+  flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
-.insightsHorizonCompact {
+.insightsViewportDateCompact {
   display: none;
 }
 
@@ -1070,17 +1064,6 @@ $pane_header_height: 40px;
 
   .MuiIconButton-root {
     color: $interactive_blue;
-  }
-}
-
-.insightsViewportText {
-  min-width: 0;
-  flex: 1 1 auto;
-
-  .MuiTypography-root {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 }
 
@@ -1320,18 +1303,25 @@ $pane_header_height: 40px;
     padding: 4px 8px;
   }
 
-  .insightsHorizon {
-    width: 80px;
-    height: 44px;
-    flex-basis: 80px;
+  .insightsViewportDate {
+    flex: 1 1 80px;
+    font-size: 0.72rem;
+    line-height: 1.2;
+    white-space: normal;
   }
 
-  .insightsHorizonLong {
+  .insightsViewportDateLong {
     display: none;
   }
 
-  .insightsHorizonCompact {
-    display: inline;
+  .insightsViewportDateCompact {
+    display: flex;
+    flex-direction: column;
+
+    // Preserve the range relationship when the dates wrap onto separate lines.
+    span + span::before {
+      content: "– ";
+    }
   }
 
   .insightsViewportButtons {
@@ -1344,10 +1334,6 @@ $pane_header_height: 40px;
       height: 44px;
       flex-basis: 44px;
     }
-  }
-
-  .insightsViewportText {
-    display: none;
   }
 
   .insightEventList {
@@ -1748,6 +1734,11 @@ $pane_header_height: 40px;
 
 // The canvas is transparent, so one quiet surface behind it frames the axes and plot together.
 // Inset shadow behaves like a border without changing uPlot's measured width.
+.accessibleChart {
+  width: 100%;
+  min-width: 0;
+}
+
 html[data-theme="dark"] .uplot {
   overflow: hidden;
   border-radius: 8px;

--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -3,6 +3,7 @@ import uPlot from "uplot";
 import UPlotChart, { BuildContext } from "./UPlotChart";
 import { padRange, stepTicks, titlePlugin, xAxis, yAxis } from "./UPlotHelpers";
 import {
+  axisTicksAreYearly,
   formatMinuteAsMonthAxis,
   formatMonthChartAxis,
   MINUTES_PER_MONTH,
@@ -89,10 +90,20 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         },
         values: (_u, splits) => {
           const s = getState();
+          const minuteScale = s.startingYear !== undefined;
+          const yearOnly = axisTicksAreYearly(
+            splits,
+            minuteScale ? MINUTES_PER_MONTH : 1,
+          );
           return splits.map((t) =>
-            s.startingYear === undefined
-              ? formatMonthChartAxis(t, s.multiyear)
-              : formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear),
+            !minuteScale
+              ? formatMonthChartAxis(t, s.multiyear, yearOnly)
+              : formatMinuteAsMonthAxis(
+                  t,
+                  s.startingYear!,
+                  s.multiyear,
+                  yearOnly,
+                ),
           );
         },
       }),

--- a/src/components/base/ChartForecastDemandByType.tsx
+++ b/src/components/base/ChartForecastDemandByType.tsx
@@ -7,6 +7,7 @@ import {
   TickPresentFutureType,
 } from "../../Types";
 import {
+  axisTicksAreYearly,
   formatMinuteAsMonthAxis,
   formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
@@ -72,11 +73,13 @@ function buildOptions(showXLabels: boolean) {
         },
         values: (_u, splits) => {
           const state = getState();
+          const yearOnly = axisTicksAreYearly(splits, MINUTES_PER_MONTH);
           return splits.map((minute) =>
             formatMinuteAsMonthAxis(
               minute,
               state.startingYear,
               state.multiyear,
+              yearOnly,
             ),
           );
         },

--- a/src/components/base/ChartForecastFuelPrices.tsx
+++ b/src/components/base/ChartForecastFuelPrices.tsx
@@ -13,6 +13,7 @@ import {
   yAxis,
 } from "./UPlotHelpers";
 import {
+  axisTicksAreYearly,
   formatMinuteAsMonthAxis,
   formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
@@ -76,8 +77,9 @@ function buildOptions(showXLabels: boolean) {
         },
         values: (_u, splits) => {
           const s = getState();
+          const yearOnly = axisTicksAreYearly(splits, MINUTES_PER_MONTH);
           return splits.map((t) =>
-            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear),
+            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear, yearOnly),
           );
         },
       }),

--- a/src/components/base/ChartForecastRenewableCapacityFactor.tsx
+++ b/src/components/base/ChartForecastRenewableCapacityFactor.tsx
@@ -3,6 +3,7 @@ import uPlot from "uplot";
 import { HOURS_PER_YEAR_REAL } from "../../Constants";
 import { GENERATORS } from "../../data/Facilities";
 import {
+  axisTicksAreYearly,
   formatMinuteAsMonthAxis,
   formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
@@ -169,12 +170,14 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         },
         values: (_u, splits) => {
           const state = getState();
+          const yearOnly = axisTicksAreYearly(splits, MINUTES_PER_MONTH);
           return state.showXLabels
             ? splits.map((minute) =>
                 formatMinuteAsMonthAxis(
                   minute,
                   state.startingYear,
                   state.multiyear,
+                  yearOnly,
                 ),
               )
             : splits.map(() => "");

--- a/src/components/base/ChartForecastStorage.tsx
+++ b/src/components/base/ChartForecastStorage.tsx
@@ -11,6 +11,7 @@ import {
 } from "./UPlotHelpers";
 import { TickPresentFutureType } from "../../Types";
 import {
+  axisTicksAreYearly,
   formatMinuteAsMonthAxis,
   formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
@@ -64,8 +65,9 @@ function buildOptions(showXLabels: boolean) {
         },
         values: (_u, splits) => {
           const s = getState();
+          const yearOnly = axisTicksAreYearly(splits, MINUTES_PER_MONTH);
           return splits.map((t) =>
-            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear),
+            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear, yearOnly),
           );
         },
       }),

--- a/src/components/base/ChartForecastSupplyByFuel.tsx
+++ b/src/components/base/ChartForecastSupplyByFuel.tsx
@@ -9,6 +9,7 @@ import {
   yAxis,
 } from "./UPlotHelpers";
 import {
+  axisTicksAreYearly,
   formatMinuteAsMonthAxis,
   formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
@@ -109,8 +110,9 @@ function buildOptions(
         },
         values: (_u, splits) => {
           const s = getState();
+          const yearOnly = axisTicksAreYearly(splits, MINUTES_PER_MONTH);
           return splits.map((t) =>
-            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear),
+            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear, yearOnly),
           );
         },
       }),

--- a/src/components/base/ChartForecastSupplyDemand.tsx
+++ b/src/components/base/ChartForecastSupplyDemand.tsx
@@ -4,7 +4,6 @@ import UPlotChart, { BuildContext } from "./UPlotChart";
 import {
   bandsPlugin,
   FORECAST_AXIS_LEFT,
-  FORECAST_AXIS_RIGHT,
   padRange,
   spansFromEdges,
   stepTicks,
@@ -13,6 +12,7 @@ import {
 } from "./UPlotHelpers";
 import { TickPresentFutureType } from "../../Types";
 import {
+  axisTicksAreYearly,
   formatMinuteAsMonthAxis,
   formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
@@ -50,9 +50,9 @@ function buildOptions(showXLabels: boolean) {
   return ({ getState, scale }: BuildContext<State>): uPlot.Options => ({
     width: 0, // set by UPlotChart
     height: 0,
-    // Right gutter reserved rather than used, so this plot ends where the weather chart's
-    // second axis makes that one end -- see FORECAST_AXIS_RIGHT
-    padding: [5 * scale, FORECAST_AXIS_RIGHT * scale, 0, 0],
+    // Keep only enough trailing room for a centred x-axis label. This chart has no right axis,
+    // so reserving the weather chart's gutter made its plot visibly narrower than its peers.
+    padding: [5 * scale, 24 * scale, 0, 0],
     cursor: {
       x: true,
       y: false,
@@ -78,8 +78,9 @@ function buildOptions(showXLabels: boolean) {
         },
         values: (_u, splits) => {
           const s = getState();
+          const yearOnly = axisTicksAreYearly(splits, MINUTES_PER_MONTH);
           return splits.map((t) =>
-            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear),
+            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear, yearOnly),
           );
         },
       }),

--- a/src/components/base/ChartForecastWater.tsx
+++ b/src/components/base/ChartForecastWater.tsx
@@ -13,6 +13,7 @@ import {
 } from "./UPlotHelpers";
 import { TickPresentFutureType } from "../../Types";
 import {
+  axisTicksAreYearly,
   formatMinuteAsMonthAxis,
   formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
@@ -72,8 +73,9 @@ function buildOptions(showXLabels: boolean) {
         },
         values: (_u, splits) => {
           const s = getState();
+          const yearOnly = axisTicksAreYearly(splits, MINUTES_PER_MONTH);
           return splits.map((t) =>
-            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear),
+            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear, yearOnly),
           );
         },
       }),

--- a/src/components/base/ChartForecastWeather.tsx
+++ b/src/components/base/ChartForecastWeather.tsx
@@ -13,6 +13,7 @@ import {
 import { TICK_MINUTES } from "../../Constants";
 import { TickPresentFutureType, UnitSystemType } from "../../Types";
 import {
+  axisTicksAreYearly,
   formatMinuteAsMonthAxis,
   formatMinuteAsTooltipHeader,
   MINUTES_PER_MONTH,
@@ -76,8 +77,9 @@ function buildOptions({ getState, scale }: BuildContext<State>): uPlot.Options {
         },
         values: (_u, splits) => {
           const s = getState();
+          const yearOnly = axisTicksAreYearly(splits, MINUTES_PER_MONTH);
           return splits.map((t) =>
-            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear),
+            formatMinuteAsMonthAxis(t, s.startingYear, s.multiyear, yearOnly),
           );
         },
       }),

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -408,7 +408,7 @@ describe("Insights layers", () => {
 
     expect(screen.queryByRole("combobox", { name: "Time horizon" })).toBeNull();
     expect(
-      screen.getByLabelText("Displayed date range: Jan 2020 – Jan 2021"),
+      screen.getByLabelText("Displayed date range: 2020–21"),
     ).toBeVisible();
   });
 
@@ -426,6 +426,9 @@ describe("Insights layers", () => {
     const zoomed = JSON.parse(supply.getAttribute("data-domain") || "[]");
     expect(zoomed[1] - zoomed[0]).toBeCloseTo((initial[1] - initial[0]) / 2);
     expect(cash).toHaveAttribute("data-domain", JSON.stringify(zoomed));
+    expect(
+      screen.getByLabelText("Displayed date range: Apr–Oct 2020"),
+    ).toBeVisible();
     expect(screen.getByRole("button", { name: "Pan earlier" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Pan later" })).toBeEnabled();
 
@@ -436,6 +439,9 @@ describe("Insights layers", () => {
       "data-domain",
       JSON.stringify([0, 20 * 12 * MINUTES_PER_MONTH]),
     );
+    expect(
+      screen.getByLabelText("Displayed date range: 2020–40"),
+    ).toBeVisible();
   });
 
   it("uses hourly points for the continuous forecast", () => {

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -152,7 +152,13 @@ function renderInsights(
 
 function gameWithHistory(): GameType {
   const game = createGame({ scenarioId: 100 });
-  game.date.year = game.startingYear + 2;
+  game.date = {
+    ...game.date,
+    minute: 24 * MINUTES_PER_MONTH,
+    monthsElapsed: 24,
+    monthNumber: 1,
+    year: game.startingYear + 2,
+  };
   game.monthlyHistory = [
     {
       ...EMPTY_HISTORY,
@@ -378,7 +384,7 @@ describe("Insights layers", () => {
     expect(region).not.toHaveTextContent("Outside range");
   });
 
-  it("does not show forecast event annotations in historical views", async () => {
+  it("ignores the removed stored horizon and shows only events in the viewport", () => {
     localStorage.setItem("insightsRange", "all");
     renderInsights(100, gameWithHistory(), [
       {
@@ -396,18 +402,14 @@ describe("Insights layers", () => {
     ).toBeNull();
   });
 
-  it("offers one rolling 12-month range instead of separate calendar years", async () => {
+  it("replaces preset horizons with a displayed 12-month date range", () => {
     localStorage.setItem("insightsRange", "current");
     renderInsights();
 
-    const range = screen.getByRole("combobox", { name: "Time horizon" });
-    expect(range).toHaveTextContent("Next 12 months");
-    await user.click(range);
-
-    const options = within(await screen.findByRole("listbox"));
-    expect(options.getByText("Next 12 months")).toBeVisible();
-    expect(options.queryByText("Current year")).toBeNull();
-    expect(options.queryByText("Next year")).toBeNull();
+    expect(screen.queryByRole("combobox", { name: "Time horizon" })).toBeNull();
+    expect(
+      screen.getByLabelText("Displayed date range: Jan 2020 – Jan 2021"),
+    ).toBeVisible();
   });
 
   it("zooms and pans every insight chart on one shared time viewport", async () => {
@@ -415,39 +417,94 @@ describe("Insights layers", () => {
 
     const supply = screen.getByTestId("supply-demand-chart");
     const cash = screen.getByTestId("chartInsightsCashPlot");
-    const full = JSON.parse(supply.getAttribute("data-domain") || "[]");
-    expect(cash).toHaveAttribute("data-domain", JSON.stringify(full));
+    const initial = JSON.parse(supply.getAttribute("data-domain") || "[]");
+    expect(cash).toHaveAttribute("data-domain", JSON.stringify(initial));
     expect(screen.getByRole("button", { name: "Pan earlier" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Zoom out" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeEnabled();
 
     await user.click(screen.getByRole("button", { name: "Zoom in" }));
     const zoomed = JSON.parse(supply.getAttribute("data-domain") || "[]");
-    expect(zoomed[1] - zoomed[0]).toBeCloseTo((full[1] - full[0]) / 2);
+    expect(zoomed[1] - zoomed[0]).toBeCloseTo((initial[1] - initial[0]) / 2);
     expect(cash).toHaveAttribute("data-domain", JSON.stringify(zoomed));
     expect(screen.getByRole("button", { name: "Pan earlier" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Pan later" })).toBeEnabled();
 
     await user.click(screen.getByRole("button", { name: "Pan later" }));
     expect(supply.getAttribute("data-domain")).not.toBe(JSON.stringify(zoomed));
-    await user.click(
-      screen.getByRole("button", { name: "Fit 1-year horizon" }),
+    await user.click(screen.getByRole("button", { name: "Fit full timeline" }));
+    expect(supply).toHaveAttribute(
+      "data-domain",
+      JSON.stringify([0, 20 * 12 * MINUTES_PER_MONTH]),
     );
-    expect(supply).toHaveAttribute("data-domain", JSON.stringify(full));
   });
 
-  it.each([
-    ["next10", "2880"],
-    ["next20", "5760"],
-  ])("uses hourly points for the %s forecast", (range, expectedPoints) => {
-    localStorage.setItem("insightsRange", range);
+  it("uses hourly points for the continuous forecast", () => {
     localStorage.setItem("insightsLayers", JSON.stringify(["weather"]));
     renderInsights();
 
-    expect(screen.getByRole("img")).toHaveAttribute(
-      "data-points",
-      expectedPoints,
-    );
     expect(screen.getByRole("img")).toHaveAttribute("data-step", "60");
+  });
+
+  it("advances the end while keeping a scenario-start viewport anchored", () => {
+    const game = createGame({ scenarioId: 100 });
+    const view = renderInsights(100, game);
+    const supply = screen.getByTestId("supply-demand-chart");
+    expect(supply).toHaveAttribute(
+      "data-domain",
+      JSON.stringify([0, 12 * MINUTES_PER_MONTH]),
+    );
+
+    const nextGame = {
+      ...game,
+      date: {
+        ...game.date,
+        minute: game.date.minute + MINUTES_PER_MONTH,
+        monthsElapsed: game.date.monthsElapsed + 1,
+      },
+    };
+    view.rerender(
+      <Insights
+        game={nextGame}
+        selectedFacilityId={null}
+        facilityDragActive={false}
+        onDelta={() => undefined}
+      />,
+    );
+
+    expect(supply).toHaveAttribute(
+      "data-domain",
+      JSON.stringify([0, 13 * MINUTES_PER_MONTH]),
+    );
+  });
+
+  it("slides both ends of an unanchored viewport as the game advances", async () => {
+    const game = createGame({ scenarioId: 100 });
+    const view = renderInsights(100, game);
+    const supply = screen.getByTestId("supply-demand-chart");
+    await user.click(screen.getByRole("button", { name: "Zoom in" }));
+    const before = JSON.parse(supply.getAttribute("data-domain") || "[]");
+
+    const nextGame = {
+      ...game,
+      date: {
+        ...game.date,
+        minute: game.date.minute + MINUTES_PER_MONTH,
+        monthsElapsed: game.date.monthsElapsed + 1,
+      },
+    };
+    view.rerender(
+      <Insights
+        game={nextGame}
+        selectedFacilityId={null}
+        facilityDragActive={false}
+        onDelta={() => undefined}
+      />,
+    );
+    const after = JSON.parse(supply.getAttribute("data-domain") || "[]");
+
+    expect(after).toEqual(
+      before.map((minute: number) => minute + MINUTES_PER_MONTH),
+    );
   });
 
   it("keeps tutorial targets visible without duplicating stored layers", () => {
@@ -637,7 +694,7 @@ describe("Insights layers", () => {
     ).toHaveAttribute("data-sync-key", "insights");
   });
 
-  it("charts recorded monthly data and disables forecast-only layers", async () => {
+  it("combines recorded monthly data with the continuous forecast", async () => {
     localStorage.setItem(
       "insightsLayers",
       JSON.stringify(["supplyDemand", "profit", "fuelPrices"]),
@@ -645,49 +702,31 @@ describe("Insights layers", () => {
     const game = gameWithHistory();
     renderInsights(100, game);
 
-    await user.click(screen.getByRole("combobox", { name: "Time horizon" }));
-    const ranges = within(await screen.findByRole("listbox"));
-    expect(ranges.getByText(String(game.startingYear))).toBeVisible();
-    await user.click(ranges.getByText("All recorded"));
+    await user.click(screen.getByRole("button", { name: "Fit full timeline" }));
 
     expect(
-      screen.queryByRole("region", { name: "Planning controls" }),
-    ).toBeNull();
-    expect(
-      screen.getByText(
-        "Monthly records · forecast-only layers are unavailable",
-      ),
+      screen.getByRole("region", { name: "Planning controls" }),
     ).toBeVisible();
     expect(
       screen.getByText("Supply & Demand", { selector: "h6" }),
     ).toBeVisible();
     expect(screen.getByText("Profit", { selector: "h6" })).toBeVisible();
-    expect(screen.queryByText("Fuel Prices", { selector: "h6" })).toBeNull();
-    expect(screen.getByTestId("chartInsightsProfitPlot")).toHaveAttribute(
-      "data-points",
-      "3",
-    );
-    expect(screen.getByTestId("supply-demand-chart")).toHaveAttribute(
-      "data-points",
-      "3",
-    );
-    expect(screen.getByText(/Energy not served:/)).toBeVisible();
-
-    await user.click(screen.getByRole("combobox", { name: "Time horizon" }));
-    await user.click(
-      within(await screen.findByRole("listbox")).getByText(
-        String(game.startingYear),
+    expect(screen.getByText("Fuel Prices", { selector: "h6" })).toBeVisible();
+    expect(
+      Number(
+        screen
+          .getByTestId("chartInsightsProfitPlot")
+          .getAttribute("data-points"),
       ),
-    );
-    expect(screen.getByTestId("chartInsightsProfitPlot")).toHaveAttribute(
-      "data-points",
-      "2",
-    );
+    ).toBeGreaterThan(240);
+    expect(
+      Number(
+        screen.getByTestId("supply-demand-chart").getAttribute("data-points"),
+      ),
+    ).toBeGreaterThan(3);
 
     await user.click(screen.getByRole("button", { name: /Layers/ }));
-    expect(
-      screen.getByRole("checkbox", { name: "Fuel Prices" }),
-    ).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Fuel Prices" })).toBeEnabled();
     expect(screen.getByRole("checkbox", { name: "Profit" })).toBeEnabled();
   });
 

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -79,7 +79,6 @@ import {
   largeMassUnit,
 } from "../../helpers/Units";
 import {
-  getStorageChoice,
   getStorageJson,
   getStorageString,
   setStorageKeyValue,
@@ -124,9 +123,6 @@ import {
   rangesEqual,
   zoomChartViewport,
 } from "../base/ChartViewportContext";
-
-export type InsightRange =
-  "all" | "next1" | "next5" | "next10" | "next20" | `year:${number}`;
 
 export type InsightLayerId =
   | "supplyDemand"
@@ -241,31 +237,14 @@ export const INSIGHT_PRESETS: Record<
   },
 };
 
-const RANGE_KEY = "insightsRange";
 const LAYERS_KEY = "insightsLayers";
 const ACTIVE_PRESET_KEY = "insightsActivePreset";
 const PRESET_LIBRARY_KEY = "insightsPresetLibrary";
 export const MAX_CUSTOM_INSIGHT_PRESETS = 10;
 const MAX_PRESET_NAME_LENGTH = 40;
-const FORECAST_RANGE_OPTIONS: readonly InsightRange[] = [
-  "next1",
-  "next5",
-  "next10",
-  "next20",
-];
 const SYNC_KEY = "insights";
 const GROUPS: LayerGroup[] = ["Grid", "Customers", "Economics", "Environment"];
 const ALL_LAYER_IDS = new Set(INSIGHT_LAYERS.map((layer) => layer.id));
-const HISTORICAL_LAYER_IDS = new Set<InsightLayerId>([
-  "supplyDemand",
-  "profit",
-  "revenue",
-  "expenses",
-  "cash",
-  "customers",
-  "emissions",
-  "financeDetails",
-]);
 const HOURS_PER_RECORDED_MONTH = 24 * GAME_TO_REAL_YEARS;
 
 function formatRateCompact(rate: number): string {
@@ -300,9 +279,9 @@ interface BlackoutEdges {
 }
 
 interface ProjectionView {
-  historical: boolean;
   timeline: TickPresentFutureType[];
   sampled: TickPresentFutureType[];
+  supplyDemandTimeline: TickPresentFutureType[];
   domain: { x: [number, number]; y: [number, number] };
   blackouts: BlackoutEdges[];
   blackoutTotalWh: number;
@@ -329,7 +308,6 @@ export interface DispatchProps {
 export interface Props extends StateProps, DispatchProps {}
 
 interface State {
-  range: InsightRange;
   layers: InsightLayerId[];
   preset: InsightPresetId;
   presetDirty: boolean;
@@ -341,21 +319,35 @@ interface State {
   layersOpen: boolean;
   leversOpen: boolean;
   activeEventKey?: string;
-  viewport?: ChartViewportRange;
+  viewport: ChartViewportRange;
   viewportAnnouncement: string;
 }
 
 const VIEWPORT_ZOOM_FACTOR = 0.5;
 const VIEWPORT_PAN_FRACTION = 0.25;
+const DEFAULT_VIEWPORT_MONTHS = 12;
+const MAX_FORECAST_YEARS = 20;
+
+function viewportBounds(game: GameType): ChartViewportRange {
+  return [0, game.date.minute + MAX_FORECAST_YEARS * 12 * MINUTES_PER_MONTH];
+}
+
+function initialViewport(game: GameType): ChartViewportRange {
+  const bounds = viewportBounds(game);
+  return clampChartViewport(
+    bounds,
+    [
+      game.date.minute,
+      game.date.minute + DEFAULT_VIEWPORT_MONTHS * MINUTES_PER_MONTH,
+    ],
+    MINUTES_PER_MONTH,
+  );
+}
 
 function viewportLabel(
   range: ChartViewportRange,
-  bounds: ChartViewportRange,
   startingYear: number,
 ): string {
-  if (rangesEqual(range, bounds)) {
-    return "Full selected range";
-  }
   const start = getDateFromMinute(range[0], startingYear);
   const end = getDateFromMinute(range[1], startingYear);
   const left = `${start.month} ${start.year}`;
@@ -363,44 +355,11 @@ function viewportLabel(
   return left === right ? left : `${left} – ${right}`;
 }
 
-function horizonLabels(range: InsightRange): {
-  compact: string;
-  full: string;
-  description: string;
-} {
-  if (range === "all") {
-    return {
-      compact: "All",
-      full: "All recorded",
-      description: "recorded history",
-    };
-  }
-  const year = historicalYear(range);
-  if (year !== null) {
-    return {
-      compact: String(year),
-      full: String(year),
-      description: String(year),
-    };
-  }
-  const years = rangeYears(range) || 1;
-  return {
-    compact: `${years}y`,
-    full: years === 1 ? "Next 12 months" : `Next ${years} years`,
-    description: `${years}-year horizon`,
-  };
-}
-
 function viewportAnnouncement(
   range: ChartViewportRange,
-  bounds: ChartViewportRange,
   startingYear: number,
-  horizon: InsightRange,
 ): string {
-  const description = horizonLabels(horizon).description;
-  return rangesEqual(range, bounds)
-    ? `Showing the full ${description}`
-    : `Showing ${viewportLabel(range, bounds, startingYear)} within the ${description}`;
+  return `Showing ${viewportLabel(range, startingYear)}`;
 }
 
 function timelineWithin(
@@ -588,39 +547,6 @@ export function withRequiredLayers(
   return next;
 }
 
-function rangeYears(range: InsightRange): number {
-  return range.startsWith("next") ? Number(range.slice(4)) : 0;
-}
-
-function historicalYear(range: InsightRange): number | null {
-  return range.startsWith("year:") ? Number(range.slice(5)) : null;
-}
-
-function isHistoricalRange(range: InsightRange): boolean {
-  return range === "all" || historicalYear(range) !== null;
-}
-
-function historyRange(year: number): InsightRange {
-  return `year:${year}`;
-}
-
-function playedHistoryYears(game: GameType): number[] {
-  return [...new Set(game.monthlyHistory.map((month) => month.year))].sort(
-    (a, b) => b - a,
-  );
-}
-
-function rangeOptions(game: GameType): InsightRange[] {
-  if (!game.monthlyHistory.length) {
-    return [...FORECAST_RANGE_OPTIONS];
-  }
-  return [
-    ...FORECAST_RANGE_OPTIONS,
-    "all",
-    ...playedHistoryYears(game).map(historyRange),
-  ];
-}
-
 function monthMinute(month: MonthlyHistoryType, startingYear: number): number {
   return (
     ((month.year - startingYear) * 12 + month.month - 1) * MINUTES_PER_MONTH
@@ -729,7 +655,6 @@ export default class Insights extends React.Component<Props, State> {
       : matchingPreset(layers, presetLibrary);
     const savedLayers = presetDefinition(preset, presetLibrary)?.layers;
     this.state = {
-      range: getStorageChoice(RANGE_KEY, rangeOptions(props.game), "next1"),
       layers,
       preset,
       presetDirty: !savedLayers || !sameLayers(layers, savedLayers),
@@ -741,7 +666,7 @@ export default class Insights extends React.Component<Props, State> {
       layersOpen: false,
       leversOpen: true,
       activeEventKey: undefined,
-      viewport: undefined,
+      viewport: initialViewport(props.game),
       viewportAnnouncement: "",
     };
   }
@@ -772,21 +697,40 @@ export default class Insights extends React.Component<Props, State> {
 
   public componentDidUpdate(previousProps: Props) {
     if (
+      this.props.game.date.monthsElapsed !==
+      previousProps.game.date.monthsElapsed
+    ) {
+      const elapsedMonths =
+        this.props.game.date.monthsElapsed -
+        previousProps.game.date.monthsElapsed;
+      const delta = elapsedMonths * MINUTES_PER_MONTH;
+      const bounds = viewportBounds(this.props.game);
+      this.setState((state) => {
+        const anchoredAtScenarioStart = state.viewport[0] === bounds[0];
+        const viewport = clampChartViewport(
+          bounds,
+          [
+            anchoredAtScenarioStart ? bounds[0] : state.viewport[0] + delta,
+            state.viewport[1] + delta,
+          ],
+          MINUTES_PER_MONTH,
+        );
+        return {
+          viewport,
+          viewportAnnouncement: viewportAnnouncement(
+            viewport,
+            this.props.game.startingYear,
+          ),
+        };
+      });
+    }
+    if (
       this.props.focusLayer &&
       this.props.focusLayer !== previousProps.focusLayer &&
       !this.state.layers.includes(this.props.focusLayer)
     ) {
       this.setLayers([...this.state.layers, this.props.focusLayer]);
     }
-  }
-
-  private setRange(range: InsightRange) {
-    setStorageKeyValue(RANGE_KEY, range);
-    this.setState({
-      range,
-      viewport: undefined,
-      viewportAnnouncement: `Showing the full ${horizonLabels(range).description}`,
-    });
   }
 
   private setLayers(
@@ -1029,82 +973,13 @@ export default class Insights extends React.Component<Props, State> {
     });
   }
 
-  private getHistoricalProjection(now: TickPresentFutureType): ProjectionView {
-    const { game } = this.props;
-    const year = historicalYear(this.state.range);
-    const financePast = game.monthlyHistory.filter(
-      (month) => year === null || month.year === year,
-    );
-    const months = [...financePast].reverse();
-    const timeline = months.map((month) => {
-      // The historical supply chart reads these three fields only. Cloning a real tick keeps the
-      // shared chart contract intact without pretending monthlyHistory retained the other layers.
-      const tick = { ...now } as TickPresentFutureType;
-      tick.minute = monthMinute(month, game.startingYear);
-      tick.supplyW = month.supplyWh / HOURS_PER_RECORDED_MONTH;
-      tick.demandW = month.demandWh / HOURS_PER_RECORDED_MONTH;
-      return tick;
-    });
-    const rangeMin = timeline[0].minute;
-    const rangeMax = timeline[timeline.length - 1].minute + MINUTES_PER_MONTH;
-    let domainMin = Number.POSITIVE_INFINITY;
-    let domainMax = 0;
-    let blackoutTotalWh = 0;
-    for (let i = 0; i < timeline.length; i++) {
-      const tick = timeline[i];
-      const month = months[i];
-      domainMin = Math.min(domainMin, tick.supplyW, tick.demandW);
-      domainMax = Math.max(domainMax, tick.supplyW, tick.demandW);
-      blackoutTotalWh += Math.max(0, month.demandWh - month.supplyWh);
-    }
-
-    return {
-      historical: true,
-      timeline,
-      sampled: timeline,
-      domain: { x: [rangeMin, rangeMax], y: [domainMin, domainMax] },
-      // The monthly record knows how much energy went unserved, but not when. Drawing a blackout
-      // band across the whole month would imply precision the saved data does not have.
-      blackouts: [
-        { minute: rangeMin, value: 0 },
-        { minute: rangeMax, value: 0 },
-      ],
-      blackoutTotalWh,
-      largestBlackout: {
-        wh: 0,
-        peakW: 0,
-        start: rangeMin,
-        end: rangeMin,
-      },
-      hasStorage: false,
-      hasHydro: false,
-      financePast,
-      financeProjected: [],
-      projectionStepMinutes: MINUTES_PER_MONTH,
-    };
-  }
-
   private getProjection(now: TickPresentFutureType): ProjectionView {
     const { game } = this.props;
-    const years = rangeYears(this.state.range);
-    const nextYearMinute =
-      (game.date.year - game.startingYear + 1) * 12 * MINUTES_PER_MONTH;
-    const projectionStepMinutes =
-      this.state.range === "next10" || this.state.range === "next20"
-        ? 60
-        : TICK_MINUTES;
+    const projectionStepMinutes = 60;
     const tickScale = projectionStepMinutes / TICK_MINUTES;
-    const ticks =
-      years > 0
-        ? (TICKS_PER_YEAR * years) / tickScale
-        : Math.max(
-            1,
-            Math.ceil((nextYearMinute - game.date.minute) / TICK_MINUTES),
-          );
-    const monthsAhead =
-      years > 0 ? years * 12 : Math.max(0, 12 - game.date.monthNumber);
+    const ticks = (TICKS_PER_YEAR * MAX_FORECAST_YEARS) / tickScale;
+    const monthsAhead = MAX_FORECAST_YEARS * 12;
     const key = [
-      this.state.range,
       game.date.monthsElapsed,
       game.monthlyHistory.length,
       game.dollarsPerkWh,
@@ -1114,11 +989,6 @@ export default class Insights extends React.Component<Props, State> {
     if (this.projectionCache?.key === key) {
       return this.projectionCache.projection;
     }
-    if (isHistoricalRange(this.state.range)) {
-      const projection = this.getHistoricalProjection(now);
-      this.projectionCache = { key, projection };
-      return projection;
-    }
 
     const timeline = generateNewTimeline(
       game,
@@ -1127,22 +997,35 @@ export default class Insights extends React.Component<Props, State> {
       ticks,
       projectionStepMinutes,
     );
+    const historicalSupplyDemand = [...game.monthlyHistory]
+      .reverse()
+      .map((month) => {
+        // Monthly history retains supply and demand but not the other forecast layers. Keep it
+        // on the supply/demand chart and let forecast-only charts begin at the current month.
+        const tick = { ...now } as TickPresentFutureType;
+        tick.minute = monthMinute(month, game.startingYear);
+        tick.supplyW = month.supplyWh / HOURS_PER_RECORDED_MONTH;
+        tick.demandW = month.demandWh / HOURS_PER_RECORDED_MONTH;
+        return tick;
+      });
     let domainMin = Number.POSITIVE_INFINITY;
     let domainMax = 0;
-    for (const tick of timeline) {
+    for (const tick of [...historicalSupplyDemand, ...timeline]) {
       domainMin = Math.min(domainMin, tick.supplyW, tick.demandW);
       domainMax = Math.max(domainMax, tick.supplyW, tick.demandW);
     }
-    const rangeMin = timeline[0].minute;
-    const rangeMax = timeline[timeline.length - 1].minute;
+    const [rangeMin, rangeMax] = viewportBounds(game);
+    const forecastMin = timeline[0].minute;
+    const forecastMax = timeline[timeline.length - 1].minute;
 
     let blackoutTotalWh = 0;
-    let current = { wh: 0, peakW: 0, start: rangeMin, end: rangeMin };
+    let current = { wh: 0, peakW: 0, start: forecastMin, end: forecastMin };
     let largestBlackout = current;
     let isBlackout = timeline[0].demandW > timeline[0].supplyW;
     const blackouts: BlackoutEdges[] = [{ minute: rangeMin, value: 0 }];
     if (isBlackout) {
-      blackouts.push({ minute: rangeMin, value: domainMax });
+      blackouts.push({ minute: forecastMin, value: 0 });
+      blackouts.push({ minute: forecastMin, value: domainMax });
     }
     for (const tick of timeline) {
       if (tick.demandW > tick.supplyW) {
@@ -1168,15 +1051,18 @@ export default class Insights extends React.Component<Props, State> {
         }
       }
     }
-    blackouts.push({ minute: rangeMax, value: isBlackout ? domainMax : 0 });
+    blackouts.push({
+      minute: forecastMax,
+      value: isBlackout ? domainMax : 0,
+    });
+    blackouts.push({ minute: rangeMax, value: 0 });
     if (current.wh > largestBlackout.wh) {
-      largestBlackout = { ...current, end: current.end || rangeMax };
+      largestBlackout = { ...current, end: current.end || forecastMax };
     }
 
-    const sampleYears = Math.max(1, years);
     const sampled = sampleForecastTimeline(
       timeline,
-      240 * sampleYears,
+      240 * MAX_FORECAST_YEARS,
       projectionStepMinutes,
     );
 
@@ -1186,16 +1072,16 @@ export default class Insights extends React.Component<Props, State> {
       game.startingYear,
     ).slice(1, 1 + monthsAhead);
     const projection: ProjectionView = {
-      historical: false,
       timeline,
       sampled,
+      supplyDemandTimeline: [...historicalSupplyDemand, ...timeline],
       domain: { x: [rangeMin, rangeMax], y: [domainMin, domainMax] },
       blackouts,
       blackoutTotalWh,
       largestBlackout,
       hasStorage: timeline.some((tick) => tick.storedWh > 0),
       hasHydro: game.facilities.some((facility) => facility.fuel === "Hydro"),
-      financePast: [],
+      financePast: game.monthlyHistory,
       financeProjected: [currentMonth, ...projectedMonths],
       projectionStepMinutes,
     };
@@ -1204,9 +1090,6 @@ export default class Insights extends React.Component<Props, State> {
   }
 
   private available(layer: InsightLayerDefinition, projection: ProjectionView) {
-    if (projection.historical) {
-      return HISTORICAL_LAYER_IDS.has(layer.id);
-    }
     return (
       !layer.availability ||
       (layer.availability === "storage" && projection.hasStorage) ||
@@ -1408,8 +1291,7 @@ export default class Insights extends React.Component<Props, State> {
         {GROUPS.map((group) => {
           const layers = INSIGHT_LAYERS.filter(
             (layer) =>
-              layer.group === group &&
-              (projection.historical || this.available(layer, projection)),
+              layer.group === group && this.available(layer, projection),
           );
           return (
             <div className="insightsLayerGroup" key={group}>
@@ -1421,11 +1303,7 @@ export default class Insights extends React.Component<Props, State> {
                     <Checkbox
                       id={`insightsLayer${layer.id[0].toUpperCase()}${layer.id.slice(1)}`}
                       checked={this.state.layers.includes(layer.id)}
-                      disabled={
-                        required.includes(layer.id) ||
-                        (projection.historical &&
-                          !HISTORICAL_LAYER_IDS.has(layer.id))
-                      }
+                      disabled={required.includes(layer.id)}
                       onChange={() => this.toggleLayer(layer.id)}
                     />
                   }
@@ -1456,7 +1334,7 @@ export default class Insights extends React.Component<Props, State> {
       selected && facilityLifetime(selected as FacilityOperatingType);
     return (
       <>
-        {!projection.historical && selected && lifetime && (
+        {selected && lifetime && (
           <div className="selectedFacilitySummary">
             <strong>{selected.name}</strong>: {formatWattHours(lifetime.wh)}{" "}
             delivered · {formatMoneyConcise(lifetime.profit)} profit
@@ -1494,14 +1372,9 @@ export default class Insights extends React.Component<Props, State> {
   ) {
     const clamped = clampChartViewport(bounds, next, minSpan);
     this.setState({
-      viewport: rangesEqual(clamped, bounds) ? undefined : clamped,
+      viewport: clamped,
       viewportAnnouncement: announce
-        ? viewportAnnouncement(
-            clamped,
-            bounds,
-            this.props.game.startingYear,
-            this.state.range,
-          )
+        ? viewportAnnouncement(clamped, this.props.game.startingYear)
         : this.state.viewportAnnouncement,
     });
   }
@@ -1510,10 +1383,11 @@ export default class Insights extends React.Component<Props, State> {
     bounds: ChartViewportRange,
     range: ChartViewportRange,
     minSpan: number,
-    years: number[],
   ) {
     const full = rangesEqual(bounds, range);
     const span = range[1] - range[0];
+    const rangeLabel = viewportLabel(range, this.props.game.startingYear);
+    const [startLabel, endLabel] = rangeLabel.split(" – ");
     const setRange = (next: ChartViewportRange) =>
       this.setViewport(bounds, minSpan, next);
     const iconButton = (
@@ -1541,42 +1415,19 @@ export default class Insights extends React.Component<Props, State> {
         aria-label="Chart time navigation"
         aria-describedby="insightsViewportHint"
       >
-        <Select
-          id="insightsRange"
-          value={this.state.range}
-          onChange={(event: SelectChangeEvent<InsightRange>) =>
-            this.setRange(event.target.value as InsightRange)
-          }
-          className="insightsHorizon"
-          aria-label="Time horizon"
-          renderValue={(value) => {
-            const labels = horizonLabels(value as InsightRange);
-            return (
-              <span className="insightsHorizonValue">
-                <span className="srOnly">{labels.full}</span>
-                <span className="insightsHorizonLong" aria-hidden="true">
-                  {labels.full}
-                </span>
-                <span className="insightsHorizonCompact" aria-hidden="true">
-                  {labels.compact}
-                </span>
-              </span>
-            );
-          }}
+        <Typography
+          className="insightsViewportDate"
+          variant="body2"
+          aria-label={`Displayed date range: ${rangeLabel}`}
         >
-          <MenuItem value="next1">Next 12 months</MenuItem>
-          <MenuItem value="next5">Next 5 years</MenuItem>
-          <MenuItem value="next10">Next 10 years</MenuItem>
-          <MenuItem value="next20">Next 20 years</MenuItem>
-          {!!this.props.game.monthlyHistory.length && (
-            <MenuItem value="all">All recorded</MenuItem>
-          )}
-          {years.map((year) => (
-            <MenuItem value={historyRange(year)} key={year}>
-              {year}
-            </MenuItem>
-          ))}
-        </Select>
+          <span className="insightsViewportDateLong" aria-hidden="true">
+            {rangeLabel}
+          </span>
+          <span className="insightsViewportDateCompact" aria-hidden="true">
+            <span>{startLabel}</span>
+            {endLabel && <span>{endLabel}</span>}
+          </span>
+        </Typography>
         <div className="insightsViewportButtons">
           {iconButton(
             "Pan earlier",
@@ -1602,11 +1453,8 @@ export default class Insights extends React.Component<Props, State> {
               ),
             ),
           )}
-          {iconButton(
-            `Fit ${horizonLabels(this.state.range).description}`,
-            <FitScreenIcon />,
-            full,
-            () => setRange(bounds),
+          {iconButton("Fit full timeline", <FitScreenIcon />, full, () =>
+            setRange(bounds),
           )}
           {iconButton("Zoom in", <ZoomInIcon />, span <= minSpan, () =>
             setRange(
@@ -1627,12 +1475,6 @@ export default class Insights extends React.Component<Props, State> {
                 ),
               ),
           )}
-        </div>
-        <div className="insightsViewportText">
-          <Typography variant="body2">
-            {viewportLabel(range, bounds, this.props.game.startingYear)} ·
-            Ctrl-scroll or drag
-          </Typography>
         </div>
         <span id="insightsViewportHint" className="srOnly">
           Pinch or use the zoom controls to zoom. Swipe, drag, or use the pan
@@ -1696,7 +1538,7 @@ export default class Insights extends React.Component<Props, State> {
             <>
               <ChartForecastSupplyDemand
                 height={140}
-                timeline={projection.sampled}
+                timeline={projection.supplyDemandTimeline}
                 blackouts={projection.blackouts}
                 domain={projection.domain}
                 startingYear={game.startingYear}
@@ -1705,19 +1547,10 @@ export default class Insights extends React.Component<Props, State> {
               />
               {projection.blackoutTotalWh > 0 && (
                 <Typography className="insightsWarning" variant="body2">
-                  {projection.historical ? (
-                    <>
-                      Energy not served:{" "}
-                      {formatWattHours(projection.blackoutTotalWh)}
-                    </>
-                  ) : (
-                    <>
-                      Forecasted shortfall: ~
-                      {formatWattHours(projection.blackoutTotalWh)} of demand
-                      not met · largest shortage{" "}
-                      {formatWatts(projection.largestBlackout.peakW)}
-                    </>
-                  )}
+                  Forecasted shortfall: ~
+                  {formatWattHours(projection.blackoutTotalWh)} of demand not
+                  met · largest shortage{" "}
+                  {formatWatts(projection.largestBlackout.peakW)}
                 </Typography>
               )}
             </>
@@ -2032,12 +1865,16 @@ export default class Insights extends React.Component<Props, State> {
       viewportBounds[1] - viewportBounds[0],
       MINUTES_PER_MONTH,
     );
-    const viewportRange = this.state.viewport
-      ? clampChartViewport(viewportBounds, this.state.viewport, minViewportSpan)
-      : viewportBounds;
-    const viewportTimeline = rangesEqual(viewportRange, viewportBounds)
-      ? projection.timeline
-      : timelineWithin(projection.timeline, viewportRange);
+    const viewportRange = clampChartViewport(
+      viewportBounds,
+      this.state.viewport,
+      minViewportSpan,
+    );
+    const viewportTimeline = timelineWithin(projection.timeline, viewportRange);
+    const viewportSupplyDemand = timelineWithin(
+      projection.supplyDemandTimeline,
+      viewportRange,
+    );
     const viewportSampleInterval = Math.max(
       projection.projectionStepMinutes,
       Math.ceil(
@@ -2046,23 +1883,44 @@ export default class Insights extends React.Component<Props, State> {
           projection.projectionStepMinutes,
       ) * projection.projectionStepMinutes,
     );
-    const viewportProjection: ProjectionView = rangesEqual(
-      viewportRange,
-      viewportBounds,
-    )
-      ? projection
-      : {
-          ...projection,
-          domain: { ...projection.domain, x: viewportRange },
-          timeline: viewportTimeline,
-          sampled: projection.historical
-            ? viewportTimeline
-            : sampleForecastTimeline(
-                viewportTimeline,
-                viewportSampleInterval,
-                projection.projectionStepMinutes,
-              ),
-        };
+    const sampled = sampleForecastTimeline(
+      viewportTimeline,
+      viewportSampleInterval,
+      projection.projectionStepMinutes,
+    );
+    const supplyDemandTimeline = sampleForecastTimeline(
+      viewportSupplyDemand,
+      viewportSampleInterval,
+      projection.projectionStepMinutes,
+    );
+    let viewportDomainMin = Number.POSITIVE_INFINITY;
+    let viewportDomainMax = Number.NEGATIVE_INFINITY;
+    for (const tick of supplyDemandTimeline) {
+      viewportDomainMin = Math.min(
+        viewportDomainMin,
+        tick.supplyW,
+        tick.demandW,
+      );
+      viewportDomainMax = Math.max(
+        viewportDomainMax,
+        tick.supplyW,
+        tick.demandW,
+      );
+    }
+    const viewportProjection: ProjectionView = {
+      ...projection,
+      domain: {
+        x: viewportRange,
+        y:
+          Number.isFinite(viewportDomainMin) &&
+          Number.isFinite(viewportDomainMax)
+            ? [viewportDomainMin, viewportDomainMax]
+            : projection.domain.y,
+      },
+      timeline: viewportTimeline,
+      sampled,
+      supplyDemandTimeline,
+    };
     const viewportContext = {
       bounds: viewportBounds,
       range: viewportRange,
@@ -2077,7 +1935,6 @@ export default class Insights extends React.Component<Props, State> {
           announce,
         ),
     };
-    const years = playedHistoryYears(game);
     const visible = this.state.layers.filter((id) => {
       const definition = INSIGHT_LAYERS.find((layer) => layer.id === id);
       return !!definition && this.available(definition, projection);
@@ -2097,14 +1954,12 @@ export default class Insights extends React.Component<Props, State> {
       !!selectedDefault &&
       !!this.state.presetLibrary.defaults[selectedDefault] &&
       !this.state.presetDirty;
-    const upcomingEvents = projection.historical
-      ? []
-      : (this.props.upcomingEvents || []).filter(
-          (event) =>
-            event.startsMinute !== undefined &&
-            event.startsMinute >= projection.domain.x[0] &&
-            event.startsMinute <= projection.domain.x[1],
-        );
+    const upcomingEvents = (this.props.upcomingEvents || []).filter(
+      (event) =>
+        event.startsMinute !== undefined &&
+        event.startsMinute >= viewportRange[0] &&
+        event.startsMinute <= viewportRange[1],
+    );
     const annotations = {
       events: upcomingEvents.map((event, index) => ({
         key: event.key,
@@ -2299,18 +2154,11 @@ export default class Insights extends React.Component<Props, State> {
             </Menu>
           </Toolbar>
           {this.renderLayerPanel(projection)}
-          {projection.historical ? (
-            <Typography className="insightsHistoryNotice" color="textSecondary">
-              Monthly records · forecast-only layers are unavailable
-            </Typography>
-          ) : (
-            this.renderLevers(now)
-          )}
+          {this.renderLevers(now)}
           {this.renderViewportControls(
             viewportBounds,
             viewportRange,
             minViewportSpan,
-            years,
           )}
           {!!upcomingEvents.length && (
             <InsightEventRail

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -350,9 +350,14 @@ function viewportLabel(
 ): string {
   const start = getDateFromMinute(range[0], startingYear);
   const end = getDateFromMinute(range[1], startingYear);
-  const left = `${start.month} ${start.year}`;
-  const right = `${end.month} ${end.year}`;
-  return left === right ? left : `${left} – ${right}`;
+  if (start.year !== end.year) {
+    const sameCentury =
+      Math.floor(start.year / 100) === Math.floor(end.year / 100);
+    const endYear = sameCentury ? String(end.year).slice(-2) : end.year;
+    return `${start.year}–${endYear}`;
+  }
+  if (start.month === end.month) return `${start.month} ${start.year}`;
+  return `${start.month}–${end.month} ${start.year}`;
 }
 
 function viewportAnnouncement(
@@ -1387,7 +1392,6 @@ export default class Insights extends React.Component<Props, State> {
     const full = rangesEqual(bounds, range);
     const span = range[1] - range[0];
     const rangeLabel = viewportLabel(range, this.props.game.startingYear);
-    const [startLabel, endLabel] = rangeLabel.split(" – ");
     const setRange = (next: ChartViewportRange) =>
       this.setViewport(bounds, minSpan, next);
     const iconButton = (
@@ -1420,13 +1424,7 @@ export default class Insights extends React.Component<Props, State> {
           variant="body2"
           aria-label={`Displayed date range: ${rangeLabel}`}
         >
-          <span className="insightsViewportDateLong" aria-hidden="true">
-            {rangeLabel}
-          </span>
-          <span className="insightsViewportDateCompact" aria-hidden="true">
-            <span>{startLabel}</span>
-            {endLabel && <span>{endLabel}</span>}
-          </span>
+          {rangeLabel}
         </Typography>
         <div className="insightsViewportButtons">
           {iconButton(

--- a/src/helpers/DateTime.test.tsx
+++ b/src/helpers/DateTime.test.tsx
@@ -1,5 +1,8 @@
 import {
+  axisTicksAreYearly,
   EMPTY_HISTORY,
+  formatMinuteAsMonthAxis,
+  formatMonthChartAxis,
   formatMinuteOfDayChartAxis,
   getDateFromMinute,
   getHourTicks,
@@ -32,6 +35,25 @@ describe("formatMinuteOfDayChartAxis", () => {
     expect(formatMinuteOfDayChartAxis(12 * 60)).toEqual("12pm");
     expect(formatMinuteOfDayChartAxis(19 * 60)).toEqual("7pm");
     expect(formatMinuteOfDayChartAxis(5 * 1440 + 6 * 60)).toEqual("6am");
+  });
+});
+
+describe("month chart axes", () => {
+  it("uses bare years once adjacent ticks are at least a year apart", () => {
+    const yearly = [2025 * 12 + 1, 2026 * 12 + 1, 2027 * 12 + 1];
+
+    expect(axisTicksAreYearly(yearly, 1)).toBe(true);
+    expect(formatMonthChartAxis(yearly[0], true, true)).toBe("2025");
+  });
+
+  it("keeps the month when tick spacing is less than a year", () => {
+    expect(axisTicksAreYearly([1, 7, 13], 1)).toBe(false);
+    expect(formatMonthChartAxis(2025 * 12 + 1, true)).toBe("1/25");
+  });
+
+  it("converts minute-based axes to the formatter's one-based month index", () => {
+    expect(formatMinuteAsMonthAxis(0, 2019, true, true)).toBe("2019");
+    expect(formatMinuteAsMonthAxis(0, 2019, true)).toBe("1/19");
   });
 });
 

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -247,8 +247,19 @@ export function getTimeFromTimeline(
   return timeline[deltaTicks];
 }
 
-export function formatMonthChartAxis(t: number, multiyear: boolean) {
+export function axisTicksAreYearly(splits: number[], unit: number): boolean {
+  return splits.length > 1 && Math.abs(splits[1] - splits[0]) >= 12 * unit;
+}
+
+export function formatMonthChartAxis(
+  t: number,
+  multiyear: boolean,
+  yearOnly = false,
+) {
   t--;
+  if (yearOnly) {
+    return String(Math.floor(t / 12));
+  }
   if (multiyear) {
     return (
       (t % 12) +
@@ -270,10 +281,16 @@ export function formatMinuteAsMonthAxis(
   minute: number,
   startingYear: number,
   multiyear: boolean,
+  yearOnly = false,
 ): string {
   return formatMonthChartAxis(
-    getDateFromMinute(minute, startingYear).monthsElapsed + 12 * startingYear,
+    // formatMonthChartAxis accepts the one-based month index used by finance
+    // records, while a game minute resolves to a zero-based elapsed month.
+    getDateFromMinute(minute, startingYear).monthsElapsed +
+      12 * startingYear +
+      1,
     multiyear,
+    yearOnly,
   );
 }
 


### PR DESCRIPTION
## Summary

- replace the fixed Insights horizon dropdown with a shared, continuously pannable and zoomable date viewport bounded by the scenario start and 20 years ahead
- display the visible date range, advance it with game time while preserving a scenario-start anchor, and render bare years at yearly tick spacing
- align the Supply & Demand chart width with the other insight charts and refine the responsive toolbar after desktop and mobile design review

## Testing

- `npm run check`
- `npm run build`
- `npx playwright test --config e2e/playwright.config.ts e2e/insights-responsive.spec.ts --workers=4` (10 passed, 10 skipped by project guards)

## Screenshots

Desktop and mobile screenshots are attached below.

![compact-rate-controls-desktop-chromium](https://github.com/user-attachments/assets/5b48153b-12f8-460e-8879-dff8ee57c016)

![compact-rate-controls-mobile-390px](https://github.com/user-attachments/assets/4bd256b8-ddd0-4b25-986c-1a5e9436d977)