### PR TITLE
Improve Insights finance layers, hydro forecasts, and event controls

### DIFF
--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -65,6 +65,7 @@ test("upcoming scenario events stay usable across insight viewports", async ({
     await charts.first().getAttribute("data-viewport-max"),
   );
   await page.getByRole("button", { name: "Zoom to event" }).click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
   await expect
     .poll(async () => {
       const min = Number(
@@ -129,9 +130,7 @@ test("upcoming scenario events stay usable across insight viewports", async ({
       expect(box!.width).toBeCloseTo(44, 0),
     );
   }
-  await expect(
-    viewportToolbar.locator(".insightsViewportDate"),
-  ).toBeVisible();
+  await expect(viewportToolbar.locator(".insightsViewportDate")).toBeVisible();
 
   const pageOverflow = await insights.evaluate((element) =>
     Math.max(0, element.scrollWidth - element.clientWidth),
@@ -430,4 +429,65 @@ test("main-menu account actions follow the sound action", async ({
   expect(soundBox).not.toBeNull();
   expect(accountBox).not.toBeNull();
   expect(accountBox!.y).toBeGreaterThanOrEqual(soundBox!.y + soundBox!.height);
+});
+
+test("expanded finance and economic rates remain readable", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    !["desktop-chromium", "mobile-390px"].includes(testInfo.project.name),
+  );
+  await page.emulateMedia({
+    colorScheme: testInfo.project.name.startsWith("mobile") ? "dark" : "light",
+  });
+  await page.addInitScript(() => {
+    localStorage.clear();
+    localStorage.setItem(
+      "insightsLayers",
+      JSON.stringify(["financeDetails", "inflationInterest"]),
+    );
+  });
+  await page.goto("/?scenario=111");
+  await page.getByRole("button", { name: "Start game" }).click();
+  const insights = page.locator(".insights:visible");
+  if (!(await insights.isVisible()))
+    await page.getByRole("button", { name: "Insights", exact: true }).click();
+  await expect(
+    insights.getByText("Operations & maintenance", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    insights.getByText("Current interest rate", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    insights.locator("#chartInsightsInflationInterestPlotinflationRate"),
+  ).toHaveCount(1);
+  await expect(
+    insights.locator("#chartInsightsInflationInterestPlotinterestRate"),
+  ).toHaveCount(1);
+  expect(
+    await insights.evaluate(
+      (element) => element.scrollWidth - element.clientWidth,
+    ),
+  ).toBeLessThanOrEqual(1);
+  const reviewDir = process.env.REVIEW_SCREENSHOT_DIR;
+  if (reviewDir) {
+    await insights
+      .getByText("Finance details", { exact: true })
+      .scrollIntoViewIfNeeded();
+    await page.screenshot({
+      path: path.join(reviewDir, `finance-${testInfo.project.name}.png`),
+    });
+    if (testInfo.project.name === "desktop-chromium") {
+      await insights
+        .getByText("Inflation & interest rate", { exact: true })
+        .scrollIntoViewIfNeeded();
+      await page.screenshot({
+        path: path.join(reviewDir, "economic-rates-desktop.png"),
+      });
+    }
+  }
+  await insights.getByRole("button", { name: /Layers/ }).click();
+  await expect(
+    insights.getByLabel("Inflation & interest rate", { exact: true }),
+  ).toBeChecked();
 });

--- a/src/components/base/ChartForecastRenewableCapacityFactor.test.tsx
+++ b/src/components/base/ChartForecastRenewableCapacityFactor.test.tsx
@@ -1,3 +1,4 @@
+import { generateNewTimeline } from "../../reducers/Game";
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import { MINUTES_PER_MONTH } from "../../helpers/DateTime";
@@ -51,6 +52,25 @@ describe("ChartForecastRenewableCapacityFactor", () => {
     );
 
     expect(names).toEqual(expect.arrayContaining(["Wind", "Solar", "Hydro"]));
+  });
+
+  it("forecasts hydro resources in Los Angeles without a built hydro plant", () => {
+    const game = createGame({ scenarioId: 111 });
+    expect(game.facilities.some((facility) => facility.fuel === "Hydro")).toBe(
+      false,
+    );
+    const timeline = generateNewTimeline(
+      game,
+      game.timeline[0].cash,
+      game.timeline[0].customers,
+      (12 * MINUTES_PER_MONTH) / 60,
+      60,
+    );
+    const points = monthlyRenewableCapacityFactors(
+      timeline,
+      availableWeatherRenewables(game, timeline),
+    );
+    expect(points.some((point) => point.factors.Hydro > 0.005)).toBe(true);
   });
 
   it("exposes each available series as a percentage", () => {

--- a/src/components/base/InsightEventRail.tsx
+++ b/src/components/base/InsightEventRail.tsx
@@ -86,7 +86,16 @@ export default function InsightEventRail(props: Props): React.JSX.Element {
         className="insightEventPopover"
       >
         {selected && (
-          <ClickAwayListener onClickAway={closeDetails}>
+          <ClickAwayListener
+            onClickAway={(event) => {
+              if (
+                event.target instanceof Node &&
+                anchor?.contains(event.target)
+              )
+                return;
+              closeDetails();
+            }}
+          >
             <Paper elevation={6}>
               <div
                 id={`insight-event-details-${events.indexOf(selected) + 1}`}
@@ -104,7 +113,10 @@ export default function InsightEventRail(props: Props): React.JSX.Element {
                 <Button
                   size="small"
                   variant="outlined"
-                  onClick={() => onZoom(selected)}
+                  onClick={() => {
+                    onZoom(selected);
+                    closeDetails();
+                  }}
                 >
                   Zoom to event
                 </Button>

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -86,7 +86,7 @@ interface ChartKeyMetadataType {
 
 // Two tables rather than one built per render: the labels are the same either way, and only
 // the two emissions rows care which system they are read in
-function buildChartKeys(units: UnitSystemType): {
+export function buildChartKeys(units: UnitSystemType): {
   [index: string]: ChartKeyMetadataType;
 } {
   return {

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -258,6 +258,47 @@ describe("Insights layers", () => {
     expect(presetForLayers(INSIGHT_PRESETS.growth.layers)).toBe("growth");
   });
 
+  it("groups demand with customers and places rates last in economics", () => {
+    expect(
+      INSIGHT_LAYERS.find((layer) => layer.id === "demandByType")?.group,
+    ).toBe("Customers");
+    expect(
+      INSIGHT_LAYERS.filter((layer) => layer.group === "Economics").at(-1)?.id,
+    ).toBe("inflationInterest");
+  });
+
+  it("shows expanded finance rows and both rate graphs", () => {
+    localStorage.setItem(
+      "insightsLayers",
+      JSON.stringify(["financeDetails", "inflationInterest"]),
+    );
+    const game = createGame({ scenarioId: 100 });
+    renderInsights(100, game);
+    for (const label of [
+      "Fuel",
+      "Operations & maintenance",
+      "Loan interest",
+      "Carbon fees",
+      "Profit per kWh",
+      "Net worth",
+      "Current interest rate",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    const interestRow = screen.getByRole("row", {
+      name: /Current interest rate/,
+    });
+    expect(interestRow).toHaveTextContent(
+      (game.timeline[0].interestRate * 100).toFixed(2) + "%",
+    );
+    expect(
+      screen.getByTestId("chartInsightsInflationInterestPlotinflationRate"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("chartInsightsInflationInterestPlotinterestRate"),
+    ).toBeInTheDocument();
+  });
+
   it("starts new players on the five-chart overview in priority order", () => {
     renderInsights();
 
@@ -378,6 +419,7 @@ describe("Insights layers", () => {
       "data-domain",
       JSON.stringify([5.9 * MINUTES_PER_MONTH, 7.1 * MINUTES_PER_MONTH]),
     );
+    expect(screen.queryByRole("dialog")).toBeNull();
     await user.keyboard("{Escape}");
     expect(event).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("dialog")).toBeNull();

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -109,7 +109,7 @@ import ChartForecastWeather from "../base/ChartForecastWeather";
 import ChartLegend from "../base/ChartLegend";
 import GameCard from "../base/GameCard";
 import { UnitsContext } from "../base/UnitsContext";
-import { formatCustomerChange } from "./Finances";
+import { buildChartKeys, formatCustomerChange } from "./Finances";
 import { sampleForecastTimeline } from "../../helpers/ForecastSampling";
 import { ChartAnnotationsContext } from "../base/ChartAnnotationsContext";
 import InsightEventRail from "../base/InsightEventRail";
@@ -139,7 +139,8 @@ export type InsightLayerId =
   | "cash"
   | "customers"
   | "emissions"
-  | "financeDetails";
+  | "financeDetails"
+  | "inflationInterest";
 
 type LayerGroup = "Grid" | "Customers" | "Economics" | "Environment";
 
@@ -155,7 +156,7 @@ export const INSIGHT_LAYERS: readonly InsightLayerDefinition[] = [
   {
     id: "demandByType",
     label: "Demand by use",
-    group: "Grid",
+    group: "Customers",
   },
   { id: "supplyByFuel", label: "Supply by Fuel", group: "Grid" },
   {
@@ -171,6 +172,11 @@ export const INSIGHT_LAYERS: readonly InsightLayerDefinition[] = [
   { id: "cash", label: "Cash", group: "Economics" },
   { id: "financeDetails", label: "Finance details", group: "Economics" },
   { id: "fuelPrices", label: "Fuel Prices", group: "Economics" },
+  {
+    id: "inflationInterest",
+    label: "Inflation & interest rate",
+    group: "Economics",
+  },
   {
     id: "emissions",
     label: "Emissions (CO2e)",
@@ -1347,22 +1353,26 @@ export default class Insights extends React.Component<Props, State> {
         )}
         <Table size="small" className="insightsSummaryTable">
           <TableBody>
-            {[
-              ["Profit", formatMoneyConcise(summary.profit)],
-              ["Revenue", formatMoneyConcise(summary.revenue)],
-              ["Expenses", formatMoneyConcise(summary.expenses)],
-              ["Cash", formatMoneyConcise(summary.cash)],
-              ["Customers", new Intl.NumberFormat().format(summary.customers)],
-              [
-                "CO2e emitted",
-                `${formatLargeMassValueConcise(summary.kgco2e, units)} ${largeMassUnit(units)}`,
-              ],
-            ].map(([label, value]) => (
-              <TableRow key={label}>
-                <TableCell>{label}</TableCell>
-                <TableCell align="right">{value}</TableCell>
-              </TableRow>
-            ))}
+            {Object.entries(buildChartKeys(units)).map(([key, metadata]) => {
+              const value =
+                key === "interestRate"
+                  ? getTimeFromTimeline(game.date.minute, game.timeline)!
+                      .interestRate
+                  : summary[key as DerivedHistoryKeysType];
+              return (
+                <TableRow key={key}>
+                  <TableCell sx={{ pl: 2 + (metadata.nesting || 0) * 2 }}>
+                    {key === "interestRate"
+                      ? "Current interest rate"
+                      : metadata.label}
+                  </TableCell>
+                  <TableCell align="right">
+                    {(metadata.formatTable || metadata.format)(value)}
+                    {metadata.suffix ? " " + metadata.suffix : ""}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       </>
@@ -1531,6 +1541,33 @@ export default class Insights extends React.Component<Props, State> {
       );
     } else {
       switch (id) {
+        case "inflationInterest":
+          body = (
+            <>
+              {(["inflationRate", "interestRate"] as const).map((key) => (
+                <ChartFinances
+                  key={key}
+                  id={chartId + key}
+                  height={140}
+                  timeline={financeSeries(
+                    key,
+                    projection.financePast,
+                    projection.financeProjected,
+                    projection.domain.x,
+                    game.startingYear,
+                  )}
+                  title={
+                    key === "inflationRate" ? "Inflation" : "Interest rate"
+                  }
+                  format={(value) => (value * 100).toFixed(2) + "%"}
+                  startingYear={game.startingYear}
+                  domain={projection.domain.x}
+                  syncKey={SYNC_KEY}
+                />
+              ))}
+            </>
+          );
+          break;
         case "supplyDemand":
           body = (
             <>

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1,3 +1,4 @@
+import { getViableLocationCount } from "../data/FacilitySites";
 import type { AppDispatch } from "../Store";
 import cloneDeep from "lodash.clonedeep";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
@@ -1748,9 +1749,10 @@ function reforecastWeatherAndPrices(
   state: GameType,
   cumulativeMegatons: number,
 ): TickPresentFutureType[] {
-  const hasHydro = state.facilities.some(
-    (facility) => facility.fuel === "Hydro",
-  );
+  // Resource forecasts are also shown before the player builds a hydro plant.
+  const hasHydro =
+    (getViableLocationCount(state.location, "Hydro") || 0) > 0 ||
+    state.facilities.some((facility) => facility.fuel === "Hydro");
   const watershedId = state.location.watershedId || state.location.id;
   const hydrologyByMonth = new Map<
     string,


### PR DESCRIPTION
Insights now groups Demand by use under Customers, adds Inflation & interest rate at the end of Economics, and shows the full finance breakdown with nested expense rows and the company's current interest rate.

Renewable output previously displayed 0% hydro in the LA wildfire scenario because runoff forecasts were skipped until a hydro plant existed. Forecast hydrology now also runs where hydro sites are available. Event chips ignore their own click-away event so a second tap closes the details reliably, and Zoom to event closes the popup after adjusting the charts.

Validation: `npm run check` (types, lint, formatting, covered Jest suite, and all headless scenarios), `npm run build`, desktop/mobile Insights responsive tests, and a full-year LA hydro regression. Finance screenshots were reviewed in desktop light mode and mobile dark mode.

Screenshots below show the expanded finance table and economic rate graphs.

![Expanded finance details on desktop in light mode](https://github.com/user-attachments/assets/0ea5ca2b-857b-485c-999f-60766091c155)

![Expanded finance details on mobile in dark mode](https://github.com/user-attachments/assets/50d5fc62-ee71-4942-a3b4-a76750c3e29d)

![Inflation and company interest rate graphs](https://github.com/user-attachments/assets/24a39209-b2ee-44f1-91cc-b080e5413f55)