### PR TITLE
Compact generator and storage build rows on mobile

### DIFF
--- a/e2e/app-spacing.spec.ts
+++ b/e2e/app-spacing.spec.ts
@@ -70,15 +70,11 @@ test("phone surfaces share stable gutters and compact chrome", async ({
   expect(firstBuildCard!.x).toBeCloseTo(8, 0);
   expect(firstBuildCard!.width).toBeCloseTo(page.viewportSize()!.width - 16, 0);
 
-  const buildAction = page
-    .locator(".cardList > .build-list-item .MuiCardHeader-action")
-    .first();
-  const buyButton = await buildAction.getByRole("button").boundingBox();
-  const buildTiming = await buildAction.locator("p").boundingBox();
-  expect(buyButton).not.toBeNull();
-  expect(buildTiming).not.toBeNull();
-  expect(
-    buildTiming!.x - (buyButton!.x + buyButton!.width),
-  ).toBeGreaterThanOrEqual(7);
+  const card = page.locator(".cardList > .buildOption").first();
+  await expect(
+    card.getByRole("button", { name: /Review purchase of/ }),
+  ).toBeVisible();
+  await expect(card.locator(".buildOptionMetrics")).toContainText("Build time");
+  await expectNoHorizontalOverflow(card);
   await expectNoHorizontalOverflow(page.locator("#topbar"));
 });

--- a/e2e/build-options.spec.ts
+++ b/e2e/build-options.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test } from "@playwright/test";
+
+for (const theme of ["light", "dark"] as const) {
+  test(`build options remain compact and usable in ${theme}`, async ({
+    page,
+  }, testInfo) => {
+    await page.addInitScript((mode) => {
+      localStorage.clear();
+      localStorage.setItem("theme", mode);
+    }, theme);
+    await page.goto("/?scenario=103");
+    await page.getByRole("button", { name: "Start game", exact: true }).click();
+    if (!(await page.locator("#facilitiesPane").isVisible())) {
+      await page
+        .getByRole("button", { name: "Facilities", exact: true })
+        .click();
+    }
+    for (const kind of ["Generator", "Storage"]) {
+      await page.locator(`.button-build${kind}`).click();
+      const cards = page.locator(".buildOption");
+      const first = cards.first();
+      await expect(first).toBeVisible();
+      await expect(page.locator("main.base_main")).toHaveCount(1);
+      for (const card of await cards.all()) {
+        expect(
+          await card.evaluate((el) => el.scrollWidth - el.clientWidth),
+        ).toBeLessThanOrEqual(1);
+      }
+      const metrics = first.locator(".buildOptionMetrics");
+      await expect(metrics).toContainText("Build cost");
+      await expect(metrics).toContainText("Build time");
+      await expect(metrics).toContainText(
+        kind === "Storage" ? "Round-trip efficiency" : "Typical output",
+      );
+      const review = first.getByRole("button", { name: /Review purchase of/ });
+      const header = first.locator(".MuiCardHeader-root");
+      const box = (await first.boundingBox())!;
+      expect(box.height).toBeLessThan(kind === "Generator" ? 230 : 285);
+      expect((await review.boundingBox())!.height).toBeGreaterThanOrEqual(
+        testInfo.project.use.hasTouch ? 44 : 40,
+      );
+      expect((await header.boundingBox())!.height).toBeLessThan(90);
+      await page.screenshot({
+        path: testInfo.outputPath(`${kind}-${theme}.png`),
+      });
+      if (kind === "Generator") {
+        await first.getByRole("button", { name: /^Compare/ }).click();
+        await expect(
+          page.getByRole("region", { name: "Generator comparison" }),
+        ).toContainText("Comparing 1/3");
+        await page.getByRole("button", { name: "Clear", exact: true }).click();
+        const sort = page.getByRole("combobox", { name: "Sort facilities" });
+        if (await sort.isVisible()) {
+          await sort.click();
+          await page.getByRole("option", { name: "Cost per MWh" }).click();
+        } else {
+          await page.getByRole("button", { name: /^Sort facilities:/ }).click();
+          await page.getByRole("menuitem", { name: "Cost per MWh" }).click();
+        }
+        await expect(first.locator(".buildOptionMetrics")).toContainText(
+          "Lifetime cost / MWh",
+        );
+        expect(
+          await first.evaluate((el) => el.scrollWidth - el.clientWidth),
+        ).toBeLessThanOrEqual(1);
+      }
+      await first.getByRole("button", { name: /Show .* details/ }).click();
+      await expect(first.locator(".buildOptionDescription")).toBeVisible();
+      await expect(first.getByRole("table")).toBeVisible();
+      await review.click();
+      await expect(page.getByRole("dialog")).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Pay cash", exact: true }),
+      ).toBeVisible();
+      await page
+        .getByRole("dialog")
+        .getByRole("button", { name: "close" })
+        .click();
+      await expect(page.getByRole("dialog")).not.toBeVisible();
+      await page.getByRole("button", { name: "close", exact: true }).click();
+      await expect(cards).toHaveCount(0);
+    }
+  });
+}
+
+for (const theme of ["light", "dark"] as const) {
+  test(`battery metrics in ${theme}`, async ({ page }, testInfo) => {
+    await page.addInitScript((mode) => {
+      localStorage.clear();
+      localStorage.setItem("theme", mode);
+    }, theme);
+    await page.goto("/?scenario=100");
+    await page.getByRole("button", { name: "Start game", exact: true }).click();
+    if (!(await page.locator("#facilitiesPane").isVisible())) {
+      await page
+        .getByRole("button", { name: "Facilities", exact: true })
+        .click();
+    }
+    await page.locator(".button-buildStorage").click();
+    const battery = page.locator(".buildOption").filter({
+      has: page.getByRole("button", { name: /Battery details/ }),
+    });
+    await expect(battery).toBeVisible();
+    await expect(page.locator("main.base_main")).toHaveCount(1);
+    await expect(battery.locator(".buildOptionMetrics")).toContainText("4 h");
+    await expect(battery.locator(".buildOptionMetrics")).toContainText("125MW");
+    await expect(battery.locator(".buildOptionMetrics")).toContainText("85%");
+    expect(
+      await battery.evaluate((el) => el.scrollWidth - el.clientWidth),
+    ).toBeLessThanOrEqual(1);
+    await page.screenshot({
+      path: testInfo.outputPath(`Storage-modern-${theme}.png`),
+    });
+    await battery.getByRole("button", { name: "Show Battery details" }).click();
+    await expect(battery).toContainText(
+      "Full-power duration assumes a full charge",
+    );
+    await expect(
+      battery.getByRole("row", { name: /Stored energy lost per hour/ }),
+    ).toContainText("0.01%");
+  });
+}

--- a/e2e/build-options.spec.ts
+++ b/e2e/build-options.spec.ts
@@ -10,6 +10,12 @@ for (const theme of ["light", "dark"] as const) {
     }, theme);
     await page.goto("/?scenario=103");
     await page.getByRole("button", { name: "Start game", exact: true }).click();
+    await expect(
+      page
+        .locator("#facilitiesPane:visible")
+        .or(page.getByRole("button", { name: "Facilities", exact: true }))
+        .first(),
+    ).toBeVisible();
     if (!(await page.locator("#facilitiesPane").isVisible())) {
       await page
         .getByRole("button", { name: "Facilities", exact: true })
@@ -91,6 +97,12 @@ for (const theme of ["light", "dark"] as const) {
     }, theme);
     await page.goto("/?scenario=100");
     await page.getByRole("button", { name: "Start game", exact: true }).click();
+    await expect(
+      page
+        .locator("#facilitiesPane:visible")
+        .or(page.getByRole("button", { name: "Facilities", exact: true }))
+        .first(),
+    ).toBeVisible();
     if (!(await page.locator("#facilitiesPane").isVisible())) {
       await page
         .getByRole("button", { name: "Facilities", exact: true })

--- a/e2e/build-options.spec.ts
+++ b/e2e/build-options.spec.ts
@@ -46,6 +46,18 @@ for (const theme of ["light", "dark"] as const) {
         testInfo.project.use.hasTouch ? 44 : 40,
       );
       expect((await header.boundingBox())!.height).toBeLessThan(90);
+      if (kind === "Generator") {
+        const compare = (await first
+          .getByRole("button", { name: /^Compare/ })
+          .boundingBox())!;
+        const reviewBox = (await review.boundingBox())!;
+        if (page.viewportSize()!.width >= 600) {
+          expect(compare.y).toBeCloseTo(reviewBox.y, 0);
+          expect(reviewBox.x - (compare.x + compare.width)).toBeCloseTo(4, 0);
+        } else {
+          expect(compare.y).toBeGreaterThan(reviewBox.y + reviewBox.height);
+        }
+      }
       await page.screenshot({
         path: testInfo.outputPath(`${kind}-${theme}.png`),
       });

--- a/src/app.scss
+++ b/src/app.scss
@@ -1553,19 +1553,6 @@ $pane_header_height: 40px;
   background: var(--bg-primary);
 }
 
-.generatorDecisionLead {
-  display: grid;
-  gap: 4px;
-  padding: 0 16px 12px;
-}
-
-.generatorBuildSubtitle {
-  display: -webkit-box;
-  overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-}
-
 .generatorComparison {
   padding: 8px 16px 10px;
   border-bottom: 1px solid var(--border-selected);
@@ -3776,5 +3763,71 @@ $sizemap: (
   }
   100% {
     background-color: transparent;
+  }
+}
+
+// Shared purchase rows: keep the decision and touch targets compact without clipping copy.
+.build-list-item.buildOption {
+  .MuiCardHeader-root {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+    gap: 8px;
+    .MuiCardHeader-avatar {
+      margin: 0;
+    }
+    .MuiCardHeader-content {
+      min-width: 0;
+    }
+    .MuiCardHeader-title {
+      font-size: 1rem;
+      font-weight: 600;
+    }
+    .MuiCardHeader-action {
+      width: auto;
+      margin: 0 !important;
+      align-self: center;
+      flex-shrink: 0;
+    }
+  }
+  .MuiButton-root {
+    min-height: 40px;
+  }
+  .buildOptionMetrics {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    padding: 0 12px 8px;
+  }
+  .buildOptionMetric {
+    min-width: 0;
+  }
+  .buildOptionContext {
+    display: block;
+    padding: 0 12px 8px;
+  }
+  .buildOptionWarning,
+  .buildOptionDescription {
+    padding: 0 12px 8px;
+  }
+  .buildOptionFooter {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin: 0 12px;
+    padding: 4px 0;
+    border-top: 1px solid var(--border-subtle);
+    .expand-details.MuiButton-root {
+      width: auto;
+      margin: 0;
+      border: 0;
+      border-radius: 4px;
+    }
+  }
+}
+@media (pointer: coarse) {
+  .build-list-item.buildOption .MuiButton-root {
+    min-height: 44px;
   }
 }

--- a/src/components/base/BuildMetric.tsx
+++ b/src/components/base/BuildMetric.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { Typography } from "@mui/material";
+export default function BuildMetric(props: {
+  label: string;
+  value: string;
+}): React.JSX.Element {
+  return (
+    <div className="buildOptionMetric">
+      <Typography variant="caption" color="textSecondary" component="div">
+        {props.label}
+      </Typography>
+      <Typography variant="body2" component="div" sx={{ fontWeight: 600 }}>
+        {props.value}
+      </Typography>
+    </div>
+  );
+}

--- a/src/components/views/BuildGenerators.test.tsx
+++ b/src/components/views/BuildGenerators.test.tsx
@@ -36,7 +36,7 @@ it("shows natural-gas base, per-start, and daily-start estimated O&M", async () 
   ).not.toBeInTheDocument();
   expect(screen.queryByText("$13.4M/yr")).not.toBeInTheDocument();
   expect(screen.queryByText("Flexible power")).toBeNull();
-  expect(screen.getByText(/typical output/)).toBeInTheDocument();
+  expect(screen.getByText(/Typical output/)).toBeInTheDocument();
   fireEvent.click(
     screen.getByRole("button", { name: "Show Natural Gas details" }),
   );
@@ -209,7 +209,7 @@ it("keeps primary generator metrics visible and discloses secondary details", ()
   );
 
   expect(screen.getByText("Natural Gas")).toBeInTheDocument();
-  expect(screen.getByText(/typical output/)).toBeInTheDocument();
+  expect(screen.getByText(/Typical output/)).toBeInTheDocument();
   expect(screen.getByText(/largest forecast shortage/)).toBeInTheDocument();
   expect(screen.getByText("Build cost")).toBeInTheDocument();
   expect(screen.getByText("Build time")).toBeInTheDocument();

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -58,6 +58,7 @@ import {
   getBuildAvailability,
   ViableLocationsRow,
 } from "../base/BuildAvailability";
+import BuildMetric from "../base/BuildMetric";
 import ConstructionBuildHeader from "../base/ConstructionBuildHeader";
 
 interface GeneratorBuildItemProps {
@@ -153,7 +154,7 @@ export function GeneratorBuildItem(
   };
 
   return (
-    <Card className="build-list-item">
+    <Card className="build-list-item buildOption">
       <CardHeader
         avatar={
           <Avatar
@@ -163,21 +164,6 @@ export function GeneratorBuildItem(
         }
         action={
           <Stack direction="row" spacing={0.5}>
-            {props.onCompare && canBuild && (
-              <Button
-                size="small"
-                variant={props.compared ? "contained" : "outlined"}
-                aria-pressed={props.compared}
-                aria-label={`Compare ${generator.name}`}
-                disabled={props.compareDisabled && !props.compared}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  props.onCompare?.();
-                }}
-              >
-                Compare
-              </Button>
-            )}
             <Button
               className="buy-button"
               size="small"
@@ -193,79 +179,81 @@ export function GeneratorBuildItem(
           </Stack>
         }
         title={generator.name}
-        subheader={
-          <span
-            className={
-              buildable && financingGap === 0
-                ? "generatorBuildSubtitle"
-                : undefined
-            }
-          >
-            {buildSubtitle}
-          </span>
-        }
       />
-      <Box className="generatorDecisionLead">
-        <Stack
-          direction="row"
-          spacing={0.75}
-          useFlexGap
-          sx={{ flexWrap: "wrap" }}
+      {!canBuild && (
+        <Typography
+          component="div"
+          className="buildOptionWarning"
+          color="textSecondary"
         >
-          <Chip
-            size="small"
-            variant="outlined"
-            label={`${formatWatts(typicalOutputW)} typical output`}
-          />
-          {gapCoverage !== undefined && (
-            <Chip
-              size="small"
-              color={gapCoverage >= 100 ? "success" : "default"}
-              label={`~${gapCoverage}% of largest forecast shortage`}
-            />
-          )}
-        </Stack>
-      </Box>
-      <Box
-        sx={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(104px, 1fr))",
-          gap: 1,
-          px: 2,
-          pb: 1.5,
-        }}
-      >
-        <GeneratorMetric
+          {buildSubtitle}
+        </Typography>
+      )}
+      <Box className="buildOptionMetrics">
+        <BuildMetric
+          label="Typical output"
+          value={formatWatts(typicalOutputW)}
+        />
+        <BuildMetric
           label="Build cost"
           value={formatMoneyConcise(generator.buildCost)}
         />
-        <GeneratorMetric
+        <BuildMetric
           label="Build time"
           value={`${Math.round(generator.yearsToBuild * 12)} mo`}
         />
         {props.secondaryMetric === "lcWh" && (
-          <GeneratorMetric
+          <BuildMetric
             label="Lifetime cost / MWh"
             value={`${fuelPrices[generator.fuel] ? "~" : ""}${formatMoneyConcise(generator.lcWh * 1000000)}/MWh`}
           />
         )}
       </Box>
-      <Button
-        color="primary"
-        className="expand-details"
-        size="small"
-        aria-label={`${expanded ? "Hide" : "Show"} ${generator.name} details`}
-        aria-expanded={expanded}
-        endIcon={expanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
-        onClick={(event) => {
-          event.stopPropagation();
-          toggleExpand();
-        }}
-      >
-        {expanded ? "Hide details" : "Show details"}
-      </Button>
+      {gapCoverage !== undefined && (
+        <Typography className="buildOptionContext" variant="caption">
+          ~{gapCoverage}% of largest forecast shortage (average output)
+        </Typography>
+      )}
+      <Box className="buildOptionFooter">
+        <Button
+          color="primary"
+          className="expand-details"
+          size="small"
+          aria-label={`${expanded ? "Hide" : "Show"} ${generator.name} details`}
+          aria-expanded={expanded}
+          endIcon={expanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
+          onClick={(event) => {
+            event.stopPropagation();
+            toggleExpand();
+          }}
+        >
+          {expanded ? "Hide details" : "Show details"}
+        </Button>
 
+        {props.onCompare && canBuild && (
+          <Button
+            size="small"
+            variant={props.compared ? "contained" : "outlined"}
+            aria-pressed={props.compared}
+            aria-label={`Compare ${generator.name}`}
+            disabled={props.compareDisabled && !props.compared}
+            onClick={(event) => {
+              event.stopPropagation();
+              props.onCompare?.();
+            }}
+          >
+            Compare
+          </Button>
+        )}
+      </Box>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
+        <Typography
+          className="buildOptionDescription"
+          variant="body2"
+          color="textSecondary"
+        >
+          {generator.description}
+        </Typography>
         {(props.advantages || []).length > 0 && (
           <Box sx={{ px: 2, pb: 1 }}>
             <Stack
@@ -587,31 +575,6 @@ export function GeneratorBuildItem(
         </DialogActions>
       </Dialog>
     </Card>
-  );
-}
-
-function GeneratorMetric(props: {
-  label: string;
-  value: string;
-}): React.JSX.Element {
-  return (
-    <Box
-      sx={{
-        minWidth: 0,
-        p: 1,
-        border: 1,
-        borderColor: "divider",
-        borderRadius: 1,
-        bgcolor: "action.hover",
-      }}
-    >
-      <Typography variant="caption" color="textSecondary" component="div">
-        {props.label}
-      </Typography>
-      <Typography variant="body2" component="div" sx={{ fontWeight: 600 }}>
-        {props.value}
-      </Typography>
-    </Box>
   );
 }
 

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -20,6 +20,7 @@ import {
   TableContainer,
   TableRow,
   Typography,
+  useMediaQuery,
 } from "@mui/material";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
@@ -82,6 +83,7 @@ export function GeneratorBuildItem(
 ): React.JSX.Element {
   const { generator, cash } = props;
   const units = useUnits();
+  const wideLayout = useMediaQuery("(min-width:600px)");
   const fuel = FUELS[generator.fuel] || {};
   const fuelPrices = getFuelPricesPerMBTU(
     props.date,
@@ -153,6 +155,22 @@ export function GeneratorBuildItem(
     toggleOpen(e);
   };
 
+  const compareAction = props.onCompare && canBuild && (
+    <Button
+      size="small"
+      variant={props.compared ? "contained" : "outlined"}
+      aria-pressed={props.compared}
+      aria-label={`Compare ${generator.name}`}
+      disabled={props.compareDisabled && !props.compared}
+      onClick={(event) => {
+        event.stopPropagation();
+        props.onCompare?.();
+      }}
+    >
+      Compare
+    </Button>
+  );
+
   return (
     <Card className="build-list-item buildOption">
       <CardHeader
@@ -164,6 +182,7 @@ export function GeneratorBuildItem(
         }
         action={
           <Stack direction="row" spacing={0.5}>
+            {wideLayout && compareAction}
             <Button
               className="buy-button"
               size="small"
@@ -230,21 +249,7 @@ export function GeneratorBuildItem(
           {expanded ? "Hide details" : "Show details"}
         </Button>
 
-        {props.onCompare && canBuild && (
-          <Button
-            size="small"
-            variant={props.compared ? "contained" : "outlined"}
-            aria-pressed={props.compared}
-            aria-label={`Compare ${generator.name}`}
-            disabled={props.compareDisabled && !props.compared}
-            onClick={(event) => {
-              event.stopPropagation();
-              props.onCompare?.();
-            }}
-          >
-            Compare
-          </Button>
-        )}
+        {!wideLayout && compareAction}
       </Box>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
         <Typography

--- a/src/components/views/BuildStorage.test.tsx
+++ b/src/components/views/BuildStorage.test.tsx
@@ -121,7 +121,9 @@ it("submits a storage purchase only once on a double-click", () => {
   );
 
   // Pumped Hydro is the first shopping card, so its price is the first purchase button.
-  fireEvent.click(screen.getAllByRole("button", { name: /^\$/ })[0]);
+  fireEvent.click(
+    screen.getAllByRole("button", { name: /^Review purchase of/ })[0],
+  );
   const takeLoan = screen.getByRole("button", { name: "Take loan" });
   fireEvent.click(takeLoan);
   fireEvent.click(takeLoan);
@@ -138,7 +140,9 @@ it("deduplicates storage purchase impact and discloses financing terms", async (
     />,
   );
 
-  fireEvent.click(screen.getAllByRole("button", { name: /^\$/ })[0]);
+  fireEvent.click(
+    screen.getAllByRole("button", { name: /^Review purchase of/ })[0],
+  );
 
   const impact = screen.getByRole("region", { name: "Expected impact" });
   expect(impact).toHaveTextContent("Cash purchase");
@@ -165,7 +169,9 @@ it("deduplicates storage purchase impact and discloses financing terms", async (
     within(screen.getByRole("dialog")).getByRole("button", { name: "close" }),
   );
   await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
-  fireEvent.click(screen.getAllByRole("button", { name: /^\$/ })[0]);
+  fireEvent.click(
+    screen.getAllByRole("button", { name: /^Review purchase of/ })[0],
+  );
   expect(
     screen.getByRole("button", { name: "Show financing terms" }),
   ).toHaveAttribute("aria-expanded", "false");

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {
   Avatar,
+  Box,
   Button,
   Card,
   CardHeader,
@@ -38,6 +39,7 @@ import {
   getBuildAvailability,
   ViableLocationsRow,
 } from "../base/BuildAvailability";
+import BuildMetric from "../base/BuildMetric";
 import ConstructionBuildHeader from "../base/ConstructionBuildHeader";
 import { GameType, StorageShoppingType } from "../../Types";
 
@@ -102,7 +104,7 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
   };
 
   return (
-    <Card className="build-list-item">
+    <Card className="build-list-item buildOption">
       <CardHeader
         avatar={
           <Avatar
@@ -113,6 +115,7 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
         action={
           <span>
             <Button
+              aria-label={`Review purchase of ${storage.name}`}
               size="small"
               variant="contained"
               color="primary"
@@ -120,30 +123,69 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
               disabled={downpayment > cash || !buildable}
               startIcon={<ConceptIcon concept="buy" fontSize="small" />}
             >
-              {formatMoneyConcise(storage.buildCost)}
+              Review
             </Button>
-            <Typography variant="body2" color="textSecondary">
-              {Math.round(storage.yearsToBuild * 12)}mo to build
-              <br />
-              {formatWatts(storage.peakW)}
-            </Typography>
           </span>
         }
         title={storage.name}
-        subheader={buildSubtitle}
       />
-      <Button
-        color="primary"
-        className="expand-details"
-        size="small"
-        aria-label={`${expanded ? "Hide" : "Show"} ${storage.name} details`}
-        aria-expanded={expanded}
-        endIcon={expanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
-        onClick={toggleExpand}
-      >
-        {expanded ? "Hide details" : "Show details"}
-      </Button>
+      {(!buildable || financingGap > 0) && (
+        <Typography
+          component="div"
+          className="buildOptionWarning"
+          color="textSecondary"
+        >
+          {buildSubtitle}
+        </Typography>
+      )}
+      <Box className="buildOptionMetrics">
+        <BuildMetric
+          label="Discharge power"
+          value={formatWatts(storage.peakW)}
+        />
+        <BuildMetric
+          label="Build cost"
+          value={formatMoneyConcise(storage.buildCost)}
+        />
+        <BuildMetric
+          label="Build time"
+          value={`${Math.round(storage.yearsToBuild * 12)} mo`}
+        />
+        <BuildMetric
+          label="Energy capacity"
+          value={formatWattHours(storage.peakWh)}
+        />
+        <BuildMetric
+          label="At full power"
+          value={`${Number((storage.peakWh / storage.peakW).toFixed(1))} h`}
+        />
+        <BuildMetric
+          label="Round-trip efficiency"
+          value={`${Math.round(storage.roundTripEfficiency * 100)}%`}
+        />
+      </Box>
+      <Box className="buildOptionFooter">
+        <Button
+          color="primary"
+          className="expand-details"
+          size="small"
+          aria-label={`${expanded ? "Hide" : "Show"} ${storage.name} details`}
+          aria-expanded={expanded}
+          endIcon={expanded ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
+          onClick={toggleExpand}
+        >
+          {expanded ? "Hide details" : "Show details"}
+        </Button>
+      </Box>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
+        <Typography
+          className="buildOptionDescription"
+          variant="body2"
+          color="textSecondary"
+        >
+          {storage.description} Full-power duration assumes a full charge;
+          actual output also depends on ramp time.
+        </Typography>
         <TableContainer>
           <Table size="small" aria-label="storage properties">
             <TableBody>
@@ -181,6 +223,18 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
                   </Typography>
                 </TableCell>
                 <TableCell align="right">{storage.spinMinutes} min</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Expected lifespan</TableCell>
+                <TableCell align="right">
+                  {storage.lifespanYears} years
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Stored energy lost per hour</TableCell>
+                <TableCell align="right">
+                  {Number((storage.hourlyLoss * 100).toFixed(3))}%
+                </TableCell>
               </TableRow>
               <ViableLocationsRow
                 remaining={storage.viableLocationsRemaining}


### PR DESCRIPTION
Generator build rows used separate bands for actions, output, metrics, and details, making mobile shopping unnecessarily tall. This change consolidates them into a compact header, labeled metric grid, and a Details/Compare footer on phones. On wider screens, Compare sits immediately left of Review in the header. The layout preserves forecast context, complete descriptions in Details, and visible purchase restrictions.

Storage uses the same layout and Review action, with discharge power, energy capacity, full-power duration, round-trip efficiency, build cost, and build time. Details also show lifespan and hourly energy losses. Touch controls remain at least 44 px on coarse-pointer devices.

Validation: `npm run check` (types, lint, formatting, covered Jest suite, all simulation scenarios), `npm run build`, and responsive browser checks at 320, 390, 768, 1280, and 1440 px in light and dark themes. Browser coverage includes comparison, sorting, details, purchase dialogs, battery metrics, and mobile overflow. Screenshots were visually reviewed.

![Compact generator rows at 390px](https://github.com/user-attachments/assets/4b832690-530f-4e08-895b-f787bc947262)

![Storage metrics and visible battery size restriction at 390px](https://github.com/user-attachments/assets/b91f24c2-f055-4857-961f-e6e50d956caa)

![Generator build screen in desktop dark mode](https://github.com/user-attachments/assets/3f887f09-eb1a-4858-b662-7ebb29c7d78e)
