### PR TITLE
Improve in-game scenario details for desktop and mobile

### DIFF
--- a/e2e/scenario-details.spec.ts
+++ b/e2e/scenario-details.spec.ts
@@ -1,0 +1,89 @@
+import path from "path";
+import { expect, test } from "@playwright/test";
+
+for (const theme of ["light", "dark"] as const) {
+  test(`scenario details reflow and dismiss in ${theme} mode`, async ({
+    page,
+  }, testInfo) => {
+    await page.addInitScript((mode) => {
+      window.localStorage.clear();
+      window.localStorage.setItem("theme", mode);
+      window.localStorage.setItem("audioEnabled", "false");
+    }, theme);
+    await page.goto("/?scenario=111");
+    await page.getByRole("button", { name: "Start game" }).click();
+    const menu = page
+      .locator("#appbar:visible")
+      .getByRole("button", { name: "menu", exact: true })
+      .first();
+    await menu.click();
+    await page.getByRole("menuitem", { name: "Scenario details" }).click();
+    const dialog = page.getByRole("dialog", { name: "Wildfire Emergency" });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByText(/Your score will appear after the first month/),
+    ).toBeAttached();
+    const back = dialog.getByRole("button", { name: "Back to game" });
+    await expect(back).toBeInViewport();
+    await expect(
+      dialog.getByRole("button", { name: "Close scenario details" }),
+    ).toBeInViewport();
+    expect(
+      await dialog.evaluate((el) => el.scrollWidth - el.clientWidth),
+    ).toBeLessThanOrEqual(1);
+    const box = await back.boundingBox();
+    expect(box!.height).toBeGreaterThanOrEqual(
+      testInfo.project.use.hasTouch ? 44 : 40,
+    );
+    await back.click();
+    await expect(dialog).not.toBeVisible();
+    await page.getByRole("button", { name: "Events", exact: true }).click();
+    await page
+      .locator("#appbar:visible")
+      .getByRole("button", { name: "fast speed", exact: true })
+      .first()
+      .click();
+    // Wait for a real completed month, then stop the clock before inspecting its score.
+    await expect(
+      page.getByText("Wildfire emergency", { exact: true }),
+    ).toBeAttached({ timeout: 25000 });
+    await page
+      .locator("#appbar:visible")
+      .getByRole("button", { name: "pause", exact: true })
+      .first()
+      .click();
+    await menu.click();
+    await page.getByRole("menuitem", { name: "Scenario details" }).click();
+    await expect(
+      dialog.getByText("Through last month · updates monthly"),
+    ).toBeAttached();
+    const content = dialog.locator(".MuiDialogContent-root");
+    expect(
+      await content.evaluate((el) => el.scrollWidth - el.clientWidth),
+    ).toBeLessThanOrEqual(1);
+    await dialog
+      .getByRole("heading", { name: "Current score" })
+      .scrollIntoViewIfNeeded();
+    await expect(back).toBeInViewport();
+    const reviewDir = process.env.REVIEW_SCREENSHOT_DIR;
+    if (
+      reviewDir &&
+      (testInfo.project.name === "desktop-chromium" ||
+        (theme === "dark" && testInfo.project.name === "mobile-390px"))
+    ) {
+      await content.evaluate((el) => {
+        el.scrollTop = 0;
+      });
+      // Finish the dialog/menu transitions before capturing the review frame.
+      await page.waitForTimeout(400);
+      await page.screenshot({
+        path: path.join(
+          reviewDir,
+          `scenario-details-${testInfo.project.name}-${theme}.png`,
+        ),
+      });
+    }
+    await page.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible();
+  });
+}

--- a/e2e/scenario-details.spec.ts
+++ b/e2e/scenario-details.spec.ts
@@ -37,7 +37,9 @@ for (const theme of ["light", "dark"] as const) {
     );
     await back.click();
     await expect(dialog).not.toBeVisible();
-    await page.getByRole("button", { name: "Events", exact: true }).click();
+    // Wide desktops already show the event pane beside the grid.
+    const events = page.getByRole("button", { name: "Events", exact: true });
+    if (await events.isVisible()) await events.click();
     await page
       .locator("#appbar:visible")
       .getByRole("button", { name: "fast speed", exact: true })

--- a/src/components/base/ScenarioDetailsDialog.tsx
+++ b/src/components/base/ScenarioDetailsDialog.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {
+  Box,
   Button,
   Dialog,
   DialogActions,
@@ -23,12 +24,7 @@ export interface Props {
   onClose: () => void;
 }
 
-/**
- * The same rundown the scenario-select screen shows -- timeframe, location and victory
- * conditions -- reachable from the in-game menu, for whenever a player forgets what they signed
- * up for partway through a run. The score is figured from monthlyHistory, which only rolls up at
- * each month's end, so it reads as "through last month" rather than this exact instant.
- */
+/** An in-game reminder of the mission and its score through completed months. */
 export default function ScenarioDetailsDialog(props: Props): React.JSX.Element {
   const { open, game, onClose } = props;
   const scenario = getScenario(game.scenarioId, game.customScenario);
@@ -41,59 +37,266 @@ export default function ScenarioDetailsDialog(props: Props): React.JSX.Element {
     history.length > 0
       ? computeScoreBreakdown(scenario, summarizeHistory(history))
       : null;
+  const facts = [
+    {
+      label: "Timeframe",
+      value: `${scenario.startingYear}–${scenario.startingYear + Math.ceil(scenario.durationMonths / 12) - 1}`,
+    },
+    ...(location ? [{ label: "Location", value: location.name }] : []),
+    { label: "Difficulty", value: game.difficulty },
+    { label: "Ownership", value: `${scenario.ownership}-owned` },
+  ];
 
   return (
     <Dialog
       open={open}
       onClose={onClose}
       aria-labelledby="scenario-details-title"
+      fullWidth
+      maxWidth="md"
+      slotProps={{
+        paper: {
+          sx: {
+            maxWidth: 840,
+            backgroundImage: "none",
+            "@media (max-width: 599px)": {
+              m: 0,
+              width: "100%",
+              maxWidth: "100%",
+              height: "100dvh",
+              maxHeight: "100dvh",
+              borderRadius: 0,
+            },
+          },
+        },
+      }}
     >
-      <DialogTitle>
-        <span id="scenario-details-title">{scenario.name}</span>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 1,
+          p: { xs: 2, sm: 3 },
+        }}
+      >
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography
+            variant="overline"
+            color="text.secondary"
+            sx={{ lineHeight: 1.5 }}
+          >
+            Scenario details
+          </Typography>
+          <DialogTitle
+            id="scenario-details-title"
+            sx={{
+              "&&": { p: 0 },
+              mt: 0.5,
+              fontSize: { xs: 24, sm: 28 },
+              fontWeight: 700,
+              lineHeight: 1.2,
+              overflowWrap: "anywhere",
+            }}
+          >
+            {scenario.name}
+          </DialogTitle>
+        </Box>
         <IconButton
-          aria-label="close"
+          aria-label="Close scenario details"
           onClick={onClose}
-          className="top-right"
-          size="large"
+          sx={{
+            width: 40,
+            height: 40,
+            "@media (pointer: coarse)": { width: 44, height: 44 },
+          }}
         >
           <CloseIcon />
         </IconButton>
-      </DialogTitle>
-      <DialogContent>
-        <p>
-          Timeframe: {scenario.startingYear} to{" "}
-          {scenario.startingYear + Math.ceil(scenario.durationMonths / 12) - 1}
-        </p>
-        {location && <p>Location: {location.name}</p>}
-        <p>Difficulty: {game.difficulty}</p>
-        <Typography variant="h6" gutterBottom>
-          Victory Conditions: {scenario.ownership}-Owned
-        </Typography>
-        <VictoryConditions
-          ownership={scenario.ownership}
-          dollarsPerkWh={scenario.dollarsPerkWh}
-          minimumCustomerRetention={scenario.minimumCustomerRetention}
-          reliabilityObjective={scenario.reliabilityObjective}
-        />
-        {breakdown && (
-          <>
-            <Typography variant="h6" gutterBottom>
-              Current score: {formatScore(totalScore(breakdown))}
+      </Box>
+      <DialogContent dividers sx={{ p: { xs: 2, sm: 3 } }}>
+        <Box
+          component="dl"
+          sx={{
+            m: 0,
+            mb: 3,
+            display: "grid",
+            gridTemplateColumns: {
+              xs: "repeat(2, minmax(0, 1fr))",
+              sm: "repeat(4, minmax(0, 1fr))",
+            },
+            gap: 2,
+          }}
+        >
+          {facts.map(({ label, value }) => (
+            <Box key={label} sx={{ minWidth: 0 }}>
+              <Typography component="dt" variant="body2" color="text.secondary">
+                {label}
+              </Typography>
+              <Typography
+                component="dd"
+                variant="body2"
+                sx={{
+                  m: 0,
+                  mt: 0.5,
+                  fontWeight: 600,
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {value}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: {
+              xs: "minmax(0, 1fr)",
+              sm: "minmax(0, 1.2fr) minmax(0, 1fr)",
+            },
+            gap: 3,
+            alignItems: "start",
+          }}
+        >
+          <Box component="section" aria-labelledby="scenario-rules-title">
+            <Typography
+              id="scenario-rules-title"
+              variant="h6"
+              component="h3"
+              sx={{ fontWeight: 700 }}
+            >
+              Victory conditions
             </Typography>
-            <div style={{ margin: "8px 0" }}>
-              {Object.keys(breakdown).map((category: string) => (
-                <div key={category}>
-                  {breakdown[category]} pts from{" "}
-                  {SCORE_LABELS[category] || category}
-                </div>
-              ))}
-            </div>
-          </>
-        )}
+            <Box
+              sx={{
+                typography: "body2",
+                "& p": {
+                  my: 0,
+                  py: 1.5,
+                  borderBottom: "1px solid",
+                  borderColor: "divider",
+                },
+                "& p:last-child": { borderBottom: 0, pb: 0 },
+              }}
+            >
+              <VictoryConditions
+                ownership={scenario.ownership}
+                dollarsPerkWh={scenario.dollarsPerkWh}
+                minimumCustomerRetention={scenario.minimumCustomerRetention}
+                reliabilityObjective={scenario.reliabilityObjective}
+              />
+            </Box>
+          </Box>
+          <Box
+            component="section"
+            aria-labelledby="scenario-score-title"
+            sx={{
+              p: 2,
+              bgcolor: "var(--bg-raised)",
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: 2,
+            }}
+          >
+            <Typography
+              id="scenario-score-title"
+              variant="h6"
+              component="h3"
+              sx={{ fontWeight: 700 }}
+            >
+              Current score
+            </Typography>
+            {breakdown ? (
+              <>
+                <Typography
+                  component="p"
+                  sx={{ mt: 1, mb: 0.5, fontVariantNumeric: "tabular-nums" }}
+                >
+                  <Box
+                    component="strong"
+                    sx={{ fontSize: 36, lineHeight: 1.2 }}
+                  >
+                    {formatScore(totalScore(breakdown))}
+                  </Box>{" "}
+                  <Box component="span" sx={{ color: "text.secondary" }}>
+                    points
+                  </Box>
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Through last month · updates monthly
+                </Typography>
+                <Box component="dl" sx={{ m: 0, mt: 2 }}>
+                  {Object.entries(breakdown).map(([category, score]) => (
+                    <Box
+                      key={category}
+                      sx={{
+                        display: "flex",
+                        alignItems: "baseline",
+                        justifyContent: "space-between",
+                        gap: 2,
+                        py: 1,
+                        borderTop: "1px solid",
+                        borderColor: "divider",
+                        typography: "body2",
+                      }}
+                    >
+                      <Box
+                        component="dt"
+                        sx={{
+                          "&::first-letter": { textTransform: "uppercase" },
+                        }}
+                      >
+                        {SCORE_LABELS[category] || category}
+                      </Box>
+                      <Box
+                        component="dd"
+                        sx={{
+                          m: 0,
+                          flexShrink: 0,
+                          fontWeight: 600,
+                          fontVariantNumeric: "tabular-nums",
+                          color:
+                            score < 0
+                              ? "var(--delta-bad)"
+                              : score > 0
+                                ? "var(--delta-good)"
+                                : "text.secondary",
+                        }}
+                      >
+                        {score > 0 ? "+" : ""}
+                        {formatScore(score)}
+                      </Box>
+                    </Box>
+                  ))}
+                </Box>
+              </>
+            ) : (
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                Your score will appear after the first month. Use the victory
+                conditions to plan your opening moves.
+              </Typography>
+            )}
+          </Box>
+        </Box>
       </DialogContent>
-      <DialogActions>
-        <Button color="primary" variant="contained" onClick={onClose}>
-          Close
+      <DialogActions
+        sx={{
+          p: 2,
+          px: { sm: 3 },
+          pb: "max(16px, env(safe-area-inset-bottom))",
+        }}
+      >
+        <Button
+          color="primary"
+          variant="contained"
+          onClick={onClose}
+          sx={{
+            minHeight: 40,
+            width: { xs: "100%", sm: "auto" },
+            "@media (pointer: coarse)": { minHeight: 44 },
+          }}
+        >
+          Back to game
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
The in-game scenario details modal now separates mission facts, victory conditions, and the current score so players can quickly review their priorities. Desktop uses two columns; phones use a full-screen, single-column dialog with a persistent Back to game button and touch-sized close control.

The score includes signed, aligned category values, an explicit completed-month timing label, and guidance before the first month finishes. Shared theme tokens provide light/dark surfaces and semantic score colors. Existing scoring calculations and victory conditions are preserved.

Validation: production build; TypeScript; lint; repository formatting; 97 covered Jest suites / 933 tests; all simulation invariants; 10 Playwright cases across 320, 390, 768, 1280, and 1440 px in light and dark modes. Browser coverage checks the first-month state, populated scores, overflow, touch targets, scrolling, and dismissal. `npm run check` initially stopped on formatting in unrelated concurrent edits; formatting subsequently passed and all remaining checks were run separately. Jest used `--runInBand --roots src` to avoid crawling nested worktrees.

Reviewed screenshots: desktop light, desktop dark, and mobile dark. The mobile score section continues below the fold while the primary action remains visible.

![Desktop light: mission rules and score](https://github.com/user-attachments/assets/67d36b9d-ebc9-48fd-a12b-9b6543e4db48)

![Desktop dark: mission rules and score](https://github.com/user-attachments/assets/25454fc7-9ea6-4731-b373-df3accbf12ea)

![Mobile dark: stacked content and persistent action](https://github.com/user-attachments/assets/04a1c911-6aaf-4548-bca1-7b3ce7e08c5c)