### PR TITLE
Add efficiency and rooftop solar customer programs

### DIFF
--- a/e2e/customer-programs.spec.ts
+++ b/e2e/customer-programs.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "@playwright/test";
+
+for (const theme of ["light", "dark"]) {
+  test(`customer programs can be explored, scheduled and cancelled in ${theme}`, async ({
+    page,
+  }, testInfo) => {
+    await page.addInitScript((mode) => {
+      localStorage.clear();
+      localStorage.setItem("theme", mode);
+    }, theme);
+    await page.goto("/?scenario=106");
+    await page.getByRole("button", { name: "Start game", exact: true }).click();
+    const insights = page.locator(".insights:visible");
+    if (!(await insights.isVisible()))
+      await page.getByRole("button", { name: "Insights", exact: true }).click();
+    const entry = insights.getByRole("button", {
+      name: "Customer programs",
+      exact: true,
+    });
+    await entry.click();
+    const dialog = page.getByRole("dialog");
+    await dialog
+      .getByRole("button", { name: "Rooftop solar rebates · Off" })
+      .click();
+    await expect(dialog).toContainText(
+      "does not directly cover an evening peak",
+    );
+    const apply = dialog.getByRole("button", { name: "Apply next month" });
+    await expect(apply).toBeDisabled();
+    await dialog.getByRole("radio", { name: /^Off/ }).focus();
+    await page.keyboard.press("ArrowDown");
+    await expect(dialog.getByRole("radio", { name: /^Small/ })).toBeChecked();
+    await expect(apply).toBeEnabled({ timeout: 30000 });
+    await expect(dialog).toContainText("Peak demand:");
+    await expect(dialog).toContainText("Charges start Feb 2020");
+    await page.keyboard.press("g");
+    await expect(dialog).toBeVisible();
+    await expect(page.locator(".buildOption")).toHaveCount(0);
+    expect(
+      await dialog.evaluate((el) => el.scrollWidth - el.clientWidth),
+    ).toBeLessThanOrEqual(1);
+    await page.screenshot({
+      path: testInfo.outputPath(`program-${theme}.png`),
+    });
+    await dialog.getByText(/^Peak demand:/).scrollIntoViewIfNeeded();
+    await page.screenshot({
+      path: testInfo.outputPath(`comparison-${theme}.png`),
+    });
+    await dialog.getByRole("button", { name: "After 12 months" }).click();
+    await expect(apply).toBeEnabled({ timeout: 30000 });
+    await expect(dialog).toContainText("Estimated utility demand · Jan 2021");
+    await dialog.getByRole("button", { name: "First effective month" }).click();
+    await expect(apply).toBeEnabled({ timeout: 30000 });
+    await apply.click();
+    await expect(dialog).toContainText("Small starts Feb 2020");
+    await dialog
+      .getByRole("button", { name: "Rooftop solar rebates · Off" })
+      .click();
+    await dialog.getByRole("radio", { name: /^Large/ }).check();
+    await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+    await expect(dialog).toContainText("Small starts Feb 2020");
+    await dialog
+      .getByRole("button", { name: "Rooftop solar rebates · Off" })
+      .click();
+    await dialog
+      .getByRole("button", { name: "Cancel scheduled change" })
+      .click();
+    await expect(dialog).not.toContainText("Small starts");
+    await page.keyboard.press("Escape");
+    await expect(dialog).toHaveCount(0);
+    await expect(entry).toBeFocused();
+  });
+}

--- a/e2e/customer-programs.spec.ts
+++ b/e2e/customer-programs.spec.ts
@@ -32,6 +32,8 @@ for (const theme of ["light", "dark"]) {
     await expect(dialog.getByRole("radio", { name: /^Small/ })).toBeChecked();
     await expect(apply).toBeEnabled({ timeout: 30000 });
     await expect(dialog).toContainText("Peak demand:");
+    await expect(dialog.getByText(/^Electricity supplied:/)).toBeVisible();
+    await expect(dialog.getByText(/^Change in utility cash/)).toBeVisible();
     await expect(dialog).toContainText("Charges start Feb 2020");
     await page.keyboard.press("g");
     await expect(dialog).toBeVisible();
@@ -56,6 +58,9 @@ for (const theme of ["light", "dark"]) {
     await dialog
       .getByRole("button", { name: "Rooftop solar rebates · Off" })
       .click();
+    await dialog.getByRole("radio", { name: /^Off/ }).check();
+    await expect(dialog).toContainText("Funding stops Feb 2020");
+    await expect(dialog).not.toContainText("Charges start");
     await dialog.getByRole("radio", { name: /^Large/ }).check();
     await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
     await expect(dialog).toContainText("Small starts Feb 2020");

--- a/e2e/customer-programs.spec.ts
+++ b/e2e/customer-programs.spec.ts
@@ -25,8 +25,10 @@ for (const theme of ["light", "dark"]) {
     await expect(dialog).toContainText(
       "does not directly cover an evening peak",
     );
-    const apply = dialog.getByRole("button", { name: "Apply next month" });
-    await expect(apply).toBeDisabled();
+    const apply = dialog.getByRole("button", { name: "Start next month" });
+    await expect(
+      dialog.getByRole("button", { name: "Stop next month" }),
+    ).toBeDisabled();
     await dialog.getByRole("radio", { name: /^Off/ }).focus();
     await page.keyboard.press("ArrowDown");
     await expect(dialog.getByRole("radio", { name: /^Small/ })).toBeChecked();
@@ -34,7 +36,7 @@ for (const theme of ["light", "dark"]) {
     await expect(dialog).toContainText("Peak demand:");
     await expect(dialog.getByText(/^Electricity supplied:/)).toBeVisible();
     await expect(dialog.getByText(/^Change in utility cash/)).toBeVisible();
-    await expect(dialog).toContainText("Charges start Feb 2020");
+    await expect(dialog).not.toContainText("Charges start");
     await page.keyboard.press("g");
     await expect(dialog).toBeVisible();
     await expect(page.locator(".buildOption")).toHaveCount(0);
@@ -59,7 +61,10 @@ for (const theme of ["light", "dark"]) {
       .getByRole("button", { name: "Rooftop solar rebates · Off" })
       .click();
     await dialog.getByRole("radio", { name: /^Off/ }).check();
-    await expect(dialog).toContainText("Funding stops Feb 2020");
+    await expect(
+      dialog.getByRole("button", { name: "Stop next month" }),
+    ).toBeVisible();
+    await expect(dialog).not.toContainText("Funding stops");
     await expect(dialog).not.toContainText("Charges start");
     await dialog.getByRole("radio", { name: /^Large/ }).check();
     await dialog.getByRole("button", { name: "Cancel", exact: true }).click();

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
       "!src/**/*.test.{ts,tsx}",
       "!src/react-app-env.d.ts",
       "!src/helpers/CustomGameForecastClient.ts",
+      "!src/helpers/PolicyPreviewClient.ts",
       "!src/workers/**/*.ts",
       "!src/testing/SimCli.tsx"
     ],

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -1,3 +1,4 @@
+import { validPolicyChange } from "./helpers/Policies";
 import cloneDeep from "lodash.clonedeep";
 import packageJson from "../package.json";
 import { isValidLocation } from "./helpers/Locations";
@@ -30,7 +31,8 @@ import {
 
 // Version 2 changes authored starting fleets and their facility IDs, so older action streams can
 // no longer reproduce the run they recorded.
-export const REPLAY_VERSION = 3;
+// Version 4 adds customer program actions; older clients must reject these streams.
+export const REPLAY_VERSION = 4;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few
@@ -58,6 +60,8 @@ export type RecordedDeltaType = Partial<
 >;
 
 const REPLAY_ACTION_NAMES: ReplayActionNameType[] = [
+  "schedulePolicy",
+  "cancelPolicy",
   "buildFacility",
   "sellFacility",
   "togglePauseFacility",
@@ -178,6 +182,11 @@ function parseActions(raw: unknown): ReplayActionType[] | null {
     ) {
       return null;
     }
+    if (
+      (action.type === "schedulePolicy" || action.type === "cancelPolicy") &&
+      !validPolicyChange(action.payload)
+    )
+      return null;
     actions.push({
       minute: action.minute,
       type: action.type as ReplayActionNameType,
@@ -204,7 +213,7 @@ export function decodeReplay(raw: unknown): ReplayType | null {
     return null;
   }
   const doc = raw as Partial<ReplayDocType>;
-  if (doc.version !== REPLAY_VERSION) {
+  if (doc.version !== REPLAY_VERSION && doc.version !== 3) {
     return null;
   }
   if (
@@ -219,7 +228,13 @@ export function decodeReplay(raw: unknown): ReplayType | null {
     return null;
   }
   const actions = parseActions(doc.actions);
-  if (!actions) {
+  if (
+    !actions ||
+    (doc.version === 3 &&
+      actions.some(
+        (a) => a.type === "schedulePolicy" || a.type === "cancelPolicy",
+      ))
+  ) {
     return null;
   }
   return {

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -14,6 +14,7 @@ import {
 import { createGame } from "./testing/Simulator";
 import { GameType } from "./Types";
 import { tickState } from "./reducers/Game";
+import { emptyPolicies } from "./helpers/Policies";
 
 jest.setTimeout(60000);
 
@@ -73,7 +74,7 @@ describe("SaveGame", () => {
   it("upgrades older saves without inventing missing chart history", () => {
     const restored = parseSave({ ...serializeSave(game), version: 1 });
     expect(restored?.version).toBe(SAVE_VERSION);
-    expect(restored?.game).toEqual(game);
+    expect(restored?.game).toEqual({ ...game, policies: emptyPolicies() });
   });
 
   // The memo must never alias the live game slice, or a Continue button would describe a game
@@ -83,7 +84,10 @@ describe("SaveGame", () => {
 
     const save = readSave();
     expect(save!.game).not.toBe(game);
-    expect(save!.game).toEqual(JSON.parse(JSON.stringify(game)));
+    expect(save!.game).toEqual({
+      ...JSON.parse(JSON.stringify(game)),
+      policies: emptyPolicies(),
+    });
   });
 
   it("reports no save when nothing has been written", () => {

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -1,3 +1,4 @@
+import { emptyPolicies, validPolicies } from "./helpers/Policies";
 import packageJson from "../package.json";
 import { MINUTES_PER_MONTH } from "./helpers/DateTime";
 import { isValidLocation } from "./helpers/Locations";
@@ -26,7 +27,9 @@ import type { AppStore } from "./Store";
 
 export const SAVE_KEY = "savedGame";
 // Initial public schema. Increment this when a post-release change becomes incompatible.
-export const SAVE_VERSION = 2;
+// Version 3 includes persistent customer programs. Accept and normalize v1/v2 saves;
+// older clients must not resume an active program as though its upgrades did not exist.
+export const SAVE_VERSION = 3;
 
 export interface SaveGameType {
   version: number;
@@ -61,7 +64,9 @@ export function parseSave(raw: unknown): SaveGameType | null {
   }
   const save = raw as Partial<SaveGameType>;
   if (
-    (save.version !== SAVE_VERSION && save.version !== 1) ||
+    (save.version !== SAVE_VERSION &&
+      save.version !== 1 &&
+      save.version !== 2) ||
     typeof save.savedAt !== "string" ||
     typeof save.appVersion !== "string"
   ) {
@@ -227,9 +232,40 @@ export function parseSave(raw: unknown): SaveGameType | null {
   ) {
     return null;
   }
+  if (
+    game.policies !== undefined &&
+    !validPolicies(
+      game.policies,
+      Math.floor(game.date.minute / MINUTES_PER_MONTH),
+    )
+  )
+    return null;
+  if (
+    [...game.timeline, ...game.monthlyHistory].some(
+      (t) =>
+        t.expensesPolicy !== undefined &&
+        (!Number.isFinite(t.expensesPolicy) || t.expensesPolicy < 0),
+    )
+  )
+    return null;
+  const normalized = {
+    ...game,
+    policyPause: undefined,
+    policies:
+      game.policies ??
+      emptyPolicies(Math.floor(game.date.minute / MINUTES_PER_MONTH)),
+    timeline: game.timeline.map((t) => ({
+      ...t,
+      expensesPolicy: t.expensesPolicy ?? 0,
+    })),
+    monthlyHistory: game.monthlyHistory.map((t) => ({
+      ...t,
+      expensesPolicy: t.expensesPolicy ?? 0,
+    })),
+  };
   // Version 1 saves remain playable. New months collect chart history; older months have only
   // their original financial and supply/demand records. Replays use a separate strict version.
-  return { ...save, version: SAVE_VERSION } as SaveGameType;
+  return { ...save, game: normalized, version: SAVE_VERSION } as SaveGameType;
 }
 
 export function readSave(): SaveGameType | null {

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -207,6 +207,8 @@ export interface ScoreType {
 // The player actions a replay has to reproduce. Everything else about a run -- weather, fuel
 // prices, demand -- falls out of the seed, so this is the whole of what the player contributed.
 export type ReplayActionNameType =
+  | "schedulePolicy"
+  | "cancelPolicy"
   | "buildFacility"
   | "sellFacility"
   | "togglePauseFacility"
@@ -350,6 +352,7 @@ export interface MonthlyHistoryType extends HistoryForecastShared {
 }
 
 interface HistoryForecastShared {
+  expensesPolicy?: number; // Monthly funded upgrades; absent in legacy histories.
   cash: number;
   customers: number;
   netWorth: number;
@@ -772,7 +775,26 @@ export interface WorldEventStateType {
   checkedKeys: string[];
 }
 
+export type PolicyId = "efficiency" | "solar";
+export type PolicyTier = "Off" | "Small" | "Large";
+export interface PolicyProgramType {
+  tier: PolicyTier;
+  adoption: number; // Fraction of the authored potential installed; persists within the run.
+  spending: number; // Actual funded upgrades this month, in nominal dollars.
+  pending?: { tier: PolicyTier; month: number };
+}
+export interface PoliciesType {
+  month: number; // Last processed elapsed month; prevents duplicate enrollment and charges.
+  programs: Record<PolicyId, PolicyProgramType>;
+}
+export interface PolicyChangeType {
+  id: PolicyId;
+  tier: PolicyTier;
+  month: number;
+}
 export interface GameType {
+  policies?: PoliciesType;
+  policyPause?: { token: string; speed: SpeedType };
   seed: number;
   difficulty: DifficultyType;
   scenarioId: number;

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -90,6 +90,7 @@ const NON_TEXT_INPUT_TYPES = new Set([
 ]);
 configure({
   ignoreEventsCondition: (event: KeyboardEvent) => {
+    if (document.querySelector('[data-customer-programs="true"]')) return true;
     if (event.key === "Escape") {
       return false;
     }

--- a/src/components/base/PolicyDemandChart.tsx
+++ b/src/components/base/PolicyDemandChart.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import UPlotChart from "./UPlotChart";
+import { chartPalette } from "../../Theme";
+import { formatWatts } from "../../helpers/Format";
+
+export default function PolicyDemandChart({
+  current,
+  changed,
+}: {
+  current: number[];
+  changed: number[];
+}) {
+  return (
+    <UPlotChart
+      ariaLabel="Estimated utility demand: current plan and with this change, over a representative day"
+      height={140}
+      state={{}}
+      data={[
+        current.map((_, i) => (i * 24) / current.length),
+        current,
+        changed,
+      ]}
+      seriesLabels={["Current plan (solid)", "With this change (dashed)"]}
+      formatSummaryValue={formatWatts}
+      buildOptions={() => ({
+        width: 0,
+        height: 0,
+        legend: { show: false },
+        scales: {
+          x: { time: false },
+          y: { range: (_u, _min, max) => [0, max * 1.1] },
+        },
+        axes: [
+          {
+            stroke: chartPalette().tickLabel,
+            grid: { stroke: chartPalette().grid },
+            ticks: { stroke: chartPalette().tick },
+            values: (_u, ticks) => ticks.map((t) => `${t}:00`),
+          },
+          {
+            stroke: chartPalette().tickLabel,
+            grid: { stroke: chartPalette().grid },
+            ticks: { stroke: chartPalette().tick },
+            size: 60,
+            values: (_u, ticks) => ticks.map((t) => formatWatts(t)),
+          },
+        ],
+        series: [
+          {},
+          { label: "Current plan", stroke: chartPalette().demand, width: 2 },
+          {
+            label: "With this change",
+            stroke: chartPalette().supply,
+            dash: [6, 4],
+            width: 2,
+          },
+        ],
+      })}
+    />
+  );
+}

--- a/src/components/views/CustomerPrograms.test.tsx
+++ b/src/components/views/CustomerPrograms.test.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import gameReducer from "../../reducers/Game";
+import { createGame } from "../../testing/Simulator";
+import * as client from "../../helpers/PolicyPreviewClient";
+import { previewPolicy } from "../../helpers/PolicyPreview";
+import CustomerPrograms from "./CustomerPrograms";
+
+jest.mock("../../helpers/PolicyPreviewClient", () => ({
+  createPolicyPreviewWorker: jest.fn(),
+}));
+
+test("stale and failed worker results cannot enable Apply, and closing terminates preview", () => {
+  jest.useFakeTimers();
+  const workers: Array<{
+    onmessage: ((event: { data: unknown }) => void) | null;
+    onerror: (() => void) | null;
+    postMessage: jest.Mock;
+    terminate: jest.Mock;
+  }> = [];
+  const stub = jest
+    .spyOn(client, "createPolicyPreviewWorker")
+    .mockImplementation(() => {
+      const worker = {
+        onmessage: null,
+        onerror: null,
+        postMessage: jest.fn(),
+        terminate: jest.fn(),
+      };
+      workers.push(worker);
+      return worker as unknown as Worker;
+    });
+  const game = createGame({ scenarioId: 106 });
+  const result = previewPolicy(
+    game,
+    { id: "solar", tier: "Small", month: 1 },
+    1,
+  );
+  const store = configureStore({
+    reducer: { game: gameReducer },
+    preloadedState: { game },
+  });
+  const view = render(
+    <Provider store={store}>
+      <CustomerPrograms game={game} onViewDemand={jest.fn()} />
+    </Provider>,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Customer programs" }));
+  fireEvent.click(
+    screen.getByRole("button", { name: "Rooftop solar rebates · Off" }),
+  );
+  fireEvent.click(screen.getByRole("radio", { name: /^Small/ }));
+  act(() => {
+    jest.advanceTimersByTime(250);
+  });
+  const old = workers[workers.length - 1];
+  fireEvent.click(screen.getByRole("radio", { name: /^Large/ }));
+  expect(old.terminate).toHaveBeenCalled();
+  act(() => {
+    old.onmessage!({ data: { result } });
+  });
+  const apply = screen.getByRole("button", { name: "Apply next month" });
+  expect(apply).toBeDisabled();
+  act(() => {
+    jest.advanceTimersByTime(250);
+  });
+  act(() => {
+    workers[workers.length - 1].onerror!();
+  });
+  expect(screen.getByRole("alert")).toHaveTextContent("Could not estimate");
+  expect(apply).toBeDisabled();
+  fireEvent.click(screen.getByRole("radio", { name: /^Small/ }));
+  act(() => {
+    jest.advanceTimersByTime(250);
+  });
+  act(() => {
+    workers[workers.length - 1].onmessage!({ data: { result } });
+  });
+  expect(apply).toBeEnabled();
+  fireEvent.keyDown(document, { key: "Escape" });
+  expect(workers[workers.length - 1].terminate).toHaveBeenCalled();
+  expect(store.getState().game.policyPause).toBeUndefined();
+  view.unmount();
+  stub.mockRestore();
+  jest.useRealTimers();
+});

--- a/src/components/views/CustomerPrograms.test.tsx
+++ b/src/components/views/CustomerPrograms.test.tsx
@@ -7,6 +7,10 @@ import { createGame } from "../../testing/Simulator";
 import * as client from "../../helpers/PolicyPreviewClient";
 import { previewPolicy } from "../../helpers/PolicyPreview";
 import CustomerPrograms from "./CustomerPrograms";
+import { PolicyId } from "../../Types";
+import { POLICIES } from "../../data/Policies";
+import { formatMoneyConcise } from "../../helpers/Format";
+import { emptyPolicies } from "../../helpers/Policies";
 
 jest.mock("../../helpers/PolicyPreviewClient", () => ({
   createPolicyPreviewWorker: jest.fn(),
@@ -85,4 +89,86 @@ test("stale and failed worker results cannot enable Apply, and closing terminate
   view.unmount();
   stub.mockRestore();
   jest.useRealTimers();
+});
+
+test.each<PolicyId>(["solar", "efficiency"])(
+  "%s keeps energy and cash tradeoffs visible when peak demand is unchanged",
+  (id) => {
+    jest.useFakeTimers();
+    const worker = {
+      onmessage: null as ((event: { data: unknown }) => void) | null,
+      postMessage: jest.fn(),
+      terminate: jest.fn(),
+    };
+    const stub = jest
+      .spyOn(client, "createPolicyPreviewWorker")
+      .mockReturnValue(worker as unknown as Worker);
+    const game = createGame({ scenarioId: 106 });
+    const result = {
+      ...previewPolicy(game, { id, tier: "Large", month: 1 }, 12),
+      current: [47000000, 40000000],
+      changed: [47000000, 30000000],
+    };
+    const store = configureStore({
+      reducer: { game: gameReducer },
+      preloadedState: { game },
+    });
+    const view = render(
+      <Provider store={store}>
+        <CustomerPrograms game={game} onViewDemand={jest.fn()} />
+      </Provider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Customer programs" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: `${POLICIES[id].name} · Off` }),
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /^Large/ }));
+    fireEvent.click(screen.getByRole("button", { name: "After 12 months" }));
+    act(() => jest.advanceTimersByTime(250));
+    act(() => worker.onmessage!({ data: { result } }));
+
+    expect(screen.getByText(/^Electricity supplied:/)).toBeVisible();
+    expect(screen.getByText(/^Change in utility cash/)).toBeVisible();
+    expect(screen.getByText(/^Change in utility cash/)).toHaveTextContent(
+      `Jan 2021: ${formatMoneyConcise(result.cashChange)}`,
+    );
+    const hint = screen.getByText(/^Little change in peak demand/);
+    expect(hint).toBeVisible();
+    expect(hint).toHaveTextContent(
+      id === "solar"
+        ? "Little change in peak demand. Daylight savings may leave the evening peak unchanged."
+        : "Little change in peak demand. Efficiency savings build gradually as upgrades are installed.",
+    );
+
+    view.unmount();
+    stub.mockRestore();
+    jest.useRealTimers();
+  },
+);
+
+test("stopped funding describes retained upgrades without announcing another change", () => {
+  const game = createGame({ scenarioId: 106 });
+  game.policies = emptyPolicies();
+  game.policies.programs.efficiency.adoption = 0.05;
+  const store = configureStore({
+    reducer: { game: gameReducer },
+    preloadedState: { game },
+  });
+  const view = render(
+    <Provider store={store}>
+      <CustomerPrograms game={game} onViewDemand={jest.fn()} />
+    </Provider>,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Customer programs" }));
+  fireEvent.click(
+    screen.getByRole("button", { name: "Efficiency rebates · Off" }),
+  );
+  expect(screen.getByText(/Installed upgrades retained/)).toHaveTextContent(
+    "5%",
+  );
+  expect(screen.queryByText(/Building up/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Funding stops/)).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole("radio", { name: /^Small/ }));
+  expect(screen.getByText(/Charges start Feb 2020/)).toBeVisible();
+  view.unmount();
 });

--- a/src/components/views/CustomerPrograms.test.tsx
+++ b/src/components/views/CustomerPrograms.test.tsx
@@ -65,7 +65,7 @@ test("stale and failed worker results cannot enable Apply, and closing terminate
   act(() => {
     old.onmessage!({ data: { result } });
   });
-  const apply = screen.getByRole("button", { name: "Apply next month" });
+  const apply = screen.getByRole("button", { name: "Start next month" });
   expect(apply).toBeDisabled();
   act(() => {
     jest.advanceTimersByTime(250);
@@ -167,8 +167,15 @@ test("stopped funding describes retained upgrades without announcing another cha
     "5%",
   );
   expect(screen.queryByText(/Building up/)).not.toBeInTheDocument();
-  expect(screen.queryByText(/Funding stops/)).not.toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Stop next month" }),
+  ).toBeDisabled();
   fireEvent.click(screen.getByRole("radio", { name: /^Small/ }));
-  expect(screen.getByText(/Charges start Feb 2020/)).toBeVisible();
+  expect(
+    screen.getByRole("button", { name: "Start next month" }),
+  ).toBeVisible();
+  expect(
+    screen.queryByText(/Charges start|Funding stops/),
+  ).not.toBeInTheDocument();
   view.unmount();
 });

--- a/src/components/views/CustomerPrograms.tsx
+++ b/src/components/views/CustomerPrograms.tsx
@@ -180,7 +180,9 @@ function Decision({
               {current!.adoption >= 1
                 ? "Fully adopted"
                 : current!.adoption > 0
-                  ? "Building up"
+                  ? current!.tier === "Off"
+                    ? "Installed upgrades retained"
+                    : "Building up"
                   : "No funded upgrades yet"}{" "}
               · {Math.round(current!.adoption * 100)}% of eligible potential
               installed
@@ -203,6 +205,10 @@ function Decision({
             </RadioGroup>
             <Typography variant="body2">
               Off stops new spending; installed upgrades remain.
+            </Typography>
+            <Typography variant="body2">
+              Small installs upgrades at a lower cost per upgrade. Large
+              installs them faster, at a higher cost per upgrade.
             </Typography>
             <Typography variant="body2">
               Rebates cost money and reduce electricity sales.
@@ -247,12 +253,29 @@ function Decision({
                         Peak demand: {formatWatts(peakBefore)} →{" "}
                         {formatWatts(peakAfter)}
                       </Typography>
+                      <Typography>
+                        Electricity supplied:{" "}
+                        {formatWattHours(result.before.supplyWh)} →{" "}
+                        {formatWattHours(result.after.supplyWh)} in{" "}
+                        {labelMonth(game, month)}
+                      </Typography>
+                      <Typography>
+                        Change in utility cash from now through{" "}
+                        {labelMonth(game, month)}:{" "}
+                        {formatMoneyConcise(result.cashChange)}
+                      </Typography>
+                      <Typography variant="body2">
+                        Includes program spending, less electricity sold, and
+                        actual dispatch costs.
+                      </Typography>
                       {(formatWatts(peakBefore) === formatWatts(peakAfter) ||
                         Math.abs(peakAfter - peakBefore) <
                           peakBefore * 0.001) && (
                         <Typography variant="body2">
-                          Little change yet. Adoption builds gradually; daylight
-                          savings may leave the evening peak unchanged.
+                          Little change in peak demand.{" "}
+                          {selected === "solar"
+                            ? "Daylight savings may leave the evening peak unchanged."
+                            : "Efficiency savings build gradually as upgrades are installed."}
                         </Typography>
                       )}
                     </Box>
@@ -263,15 +286,6 @@ function Decision({
                         inflation. Spending pays only for new upgrades and stops
                         at full adoption. Installed upgrades persist for this
                         run.
-                      </Typography>
-                      <Typography variant="body2">
-                        Electricity supplied in {labelMonth(game, month)}:{" "}
-                        {formatWattHours(result.before.supplyWh)} →{" "}
-                        {formatWattHours(result.after.supplyWh)}. Change in
-                        utility cash from now through {labelMonth(game, month)}:{" "}
-                        {formatMoneyConcise(result.cashChange)}. Includes
-                        program spending, less electricity sold, and actual
-                        dispatch costs.
                       </Typography>
                       <Typography variant="body2">
                         Estimates hold weather, fuel prices, fleet, rate and
@@ -319,9 +333,11 @@ function Decision({
       <DialogActions
         sx={{ p: 2, flexWrap: "wrap", gap: 1, "& button": { minHeight: 44 } }}
       >
-        {selected && effective < end && (
+        {selected && !unchanged && effective < end && (
           <Typography variant="body2" sx={{ width: "100%" }}>
-            Charges start {labelMonth(game, effective)} · until changed
+            {tier === "Off"
+              ? `Funding stops ${labelMonth(game, effective)}`
+              : `Charges start ${labelMonth(game, effective)} · until changed`}
           </Typography>
         )}
         <Button onClick={() => (selected ? setSelected(undefined) : onClose())}>

--- a/src/components/views/CustomerPrograms.tsx
+++ b/src/components/views/CustomerPrograms.tsx
@@ -333,13 +333,6 @@ function Decision({
       <DialogActions
         sx={{ p: 2, flexWrap: "wrap", gap: 1, "& button": { minHeight: 44 } }}
       >
-        {selected && !unchanged && effective < end && (
-          <Typography variant="body2" sx={{ width: "100%" }}>
-            {tier === "Off"
-              ? `Funding stops ${labelMonth(game, effective)}`
-              : `Charges start ${labelMonth(game, effective)} · until changed`}
-          </Typography>
-        )}
         <Button onClick={() => (selected ? setSelected(undefined) : onClose())}>
           {selected ? "Cancel" : "Close"}
         </Button>
@@ -356,7 +349,7 @@ function Decision({
               setSelected(undefined);
             }}
           >
-            Apply next month
+            {tier === "Off" ? "Stop next month" : "Start next month"}
           </Button>
         )}
       </DialogActions>

--- a/src/components/views/CustomerPrograms.tsx
+++ b/src/components/views/CustomerPrograms.tsx
@@ -1,0 +1,406 @@
+import * as React from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+  useMediaQuery,
+} from "@mui/material";
+import { useAppDispatch, useAppSelector } from "../../Store";
+import {
+  cancelPolicy,
+  closePolicyDecision,
+  openPolicyDecision,
+  schedulePolicy,
+} from "../../reducers/GameActions";
+import { GameType, PolicyId, PolicyTier } from "../../Types";
+import { POLICIES, POLICY_IDS, POLICY_TIERS } from "../../data/Policies";
+import {
+  emptyPolicies,
+  policyAvailable,
+  policyBudget,
+} from "../../helpers/Policies";
+import { getDateFromMinute, MINUTES_PER_MONTH } from "../../helpers/DateTime";
+import {
+  formatMoneyConcise,
+  formatWatts,
+  formatWattHours,
+} from "../../helpers/Format";
+import { getScenario } from "../../data/Scenarios";
+import { createPolicyPreviewWorker } from "../../helpers/PolicyPreviewClient";
+import { PolicyPreviewResult } from "../../helpers/PolicyPreview";
+import PolicyDemandChart from "../base/PolicyDemandChart";
+
+const labelMonth = (game: GameType, month: number) => {
+  const d = getDateFromMinute(month * MINUTES_PER_MONTH, game.startingYear);
+  return `${d.month} ${d.year}`;
+};
+
+function Decision({
+  onClose,
+  onViewDemand,
+}: {
+  onClose: () => void;
+  onViewDemand: () => void;
+}) {
+  const game = useAppSelector((s) => s.game);
+  const dispatch = useAppDispatch();
+  const phone = useMediaQuery("(max-width:600px)");
+  const token = React.useId();
+  React.useEffect(() => {
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", closeOnEscape, true);
+    return () => document.removeEventListener("keydown", closeOnEscape, true);
+  }, [onClose]);
+  const [selected, setSelected] = React.useState<PolicyId>();
+  const [tier, setTier] = React.useState<PolicyTier>("Off");
+  const [later, setLater] = React.useState(false);
+  const [preview, setPreview] = React.useState<{
+    key: string;
+    snapshot: GameType;
+    result?: PolicyPreviewResult;
+    error?: string;
+  }>();
+  React.useEffect(() => {
+    dispatch(openPolicyDecision(token));
+    return () => {
+      dispatch(closePolicyDecision(token));
+    };
+  }, [dispatch, token]);
+  const effective = game.date.monthsElapsed + 1;
+  const end =
+    getScenario(game.scenarioId, game.customScenario)?.durationMonths ?? 0;
+  const month = later ? Math.min(effective + 11, end - 1) : effective;
+  const key = `${selected}/${tier}/${month}/${game.date.minute}`;
+  React.useEffect(() => {
+    if (!selected || effective >= end) return;
+    let worker: Worker | undefined;
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      try {
+        worker = createPolicyPreviewWorker();
+        worker.onmessage = (event) => {
+          if (!cancelled) setPreview({ key, snapshot: game, ...event.data });
+        };
+        worker.onerror = () => {
+          if (!cancelled)
+            setPreview({
+              key,
+              snapshot: game,
+              error:
+                "Could not estimate this change. Reopen the program to retry.",
+            });
+        };
+        worker.postMessage({
+          game: JSON.parse(JSON.stringify(game)),
+          change: { id: selected, tier, month: effective },
+          month,
+        });
+      } catch (_error) {
+        setPreview({
+          key,
+          snapshot: game,
+          error: "Could not start the preview. Reopen the program to retry.",
+        });
+      }
+    }, 250);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      worker?.terminate();
+    };
+  }, [game, selected, tier, month, effective, end, key]);
+  const programs = game.policies?.programs ?? emptyPolicies().programs;
+  const current = selected ? programs[selected] : undefined;
+  const settled = preview?.key === key && preview.snapshot === game;
+  const result = settled ? preview.result : undefined;
+  const error = settled ? preview.error : undefined;
+  const unchanged = tier === (current?.pending?.tier ?? current?.tier ?? "Off");
+  const peakBefore = result ? Math.max(...result.current) : 0;
+  const peakAfter = result ? Math.max(...result.changed) : 0;
+  return (
+    <Dialog
+      open
+      fullScreen={phone}
+      fullWidth
+      maxWidth="sm"
+      onClose={onClose}
+      aria-labelledby="program-title"
+      data-customer-programs="true"
+    >
+      <DialogTitle id="program-title">
+        {selected ? POLICIES[selected].name : "Customer programs"}
+      </DialogTitle>
+      <DialogContent dividers>
+        {!selected ? (
+          <Box sx={{ display: "grid", gap: 2 }}>
+            {POLICY_IDS.map((id) => (
+              <Box key={id}>
+                <Button
+                  sx={{ minHeight: 44, textAlign: "left" }}
+                  onClick={() => {
+                    setSelected(id);
+                    setTier(programs[id].pending?.tier ?? programs[id].tier);
+                    setLater(false);
+                  }}
+                >
+                  {POLICIES[id].name} · {programs[id].tier}
+                </Button>
+                <Typography>{POLICIES[id].description}</Typography>
+                {programs[id].pending && (
+                  <Typography variant="body2">
+                    {programs[id].pending!.tier} starts{" "}
+                    {labelMonth(game, programs[id].pending!.month)}
+                  </Typography>
+                )}
+              </Box>
+            ))}
+            <Typography variant="body2">
+              Funding continues monthly until changed. Installed upgrades stay
+              for the rest of this run, including after funding stops.
+            </Typography>
+          </Box>
+        ) : (
+          <Box sx={{ display: "grid", gap: 2 }}>
+            <Typography>{POLICIES[selected].mechanism}</Typography>
+            <Typography variant="body2">
+              {current!.adoption >= 1
+                ? "Fully adopted"
+                : current!.adoption > 0
+                  ? "Building up"
+                  : "No funded upgrades yet"}{" "}
+              · {Math.round(current!.adoption * 100)}% of eligible potential
+              installed
+            </Typography>
+            <RadioGroup
+              row={!phone}
+              aria-label="Monthly funding"
+              value={tier}
+              onChange={(e) => setTier(e.target.value as PolicyTier)}
+            >
+              {POLICY_TIERS.map((choice) => (
+                <FormControlLabel
+                  key={choice}
+                  value={choice}
+                  control={<Radio />}
+                  sx={{ minHeight: 44, m: 0, flex: 1 }}
+                  label={`${choice} · ${choice === "Off" ? "$0/month" : `up to ${formatMoneyConcise(policyBudget(game, selected, choice, effective))}/month`}`}
+                />
+              ))}
+            </RadioGroup>
+            <Typography variant="body2">
+              Off stops new spending; installed upgrades remain.
+            </Typography>
+            <Typography variant="body2">
+              Rebates cost money and reduce electricity sales.
+            </Typography>
+            {effective >= end ? (
+              <Alert severity="info">
+                This run ends before another funding change could take effect.
+              </Alert>
+            ) : (
+              <>
+                <Typography component="h3" variant="subtitle1">
+                  Estimated utility demand · {labelMonth(game, month)}
+                </Typography>
+                {end - 1 > effective && (
+                  <Button onClick={() => setLater(!later)}>
+                    {later
+                      ? "First effective month"
+                      : end > effective + 11
+                        ? "After 12 months"
+                        : `By ${labelMonth(game, end - 1)}`}
+                  </Button>
+                )}
+                {error ? (
+                  <Alert severity="error">{error}</Alert>
+                ) : !result ? (
+                  <Typography role="status">Estimating this choice…</Typography>
+                ) : (
+                  <>
+                    <Typography variant="body2">
+                      Current plan ━ · With this change ┄
+                    </Typography>
+                    <PolicyDemandChart
+                      current={result.current}
+                      changed={result.changed}
+                    />
+                    <Box role="status">
+                      <Typography>
+                        Program spending: {formatMoneyConcise(result.spending)}{" "}
+                        in {labelMonth(game, month)}
+                      </Typography>
+                      <Typography>
+                        Peak demand: {formatWatts(peakBefore)} →{" "}
+                        {formatWatts(peakAfter)}
+                      </Typography>
+                      {(formatWatts(peakBefore) === formatWatts(peakAfter) ||
+                        Math.abs(peakAfter - peakBefore) <
+                          peakBefore * 0.001) && (
+                        <Typography variant="body2">
+                          Little change yet. Adoption builds gradually; daylight
+                          savings may leave the evening peak unchanged.
+                        </Typography>
+                      )}
+                    </Box>
+                    <details>
+                      <summary>Why this changes</summary>
+                      <Typography variant="body2">
+                        {POLICIES[selected].tradeoff} Budgets adjust with
+                        inflation. Spending pays only for new upgrades and stops
+                        at full adoption. Installed upgrades persist for this
+                        run.
+                      </Typography>
+                      <Typography variant="body2">
+                        Electricity supplied in {labelMonth(game, month)}:{" "}
+                        {formatWattHours(result.before.supplyWh)} →{" "}
+                        {formatWattHours(result.after.supplyWh)}. Change in
+                        utility cash from now through {labelMonth(game, month)}:{" "}
+                        {formatMoneyConcise(result.cashChange)}. Includes
+                        program spending, less electricity sold, and actual
+                        dispatch costs.
+                      </Typography>
+                      <Typography variant="body2">
+                        Estimates hold weather, fuel prices, fleet, rate and
+                        customer assumptions, and other accepted programs
+                        constant. Efficiency is a simplified end-use reduction
+                        for homes and businesses. Solar offsets their remaining
+                        load after efficiency; surplus is curtailed. No export
+                        payments or utility generation credits. Hint: compare
+                        daylight savings with the time of your shortage.
+                      </Typography>
+                    </details>
+                    {result.after.cash < 0 && (
+                      <Alert severity="warning">
+                        Projected cash is negative. Existing debt rules still
+                        apply.
+                      </Alert>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+            {current!.pending && (
+              <Button
+                onClick={() => {
+                  dispatch(
+                    cancelPolicy({ id: selected, ...current!.pending! }),
+                  );
+                  setSelected(undefined);
+                }}
+              >
+                Cancel scheduled change
+              </Button>
+            )}
+            <Button
+              onClick={() => {
+                onClose();
+                onViewDemand();
+              }}
+            >
+              View demand
+            </Button>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions
+        sx={{ p: 2, flexWrap: "wrap", gap: 1, "& button": { minHeight: 44 } }}
+      >
+        {selected && effective < end && (
+          <Typography variant="body2" sx={{ width: "100%" }}>
+            Charges start {labelMonth(game, effective)} · until changed
+          </Typography>
+        )}
+        <Button onClick={() => (selected ? setSelected(undefined) : onClose())}>
+          {selected ? "Cancel" : "Close"}
+        </Button>
+        {selected && (
+          <Button
+            variant="contained"
+            disabled={
+              unchanged || !result || effective >= end || !!game.replayPlayback
+            }
+            onClick={() => {
+              dispatch(
+                schedulePolicy({ id: selected, tier, month: effective }),
+              );
+              setSelected(undefined);
+            }}
+          >
+            Apply next month
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default function CustomerPrograms({
+  game,
+  onViewDemand,
+}: {
+  game: GameType;
+  onViewDemand: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  if (!policyAvailable(game) || game.replayPlayback) return null;
+  const programs = game.policies?.programs;
+  const active = POLICY_IDS.filter(
+    (id) => programs?.[id].tier && programs[id].tier !== "Off",
+  ).length;
+  const pending = POLICY_IDS.some((id) => programs?.[id].pending);
+  const budget = POLICY_IDS.reduce(
+    (sum, id) =>
+      sum +
+      policyBudget(
+        game,
+        id,
+        programs?.[id].tier ?? "Off",
+        game.date.monthsElapsed,
+      ),
+    0,
+  );
+  return (
+    <Box
+      sx={{
+        maxWidth: "100%",
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        gap: 1,
+      }}
+    >
+      <Button onClick={() => setOpen(true)} sx={{ minHeight: 44 }}>
+        Customer programs
+      </Button>
+      {pending ? (
+        <Typography variant="caption">
+          Change starts {labelMonth(game, game.date.monthsElapsed + 1)}
+        </Typography>
+      ) : (
+        active > 0 && (
+          <Typography variant="caption">
+            {active} program{active > 1 ? "s" : ""} active · up to{" "}
+            {formatMoneyConcise(budget)}/month
+          </Typography>
+        )
+      )}
+      {open && (
+        <Decision onClose={() => setOpen(false)} onViewDemand={onViewDemand} />
+      )}
+    </Box>
+  );
+}

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -155,6 +155,13 @@ export function buildChartKeys(units: UnitSystemType): {
       formatTable: formatMoneyStable,
       nesting: 1,
     },
+    expensesPolicy: {
+      label: "Customer programs",
+      higherIsBetter: false,
+      format: formatMoneyConcise,
+      formatTable: formatMoneyStable,
+      nesting: 1,
+    },
     expensesInterest: {
       label: "Loan interest",
       higherIsBetter: false,

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import CustomerPrograms from "./CustomerPrograms";
 import {
   Button,
   Checkbox,
@@ -1200,6 +1201,10 @@ export default class Insights extends React.Component<Props, State> {
         >
           <span className="insightsRateToggleLabel">Rate controls</span>
         </Button>
+        <CustomerPrograms
+          game={game}
+          onViewDemand={() => this.setLayers(["demandByType"])}
+        />
         <Typography
           className="insightsRateSummaryDesktop"
           variant="body2"

--- a/src/components/views/StoryEventSelectors.ts
+++ b/src/components/views/StoryEventSelectors.ts
@@ -62,7 +62,7 @@ export function selectUpcomingStoryEvents(
         month.expensesFuel,
         month.expensesOM,
         month.expensesCarbonFee,
-        month.expensesInterest,
+        month.expensesInterest + (month.expensesPolicy || 0),
         month.peakDemandW,
         Object.entries(month.deliveredWhByFuel)
           .sort(([a], [b]) => a.localeCompare(b))

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -45,6 +45,7 @@ export type ManualGroupType = (typeof MANUAL_GROUPS)[number];
 // them here rather than passing raw strings means renaming an entry breaks the build instead of
 // silently breaking the link.
 export const MANUAL_ENTRY = {
+  CUSTOMER_PROGRAMS: "Customer programs",
   HOW_TO_PLAY: "How to Play",
   BASELOAD_VS_PEAKER: "Baseload vs Peaker",
   BLACKOUTS: "Blackouts",
@@ -137,6 +138,25 @@ export function manualEntryText(node: React.ReactNode): string {
 }
 
 export const MANUAL_ENTRIES: ManualEntryType[] = [
+  {
+    title: "Customer programs",
+    group: "Gameplay",
+    keywords: "efficiency rooftop solar rebates funding adoption demand",
+    entry: (
+      <p>
+        In Insights, Customer programs lets you fund efficiency or rooftop solar
+        rebates. Choose Off, Small, or Large and compare estimated utility
+        demand before applying next month. Funding persists until changed.
+        Charges pay only for new upgrades, up to the monthly budget, and stop at
+        full adoption. Off stops new adoption and spending; installed upgrades
+        stay for the rest of the run. Efficiency reduces residential and
+        commercial use. Solar offsets their remaining daylight load, with
+        surplus curtailed and no export payment. It does not directly cover an
+        evening peak. Lower demand also means less electricity sold, so compare
+        cash as well as peak demand.
+      </p>
+    ),
+  },
   {
     title: MANUAL_ENTRY.HOW_TO_PLAY,
     group: "Gameplay",

--- a/src/data/Policies.tsx
+++ b/src/data/Policies.tsx
@@ -1,0 +1,37 @@
+import type { PolicyId, PolicyTier } from "../Types";
+
+export const POLICY_IDS: PolicyId[] = ["efficiency", "solar"];
+export const POLICY_TIERS: PolicyTier[] = ["Off", "Small", "Large"];
+// Explicit launch availability: modern, longer scenarios and custom games. Historical
+// scenarios and introductory tutorials deliberately have no program entry.
+export const POLICY_SCENARIOS = [
+  100, 101, 104, 105, 106, 107, 108, 110, 111, 999,
+];
+export const POLICIES = {
+  efficiency: {
+    name: "Efficiency rebates",
+    description: "Help homes and businesses use less electricity.",
+    mechanism:
+      "Grows gradually. Reduces residential and commercial electricity use throughout the day.",
+    tradeoff:
+      "Upgrades cost money and mean less electricity sold, in exchange for avoided generation costs and possible reliability benefits.",
+    cap: 0.2,
+    costPerCustomer: 30,
+  },
+  solar: {
+    name: "Rooftop solar rebates",
+    description: "Help customers make electricity during daylight.",
+    mechanism:
+      "Grows gradually. Helps in daylight; does not directly cover an evening peak.",
+    tradeoff:
+      "Rebates cost money and mean less electricity sold. Surplus is curtailed: there are no export payments or utility generation credits.",
+    cap: 300, // Watts per initial market customer, scaled with scenario demand, at full adoption.
+    costPerCustomer: 60,
+  },
+} as const;
+// Large buys more absolute adoption, at a higher cost per extra installation.
+export const POLICY_FUNDING = {
+  Off: { adoption: 0, cost: 0 },
+  Small: { adoption: 0.02, cost: 0.02 },
+  Large: { adoption: 0.05, cost: 0.07 },
+} as const;

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -22,7 +22,8 @@ const latestMonthProfit = (state: AppStateType) => {
         month.expensesFuel -
         month.expensesOM -
         month.expensesCarbonFee -
-        month.expensesInterest
+        month.expensesInterest -
+        (month.expensesPolicy || 0)
     : undefined;
 };
 

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -39,6 +39,7 @@ export const EMPTY_HISTORY = {
   expensesOM: 0,
   expensesCarbonFee: 0,
   expensesInterest: 0,
+  expensesPolicy: 0,
   netWorth: 0,
   interestRate: 0,
   inflationRate: 0,
@@ -78,6 +79,7 @@ export function reduceHistories(
   acc.expensesOM += t.expensesOM;
   acc.expensesCarbonFee += t.expensesCarbonFee;
   acc.expensesInterest += t.expensesInterest;
+  acc.expensesPolicy = (acc.expensesPolicy || 0) + (t.expensesPolicy || 0);
   acc.cash = t.cash;
   acc.customers = t.customers;
   acc.netWorth = t.netWorth;
@@ -94,7 +96,11 @@ export function deriveExpandedSummary(
   s: MonthlyHistoryType,
 ): DerivedHistoryType {
   const expenses =
-    s.expensesFuel + s.expensesOM + s.expensesCarbonFee + s.expensesInterest;
+    s.expensesFuel +
+    s.expensesOM +
+    s.expensesCarbonFee +
+    s.expensesInterest +
+    (s.expensesPolicy || 0);
   const supplykWh = (s.supplyWh || 1) / 1000;
   return {
     ...s,
@@ -202,6 +208,8 @@ function accumulateTick(
   summary.expensesOM += t.expensesOM;
   summary.expensesCarbonFee += t.expensesCarbonFee;
   summary.expensesInterest += t.expensesInterest;
+  summary.expensesPolicy =
+    (summary.expensesPolicy || 0) + (t.expensesPolicy || 0);
   summary.cash = t.cash;
   summary.customers = t.customers;
   summary.netWorth = t.netWorth;

--- a/src/helpers/Policies.test.tsx
+++ b/src/helpers/Policies.test.tsx
@@ -1,0 +1,238 @@
+import cloneDeep from "lodash.clonedeep";
+import {
+  advancePolicies,
+  applyPolicyDemand,
+  emptyPolicies,
+  policyBudget,
+} from "./Policies";
+import { createGame, createGameFromReplay } from "../testing/Simulator";
+import gameReducer, {
+  generateNewTimeline,
+  tickState,
+  setSpeed,
+} from "../reducers/Game";
+import {
+  schedulePolicy,
+  cancelPolicy,
+  openPolicyDecision,
+  closePolicyDecision,
+} from "../reducers/GameActions";
+import {
+  getTimeFromTimeline,
+  summarizeTimeline,
+  deriveExpandedSummary,
+} from "./DateTime";
+import { previewPolicy } from "./PolicyPreview";
+import { parseSave, serializeSave } from "../SaveGame";
+import { decodeReplay, serializeReplay } from "../Replay";
+import { TICKS_PER_MONTH } from "../Constants";
+import { GameType } from "../Types";
+
+function month(game: GameType) {
+  const target = game.date.monthsElapsed + 1;
+  while (game.date.monthsElapsed < target) tickState(game);
+}
+const change = { id: "efficiency", tier: "Small", month: 1 } as const;
+
+test("only the dialog that owns a pause restores its previous speed", () => {
+  jest.useFakeTimers();
+  let game = {
+    ...createGame({ scenarioId: 106 }),
+    speed: "SLOW" as const,
+  } as GameType;
+  game = gameReducer(game, openPolicyDecision("one"));
+  expect(game.speed).toBe("PAUSED");
+  expect(gameReducer(game, closePolicyDecision("other")).speed).toBe("PAUSED");
+  expect(gameReducer(game, closePolicyDecision("one")).speed).toBe("SLOW");
+  game = gameReducer(game, setSpeed("NORMAL"));
+  expect(gameReducer(game, closePolicyDecision("one")).speed).toBe("NORMAL");
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+test("forecast resolution cannot multiply monthly spending or mutate live adoption", () => {
+  const game = createGame({
+    scenarioId: 106,
+    initialPrograms: { efficiency: "Large", solar: "Small" },
+  });
+  const snapshot = cloneDeep(game.policies);
+  const now = game.timeline[0];
+  const fine = generateNewTimeline(
+    game,
+    now.cash,
+    now.customers,
+    TICKS_PER_MONTH * 3,
+  );
+  const hourly = generateNewTimeline(
+    game,
+    now.cash,
+    now.customers,
+    (TICKS_PER_MONTH * 3) / 4,
+    60,
+  );
+  const expense = (timeline: typeof fine) =>
+    timeline.reduce((sum, t) => sum + (t.expensesPolicy || 0), 0);
+  expect(expense(hourly)).toBeCloseTo(expense(fine));
+  expect(game.policies).toEqual(snapshot);
+});
+
+test("schedule, replace, cancel and reject stale/no-op edits without recording them", () => {
+  let game = createGame({ scenarioId: 106, seed: 4 });
+  game = gameReducer(game, schedulePolicy(change));
+  expect(game.policies!.programs.efficiency.pending).toEqual({
+    tier: "Small",
+    month: 1,
+  });
+  const log = game.replayLog!.length;
+  expect(gameReducer(game, schedulePolicy(change)).replayLog).toHaveLength(log);
+  expect(
+    gameReducer(game, schedulePolicy({ ...change, month: 2 })).replayLog,
+  ).toHaveLength(log);
+  game = gameReducer(game, schedulePolicy({ ...change, tier: "Large" }));
+  expect(
+    gameReducer(game, cancelPolicy(change)).policies!.programs.efficiency
+      .pending!.tier,
+  ).toBe("Large");
+  game = gameReducer(game, cancelPolicy({ ...change, tier: "Large" }));
+  expect(game.policies!.programs.efficiency.pending).toBeUndefined();
+  expect(game.policies!.programs.efficiency.spending).toBe(0);
+  const tutorial = createGame({ scenarioId: 0 });
+  expect(
+    gameReducer(tutorial, schedulePolicy(change)).policies,
+  ).toBeUndefined();
+  const ended = { ...game, date: { ...game.date, monthsElapsed: 191 } };
+  expect(
+    gameReducer(ended, schedulePolicy({ ...change, month: 192 })).replayLog,
+  ).toEqual(game.replayLog);
+  const replay = { ...game, replayPlayback: { actions: [], index: 0 } };
+  expect(gameReducer(replay, schedulePolicy(change))).toEqual(replay);
+});
+
+test("adoption and actual spending are bounded, idempotent, and stop at saturation", () => {
+  const game = createGame({ scenarioId: 106 });
+  game.policies = emptyPolicies();
+  const program = game.policies.programs.efficiency;
+  program.tier = "Large";
+  program.adoption = 0.99;
+  advancePolicies(game, 1);
+  expect(program.adoption).toBe(1);
+  expect(program.spending).toBeCloseTo(
+    policyBudget(game, "efficiency", "Large", 1) * 0.2,
+  );
+  const saved = cloneDeep(game.policies);
+  advancePolicies(game, 1);
+  expect(game.policies).toEqual(saved);
+  advancePolicies(game, 2);
+  expect(program.spending).toBe(0);
+});
+
+test("solar affects only eligible daylight load after efficiency; neutral demand is exact", () => {
+  const game = createGame({ scenarioId: 106 });
+  const original = cloneDeep(game.timeline[0]);
+  const tick = cloneDeep(original);
+  applyPolicyDemand(game, tick);
+  expect(tick).toEqual(original);
+  game.policies = emptyPolicies();
+  game.policies.programs.solar.adoption = 1;
+  tick.solarIrradianceWM2 = 0;
+  applyPolicyDemand(game, tick);
+  expect(tick.demandByType).toEqual(original.demandByType);
+  game.policies.programs.efficiency.adoption = 1;
+  tick.solarIrradianceWM2 = 100000;
+  applyPolicyDemand(game, tick);
+  expect(tick.demandByType.Residential).toBe(0);
+  expect(tick.demandByType.Commercial).toBe(0);
+  expect(tick.demandByType["Data centers"]).toBe(
+    original.demandByType["Data centers"],
+  );
+  expect(tick.demandByType.Industrial).toBe(original.demandByType.Industrial);
+});
+
+test("preview is isolated, matches the real forecast and monthly costs reach cash/history", () => {
+  let game = createGame({ scenarioId: 106, seed: 4 });
+  const untouched = cloneDeep(game);
+  const preview = previewPolicy(game, change, 1);
+  expect(game).toEqual(untouched);
+  game = cloneDeep(gameReducer(game, schedulePolicy(change)));
+  const now = getTimeFromTimeline(game.date.minute, game.timeline)!;
+  const forecast = generateNewTimeline(
+    game,
+    now.cash,
+    now.customers,
+    TICKS_PER_MONTH * 2,
+  );
+  expect(forecast.slice(TICKS_PER_MONTH).map((t) => t.demandW)).toEqual(
+    preview.changed,
+  );
+  month(game);
+  expect(game.policies!.programs.efficiency.adoption).toBe(0.02);
+  const expected = game.policies!.programs.efficiency.spending;
+  expect(
+    summarizeTimeline(game.timeline, game.startingYear).expensesPolicy,
+  ).toBeCloseTo(expected);
+  const first = cloneDeep(game.timeline);
+  month(game);
+  expect(game.monthlyHistory[0].expensesPolicy).toBeCloseTo(expected);
+  expect(
+    deriveExpandedSummary(game.monthlyHistory[0]).expenses,
+  ).toBeGreaterThanOrEqual(expected);
+  expect(
+    first.every(
+      (t) =>
+        Object.values(t.demandByType).reduce((a, b) => a + b, 0) === t.demandW,
+    ),
+  ).toBe(true);
+});
+
+test("Off preserves installed upgrades through save/load and actions replay deterministically", () => {
+  let game = cloneDeep(
+    gameReducer(
+      createGame({ scenarioId: 106, seed: 4 }),
+      schedulePolicy(change),
+    ),
+  );
+  month(game);
+  game = cloneDeep(
+    gameReducer(game, schedulePolicy({ ...change, tier: "Off", month: 2 })),
+  );
+  month(game);
+  const stock = game.policies!.programs.efficiency.adoption;
+  expect(stock).toBe(0.02);
+  expect(game.policies!.programs.efficiency.spending).toBe(0);
+  const restored = parseSave(
+    JSON.parse(JSON.stringify(serializeSave(game))),
+  )!.game;
+  expect(restored.policies).toEqual(game.policies);
+  const replay = createGameFromReplay(serializeReplay(game)!);
+  month(replay);
+  month(replay);
+  expect(replay.policies).toEqual(game.policies);
+  expect(replay.timeline.map((t) => t.cash)).toEqual(
+    game.timeline.map((t) => t.cash),
+  );
+  month(restored);
+  expect(restored.policies!.programs.efficiency.adoption).toBe(stock);
+});
+
+test("legacy neutral saves migrate; malformed stocks and new replay payloads are rejected", () => {
+  const game = createGame({ scenarioId: 106 });
+  const migrated = parseSave(serializeSave(game))!;
+  expect(migrated.game.policies!.programs.solar.adoption).toBe(0);
+  const bad = cloneDeep(migrated);
+  bad.game.policies!.programs.solar.adoption = 2;
+  expect(parseSave(bad)).toBeNull();
+  const replay = serializeReplay(game)!;
+  expect(
+    decodeReplay({
+      ...replay,
+      actions: [
+        {
+          type: "schedulePolicy",
+          minute: 0,
+          payload: { ...change, tier: "Huge" },
+        },
+      ],
+    }),
+  ).toBeNull();
+  expect(decodeReplay({ ...replay, version: 3 })).not.toBeNull();
+});

--- a/src/helpers/Policies.tsx
+++ b/src/helpers/Policies.tsx
@@ -1,0 +1,142 @@
+import type {
+  GameType,
+  PoliciesType,
+  PolicyChangeType,
+  PolicyId,
+  PolicyTier,
+  TickPresentFutureType,
+} from "../Types";
+import {
+  POLICIES,
+  POLICY_IDS,
+  POLICY_TIERS,
+  POLICY_SCENARIOS,
+  POLICY_FUNDING,
+} from "../data/Policies";
+import { getInflationIndex } from "../data/Economy";
+import { EQUATOR_RADIANCE } from "../Constants";
+import { getDateFromMinute, MINUTES_PER_MONTH } from "./DateTime";
+
+export function emptyPolicies(month = 0): PoliciesType {
+  return {
+    month,
+    programs: {
+      efficiency: { tier: "Off", adoption: 0, spending: 0 },
+      solar: { tier: "Off", adoption: 0, spending: 0 },
+    },
+  };
+}
+export function policyAvailable(game: GameType): boolean {
+  return (
+    POLICY_SCENARIOS.includes(game.scenarioId) &&
+    !game.customScenario?.tutorialSteps &&
+    (game.customScenario?.durationMonths ?? 240) >= 6
+  );
+}
+export function validPolicyChange(value: unknown): value is PolicyChangeType {
+  const p = value as PolicyChangeType | undefined;
+  return (
+    !!p &&
+    POLICY_IDS.includes(p.id) &&
+    POLICY_TIERS.includes(p.tier) &&
+    Number.isInteger(p.month) &&
+    p.month > 0
+  );
+}
+export function validPolicies(
+  value: unknown,
+  currentMonth: number,
+): value is PoliciesType {
+  const p = value as PoliciesType | undefined;
+  return (
+    !!p &&
+    Number.isInteger(p.month) &&
+    p.month >= 0 &&
+    p.month === currentMonth &&
+    !!p.programs &&
+    POLICY_IDS.every((id) => {
+      const s = p.programs[id];
+      return (
+        !!s &&
+        POLICY_TIERS.includes(s.tier) &&
+        Number.isFinite(s.adoption) &&
+        s.adoption >= 0 &&
+        s.adoption <= 1 &&
+        Number.isFinite(s.spending) &&
+        s.spending >= 0 &&
+        (!s.pending ||
+          (validPolicyChange({ id, ...s.pending }) &&
+            s.pending.month === currentMonth + 1))
+      );
+    })
+  );
+}
+export function policyBudget(
+  game: GameType,
+  id: PolicyId,
+  tier: PolicyTier,
+  month: number,
+): number {
+  if (tier === "Off") return 0;
+  return (
+    game.customerMarketSize *
+    game.startingDemandScale *
+    POLICIES[id].costPerCustomer *
+    POLICY_FUNDING[tier].cost *
+    getInflationIndex(
+      getDateFromMinute(month * MINUTES_PER_MONTH, game.startingYear),
+      game.startingYear,
+      game.seed,
+    )
+  );
+}
+/** Activation, then funded installations, then their spending. Idempotent per month.
+ * Forecast callers own a private copy. Installed measures never retire during this run. */
+export function advancePolicies(game: GameType, month: number): PolicyId[] {
+  if (!game.policies) return [];
+  const activated: PolicyId[] = [];
+  const p = game.policies;
+  for (let m = p.month + 1; m <= month; m++) {
+    POLICY_IDS.forEach((id) => {
+      const s = p.programs[id];
+      if (s.pending && s.pending.month <= m) {
+        s.tier = s.pending.tier;
+        delete s.pending;
+        activated.push(id);
+      }
+      const increment = Math.min(
+        1 - s.adoption,
+        POLICY_FUNDING[s.tier].adoption,
+      );
+      s.spending =
+        increment > 0
+          ? (policyBudget(game, id, s.tier, m) * increment) /
+            POLICY_FUNDING[s.tier].adoption
+          : 0;
+      s.adoption = Math.min(1, s.adoption + increment);
+    });
+    p.month = m;
+  }
+  return activated;
+}
+export function applyPolicyDemand(game: GameType, tick: TickPresentFutureType) {
+  const p = game.policies?.programs;
+  if (!p || (!p.efficiency.adoption && !p.solar.adoption)) return;
+  const reduction = 1 - p.efficiency.adoption * POLICIES.efficiency.cap;
+  const residential = tick.demandByType.Residential * reduction;
+  const commercial = tick.demandByType.Commercial * reduction;
+  const load = residential + commercial;
+  const solar =
+    (p.solar.adoption *
+      POLICIES.solar.cap *
+      game.customerMarketSize *
+      game.startingDemandScale *
+      Math.max(0, tick.solarIrradianceWM2)) /
+    EQUATOR_RADIANCE;
+  const remaining = load > 0 ? Math.max(0, load - solar) / load : 0;
+  tick.demandByType = {
+    ...tick.demandByType,
+    Residential: residential * remaining,
+    Commercial: commercial * remaining,
+  };
+}

--- a/src/helpers/PolicyPreview.ts
+++ b/src/helpers/PolicyPreview.ts
@@ -1,0 +1,45 @@
+import cloneDeep from "lodash.clonedeep";
+import { GameType, PolicyChangeType, TickPresentFutureType } from "../Types";
+import { generateNewTimeline } from "../reducers/Game";
+import {
+  getTimeFromTimeline,
+  MINUTES_PER_MONTH,
+  summarizeTimeline,
+} from "./DateTime";
+import { advancePolicies, emptyPolicies } from "./Policies";
+import { TICK_MINUTES } from "../Constants";
+
+export function previewPolicy(
+  game: GameType,
+  change: PolicyChangeType,
+  month: number,
+) {
+  const draft = cloneDeep(game);
+  draft.policies ??= emptyPolicies(game.date.monthsElapsed);
+  const program = draft.policies.programs[change.id];
+  if (change.tier === program.tier) delete program.pending;
+  else program.pending = { tier: change.tier, month: change.month };
+  const now = getTimeFromTimeline(game.date.minute, game.timeline);
+  if (!now) throw new Error("No current simulation tick");
+  const ticks = Math.ceil(
+    ((month + 1) * MINUTES_PER_MONTH - game.date.minute) / TICK_MINUTES,
+  );
+  const before = generateNewTimeline(game, now.cash, now.customers, ticks);
+  const after = generateNewTimeline(draft, now.cash, now.customers, ticks);
+  const selected = (timeline: TickPresentFutureType[]) =>
+    timeline.filter((t) => Math.floor(t.minute / MINUTES_PER_MONTH) === month);
+  const current = selected(before);
+  const changed = selected(after);
+  advancePolicies(draft, month);
+  return {
+    spending: draft.policies!.programs[change.id].spending,
+    current: current.map((t) => t.demandW),
+    changed: changed.map((t) => t.demandW),
+    before: summarizeTimeline(current, game.startingYear),
+    after: summarizeTimeline(changed, game.startingYear),
+    // The balance difference spans the same period as the projection, including every
+    // intervening month's program spending, reduced sales, dispatch, and debt payments.
+    cashChange: after[after.length - 1].cash - before[before.length - 1].cash,
+  };
+}
+export type PolicyPreviewResult = ReturnType<typeof previewPolicy>;

--- a/src/helpers/PolicyPreviewClient.ts
+++ b/src/helpers/PolicyPreviewClient.ts
@@ -1,0 +1,5 @@
+export function createPolicyPreviewWorker(): Worker {
+  return new Worker(
+    new URL("../workers/PolicyPreview.worker.ts", import.meta.url),
+  );
+}

--- a/src/helpers/Story.tsx
+++ b/src/helpers/Story.tsx
@@ -24,7 +24,8 @@ export function buildStoryPeriodSnapshot(
     summary.expensesFuel +
     summary.expensesOM +
     summary.expensesCarbonFee +
-    summary.expensesInterest;
+    summary.expensesInterest +
+    (summary.expensesPolicy || 0);
   return {
     deliveredWhByFuel: { ...summary.deliveredWhByFuel },
     demandWh: summary.demandWh,
@@ -74,7 +75,8 @@ export function buildStorySnapshot(
     prior12Months.expensesFuel +
     prior12Months.expensesOM +
     prior12Months.expensesCarbonFee +
-    prior12Months.expensesInterest;
+    prior12Months.expensesInterest +
+    (prior12Months.expensesPolicy || 0);
   return {
     deliveredWhByFuel12m: { ...prior12Months.deliveredWhByFuel },
     demandWh12m: prior12Months.demandWh,

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1,4 +1,18 @@
 import { getViableLocationCount } from "../data/FacilitySites";
+import {
+  advancePolicies,
+  applyPolicyDemand,
+  emptyPolicies,
+  policyAvailable,
+  validPolicyChange,
+} from "../helpers/Policies";
+import { POLICIES, POLICY_IDS } from "../data/Policies";
+import {
+  schedulePolicy,
+  cancelPolicy,
+  openPolicyDecision,
+  closePolicyDecision,
+} from "./GameActions";
 import type { AppDispatch } from "../Store";
 import cloneDeep from "lodash.clonedeep";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
@@ -705,13 +719,20 @@ export const gameSlice = createSlice({
       // Assigned onto the draft rather than spread into a new object, which is equivalent for a
       // partial merge and is what lets the recorder below append to the draft's own log. Immer
       // rejects a reducer that both mutates its draft and returns a replacement for it
-      Object.assign(state, action.payload);
+      const {
+        policies: _policies,
+        policyPause: _policyPause,
+        ...payload
+      } = action.payload;
+      Object.assign(state, payload);
       const recorded = recordedDelta(action.payload);
       if (recorded) {
         recordReplayAction(state, "delta", recorded);
       }
     },
     initGame: (state, action: PayloadAction<NewGameAction>) => {
+      delete state.policies;
+      delete state.policyPause;
       const a = action.payload;
       previouslyInBlackout = false;
       blackoutUnservedWh = 0;
@@ -893,6 +914,7 @@ export const gameSlice = createSlice({
       recordReplayAction(state, "reprioritizeFacility", action.payload);
     },
     setSpeed: (state, action: PayloadAction<SpeedType>) => {
+      delete state.policyPause;
       // Global keyboard shortcuts still fire over full-screen cards. Keep their quotes and
       // instructions frozen until the player actually closes the card.
       if (
@@ -994,12 +1016,14 @@ export const gameSlice = createSlice({
         // Navigating anywhere else (rather than backing out) still counts as leaving it
         restoreSpeedAfterBlockingCard(state);
       } else if (state.inGame && speedBeforeBlockingCard === undefined) {
-        speedBeforeBlockingCard = state.speed;
+        speedBeforeBlockingCard = state.policyPause?.speed ?? state.speed;
+        delete state.policyPause;
         state.speed = "PAUSED";
       }
     });
     builder.addCase(navigateBack, restoreSpeedAfterBlockingCard);
     builder.addCase(dialogOpen, (state) => {
+      delete state.policyPause;
       speedBeforeDialog = state.speed;
       state.speed = "PAUSED";
     });
@@ -1007,9 +1031,34 @@ export const gameSlice = createSlice({
       state.speed = speedBeforeDialog;
       ensureTicking(state);
     });
+    builder.addCase(schedulePolicy, (state, action) => {
+      if (
+        !state.replayPlayback &&
+        applyPolicyEdit(state, action.payload, false)
+      )
+        recordReplayAction(state, "schedulePolicy", action.payload);
+    });
+    builder.addCase(cancelPolicy, (state, action) => {
+      if (!state.replayPlayback && applyPolicyEdit(state, action.payload, true))
+        recordReplayAction(state, "cancelPolicy", action.payload);
+    });
+    builder.addCase(openPolicyDecision, (state, action) => {
+      if (!state.policyPause) {
+        state.policyPause = { token: action.payload, speed: state.speed };
+        state.speed = "PAUSED";
+      }
+    });
+    builder.addCase(closePolicyDecision, (state, action) => {
+      if (state.policyPause?.token === action.payload) {
+        if (state.speed === "PAUSED") state.speed = state.policyPause.speed;
+        delete state.policyPause;
+        ensureTicking(state);
+      }
+    });
     // The score screen stops the clock the same way any other dialog does - "Keep playing"
     // resumes at whatever speed the run was going when it ended
     builder.addCase(victoryOpen, (state) => {
+      delete state.policyPause;
       speedBeforeDialog = state.speed;
       state.speed = "PAUSED";
     });
@@ -1144,9 +1193,53 @@ function applyReprioritizeFacility(
  * skipped rather than allowed to crash the sim mid-tick -- a replay that plays back slightly
  * wrong is a disappointment, one that throws takes the whole game down with it.
  */
+function applyPolicyEdit(
+  state: GameType,
+  payload: unknown,
+  cancel: boolean,
+): boolean {
+  const scenario = getScenario(state.scenarioId, state.customScenario);
+  if (
+    !validPolicyChange(payload) ||
+    !policyAvailable(state) ||
+    !scenario ||
+    !state.timeline.length ||
+    state.date.monthsElapsed !==
+      Math.floor(state.date.minute / MINUTES_PER_MONTH) ||
+    payload.month !== state.date.monthsElapsed + 1 ||
+    payload.month >= scenario.durationMonths
+  )
+    return false;
+  const existing = state.policies?.programs[payload.id];
+  if (cancel) {
+    if (
+      !existing?.pending ||
+      existing.pending.month !== payload.month ||
+      existing.pending.tier !== payload.tier
+    )
+      return false;
+    delete existing.pending;
+  } else {
+    if (payload.tier === (existing?.pending?.tier ?? existing?.tier ?? "Off"))
+      return false;
+    state.policies ??= emptyPolicies(state.date.monthsElapsed);
+    const program = state.policies.programs[payload.id];
+    if (payload.tier === program.tier) delete program.pending;
+    else program.pending = { tier: payload.tier, month: payload.month };
+  }
+  // Accepted changes start next month; the current month's demand and customer balance
+  // already happened. Long-range callers project the new pending state independently.
+  state.timeline = reforecastSupply(state, true);
+  return true;
+}
+
 function applyReplayAction(state: GameType, entry: ReplayActionType) {
   const payload = entry.payload;
   switch (entry.type) {
+    case "schedulePolicy":
+    case "cancelPolicy":
+      applyPolicyEdit(state, payload, entry.type === "cancelPolicy");
+      break;
     case "buildFacility": {
       const build = payload as Partial<BuildFacilityAction>;
       if (typeof build?.facility === "object" && build.facility !== null) {
@@ -1345,6 +1438,17 @@ export function tickState(state: GameType) {
       state.interestRate =
         getPrimeRate(state.date, state.seed) * state.creditPremium;
       const storyPriceFuels = updateWorldEvents(state);
+      const activatedPrograms = advancePolicies(
+        state,
+        state.date.monthsElapsed,
+      );
+      activatedPrograms.forEach((id) =>
+        logGameEvent(
+          state,
+          "WORLD_EVENT",
+          `${POLICIES[id].name}: ${state.policies!.programs[id].tier} funding starts this month.`,
+        ),
+      );
       state.timeline = generateNewTimeline(state, cash, customers);
       logFuelPriceMoves(state, storyPriceFuels);
       logFuelCrossovers(state);
@@ -1720,6 +1824,7 @@ function getDemandW(
     game.location,
     game.loadAdditions,
   );
+  applyPolicyDemand(game, now);
   return DEMAND_TYPES.reduce(
     (total, type) => total + now.demandByType[type],
     0,
@@ -1821,11 +1926,21 @@ function reforecastDemand(
   state: GameType,
   tickScale = 1,
 ): TickPresentFutureType[] {
+  const projection = { ...state, policies: cloneDeep(state.policies) };
   let prev = state.timeline[0];
   return state.timeline.map((t: TickPresentFutureType) => {
     if (t.minute >= state.date.minute) {
       const date = getDateFromMinute(t.minute, state.startingYear);
-      t.demandW = getDemandW(date, state, prev, t, tickScale);
+      advancePolicies(projection, date.monthsElapsed);
+      t = { ...t };
+      t.expensesPolicy =
+        (POLICY_IDS.reduce(
+          (sum, id) => sum + (projection.policies?.programs[id].spending || 0),
+          0,
+        ) *
+          tickScale) /
+        TICKS_PER_MONTH;
+      t.demandW = getDemandW(date, projection, prev, t, tickScale);
       prev = t;
       return t;
     }
@@ -2358,6 +2473,7 @@ function updateSupplyFacilitiesFinances(
       expensesFuel -
       expensesCarbonFee -
       expensesInterest -
+      (now.expensesPolicy || 0) -
       principalRepayment,
   );
   now.netWorth = getNetWorth(facilities, now.cash, now.minute);
@@ -2527,6 +2643,7 @@ export function generateNewTimeline(
       expensesOM: 0,
       expensesCarbonFee: 0,
       expensesInterest: 0,
+      expensesPolicy: 0,
       kgco2e: 0,
       // Both overwritten by updateSupplyFacilitiesFinances, from each tick's own date
       interestRate: 0,

--- a/src/reducers/GameActions.tsx
+++ b/src/reducers/GameActions.tsx
@@ -1,5 +1,16 @@
 import { createAction } from "@reduxjs/toolkit";
-import type { GameType, ReplayType } from "../Types";
+import type { GameType, ReplayType, PolicyChangeType } from "../Types";
+
+export const schedulePolicy = createAction<PolicyChangeType>(
+  "game/schedulePolicy",
+);
+export const cancelPolicy = createAction<PolicyChangeType>("game/cancelPolicy");
+export const openPolicyDecision = createAction<string>(
+  "game/openPolicyDecision",
+);
+export const closePolicyDecision = createAction<string>(
+  "game/closePolicyDecision",
+);
 
 /**
  * The game actions that other slices react to, declared here rather than by the game slice so that

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,6 +1,14 @@
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
+jest.mock("./helpers/PolicyPreviewClient", () => ({
+  createPolicyPreviewWorker: () => ({
+    onmessage: null,
+    onerror: null,
+    postMessage: () => undefined,
+    terminate: () => undefined,
+  }),
+}));
 
 // uPlot watches for device-pixel-ratio changes as soon as it is imported, and jsdom has no
 // matchMedia, so merely importing a chart would fail a suite. The charts never render in jsdom

--- a/src/testing/Invariants.tsx
+++ b/src/testing/Invariants.tsx
@@ -153,6 +153,31 @@ export function checkTick(
       collector.add("tick value is finite", when, `${field} = ${now[field]}`);
     }
   });
+  if (
+    !Number.isFinite(now.expensesPolicy ?? 0) ||
+    (now.expensesPolicy ?? 0) < 0
+  ) {
+    collector.add(
+      "policy spending is finite and non-negative",
+      when,
+      `${now.expensesPolicy}`,
+    );
+  }
+  if (state.policies) {
+    Object.values(state.policies.programs).forEach((program) => {
+      if (
+        program.adoption < 0 ||
+        program.adoption > 1 ||
+        !Number.isFinite(program.adoption)
+      ) {
+        collector.add(
+          "policy adoption is bounded",
+          when,
+          `${program.adoption}`,
+        );
+      }
+    });
+  }
 
   NON_NEGATIVE_TICK_FIELDS.forEach((field) => {
     const value = now[field];
@@ -202,7 +227,8 @@ export function checkTick(
       now.expensesFuel +
       now.expensesOM +
       now.expensesCarbonFee +
-      now.expensesInterest;
+      now.expensesInterest +
+      (now.expensesPolicy || 0);
     const maxPrincipal = state.facilities.reduce(
       (acc: number, f: FacilityOperatingType) =>
         acc +

--- a/src/testing/PolicyBalance.test.tsx
+++ b/src/testing/PolicyBalance.test.tsx
@@ -1,0 +1,41 @@
+import { runSimulation } from "./Simulator";
+import { PolicyTier } from "../Types";
+
+// Same seed, fleet, rates, and existing commitments. These are tradeoff checks, not a
+// claim that a mathematical optimum replaces first-time-player testing.
+describe.each([105, 106, 107])(
+  "customer program balance in scenario %s",
+  (scenarioId) => {
+    test("Off, Small, Large and combined preserve accounting and trade cash for demand", () => {
+      const play = (efficiency: PolicyTier, solar: PolicyTier) =>
+        runSimulation({
+          scenarioId,
+          seed: 4,
+          months: 12,
+          initialPrograms: { efficiency, solar },
+        });
+      const off = play("Off", "Off");
+      const small = play("Small", "Off");
+      const large = play("Large", "Off");
+      const solar = play("Off", "Large");
+      const both = play("Large", "Large");
+      [off, small, large, solar, both].forEach((result) =>
+        expect(result.violations).toEqual([]),
+      );
+      // First effective month comparisons share identical customer assumptions and horizon.
+      const baseline = off.months[1];
+      expect(small.months[1].demandWh).toBeLessThan(baseline.demandWh);
+      expect(large.months[1].demandWh).toBeLessThan(small.months[1].demandWh);
+      expect(both.months[1].demandWh).toBeLessThan(large.months[1].demandWh);
+      expect(both.months[1].cash).toBeLessThan(baseline.cash);
+      const smallCost =
+        small.months[1].expensesPolicy! /
+        (baseline.demandWh - small.months[1].demandWh);
+      const largeCost =
+        large.months[1].expensesPolicy! /
+        (baseline.demandWh - large.months[1].demandWh);
+      expect(smallCost).toBeLessThan(largeCost);
+      expect(off.months.every((m) => m.expensesPolicy === 0)).toBe(true);
+    });
+  },
+);

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -1,5 +1,14 @@
 # Headless simulation
 
+Customer program balance coverage lives in `PolicyBalance.test.tsx`. The simulator accepts
+`initialPrograms: { efficiency: "Small", solar: "Large" }` and schedules each through the real
+reducer for month two. The matrix compares Off, Small, Large, solar-only, and combined funding
+in Paradise, Data Center Boom, and Deep Freeze, including every cash/energy invariant.
+Program costs are authored game assumptions, scaled by initial customer market and demand
+scale, then inflated from the starting year. Adoption is allocated once at the month boundary;
+its actual cost is spread across that month's ticks. Installed upgrades persist within the run.
+These automated tradeoff checks do not replace the issue's proposed first-time-player playtest.
+
 Plays the game without a browser, then checks that the economy behaved lawfully. A 20 year
 scenario runs in about half a second, so a change to the simulation can be sanity checked in
 seconds instead of by clicking through the UI in real time.

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -2,6 +2,8 @@
 // the end of game dialogs), so it needs a live store to reach even though the simulation drives
 // the reducer directly. Importing Store creates and registers it.
 import cloneDeep from "lodash.clonedeep";
+import { schedulePolicy } from "../reducers/GameActions";
+import type { PolicyId, PolicyTier } from "../Types";
 import "../Store";
 import gameReducer, {
   buildFacility,
@@ -67,6 +69,7 @@ function scenarioLocation(scenario: ScenarioType): LocationType {
 }
 
 export interface SimOptionsType {
+  initialPrograms?: Partial<Record<PolicyId, PolicyTier>>;
   scenarioId: number;
   // A scenario that isn't in SCENARIOS - a custom game, or one being tried out. Its id wins over
   // scenarioId, the same way the real game treats the one on the slice
@@ -83,6 +86,7 @@ export interface SimOptionsType {
 }
 
 export interface ResolvedSimOptionsType {
+  initialPrograms?: Partial<Record<PolicyId, PolicyTier>>;
   scenarioId: number;
   difficulty: DifficultyType;
   months: number;
@@ -224,6 +228,12 @@ function setUpGame(
     state = gameReducer(state, sellFacility(options.sellFacilityId));
   }
   // Redux Toolkit freezes reducer output in development; the tick loop mutates state in place
+  Object.entries(options.initialPrograms || {}).forEach(([id, tier]) => {
+    state = gameReducer(
+      state,
+      schedulePolicy({ id: id as PolicyId, tier, month: 1 }),
+    );
+  });
   return cloneDeep(state);
 }
 
@@ -305,6 +315,7 @@ function resolveOptions(
   options: SimOptionsType,
 ): ResolvedSimOptionsType {
   return {
+    initialPrograms: options.initialPrograms,
     scenarioId: scenario.id,
     difficulty: options.difficulty || "Employee",
     months: options.months || scenario.durationMonths || 12 * 20,

--- a/src/workers/PolicyPreview.worker.ts
+++ b/src/workers/PolicyPreview.worker.ts
@@ -1,0 +1,34 @@
+import { initEconomy } from "../data/Economy";
+import { initFuelPrices } from "../data/FuelPrices";
+import { initWeather } from "../data/Weather";
+import { previewPolicy } from "../helpers/PolicyPreview";
+import { GameType, PolicyChangeType } from "../Types";
+
+const worker = globalThis as unknown as Worker;
+const load = (initialize: (done: (error?: string) => void) => void) =>
+  new Promise<void>((resolve, reject) =>
+    initialize((error) => (error ? reject(new Error(error)) : resolve())),
+  );
+worker.onmessage = async (
+  event: MessageEvent<{
+    game: GameType;
+    change: PolicyChangeType;
+    month: number;
+  }>,
+) => {
+  try {
+    const { game, change, month } = event.data;
+    await Promise.all([
+      load(initEconomy),
+      load(initFuelPrices),
+      load((done) => initWeather(game.location, done)),
+    ]);
+    worker.postMessage({ result: previewPolicy(game, change, month) });
+  } catch (_error) {
+    worker.postMessage({
+      error:
+        "Could not estimate this change. Try another choice or reopen the program.",
+    });
+  }
+};
+export {};


### PR DESCRIPTION
Adds the two customer programs described in the [revised scope of #63](https://github.com/toddmedema/electrify/issues/63#issuecomment-5572013708). Players can try efficiency or rooftop solar rebates in Insights, compare demand and cash estimates, and schedule Off/Small/Large funding for the next calendar month.

- Monthly activation, bounded adoption, inflation-adjusted budgets, and spending only on funded upgrades. Installed upgrades persist after funding stops; rooftop output offsets eligible daylight demand after efficiency, with surplus curtailed.
- Isolated, cancellable worker previews use the real forecast. The responsive dialog pauses play, supports keyboard funding choices, shows pending edits/cancellation, and exposes first-month and later comparisons with text alternatives and cash warnings.
- Program costs flow through cash, monthly history, Finances, scenario accounting, and simulator invariants. Save v3 migrates v1/v2 to neutral programs; replay v4 reads neutral v3 streams and validates new actions. Older clients reject the new versions.

An independent review agent completed an actual-browser usability walkthrough, a second agent implemented its feedback, and the reviewer retested the amended UI. Fixed four observed issues: an unchanged peak no longer implies negligible energy savings; energy and cumulative cash effects are visible without expanding details; Off announces funding stopping rather than new charges; and stopped programs say installed upgrades are retained rather than still building up. Added concise guidance explaining Small's lower cost per upgrade and Large's faster adoption.

The review covered desktop light and 320px dark views, first-month/12-month comparisons, applying and cancelling edits, and advancing the real clock through activation and stopping. February efficiency adoption remained at 5% after funding stopped in March. The amended flow had no remaining blocking defect observed. This was an agent-led walkthrough, not a human participant study. Its evidence supported preserving the authored balance numbers; the existing seeded balance cases support cash/demand tradeoffs, not claims of optimal balance.

Validation: Node 24 with lockfile dependencies; `npm run check` (957 tests plus every headless scenario); `npm run build`; all 12 customer-program browser checks across 320, 390, 768, 1024, 1280, and 1440 px in light/dark mode. Five tutorial viewport checks passed in the combined run; the 390px tutorial timed out once waiting for its retry control and then passed twice in isolation. Regression tests cover visible energy/cash effects with an unchanged peak, retained upgrades after stopping, and Start/Stop button wording without a duplicate footer date row. Balance coverage compares Off/Small/Large/solar-only/combined programs in Paradise, Data Center Boom, and Deep Freeze.

Earlier broader browser testing also encountered two scenario-details timeouts waiting for the unrelated “Wildfire emergency” event label on desktop (light/dark).

Funding actions now say “Start next month” or “Stop next month” for Off. The duplicate date row above the buttons has been removed. This follow-up passed the full check and build plus four desktop/320px browser checks in light/dark mode.

Closes #63.

![Desktop Start next month action without duplicate date row](https://github.com/user-attachments/assets/f0aabb55-04d9-4c66-b8b0-a7db3c5920f0)

![Compact mobile footer with Start next month action](https://github.com/user-attachments/assets/1c4187d1-dea5-404d-a646-52fb52e495ee)