### PR TITLE
Preserve Insights history and fix customer growth and scenario targets

### DIFF
--- a/e2e/insights-history.spec.ts
+++ b/e2e/insights-history.spec.ts
@@ -1,0 +1,84 @@
+import path from "path";
+import { expect, test } from "@playwright/test";
+
+test("public insights retain the benchmark and an absolute customer objective", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    !["desktop-chromium", "mobile-390px"].includes(testInfo.project.name),
+  );
+  await page.emulateMedia({
+    colorScheme:
+      testInfo.project.name === "desktop-chromium" ? "dark" : "light",
+  });
+  await page.addInitScript(() => {
+    localStorage.clear();
+    localStorage.setItem(
+      "insightsLayers",
+      JSON.stringify(["demandByType", "customers", "supplyDemand"]),
+    );
+  });
+  await page.goto("/?scenario=106");
+  await page.getByRole("button", { name: "Start game" }).click();
+  if (!(await page.locator(".insights").isVisible())) {
+    await page.getByRole("button", { name: "Insights", exact: true }).click();
+  }
+  await expect(page.locator(".insightsLevers")).toContainText(
+    "market benchmark",
+  );
+  await expect(page.locator(".insightsLevers")).toContainText("+1.5%");
+  await page
+    .locator("#appbar:visible")
+    .getByRole("button", { name: "fast speed" })
+    .first()
+    .click();
+  await expect(
+    page.getByText(/Past charts show monthly averages/),
+  ).toBeVisible();
+  await page
+    .locator("#appbar:visible")
+    .getByRole("button", { name: "pause", exact: true })
+    .first()
+    .click();
+  expect(
+    await page
+      .locator(".insightsLevers")
+      .evaluate((el) => el.scrollWidth - el.clientWidth),
+  ).toBeLessThanOrEqual(1);
+  if (testInfo.project.name === "mobile-390px") {
+    const metrics = await page.locator(".insightsRateMetric").all();
+    const boxes = await Promise.all(
+      metrics.map((metric) => metric.boundingBox()),
+    );
+    expect(new Set(boxes.map((box) => box!.y)).size).toBe(1);
+    await expect(page.locator(".insightsRateMetricGrowth")).toContainText(
+      "Customer growth / yr",
+    );
+  }
+  const reviewDir = process.env.REVIEW_SCREENSHOT_DIR;
+  if (reviewDir) {
+    await page.screenshot({
+      path: path.join(
+        reviewDir,
+        `public-insights-${testInfo.project.name}.png`,
+      ),
+      fullPage: true,
+    });
+  }
+  await page
+    .locator("#appbar:visible")
+    .getByRole("button", { name: "menu", exact: true })
+    .first()
+    .click();
+  await page.getByRole("menuitem", { name: "Scenario details" }).click();
+  await expect(page.getByRole("dialog")).toContainText("14,850 customers");
+  await expect(page.getByRole("dialog")).toContainText("16,500 at the start");
+  if (reviewDir && testInfo.project.name === "desktop-chromium") {
+    await page.getByRole("menu").waitFor({ state: "hidden" });
+    await page.waitForTimeout(400);
+    await page.screenshot({
+      path: path.join(reviewDir, "customer-objective.png"),
+      fullPage: true,
+    });
+  }
+});

--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -129,9 +129,7 @@ test("upcoming scenario events stay usable across insight viewports", async ({
       expect(box!.width).toBeCloseTo(44, 0),
     );
   }
-  await expect(
-    viewportToolbar.locator(".insightsViewportDate"),
-  ).toBeVisible();
+  await expect(viewportToolbar.locator(".insightsViewportDate")).toBeVisible();
 
   const pageOverflow = await insights.evaluate((element) =>
     Math.max(0, element.scrollWidth - element.clientWidth),
@@ -248,6 +246,18 @@ test("insights header controls stay aligned in one compact row", async ({
       Math.max(0, element.scrollWidth - element.clientWidth),
     );
   expect(headerOverflow).toBeLessThanOrEqual(1);
+
+  if (testInfo.project.name === "desktop-chromium") {
+    const [group, layerButton] = await Promise.all([
+      page.locator(".insightsPresetControls").boundingBox(),
+      page.locator("#insightsLayersButton").boundingBox(),
+    ]);
+    expect(layerButton!.x - group!.x - group!.width).toBeCloseTo(8, 0);
+    await expect(page.locator(".insightsHeaderControls")).toHaveCSS(
+      "justify-content",
+      "flex-end",
+    );
+  }
 
   if (testInfo.project.name.startsWith("mobile-")) {
     const header = await page.locator(".insightsHeader").boundingBox();

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -30,7 +30,7 @@ import {
 
 // Version 2 changes authored starting fleets and their facility IDs, so older action streams can
 // no longer reproduce the run they recorded.
-export const REPLAY_VERSION = 2;
+export const REPLAY_VERSION = 3;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -1,4 +1,4 @@
-import { getTimeFromTimeline } from "./helpers/DateTime";
+import { getTimeFromTimeline, summarizeTimeline } from "./helpers/DateTime";
 import {
   clearSave,
   clearSaveFor,
@@ -53,6 +53,27 @@ describe("SaveGame", () => {
       game.facilities.find((facility) => facility.name === "Oil")
         ?.variableOperatingCostPerMWh,
     );
+  });
+
+  it("round trips every monthly chart layer and rejects corrupt chart values", () => {
+    const recorded = {
+      ...game,
+      date: { ...game.date, minute: 1440 },
+      monthlyHistory: [summarizeTimeline(game.timeline, game.startingYear)],
+    };
+    const raw = JSON.parse(JSON.stringify(serializeSave(recorded)));
+    const restored = parseSave(raw);
+    expect(restored?.game.monthlyHistory[0].chartAverage).toEqual(
+      recorded.monthlyHistory[0].chartAverage,
+    );
+    raw.game.monthlyHistory[0].chartAverage.demandByType.Residential = "bad";
+    expect(parseSave(raw)).toBeNull();
+  });
+
+  it("upgrades older saves without inventing missing chart history", () => {
+    const restored = parseSave({ ...serializeSave(game), version: 1 });
+    expect(restored?.version).toBe(SAVE_VERSION);
+    expect(restored?.game).toEqual(game);
   });
 
   // The memo must never alias the live game slice, or a Continue button would describe a game

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -26,7 +26,7 @@ import type { AppStore } from "./Store";
 
 export const SAVE_KEY = "savedGame";
 // Initial public schema. Increment this when a post-release change becomes incompatible.
-export const SAVE_VERSION = 1;
+export const SAVE_VERSION = 2;
 
 export interface SaveGameType {
   version: number;
@@ -61,7 +61,7 @@ export function parseSave(raw: unknown): SaveGameType | null {
   }
   const save = raw as Partial<SaveGameType>;
   if (
-    save.version !== SAVE_VERSION ||
+    (save.version !== SAVE_VERSION && save.version !== 1) ||
     typeof save.savedAt !== "string" ||
     typeof save.appVersion !== "string"
   ) {
@@ -171,6 +171,30 @@ export function parseSave(raw: unknown): SaveGameType | null {
         return true;
       }
       const record = month as Partial<GameType["monthlyHistory"][number]>;
+      const chart = record.chartAverage;
+      if (
+        chart !== undefined &&
+        (typeof chart !== "object" ||
+          chart === null ||
+          !chart.demandByType ||
+          !chart.supplyByFuel ||
+          !chart.renewableCapacityFactors ||
+          Object.values(chart).some((value) =>
+            typeof value === "number"
+              ? !Number.isFinite(value)
+              : typeof value !== "object" ||
+                value === null ||
+                Object.values(value).some(
+                  (entry) =>
+                    typeof entry !== "number" || !Number.isFinite(entry),
+                ),
+          ) ||
+          typeof record.chartTickWeight !== "number" ||
+          !Number.isFinite(record.chartTickWeight) ||
+          record.chartTickWeight <= 0)
+      ) {
+        return true;
+      }
       return (
         typeof record.deliveredWhByFuel !== "object" ||
         record.deliveredWhByFuel === null ||
@@ -203,7 +227,9 @@ export function parseSave(raw: unknown): SaveGameType | null {
   ) {
     return null;
   }
-  return save as SaveGameType;
+  // Version 1 saves remain playable. New months collect chart history; older months have only
+  // their original financial and supply/demand records. Replays use a separate strict version.
+  return { ...save, version: SAVE_VERSION } as SaveGameType;
 }
 
 export function readSave(): SaveGameType | null {

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -289,8 +289,7 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     minute: number;
     supplyW: number; // Watts
     demandW: number; // Watts
-    // Components sum to demandW. Kept on forecast ticks so Insights can explain what is driving
-    // load without bloating the long-lived monthly history in saves.
+    // Components sum to demandW; monthly chart averages preserve the breakdown in saves.
     demandByType: DemandByTypeType;
     solarIrradianceWM2: number;
     windKph: number;
@@ -311,6 +310,7 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     // The exponentially smoothed bill customers respond to, rather than the slider's latest value
     customerRate: number;
     supplyByFuel: FuelProductionType;
+    renewableCapacityFactors?: Record<string, number>;
   };
 
 export type DerivedHistoryKeysType = Exclude<
@@ -333,6 +333,9 @@ export interface DerivedHistoryType extends MonthlyHistoryType {
 
 // Basically, downsample per-tick information so that I can store it for the entire game, which could go 100+ years
 export interface MonthlyHistoryType extends HistoryForecastShared {
+  // Compact monthly averages for all non-financial Insights layers.
+  chartAverage?: TickPresentFutureType;
+  chartTickWeight?: number;
   year: number;
   month: number;
   supplyWh: number; // total

--- a/src/app.scss
+++ b/src/app.scss
@@ -864,6 +864,7 @@ $pane_header_height: 40px;
 
 .insightsHeaderControls {
   display: flex;
+  justify-content: flex-end;
   min-width: 0;
   flex: 1 1 auto;
   align-items: center;
@@ -1361,7 +1362,7 @@ $pane_header_height: 40px;
       align-items: stretch;
 
       &.insightsRateMetricsPublic {
-        grid-template-columns: 72px minmax(0, 1fr);
+        grid-template-columns: 68px 60px minmax(0, 1fr);
       }
     }
 
@@ -1380,7 +1381,7 @@ $pane_header_height: 40px;
     }
 
     .insightsRateMetricGrowth {
-      grid-column: 2;
+      grid-column: 3;
     }
 
     .insightsRateMetricLabel,

--- a/src/components/base/ChartForecastRenewableCapacityFactor.tsx
+++ b/src/components/base/ChartForecastRenewableCapacityFactor.tsx
@@ -88,6 +88,18 @@ function capacityFactor(
   technology: GeneratorShoppingType,
   ticks: TickPresentFutureType[],
 ): number {
+  if (
+    ticks.every(
+      (tick) => tick.renewableCapacityFactors?.[technology.name] !== undefined,
+    )
+  ) {
+    return (
+      ticks.reduce(
+        (sum, tick) => sum + tick.renewableCapacityFactors![technology.name],
+        0,
+      ) / ticks.length
+    );
+  }
   switch (technology.name) {
     case "Wind":
       return getWindCapacityFactor(ticks.map((tick) => tick.windKph));

--- a/src/components/base/CustomerGrowthChallenge.tsx
+++ b/src/components/base/CustomerGrowthChallenge.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { connect } from "react-redux";
+import { AppStateType } from "../../Types";
+import TutorialPrompt from "./TutorialPrompt";
+
+function CustomerGrowthChallenge({
+  startingCustomers,
+}: {
+  startingCustomers: number;
+}) {
+  return (
+    <TutorialPrompt
+      concepts={["rate", "customers", "money"]}
+      text={`Your turn: reach at least ${Math.ceil(startingCustomers * 1.05).toLocaleString("en-US")} customers (5% above the starting ${startingCustomers.toLocaleString("en-US")}) in six months while staying profitable and reliable.`}
+    />
+  );
+}
+
+// Authored scenarios import this component during reducer initialization. Avoid importing Store
+// (including its hooks) across that boundary; the connection reads state only when rendered.
+export default connect((state: AppStateType) => ({
+  startingCustomers: state.game.customerMarketSize / 2,
+}))(CustomerGrowthChallenge);

--- a/src/components/base/ScenarioDetailsDialog.tsx
+++ b/src/components/base/ScenarioDetailsDialog.tsx
@@ -15,6 +15,7 @@ import { getScenarioLocation } from "../../helpers/Locations";
 import { summarizeHistory } from "../../helpers/DateTime";
 import { computeScoreBreakdown, totalScore } from "../../helpers/Scoring";
 import VictoryConditions from "./VictoryConditions";
+import CustomerGrowthChallenge from "./CustomerGrowthChallenge";
 import { formatScore, SCORE_LABELS } from "./VictoryDialog";
 
 export interface Props {
@@ -69,9 +70,11 @@ export default function ScenarioDetailsDialog(props: Props): React.JSX.Element {
         <Typography variant="h6" gutterBottom>
           Victory Conditions: {scenario.ownership}-Owned
         </Typography>
+        {scenario.id === 3 && <CustomerGrowthChallenge />}
         <VictoryConditions
           ownership={scenario.ownership}
           dollarsPerkWh={scenario.dollarsPerkWh}
+          startingCustomers={scenario.startingCustomers}
           minimumCustomerRetention={scenario.minimumCustomerRetention}
           reliabilityObjective={scenario.reliabilityObjective}
         />

--- a/src/components/base/VictoryConditions.test.tsx
+++ b/src/components/base/VictoryConditions.test.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import VictoryConditions from "./VictoryConditions";
+
+it("shows the absolute data-center customer threshold beside retention", () => {
+  render(
+    <VictoryConditions
+      ownership="Public"
+      dollarsPerkWh={0.1}
+      minimumCustomerRetention={0.9}
+      startingCustomers={16500}
+    />,
+  );
+  expect(screen.getByText(/Required: retain/)).toHaveTextContent(
+    "90% of starting customers (at least 14,850 customers, from 16,500 at the start)",
+  );
+});

--- a/src/components/base/VictoryConditions.tsx
+++ b/src/components/base/VictoryConditions.tsx
@@ -6,6 +6,7 @@ import { useUnits } from "./UnitsContext";
 export interface Props {
   ownership: ScenarioType["ownership"];
   dollarsPerkWh: number;
+  startingCustomers?: number;
   minimumCustomerRetention?: number;
   reliabilityObjective?: ScenarioType["reliabilityObjective"];
 }
@@ -52,6 +53,8 @@ export default function VictoryConditions(props: Props): React.JSX.Element {
         <p>
           Required: retain at least {Math.round(minimumCustomerRetention * 100)}
           % of starting customers
+          {props.startingCustomers !== undefined &&
+            ` (at least ${Math.ceil(props.startingCustomers * minimumCustomerRetention).toLocaleString("en-US")} customers, from ${props.startingCustomers.toLocaleString("en-US")} at the start)`}
         </p>
       )}
       <p>

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -968,6 +968,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
           <VictoryConditions
             ownership={scenario.ownership}
             dollarsPerkWh={scenario.dollarsPerkWh}
+            startingCustomers={scenario.startingCustomers}
             minimumCustomerRetention={scenario.minimumCustomerRetention}
             reliabilityObjective={scenario.reliabilityObjective}
           />

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -324,7 +324,7 @@ describe("Insights layers", () => {
 
     const levers = screen.getByRole("region", { name: "Planning controls" });
     expect(levers).toHaveTextContent(/customer growth \+1.5%\/yr/i);
-    expect(levers).not.toHaveTextContent(/market/i);
+    expect(levers).toHaveTextContent(/market benchmark/i);
     expect(
       within(levers).getByText("Customer growth / yr"),
     ).toBeInTheDocument();

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -1005,14 +1005,24 @@ export default class Insights extends React.Component<Props, State> {
     const historicalSupplyDemand = [...game.monthlyHistory]
       .reverse()
       .map((month) => {
-        // Monthly history retains supply and demand but not the other forecast layers. Keep it
-        // on the supply/demand chart and let forecast-only charts begin at the current month.
         const tick = { ...now } as TickPresentFutureType;
         tick.minute = monthMinute(month, game.startingYear);
         tick.supplyW = month.supplyWh / HOURS_PER_RECORDED_MONTH;
         tick.demandW = month.demandWh / HOURS_PER_RECORDED_MONTH;
         return tick;
       });
+    const historicalCharts = [...game.monthlyHistory]
+      .reverse()
+      .flatMap((month) =>
+        month.chartAverage
+          ? [
+              {
+                ...month.chartAverage,
+                minute: monthMinute(month, game.startingYear),
+              } as TickPresentFutureType,
+            ]
+          : [],
+      );
     let domainMin = Number.POSITIVE_INFINITY;
     let domainMax = 0;
     for (const tick of [...historicalSupplyDemand, ...timeline]) {
@@ -1077,15 +1087,19 @@ export default class Insights extends React.Component<Props, State> {
       game.startingYear,
     ).slice(1, 1 + monthsAhead);
     const projection: ProjectionView = {
-      timeline,
-      sampled,
+      timeline: [...historicalCharts, ...timeline],
+      sampled: [...historicalCharts, ...sampled],
       supplyDemandTimeline: [...historicalSupplyDemand, ...timeline],
       domain: { x: [rangeMin, rangeMax], y: [domainMin, domainMax] },
       blackouts,
       blackoutTotalWh,
       largestBlackout,
-      hasStorage: timeline.some((tick) => tick.storedWh > 0),
-      hasHydro: game.facilities.some((facility) => facility.fuel === "Hydro"),
+      hasStorage: [...historicalCharts, ...timeline].some(
+        (tick) => tick.storedWh > 0,
+      ),
+      hasHydro:
+        game.facilities.some((facility) => facility.fuel === "Hydro") ||
+        historicalCharts.some((tick) => tick.hydroReservoirCapacityWh > 0),
       financePast: game.monthlyHistory,
       financeProjected: [currentMonth, ...projectedMonths],
       projectionStepMinutes,
@@ -1166,7 +1180,7 @@ export default class Insights extends React.Component<Props, State> {
     const rateSummary =
       scenario.ownership === "Investor"
         ? `Rate ${formatMoneyConcise(game.dollarsPerkWh)} per kilowatt hour; market rate ${formatMoneyConcise(marketRate)}; projected customers ${formattedCustomerChange} next month.`
-        : `Rate ${formatMoneyConcise(game.dollarsPerkWh)} per kilowatt hour; customer growth plus ${(ORGANIC_GROWTH_MAX_ANNUAL * 100).toFixed(1)} percent per year.`;
+        : `Rate ${formatMoneyConcise(game.dollarsPerkWh)} per kilowatt hour; market benchmark ${formatMoneyConcise(marketRate)}; customer growth plus ${(ORGANIC_GROWTH_MAX_ANNUAL * 100).toFixed(1)} percent per year. Public utility customers do not switch based on rates.`;
     return (
       <section className="insightsLevers" aria-label="Planning controls">
         <Button
@@ -1197,7 +1211,8 @@ export default class Insights extends React.Component<Props, State> {
           {scenario.ownership === "Public" && (
             <>
               {" "}
-              · customer growth{" "}
+              · market benchmark {formatMoneyConcise(marketRate)} · customer
+              growth{" "}
               <strong>
                 +{(ORGANIC_GROWTH_MAX_ANNUAL * 100).toFixed(1)}%/yr
               </strong>
@@ -1216,14 +1231,14 @@ export default class Insights extends React.Component<Props, State> {
               {formatRateCompact(game.dollarsPerkWh)}/kWh
             </strong>
           </span>
+          <span className="insightsRateMetric">
+            <span className="insightsRateMetricLabel">Market</span>
+            <span className="insightsRateMetricValue">
+              {formatRateCompact(marketRate)}
+            </span>
+          </span>
           {scenario.ownership === "Investor" ? (
             <>
-              <span className="insightsRateMetric">
-                <span className="insightsRateMetricLabel">Market</span>
-                <span className="insightsRateMetricValue">
-                  {formatRateCompact(marketRate)}
-                </span>
-              </span>
               <span className="insightsRateMetric">
                 <span className="insightsRateMetricLabel">Customers / mo</span>
                 <strong className="insightsRateMetricValue">
@@ -2153,6 +2168,14 @@ export default class Insights extends React.Component<Props, State> {
           </Toolbar>
           {this.renderLayerPanel(projection)}
           {this.renderLevers(now)}
+          {game.monthlyHistory.length > 0 && (
+            <Typography variant="caption" color="textSecondary" sx={{ px: 2 }}>
+              Past charts show monthly averages; financial charts show monthly
+              totals or ending balances.
+              {game.monthlyHistory.some((month) => !month.chartAverage) &&
+                " Older saves have only financial and supply/demand history until new months are recorded."}
+            </Typography>
+          )}
           {this.renderViewportControls(
             viewportBounds,
             viewportRange,

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -487,6 +487,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
               <VictoryConditions
                 ownership={scenario.ownership}
                 dollarsPerkWh={scenario.dollarsPerkWh}
+                startingCustomers={scenario.startingCustomers}
                 minimumCustomerRetention={scenario.minimumCustomerRetention}
                 reliabilityObjective={scenario.reliabilityObjective}
               />

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import CustomerGrowthChallenge from "../components/base/CustomerGrowthChallenge";
 
 import TutorialPrompt from "../components/base/TutorialPrompt";
 import { AppStateType, ScenarioType } from "../Types";
@@ -511,12 +512,7 @@ export const SCENARIOS = [
       },
       {
         card: "INSIGHTS",
-        content: (
-          <TutorialPrompt
-            concepts={["rate", "customers", "money"]}
-            text="Your turn: grow customers by at least 5% in six months while staying profitable and reliable."
-          />
-        ),
+        content: <CustomerGrowthChallenge />,
         hint: "A modest discount below the market rate attracts customers. Check the financial forecast too: a rate that is too low can grow sales while losing money.",
         capstone: {
           success: pricingCapstoneSucceeded,

--- a/src/helpers/Customers.test.tsx
+++ b/src/helpers/Customers.test.tsx
@@ -1,14 +1,49 @@
 import {
   CUSTOMER_RATE_MEMORY_MONTHS,
+  getMarketRate,
   customerMarketSizeAt,
   customerSwitchingRate,
   nextCustomerCount,
   projectCustomerChange,
   updateCustomerRate,
 } from "./Customers";
-import { TICKS_PER_MONTH } from "../Constants";
+import { TICKS_PER_MONTH, TICKS_PER_YEAR } from "../Constants";
+import { initEconomyFromCsv } from "../data/Economy";
 
 describe("customer price competition", () => {
+  it("preserves a small utility's growth across a whole year", () => {
+    let customers = 100;
+    for (let tick = 0; tick < TICKS_PER_YEAR; tick++) {
+      customers = nextCustomerCount({
+        customers,
+        customerRate: 0.1,
+        marketRate: 0.1,
+        marketSize: 200,
+        ownership: "Public",
+      });
+    }
+    expect(customers).toBeCloseTo(100 * Math.exp(0.015), 2);
+  });
+
+  it("compounds the market benchmark with inflation every year", () => {
+    initEconomyFromCsv(
+      "month,year,prime,inflation\n" +
+        [2020, 2021, 2022]
+          .flatMap((year) =>
+            Array.from(
+              { length: 12 },
+              (_, month) => `${month + 1},${year},4,0.12`,
+            ),
+          )
+          .join("\n"),
+    );
+    for (let year = 2020; year <= 2022; year++) {
+      expect(getMarketRate(0.1, { year, monthNumber: 1 }, 2020, 1)).toBeCloseTo(
+        0.1 * Math.pow(1.01, (year - 2020) * 12),
+        10,
+      );
+    }
+  });
   it("gains customers below market, holds share at market, and loses above it", () => {
     const base = {
       customers: 1_000_000,

--- a/src/helpers/Customers.tsx
+++ b/src/helpers/Customers.tsx
@@ -96,10 +96,9 @@ export function nextCustomerCount({
         : Math.max(0, customers);
     change += (switchingBase * switchingRate * tickScale) / TICKS_PER_YEAR;
   }
-  const next = Math.max(0, Math.round(customers + change));
-  return ownership === "Investor"
-    ? Math.min(Math.round(marketSize), next)
-    : next;
+  // Preserve fractional customers between ticks: rounding here erases small utilities' growth.
+  const next = Math.max(0, customers + change);
+  return ownership === "Investor" ? Math.min(marketSize, next) : next;
 }
 
 /** The addressable market grows with the same underlying population trend as neutral customers. */

--- a/src/helpers/DateTime.test.tsx
+++ b/src/helpers/DateTime.test.tsx
@@ -207,6 +207,32 @@ describe("summarizeTimeline", () => {
     );
   });
 
+  it("records chart averages without mutating ticks, including nonlinear wind output", () => {
+    const timeline = ticks([100, 200]);
+    timeline.forEach((tick, index) => {
+      tick.demandByType = {
+        Residential: 100 + index * 100,
+        Commercial: 0,
+        Industrial: 0,
+        Transportation: 0,
+        "Data centers": 100,
+      };
+      tick.windKph = index * 100;
+      tick.windAirborneKph = 0;
+      tick.solarIrradianceWM2 = 0;
+      tick.storedWh = index * 1000;
+    });
+    const original = JSON.stringify(timeline);
+    const average = summarizeTimeline(timeline, 2020).chartAverage!;
+    expect(average.demandByType.Residential).toBe(150);
+    expect(average.demandByType["Data centers"]).toBe(100);
+    expect(average.supplyByFuel.Coal).toBe(65);
+    expect(average.storedWh).toBe(500);
+    expect(average.windKph).toBe(50);
+    expect(average.renewableCapacityFactors!.Wind).toBeGreaterThanOrEqual(0);
+    expect(JSON.stringify(timeline)).toBe(original);
+  });
+
   it("ends on the last tick the filter kept, not the last one in the array", () => {
     const summary = summarizeTimeline(
       ticks([100, 200, 300, 400]),

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -1,5 +1,11 @@
 import { getPosition, getTimes } from "suncalc";
 import {
+  getWindCapacityFactor,
+  getOffshoreWindCapacityFactor,
+  getAirborneWindCapacityFactor,
+  getSolarCapacityFactor,
+} from "./Energy";
+import {
   DAYS_PER_MONTH,
   DAYS_PER_YEAR,
   GAME_TO_REAL_YEARS,
@@ -112,6 +118,57 @@ function accumulateTick(
   tickScale: number,
 ) {
   const date = getMonthYearFromMinute(t.minute, startingYear);
+  const weight = summary.chartTickWeight || 0;
+  const share = tickScale / (weight + tickScale);
+  const factors = {
+    Wind: getWindCapacityFactor([t.windKph]),
+    "Offshore Wind": getOffshoreWindCapacityFactor(
+      t.windOffshoreKph === undefined ? [] : [t.windOffshoreKph],
+    ),
+    "Airborne Wind": getAirborneWindCapacityFactor([t.windAirborneKph]),
+    Solar: getSolarCapacityFactor([t.solarIrradianceWM2]),
+  };
+  // Runtime dispatch metadata uses symbol keys and must never enter a persisted chart record.
+  const sample = Object.fromEntries(Object.entries(t)) as TickPresentFutureType;
+  sample.renewableCapacityFactors = factors;
+  if (!summary.chartAverage) {
+    summary.chartAverage = {
+      ...sample,
+      demandByType: { ...t.demandByType },
+      supplyByFuel: { ...t.supplyByFuel },
+    } as TickPresentFutureType;
+  } else {
+    // Average levels, including fuel prices and weather. Financial totals live above this
+    // chart-only record. Clone nested maps so summarizing never mutates simulation ticks.
+    const average = summary.chartAverage;
+    for (const key of Object.keys(sample) as (keyof TickPresentFutureType)[]) {
+      const value = sample[key];
+      if (typeof value === "number") {
+        Object.assign(average, {
+          [key]:
+            Number(average[key] ?? value) +
+            (value - Number(average[key] ?? value)) * share,
+        });
+      }
+    }
+    for (const key of [
+      "demandByType",
+      "supplyByFuel",
+      "renewableCapacityFactors",
+    ] as const) {
+      const previous = average[key] as Record<string, number>;
+      const current = (sample[key] || {}) as Record<string, number>;
+      for (const name of new Set([
+        ...Object.keys(previous),
+        ...Object.keys(current),
+      ])) {
+        previous[name] =
+          (previous[name] || 0) +
+          ((current[name] || 0) - (previous[name] || 0)) * share;
+      }
+    }
+  }
+  summary.chartTickWeight = weight + tickScale;
   // Integrate instantaneous electricity (watts) to watt hours
   // Only electricity isn't multiplied by this during tick calculations (financials are)
   summary.supplyWh +=


### PR DESCRIPTION
Insights previously lost non-financial chart history after each month, and per-tick customer rounding could erase small utilities' growth. Record compact monthly chart averages in memory and saves, retain fractional customers through the simulation, and right-align the desktop preset controls.

- Preserve demand by use, generation by fuel, storage, fuel prices, weather, water, and renewable capacity factors. Average renewable output factors before aggregating weather so nonlinear generation curves remain accurate.
- Restore the inflation-adjusted market benchmark for public utilities. Regression coverage verifies annual inflation compounding; public customers remain insensitive to rate competition by design.
- Show Data Center Boom's absolute retention target: 14,850 of the original 16,500 customers. The pricing tutorial also shows its absolute 5% growth target, including from the in-game scenario dialog. Other scenario requirements already use absolute scoring quantities or reliability percentages of changing demand.

Save schema 2 upgrades version 1 saves without inventing missing history; additional chart history accumulates in newly completed months. Replay version 3 intentionally rejects earlier action streams because fractional customer growth changes simulation results.

Validation: Node 24 and npm ci; npm run check (98 suites, 939 tests, all scenario invariants); npm run build; five desktop/mobile Playwright checks covering alignment, history, market indicators, and customer objectives. Screenshots reviewed in dark desktop and light mobile layouts.

![Desktop Insights with monthly demand history and right-aligned presets](https://github.com/user-attachments/assets/21adb0d7-68d6-47f9-9138-6d8ad7e59b3a)

![Mobile Insights with market benchmark and customer growth](https://github.com/user-attachments/assets/d11a95f5-94cf-4120-9dc2-21d81c51ab7a)

![Data Center Boom absolute customer retention target](https://github.com/user-attachments/assets/5571354a-7a89-429f-b69f-00fc90ff3cc5)