### PR TITLE
Add transmission trading and intertie construction

### DIFF
--- a/e2e/transmission.spec.ts
+++ b/e2e/transmission.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+test("California players can build and understand an intertie", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    !new Set(["desktop-chromium", "mobile-320px"]).has(testInfo.project.name),
+  );
+  await page.addInitScript(() => window.localStorage.clear());
+  await page.goto("/?scenario=100");
+  await page.getByRole("button", { name: "Start game" }).click();
+
+  const facilities = page.locator(".facilities:visible");
+  if (!(await facilities.isVisible())) {
+    await page.getByRole("button", { name: "Facilities", exact: true }).click();
+  }
+  await facilities.getByRole("tab", { name: "Interties" }).click();
+  await expect(
+    facilities.getByRole("heading", { name: "Share power with nearby grids" }),
+  ).toBeVisible();
+  await expect(facilities.getByText("Pacific Northwest")).toBeVisible();
+  await expect(facilities.getByLabel("Trading rule")).toContainText(
+    "Buy for shortages, sell extra",
+  );
+
+  await facilities.getByRole("button", { name: /Build/ }).first().click();
+  await expect(facilities.getByText("Your interties")).toBeVisible();
+  await expect(facilities.getByText("Building")).toBeVisible();
+  expect(
+    await facilities.evaluate((element) =>
+      Math.max(0, element.scrollWidth - element.clientWidth),
+    ),
+  ).toBeLessThanOrEqual(1);
+});

--- a/e2e/transmission.spec.ts
+++ b/e2e/transmission.spec.ts
@@ -26,7 +26,7 @@ test("California players can build and understand an intertie", async ({
   ).toBeVisible();
   if (testInfo.project.name === "mobile-320px") {
     const firstBuild = facilities
-      .getByRole("button", { name: "Approve intertie" })
+      .getByRole("button", { name: "Approve Pacific Northwest intertie" })
       .first();
     const box = await firstBuild.boundingBox();
     expect(box).not.toBeNull();
@@ -34,7 +34,7 @@ test("California players can build and understand an intertie", async ({
   }
 
   await facilities
-    .getByRole("button", { name: "Approve intertie" })
+    .getByRole("button", { name: "Approve Pacific Northwest intertie" })
     .first()
     .click();
   await expect(facilities.getByText("Your interties")).toBeVisible();

--- a/e2e/transmission.spec.ts
+++ b/e2e/transmission.spec.ts
@@ -19,13 +19,35 @@ test("California players can build and understand an intertie", async ({
     facilities.getByRole("heading", { name: "Share power with nearby grids" }),
   ).toBeVisible();
   await expect(facilities.getByText("Pacific Northwest")).toBeVisible();
+  await expect(facilities.getByLabel("Trading rule")).toHaveCount(0);
+  await expect(facilities.getByText("Total cost").first()).toBeVisible();
+  await expect(
+    facilities.getByText("Pay $36M now · finance $144M").first(),
+  ).toBeVisible();
+  if (testInfo.project.name === "mobile-320px") {
+    const firstBuild = facilities
+      .getByRole("button", { name: "Approve intertie" })
+      .first();
+    const box = await firstBuild.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.y + box!.height).toBeLessThanOrEqual(512);
+  }
+
+  await facilities
+    .getByRole("button", { name: "Approve intertie" })
+    .first()
+    .click();
+  await expect(facilities.getByText("Your interties")).toBeVisible();
+  await expect(facilities.getByText("Building")).toBeVisible();
   await expect(facilities.getByLabel("Trading rule")).toContainText(
     "Buy for shortages, sell extra",
   );
-
-  await facilities.getByRole("button", { name: /Build/ }).first().click();
-  await expect(facilities.getByText("Your interties")).toBeVisible();
-  await expect(facilities.getByText("Building")).toBeVisible();
+  await expect(
+    page.getByText("Intertie approved — power can flow in 1 year."),
+  ).toBeVisible();
+  await expect(facilities.getByText("Northern intertie upgrade")).toHaveCount(
+    1,
+  );
   expect(
     await facilities.evaluate((element) =>
       Math.max(0, element.scrollWidth - element.clientWidth),

--- a/e2e/transmission.spec.ts
+++ b/e2e/transmission.spec.ts
@@ -54,3 +54,34 @@ test("California players can build and understand an intertie", async ({
     ),
   ).toBeLessThanOrEqual(1);
 });
+
+test("island grids do not offer interties or power exchange", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    !new Set(["desktop-chromium", "mobile-320px"]).has(testInfo.project.name),
+  );
+  await page.addInitScript(() => window.localStorage.clear());
+  await page.goto("/?scenario=105");
+  await page.getByRole("button", { name: "Start game" }).click();
+
+  const facilities = page.locator(".facilities:visible");
+  if (!(await facilities.isVisible())) {
+    await page.getByRole("button", { name: "Facilities", exact: true }).click();
+  }
+  await expect(facilities.getByRole("tab", { name: "Interties" })).toHaveCount(
+    0,
+  );
+
+  const insights = page.locator(".insights:visible");
+  if (!(await insights.isVisible())) {
+    await page.getByRole("button", { name: "Insights", exact: true }).click();
+  }
+  await insights.getByRole("button", { name: /Layers \(/ }).click();
+  await expect(
+    insights.getByRole("checkbox", { name: "Power exchange" }),
+  ).toHaveCount(0);
+  await expect(
+    insights.getByRole("heading", { name: "Power exchange" }),
+  ).toHaveCount(0);
+});

--- a/e2e/tutorial-interties.spec.ts
+++ b/e2e/tutorial-interties.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+
+test("Mission 7 teaches limited two-way interties without trapping recovery", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    !new Set(["desktop-chromium", "mobile-390px", "mobile-320px"]).has(
+      testInfo.project.name,
+    ),
+  );
+  test.setTimeout(60000);
+  await page.addInitScript(() => window.localStorage.clear());
+  await page.goto("/?scenario=112");
+  await page.getByRole("button", { name: "Start game" }).click();
+
+  await expect(page.getByLabel("Objective 1 of 10")).toBeVisible();
+  await expect(page.locator("#intertiesTab")).toBeVisible();
+
+  // The explicit copy plus automatic recovery means an eager Next cannot strand the build gate.
+  await page.getByRole("button", { name: "Next" }).click();
+  await expect(
+    page.getByRole("button", { name: "Approve Pacific Northwest intertie" }),
+  ).toBeVisible();
+  await expect(page.getByText("Pay $36M now · finance $144M")).toBeVisible();
+  await page
+    .getByRole("button", { name: "Approve Pacific Northwest intertie" })
+    .click();
+  await expect(page.getByText("Building")).toBeVisible();
+  await expect(page.getByLabel("Objective 3 of 10")).toBeVisible();
+
+  await page.getByRole("button", { name: "fast speed" }).click();
+  await expect(page.getByText(/Trading ·/)).toBeVisible({ timeout: 20000 });
+  // Construction alone is not enough: the objective advances only after this explicit pause.
+  await expect(page.getByLabel("Objective 3 of 10")).toBeVisible();
+  await page.getByRole("button", { name: "pause" }).click();
+  await expect(page.getByLabel("Objective 4 of 10")).toBeVisible();
+
+  await page.getByLabel("Trading rule").click();
+  await page.getByRole("option", { name: "Buy for shortages only" }).click();
+  await expect(page.getByLabel("Objective 5 of 10")).toBeVisible();
+  await page.locator("#plantsTab").click();
+  await page.getByRole("button", { name: "Next" }).click();
+  await page.getByRole("button", { name: "Pause Natural Gas" }).click();
+  await expect(page.getByLabel("Objective 7 of 10")).toBeVisible();
+
+  await page.getByRole("button", { name: "normal speed" }).click();
+  await expect(page.getByText(/Trading · Importing/)).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(page.locator(".gameStatus")).toContainText("Feb 2020", {
+    timeout: 20000,
+  });
+  await page.getByRole("button", { name: "pause" }).click();
+  await expect(page.getByLabel("Objective 8 of 10")).toBeVisible();
+
+  const exchange = page.locator('[data-layer="powerExchange"]');
+  await expect(exchange).toBeVisible();
+  await expect(exchange).toContainText("Power flowing");
+  await expect(exchange).toContainText("Available capacity");
+  await expect(exchange).toContainText("Neighbor price");
+  if (testInfo.project.name.startsWith("mobile-")) {
+    const [box, viewport] = await Promise.all([
+      exchange.boundingBox(),
+      page.evaluate(() => ({
+        height: window.innerHeight,
+        width: window.innerWidth,
+      })),
+    ]);
+    expect(box).not.toBeNull();
+    expect(box!.y).toBeGreaterThanOrEqual(0);
+    expect(box!.y).toBeLessThan(viewport.height - 56);
+    expect(
+      await page
+        .locator(".insights:visible")
+        .evaluate((element) => element.scrollWidth <= element.clientWidth + 1),
+    ).toBe(true);
+    for (const selector of ["#plantsTab", "#intertiesTab"]) {
+      const tabBox = await page.locator(selector).boundingBox();
+      expect(tabBox?.height).toBeGreaterThanOrEqual(44);
+    }
+  }
+
+  await page.getByRole("button", { name: "Next" }).click();
+  await expect(
+    page.getByText(/Hot, sunny weather warms the line/),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Next" }).click();
+  await expect(page.getByLabel("Objective 10 of 10")).toBeVisible();
+
+  const facilities = page.locator(".facilities:visible");
+  await facilities.getByRole("tab", { name: "Interties" }).click();
+  await facilities.getByLabel("Trading rule").click();
+  await page.getByRole("option", { name: "No trading" }).click();
+  await page.getByRole("button", { name: "fast speed" }).click();
+  await expect(page.locator(".gameStatus")).toContainText("Mar 2020", {
+    timeout: 15000,
+  });
+  await page.getByRole("button", { name: "pause" }).click();
+  await expect(page.getByLabel("Objective 10 of 10")).toBeVisible();
+
+  await facilities.getByLabel("Trading rule").click();
+  await page
+    .getByRole("option", { name: "Buy for shortages, sell extra" })
+    .click();
+  await page.getByRole("button", { name: "fast speed" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Mission complete!" }),
+  ).toBeVisible({ timeout: 15000 });
+  await expect(
+    page.getByText(/borrowed power at night and shared extra solar by day/i),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Next tutorial" })).toHaveCount(
+    0,
+  );
+});

--- a/e2e/tutorial-interties.spec.ts
+++ b/e2e/tutorial-interties.spec.ts
@@ -8,7 +8,7 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
       testInfo.project.name,
     ),
   );
-  test.setTimeout(60000);
+  test.setTimeout(90000);
   await page.addInitScript(() => {
     window.localStorage.clear();
     window.localStorage.setItem(
@@ -60,11 +60,13 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
   await page.getByRole("button", { name: "Pause Natural Gas" }).click();
   await expect(page.getByLabel("Objective 7 of 10")).toBeVisible();
 
-  await page.getByRole("button", { name: "normal speed" }).click();
+  await page.getByRole("button", { name: "fast speed" }).click();
   await expect(page.getByText(/Trading · Importing/)).toBeVisible({
     timeout: 10000,
   });
-  await expect(page.locator(".gameStatus")).toContainText("Feb 2020", {
+  // Wait for a full importing month to settle into history; seeing live flow alone must not
+  // satisfy the observation gate.
+  await expect(page.locator(".gameStatus")).toContainText("Mar 2020", {
     timeout: 20000,
   });
   await page.getByRole("button", { name: "pause" }).click();
@@ -109,7 +111,7 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
   await facilities.getByLabel("Trading rule").click();
   await page.getByRole("option", { name: "No trading" }).click();
   await page.getByRole("button", { name: "fast speed" }).click();
-  await expect(page.locator(".gameStatus")).toContainText("Mar 2020", {
+  await expect(page.locator(".gameStatus")).toContainText("Apr 2020", {
     timeout: 15000,
   });
   await page.getByRole("button", { name: "pause" }).click();

--- a/e2e/tutorial-interties.spec.ts
+++ b/e2e/tutorial-interties.spec.ts
@@ -9,9 +9,26 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
     ),
   );
   test.setTimeout(60000);
-  await page.addInitScript(() => window.localStorage.clear());
-  await page.goto("/?scenario=112");
-  await page.getByRole("button", { name: "Start game" }).click();
+  await page.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem(
+      "plays",
+      JSON.stringify({
+        plays: [0, 1, 2, 4, 3, 5].map((scenarioId) => ({
+          scenarioId,
+          date: "2026-09-08",
+        })),
+      }),
+    );
+  });
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: "Start playing", exact: true })
+    .click();
+  await expect(
+    page.getByRole("heading", { name: "Choose a game" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Start Interties" }).click();
 
   await expect(page.getByLabel("Objective 1 of 10")).toBeVisible();
   await expect(page.locator("#intertiesTab")).toBeVisible();

--- a/public/images/transmission-option-2.svg
+++ b/public/images/transmission-option-2.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:600834193d6d7abcef14f01cb7f783ea97973824a8ed87223fe0b7ac2fe9d1d3
-size 942
+oid sha256:0c86ab90d9bb88ce333b52bfdd6fee616acb592070d6b4f5cd0eb0f6abb97ab4
+size 608

--- a/public/images/transmission-option-2.svg
+++ b/public/images/transmission-option-2.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fe5136558696645eee5477c9dd661201b824fa5718de85fbfeae86fdc66c40b
+size 942

--- a/public/images/transmission-option-2.svg
+++ b/public/images/transmission-option-2.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fe5136558696645eee5477c9dd661201b824fa5718de85fbfeae86fdc66c40b
+oid sha256:600834193d6d7abcef14f01cb7f783ea97973824a8ed87223fe0b7ac2fe9d1d3
 size 942

--- a/public/images/transmission-option-2.svg
+++ b/public/images/transmission-option-2.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c86ab90d9bb88ce333b52bfdd6fee616acb592070d6b4f5cd0eb0f6abb97ab4
-size 608

--- a/public/images/transmission.svg
+++ b/public/images/transmission.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a1c9d555a18c69d3d9e1cd8c62ec9240679e4e48031219496a733626e7be6a3
+size 682

--- a/src/Replay.test.tsx
+++ b/src/Replay.test.tsx
@@ -187,6 +187,14 @@ describe("decodeReplay", () => {
     ).toEqual(replay);
   });
 
+  it("grandfathers pre-ledger replays but leaves current runs gated", () => {
+    const current = encodeReplay(aReplay());
+    expect(decodeReplay(current)?.meaningfulDecisionGateWaived).toBeUndefined();
+
+    const legacy = { ...current, version: REPLAY_VERSION - 1 };
+    expect(decodeReplay(legacy)?.meaningfulDecisionGateWaived).toBe(true);
+  });
+
   it("ignores anything that isn't a replay", () => {
     expect(decodeReplay(null)).toBeNull();
     expect(decodeReplay("nope")).toBeNull();

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -32,7 +32,8 @@ import {
 // Version 2 changes authored starting fleets and their facility IDs, so older action streams can
 // no longer reproduce the run they recorded.
 // Version 4 adds customer program actions; version 5 adds transmission builds and trading policy.
-export const REPLAY_VERSION = 5;
+// Version 6 adds the validated decision gate; older replays keep the victory rules they recorded.
+export const REPLAY_VERSION = 6;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few
@@ -140,6 +141,8 @@ export function serializeReplay(game: GameType): ReplayType | undefined {
     seed: game.seed,
     location: cloneDeep(game.location),
     actions: cloneDeep(game.replayLog),
+    meaningfulDecisionGateWaived:
+      game.meaningfulDecisionGateWaived || undefined,
   };
 }
 
@@ -232,6 +235,7 @@ export function decodeReplay(raw: unknown): ReplayType | null {
   const doc = raw as Partial<ReplayDocType>;
   if (
     doc.version !== REPLAY_VERSION &&
+    doc.version !== 5 &&
     doc.version !== 4 &&
     doc.version !== 3
   ) {
@@ -242,6 +246,8 @@ export function decodeReplay(raw: unknown): ReplayType | null {
     !isFiniteNumber(doc.seed) ||
     typeof doc.appVersion !== "string" ||
     typeof doc.difficulty !== "string" ||
+    (doc.meaningfulDecisionGateWaived !== undefined &&
+      typeof doc.meaningfulDecisionGateWaived !== "boolean") ||
     // Checked in full rather than trusted: the location's id becomes the path of the weather file
     // the loading screen fetches, and its lat/long drive the sun model
     !isValidLocation(doc.location)
@@ -255,7 +261,7 @@ export function decodeReplay(raw: unknown): ReplayType | null {
       actions.some(
         (a) => a.type === "schedulePolicy" || a.type === "cancelPolicy",
       )) ||
-    (doc.version !== REPLAY_VERSION &&
+    (doc.version < 5 &&
       actions.some(
         (a) =>
           a.type === "buildTransmissionLine" || a.type === "setTradingPolicy",
@@ -271,5 +277,9 @@ export function decodeReplay(raw: unknown): ReplayType | null {
     seed: doc.seed,
     location: doc.location,
     actions,
+    meaningfulDecisionGateWaived:
+      doc.version < REPLAY_VERSION || doc.meaningfulDecisionGateWaived
+        ? true
+        : undefined,
   };
 }

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -31,8 +31,8 @@ import {
 
 // Version 2 changes authored starting fleets and their facility IDs, so older action streams can
 // no longer reproduce the run they recorded.
-// Version 4 adds customer program actions; older clients must reject these streams.
-export const REPLAY_VERSION = 4;
+// Version 4 adds customer program actions; version 5 adds transmission builds and trading policy.
+export const REPLAY_VERSION = 5;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few
@@ -66,6 +66,8 @@ const REPLAY_ACTION_NAMES: ReplayActionNameType[] = [
   "sellFacility",
   "togglePauseFacility",
   "reprioritizeFacility",
+  "buildTransmissionLine",
+  "setTradingPolicy",
   "delta",
 ];
 
@@ -187,6 +189,21 @@ function parseActions(raw: unknown): ReplayActionType[] | null {
       !validPolicyChange(action.payload)
     )
       return null;
+    if (
+      action.type === "buildTransmissionLine" &&
+      (typeof action.payload !== "object" ||
+        action.payload === null ||
+        typeof (action.payload as { corridorId?: unknown }).corridorId !==
+          "string")
+    )
+      return null;
+    if (
+      action.type === "setTradingPolicy" &&
+      !["BALANCED", "RELIABILITY_FIRST", "SURPLUS_ONLY", "CLOSED"].includes(
+        action.payload as string,
+      )
+    )
+      return null;
     actions.push({
       minute: action.minute,
       type: action.type as ReplayActionNameType,
@@ -213,7 +230,11 @@ export function decodeReplay(raw: unknown): ReplayType | null {
     return null;
   }
   const doc = raw as Partial<ReplayDocType>;
-  if (doc.version !== REPLAY_VERSION && doc.version !== 3) {
+  if (
+    doc.version !== REPLAY_VERSION &&
+    doc.version !== 4 &&
+    doc.version !== 3
+  ) {
     return null;
   }
   if (
@@ -233,6 +254,11 @@ export function decodeReplay(raw: unknown): ReplayType | null {
     (doc.version === 3 &&
       actions.some(
         (a) => a.type === "schedulePolicy" || a.type === "cancelPolicy",
+      )) ||
+    (doc.version !== REPLAY_VERSION &&
+      actions.some(
+        (a) =>
+          a.type === "buildTransmissionLine" || a.type === "setTradingPolicy",
       ))
   ) {
     return null;

--- a/src/SaveFile.test.tsx
+++ b/src/SaveFile.test.tsx
@@ -31,6 +31,8 @@ function fakeGame(overrides: Partial<GameType> = {}): GameType {
     reportedEventKeys: [],
     eventLogReadThroughId: 0,
     worldEvents: { active: [], occurrences: [], checkedKeys: [] },
+    meaningfulDecisions: [],
+    meaningfulDecisionGateWaived: false,
     ...overrides,
   } as unknown as GameType;
 }

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -13,7 +13,11 @@ import {
 } from "./SaveGame";
 import { createGame } from "./testing/Simulator";
 import { GameType } from "./Types";
-import gameReducer, { buildTransmissionLine, tickState } from "./reducers/Game";
+import gameReducer, {
+  buildTransmissionLine,
+  delta,
+  tickState,
+} from "./reducers/Game";
 import { emptyPolicies } from "./helpers/Policies";
 
 jest.setTimeout(60000);
@@ -85,6 +89,43 @@ describe("SaveGame", () => {
       tradingPolicy: "BALANCED",
       lines: [],
     });
+  });
+
+  it("normalizes old decision progress and round-trips validated progress", () => {
+    const legacy = JSON.parse(JSON.stringify(serializeSave(game)));
+    delete legacy.game.meaningfulDecisions;
+    expect(parseSave(legacy)?.game.meaningfulDecisions).toEqual([]);
+
+    const played = gameReducer(
+      game,
+      delta({ dollarsPerkWh: game.dollarsPerkWh + 0.001 }),
+    );
+    expect(parseSave(serializeSave(played))?.game.meaningfulDecisions).toEqual(
+      played.meaningfulDecisions,
+    );
+  });
+
+  it("rejects malformed, duplicate, and future decision progress", () => {
+    const valid = gameReducer(
+      game,
+      delta({ dollarsPerkWh: game.dollarsPerkWh + 0.001 }),
+    );
+    const corrupt = JSON.parse(JSON.stringify(serializeSave(valid)));
+    corrupt.game.meaningfulDecisions[0].month =
+      corrupt.game.date.monthsElapsed + 1;
+    corrupt.game.meaningfulDecisions[0].key = `${corrupt.game.meaningfulDecisions[0].lever}@${corrupt.game.meaningfulDecisions[0].month}`;
+    expect(parseSave(corrupt)).toBeNull();
+
+    const duplicate = JSON.parse(JSON.stringify(serializeSave(valid)));
+    duplicate.game.meaningfulDecisions.push({
+      ...duplicate.game.meaningfulDecisions[0],
+    });
+    expect(parseSave(duplicate)).toBeNull();
+
+    const noOp = JSON.parse(JSON.stringify(serializeSave(valid)));
+    noOp.game.meaningfulDecisions[0].after =
+      noOp.game.meaningfulDecisions[0].before;
+    expect(parseSave(noOp)).toBeNull();
   });
 
   it("does not invent transmission when an older tutorial is restored", () => {

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -148,6 +148,14 @@ describe("SaveGame", () => {
       id: 2,
     });
     expect(parseSave(duplicate)).toBeNull();
+
+    const wrongRegion = JSON.parse(JSON.stringify(save));
+    wrongRegion.game.location.id = "PIT";
+    expect(parseSave(wrongRegion)).toBeNull();
+
+    const islanded = JSON.parse(JSON.stringify(save));
+    islanded.game.location.id = "HNL";
+    expect(parseSave(islanded)).toBeNull();
   });
 
   // The memo must never alias the live game slice, or a Continue button would describe a game

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -78,7 +78,11 @@ describe("SaveGame", () => {
   it("upgrades older saves without inventing missing chart history", () => {
     const restored = parseSave({ ...serializeSave(game), version: 1 });
     expect(restored?.version).toBe(SAVE_VERSION);
-    expect(restored?.game).toEqual({ ...game, policies: emptyPolicies() });
+    expect(restored?.game).toEqual({
+      ...game,
+      policies: emptyPolicies(),
+      meaningfulDecisionGateWaived: true,
+    });
   });
 
   it("keeps legacy saves disconnected from adjacent markets", () => {
@@ -93,8 +97,14 @@ describe("SaveGame", () => {
 
   it("normalizes old decision progress and round-trips validated progress", () => {
     const legacy = JSON.parse(JSON.stringify(serializeSave(game)));
-    delete legacy.game.meaningfulDecisions;
+    legacy.game.meaningfulDecisions = [{ key: "untrusted-old-ledger" }];
+    legacy.version = 3;
     expect(parseSave(legacy)?.game.meaningfulDecisions).toEqual([]);
+    expect(parseSave(legacy)?.game.meaningfulDecisionGateWaived).toBe(true);
+
+    const missingCurrent = JSON.parse(JSON.stringify(serializeSave(game)));
+    delete missingCurrent.game.meaningfulDecisions;
+    expect(parseSave(missingCurrent)).toBeNull();
 
     const played = gameReducer(
       game,
@@ -103,6 +113,9 @@ describe("SaveGame", () => {
     expect(parseSave(serializeSave(played))?.game.meaningfulDecisions).toEqual(
       played.meaningfulDecisions,
     );
+    expect(
+      parseSave(serializeSave(played))?.game.meaningfulDecisionGateWaived,
+    ).toBe(false);
   });
 
   it("rejects malformed, duplicate, and future decision progress", () => {

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -87,6 +87,30 @@ describe("SaveGame", () => {
     });
   });
 
+  it("does not invent transmission when an older tutorial is restored", () => {
+    const tutorial = createGame({ scenarioId: 0, seed: 249001 });
+    const save = JSON.parse(JSON.stringify(serializeSave(tutorial)));
+    save.game.transmission = { tradingPolicy: "BALANCED", lines: [] };
+
+    expect(parseSave(save)?.game.transmission).toBeUndefined();
+
+    save.game.transmission.lines.push({
+      id: 1,
+      corridorId: "california-north",
+      name: "Northern intertie upgrade",
+      capacityW: 500000000,
+      buildCost: 180000000,
+      annualOperatingCost: 3600000,
+      yearsToBuildLeft: 0,
+      minuteCreated: 0,
+      financed: false,
+      loanAmountLeft: 0,
+      loanMonthlyPayment: 0,
+      interestRate: 0,
+    });
+    expect(parseSave(save)).toBeNull();
+  });
+
   it("rejects corrupt or impossible intertie financial state", () => {
     const california = createGame({ scenarioId: 100, seed: 61 });
     const built = gameReducer(

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -13,7 +13,7 @@ import {
 } from "./SaveGame";
 import { createGame } from "./testing/Simulator";
 import { GameType } from "./Types";
-import { tickState } from "./reducers/Game";
+import gameReducer, { buildTransmissionLine, tickState } from "./reducers/Game";
 import { emptyPolicies } from "./helpers/Policies";
 
 jest.setTimeout(60000);
@@ -85,6 +85,45 @@ describe("SaveGame", () => {
       tradingPolicy: "BALANCED",
       lines: [],
     });
+  });
+
+  it("rejects corrupt or impossible intertie financial state", () => {
+    const california = createGame({ scenarioId: 100, seed: 61 });
+    const built = gameReducer(
+      california,
+      buildTransmissionLine({
+        corridorId: "california-north",
+        financed: true,
+      }),
+    );
+    const save = JSON.parse(JSON.stringify(serializeSave(built)));
+    expect(parseSave(save)).not.toBeNull();
+
+    for (const field of [
+      "capacityW",
+      "buildCost",
+      "annualOperatingCost",
+      "yearsToBuildLeft",
+      "minuteCreated",
+      "loanAmountLeft",
+      "loanMonthlyPayment",
+      "interestRate",
+    ]) {
+      const corrupt = JSON.parse(JSON.stringify(save));
+      corrupt.game.transmission.lines[0][field] = -1;
+      expect(parseSave(corrupt)).toBeNull();
+    }
+
+    const wrongCapacity = JSON.parse(JSON.stringify(save));
+    wrongCapacity.game.transmission.lines[0].capacityW = 1;
+    expect(parseSave(wrongCapacity)).toBeNull();
+
+    const duplicate = JSON.parse(JSON.stringify(save));
+    duplicate.game.transmission.lines.push({
+      ...duplicate.game.transmission.lines[0],
+      id: 2,
+    });
+    expect(parseSave(duplicate)).toBeNull();
   });
 
   // The memo must never alias the live game slice, or a Continue button would describe a game

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -77,6 +77,16 @@ describe("SaveGame", () => {
     expect(restored?.game).toEqual({ ...game, policies: emptyPolicies() });
   });
 
+  it("keeps legacy saves disconnected from adjacent markets", () => {
+    const legacy = JSON.parse(JSON.stringify(serializeSave(game)));
+    delete legacy.game.transmission;
+    const restored = parseSave({ ...legacy, version: 2 });
+    expect(restored?.game.transmission).toEqual({
+      tradingPolicy: "BALANCED",
+      lines: [],
+    });
+  });
+
   // The memo must never alias the live game slice, or a Continue button would describe a game
   // that has kept playing since it was saved
   it("reads back through storage rather than handing back the live object", () => {

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -35,9 +35,9 @@ import type { AppStore } from "./Store";
 
 export const SAVE_KEY = "savedGame";
 // Initial public schema. Increment this when a post-release change becomes incompatible.
-// Version 3 includes persistent customer programs. Accept and normalize v1/v2 saves;
-// older clients must not resume an active program as though its upgrades did not exist.
-export const SAVE_VERSION = 3;
+// Version 3 includes persistent customer programs. Version 4 adds the validated decision ledger.
+// Accept and normalize v1-v3 saves, but visibly waive the new gate for those in-progress games.
+export const SAVE_VERSION = 4;
 
 export interface SaveGameType {
   version: number;
@@ -119,7 +119,8 @@ export function parseSave(raw: unknown): SaveGameType | null {
   if (
     (save.version !== SAVE_VERSION &&
       save.version !== 1 &&
-      save.version !== 2) ||
+      save.version !== 2 &&
+      save.version !== 3) ||
     typeof save.savedAt !== "string" ||
     typeof save.appVersion !== "string"
   ) {
@@ -276,8 +277,10 @@ export function parseSave(raw: unknown): SaveGameType | null {
   }
   const currentMonth = Math.floor(game.date.minute / MINUTES_PER_MONTH);
   if (
-    game.meaningfulDecisions !== undefined &&
-    !validMeaningfulDecisions(game.meaningfulDecisions, currentMonth)
+    (save.version === SAVE_VERSION &&
+      !validMeaningfulDecisions(game.meaningfulDecisions, currentMonth)) ||
+    (game.meaningfulDecisionGateWaived !== undefined &&
+      typeof game.meaningfulDecisionGateWaived !== "boolean")
   )
     return null;
   const worldEvents = game.worldEvents as
@@ -348,7 +351,12 @@ export function parseSave(raw: unknown): SaveGameType | null {
     transmission: transmissionEnabled
       ? (game.transmission ?? emptyTransmissionState())
       : undefined,
-    meaningfulDecisions: game.meaningfulDecisions ?? [],
+    meaningfulDecisions:
+      save.version === SAVE_VERSION ? game.meaningfulDecisions! : [],
+    meaningfulDecisionGateWaived:
+      save.version === SAVE_VERSION
+        ? (game.meaningfulDecisionGateWaived ?? false)
+        : true,
     timeline: game.timeline.map((t) => ({
       ...t,
       expensesPolicy: t.expensesPolicy ?? 0,

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -9,6 +9,7 @@ import {
 } from "./LocalStorage";
 import { snackbarOpen } from "./reducers/UI";
 import { GameType, TransmissionLineOperatingType } from "./Types";
+import { validMeaningfulDecisions } from "./helpers/MeaningfulDecisions";
 import {
   emptyTransmissionState,
   intertiesEnabledForScenario,
@@ -273,6 +274,12 @@ export function parseSave(raw: unknown): SaveGameType | null {
   ) {
     return null;
   }
+  const currentMonth = Math.floor(game.date.minute / MINUTES_PER_MONTH);
+  if (
+    game.meaningfulDecisions !== undefined &&
+    !validMeaningfulDecisions(game.meaningfulDecisions, currentMonth)
+  )
+    return null;
   const worldEvents = game.worldEvents as
     Partial<GameType["worldEvents"]> | undefined;
   if (
@@ -341,6 +348,7 @@ export function parseSave(raw: unknown): SaveGameType | null {
     transmission: transmissionEnabled
       ? (game.transmission ?? emptyTransmissionState())
       : undefined,
+    meaningfulDecisions: game.meaningfulDecisions ?? [],
     timeline: game.timeline.map((t) => ({
       ...t,
       expensesPolicy: t.expensesPolicy ?? 0,

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -9,6 +9,10 @@ import {
 } from "./LocalStorage";
 import { snackbarOpen } from "./reducers/UI";
 import { GameType } from "./Types";
+import {
+  emptyTransmissionState,
+  TRANSMISSION_CORRIDORS,
+} from "./data/AdjacentMarkets";
 import type { AppStore } from "./Store";
 
 /**
@@ -240,6 +244,37 @@ export function parseSave(raw: unknown): SaveGameType | null {
     )
   )
     return null;
+  const transmission = game.transmission;
+  if (
+    transmission !== undefined &&
+    (typeof transmission !== "object" ||
+      transmission === null ||
+      !["BALANCED", "RELIABILITY_FIRST", "SURPLUS_ONLY", "CLOSED"].includes(
+        transmission.tradingPolicy,
+      ) ||
+      !Array.isArray(transmission.lines) ||
+      transmission.lines.some(
+        (line) =>
+          typeof line !== "object" ||
+          line === null ||
+          !TRANSMISSION_CORRIDORS.some(({ id }) => id === line.corridorId) ||
+          [
+            line.id,
+            line.capacityW,
+            line.buildCost,
+            line.annualOperatingCost,
+            line.yearsToBuildLeft,
+            line.minuteCreated,
+            line.loanAmountLeft,
+            line.loanMonthlyPayment,
+            line.interestRate,
+          ].some(
+            (value) => typeof value !== "number" || !Number.isFinite(value),
+          ) ||
+          typeof line.financed !== "boolean",
+      ))
+  )
+    return null;
   if (
     [...game.timeline, ...game.monthlyHistory].some(
       (t) =>
@@ -254,13 +289,22 @@ export function parseSave(raw: unknown): SaveGameType | null {
     policies:
       game.policies ??
       emptyPolicies(Math.floor(game.date.minute / MINUTES_PER_MONTH)),
+    transmission: game.transmission ?? emptyTransmissionState(),
     timeline: game.timeline.map((t) => ({
       ...t,
       expensesPolicy: t.expensesPolicy ?? 0,
+      expensesImports: t.expensesImports ?? 0,
+      revenueExports: t.revenueExports ?? 0,
+      importedW: t.importedW ?? 0,
+      exportedW: t.exportedW ?? 0,
+      transmissionCapacityW: t.transmissionCapacityW ?? 0,
+      marketPricePerMWh: t.marketPricePerMWh ?? 0,
     })),
     monthlyHistory: game.monthlyHistory.map((t) => ({
       ...t,
       expensesPolicy: t.expensesPolicy ?? 0,
+      expensesImports: t.expensesImports ?? 0,
+      revenueExports: t.revenueExports ?? 0,
     })),
   };
   // Version 1 saves remain playable. New months collect chart history; older months have only

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -8,7 +8,7 @@ import {
   setStorageKeyValue,
 } from "./LocalStorage";
 import { snackbarOpen } from "./reducers/UI";
-import { GameType } from "./Types";
+import { GameType, TransmissionLineOperatingType } from "./Types";
 import {
   emptyTransmissionState,
   TRANSMISSION_CORRIDORS,
@@ -47,6 +47,51 @@ export interface SaveGameType {
 // clearing invalidate it rather than filling it in, so what's cached is always what's in storage
 // and never an alias of the live (and still mutating) game slice.
 let cached: SaveGameType | null | undefined;
+
+function validTransmissionLine(
+  raw: unknown,
+): raw is TransmissionLineOperatingType {
+  if (typeof raw !== "object" || raw === null) return false;
+  const line = raw as Partial<TransmissionLineOperatingType>;
+  const corridor = TRANSMISSION_CORRIDORS.find(
+    ({ id }) => id === line.corridorId,
+  );
+  if (!corridor) return false;
+  const nonNegative = [
+    line.capacityW,
+    line.buildCost,
+    line.annualOperatingCost,
+    line.yearsToBuildLeft,
+    line.minuteCreated,
+    line.loanAmountLeft,
+    line.loanMonthlyPayment,
+    line.interestRate,
+  ];
+  return (
+    typeof line.name === "string" &&
+    line.name.length > 0 &&
+    Number.isInteger(line.id) &&
+    line.id! > 0 &&
+    nonNegative.every(
+      (value) =>
+        typeof value === "number" && Number.isFinite(value) && value >= 0,
+    ) &&
+    line.capacityW === corridor.capacityW &&
+    line.buildCost === corridor.buildCost &&
+    line.annualOperatingCost === corridor.annualOperatingCost &&
+    line.yearsToBuildLeft! <= corridor.yearsToBuild &&
+    Number.isInteger(line.minuteCreated) &&
+    line.interestRate! <= 1 &&
+    line.loanAmountLeft! <= corridor.buildCost &&
+    line.loanMonthlyPayment! <= corridor.buildCost &&
+    typeof line.financed === "boolean" &&
+    (line.financed
+      ? line.loanMonthlyPayment! > 0
+      : line.loanAmountLeft === 0 &&
+        line.loanMonthlyPayment === 0 &&
+        line.interestRate === 0)
+  );
+}
 
 export function serializeSave(game: GameType): SaveGameType {
   return {
@@ -253,26 +298,11 @@ export function parseSave(raw: unknown): SaveGameType | null {
         transmission.tradingPolicy,
       ) ||
       !Array.isArray(transmission.lines) ||
-      transmission.lines.some(
-        (line) =>
-          typeof line !== "object" ||
-          line === null ||
-          !TRANSMISSION_CORRIDORS.some(({ id }) => id === line.corridorId) ||
-          [
-            line.id,
-            line.capacityW,
-            line.buildCost,
-            line.annualOperatingCost,
-            line.yearsToBuildLeft,
-            line.minuteCreated,
-            line.loanAmountLeft,
-            line.loanMonthlyPayment,
-            line.interestRate,
-          ].some(
-            (value) => typeof value !== "number" || !Number.isFinite(value),
-          ) ||
-          typeof line.financed !== "boolean",
-      ))
+      transmission.lines.some((line) => !validTransmissionLine(line)) ||
+      new Set(transmission.lines.map(({ id }) => id)).size !==
+        transmission.lines.length ||
+      new Set(transmission.lines.map(({ corridorId }) => corridorId)).size !==
+        transmission.lines.length)
   )
     return null;
   if (

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -12,6 +12,7 @@ import { GameType, TransmissionLineOperatingType } from "./Types";
 import {
   emptyTransmissionState,
   intertiesEnabledForScenario,
+  corridorsForLocation,
   TRANSMISSION_CORRIDORS,
 } from "./data/AdjacentMarkets";
 import { getScenario } from "./data/Scenarios";
@@ -312,6 +313,17 @@ export function parseSave(raw: unknown): SaveGameType | null {
   )
     return null;
   if (!transmissionEnabled && transmission?.lines.length) return null;
+  const locationCorridors = game.location
+    ? corridorsForLocation(game.location)
+    : [];
+  if (
+    transmissionEnabled &&
+    transmission?.lines.some(
+      ({ corridorId }) =>
+        !locationCorridors.some(({ id }) => id === corridorId),
+    )
+  )
+    return null;
   if (
     [...game.timeline, ...game.monthlyHistory].some(
       (t) =>

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -11,8 +11,10 @@ import { snackbarOpen } from "./reducers/UI";
 import { GameType, TransmissionLineOperatingType } from "./Types";
 import {
   emptyTransmissionState,
+  intertiesEnabledForScenario,
   TRANSMISSION_CORRIDORS,
 } from "./data/AdjacentMarkets";
+import { getScenario } from "./data/Scenarios";
 import type { AppStore } from "./Store";
 
 /**
@@ -290,6 +292,10 @@ export function parseSave(raw: unknown): SaveGameType | null {
   )
     return null;
   const transmission = game.transmission;
+  const scenario = getScenario(game.scenarioId, game.customScenario);
+  const transmissionEnabled = !!(
+    scenario && intertiesEnabledForScenario(scenario, game.location)
+  );
   if (
     transmission !== undefined &&
     (typeof transmission !== "object" ||
@@ -305,6 +311,7 @@ export function parseSave(raw: unknown): SaveGameType | null {
         transmission.lines.length)
   )
     return null;
+  if (!transmissionEnabled && transmission?.lines.length) return null;
   if (
     [...game.timeline, ...game.monthlyHistory].some(
       (t) =>
@@ -319,7 +326,9 @@ export function parseSave(raw: unknown): SaveGameType | null {
     policies:
       game.policies ??
       emptyPolicies(Math.floor(game.date.minute / MINUTES_PER_MONTH)),
-    transmission: game.transmission ?? emptyTransmissionState(),
+    transmission: transmissionEnabled
+      ? (game.transmission ?? emptyTransmissionState())
+      : undefined,
     timeline: game.timeline.map((t) => ({
       ...t,
       expensesPolicy: t.expensesPolicy ?? 0,

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -275,6 +275,19 @@ export interface ReplayActionType {
   payload: unknown;
 }
 
+export type MeaningfulDecisionKindType =
+  "asset" | "sale" | "rate" | "policy" | "operation" | "dispatch" | "trading";
+
+/** One accepted player decision after same-month no-ops and reversals are coalesced. */
+export interface MeaningfulDecisionType {
+  key: string;
+  lever: string;
+  month: number;
+  kind: MeaningfulDecisionKindType;
+  before: string;
+  after: string;
+}
+
 export interface ReplayType {
   version: number;
   appVersion: string; // For bug reports
@@ -900,6 +913,9 @@ export interface GameType {
   // Optional so legacy saves and scenarios without intertie access remain readable. Enabled
   // scenarios and their normalized saves carry an explicit empty state.
   transmission?: TransmissionStateType;
+  // Reducer-validated progress for the visible CEO objective. Replays rebuild it by applying the
+  // same accepted state changes; saves persist and validate it so progress survives a reload.
+  meaningfulDecisions: MeaningfulDecisionType[];
   // Every simulation-affecting thing the player has done this run, for the replay attached to a
   // high score. Undefined means the run isn't being recorded: before a game starts, while one is
   // being watched, or once a run has grown past MAX_REPLAY_ACTIONS. Persisted with the rest of the

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -23,6 +23,55 @@ export type MonthType =
 export type DifficultyType = "Intern" | "Employee" | "Manager" | "VP" | "CEO";
 export type SpeedType = "PAUSED" | "SLOW" | "NORMAL" | "FAST";
 
+/** How an intertie may trade with neighbouring electricity markets. */
+export type TradingPolicyType =
+  "BALANCED" | "RELIABILITY_FIRST" | "SURPLUS_ONLY" | "CLOSED";
+
+/** Authored facts about a neighbouring wholesale electricity market. */
+export interface AdjacentMarketDefinitionType {
+  id: string;
+  name: string;
+  description: string;
+  basePricePerMWh: number;
+  availableSupplyW: number;
+  availableDemandW: number;
+}
+
+/** A buildable physical connection to one adjacent market. */
+export interface TransmissionCorridorDefinitionType {
+  id: string;
+  adjacentMarketId: string;
+  name: string;
+  routeType: "EXISTING" | "NEW";
+  capacityW: number;
+  buildCost: number;
+  annualOperatingCost: number;
+  yearsToBuild: number;
+  heatDerateStartsC: number;
+  heatDeratePerC: number;
+  solarDerateFraction: number;
+}
+
+export interface TransmissionLineOperatingType {
+  id: number;
+  corridorId: string;
+  name: string;
+  capacityW: number;
+  buildCost: number;
+  annualOperatingCost: number;
+  yearsToBuildLeft: number;
+  minuteCreated: number;
+  financed: boolean;
+  loanAmountLeft: number;
+  loanMonthlyPayment: number;
+  interestRate: number;
+}
+
+export interface TransmissionStateType {
+  tradingPolicy: TradingPolicyType;
+  lines: TransmissionLineOperatingType[];
+}
+
 // Deliberately open rather than a union of the places that happen to ship today: a custom game
 // may hold a location that isn't in LOCATIONS at all, so nothing is allowed to key off the
 // closed set. Resolve one through getLocation / getScenarioLocation rather than indexing
@@ -213,6 +262,8 @@ export type ReplayActionNameType =
   | "sellFacility"
   | "togglePauseFacility"
   | "reprioritizeFacility"
+  | "buildTransmissionLine"
+  | "setTradingPolicy"
   | "delta";
 
 export interface ReplayActionType {
@@ -312,6 +363,11 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     // The exponentially smoothed bill customers respond to, rather than the slider's latest value
     customerRate: number;
     supplyByFuel: FuelProductionType;
+    /** Positive gross flow into/out of the player's grid during this tick. */
+    importedW?: number;
+    exportedW?: number;
+    transmissionCapacityW?: number;
+    marketPricePerMWh?: number;
     renewableCapacityFactors?: Record<string, number>;
   };
 
@@ -353,6 +409,8 @@ export interface MonthlyHistoryType extends HistoryForecastShared {
 
 interface HistoryForecastShared {
   expensesPolicy?: number; // Monthly funded upgrades; absent in legacy histories.
+  revenueExports?: number;
+  expensesImports?: number;
   cash: number;
   customers: number;
   netWorth: number;
@@ -837,6 +895,9 @@ export interface GameType {
   // effects disabled. Undefined means enabled and is what every browser save/replay uses.
   storyEffectsDisabled?: boolean;
   facilities: Array<StorageOperatingType | GeneratorOperatingType>;
+  // Optional only at the type boundary so legacy fixtures/saves remain readable. New games and
+  // normalized saves always carry an explicit empty state.
+  transmission?: TransmissionStateType;
   // Every simulation-affecting thing the player has done this run, for the replay attached to a
   // high score. Undefined means the run isn't being recorded: before a game starts, while one is
   // being watched, or once a run has grown past MAX_REPLAY_ACTIONS. Persisted with the rest of the

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -662,6 +662,8 @@ export interface ScenarioType {
   recommendationOrder?: number;
   ownership: "Investor" | "Public";
   tutorialSteps?: TutorialStepType[];
+  /** Explicit scenario override. Tutorials default off; ordinary games use location availability. */
+  intertiesEnabled?: boolean;
   // Pins the run's RNG so it plays out identically every time. Every authored scenario leaves
   // this off and draws a fresh seed each play; only the custom game screen sets it
   seed?: number;
@@ -895,8 +897,8 @@ export interface GameType {
   // effects disabled. Undefined means enabled and is what every browser save/replay uses.
   storyEffectsDisabled?: boolean;
   facilities: Array<StorageOperatingType | GeneratorOperatingType>;
-  // Optional only at the type boundary so legacy fixtures/saves remain readable. New games and
-  // normalized saves always carry an explicit empty state.
+  // Optional so legacy saves and scenarios without intertie access remain readable. Enabled
+  // scenarios and their normalized saves carry an explicit empty state.
   transmission?: TransmissionStateType;
   // Every simulation-affecting thing the player has done this run, for the replay attached to a
   // high score. Undefined means the run isn't being recorded: before a game starts, while one is

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -278,10 +278,11 @@ export interface ReplayActionType {
 export type MeaningfulDecisionKindType =
   "asset" | "sale" | "rate" | "policy" | "operation" | "dispatch" | "trading";
 
-/** One accepted player decision after same-month no-ops and reversals are coalesced. */
+/** One accepted player decision after lifetime no-ops and reversals are coalesced. */
 export interface MeaningfulDecisionType {
   key: string;
   lever: string;
+  label: string;
   month: number;
   kind: MeaningfulDecisionKindType;
   before: string;
@@ -299,6 +300,7 @@ export interface ReplayType {
   // without it a replay would silently be re-simulated against a different city's weather
   location: LocationType;
   actions: ReplayActionType[];
+  meaningfulDecisionGateWaived?: boolean;
 }
 
 /**
@@ -916,6 +918,9 @@ export interface GameType {
   // Reducer-validated progress for the visible CEO objective. Replays rebuild it by applying the
   // same accepted state changes; saves persist and validate it so progress survives a reload.
   meaningfulDecisions: MeaningfulDecisionType[];
+  // Older in-progress saves/replays predate decision tracking. They keep their original victory
+  // rules rather than becoming impossible to finish after an upgrade.
+  meaningfulDecisionGateWaived?: boolean;
   // Every simulation-affecting thing the player has done this run, for the replay attached to a
   // high score. Undefined means the run isn't being recorded: before a game starts, while one is
   // being watched, or once a run has grown past MAX_REPLAY_ACTIONS. Persisted with the rest of the

--- a/src/app.scss
+++ b/src/app.scss
@@ -821,6 +821,132 @@ $pane_header_height: 40px;
   }
 }
 
+.facilityTabs {
+  min-height: 40px !important;
+  border-bottom: 1px solid var(--border-subtle);
+
+  .MuiTab-root {
+    min-height: 40px;
+    padding: 8px 12px;
+  }
+}
+
+.transmissionPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  background: var(--bg-sunken);
+}
+
+.transmissionIntro,
+.powerExchangeHero {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  img {
+    width: 48px;
+    height: 48px;
+    flex: 0 0 48px;
+  }
+}
+
+.tradingPolicy,
+.transmissionProject,
+.transmissionLine,
+.powerExchangeSummary {
+  background: var(--bg-primary);
+}
+
+.transmissionPanel section > h6,
+.transmissionPanel section > .MuiTypography-subtitle2 {
+  margin-bottom: 8px;
+}
+
+.transmissionProjects {
+  display: grid;
+  gap: 12px;
+}
+
+.transmissionProject {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--border-tile);
+  border-radius: 8px;
+}
+
+.transmissionProjectHeading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.transmissionMetrics,
+.powerExchangeMetrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+
+  div {
+    min-width: 0;
+  }
+
+  dt {
+    color: $font_color_faded;
+    font-size: 0.75rem;
+  }
+
+  dd {
+    margin: 2px 0 0;
+    font-weight: 600;
+  }
+}
+
+.transmissionListIcon {
+  display: block;
+  width: 40px;
+  height: 40px;
+}
+
+.transmissionEmpty {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px;
+  text-align: center;
+
+  img {
+    width: 64px;
+    height: 64px;
+  }
+}
+
+.powerExchangeSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 16px 16px;
+}
+
+@media screen and (max-width: 359px) {
+  .transmissionPanel {
+    padding: 12px;
+  }
+
+  .transmissionMetrics,
+  .powerExchangeMetrics {
+    grid-template-columns: 1fr;
+  }
+}
+
 // Keep the compact pane-header height on phones while preventing the global coarse-pointer
 // target size from making these two labeled controls spill into the chart below.
 @media (pointer: coarse) {

--- a/src/app.scss
+++ b/src/app.scss
@@ -938,10 +938,36 @@ $pane_header_height: 40px;
 
 @media screen and (max-width: 359px) {
   .transmissionPanel {
+    gap: 8px;
     padding: 12px;
   }
 
-  .transmissionMetrics,
+  .transmissionIntro {
+    img {
+      width: 40px;
+      height: 40px;
+      flex-basis: 40px;
+    }
+
+    h6 {
+      font-size: 1.125rem;
+      line-height: 1.35;
+    }
+  }
+
+  .transmissionProject {
+    gap: 8px;
+    padding: 8px;
+
+    // On the shortest supported phone, the intro teaches the decision and the market card keeps
+    // the identifying facts. Omitting this secondary flavor copy leaves the build decision and
+    // its financing above the persistent navigation instead of making the player hunt for it.
+    > .MuiTypography-body2,
+    .transmissionProjectHeading .MuiTypography-caption {
+      display: none;
+    }
+  }
+
   .powerExchangeMetrics {
     grid-template-columns: 1fr;
   }

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -229,9 +229,18 @@ function targetsOf(steps: TutorialStepType[]): string[] {
 
 /** Whether anything in the app still declares the id or class a simple selector names */
 function declares(simple: string): boolean {
+  if (simple.startsWith("[")) {
+    const attribute = simple.match(/^\[([\w-]+)/)?.[1];
+    return !!attribute && SOURCE.includes(`${attribute}=`);
+  }
   const name = simple.slice(1);
   if (simple.startsWith("#")) {
-    return SOURCE.includes(`id="${name}"`);
+    return (
+      SOURCE.includes(`id="${name}"`) ||
+      Array.from(SOURCE.matchAll(/id=\{`([^$`]*)\$\{/g)).some(([, prefix]) =>
+        name.startsWith(prefix),
+      )
+    );
   }
   // MUI generates its own class names, so there is nothing of ours to find. Those steps lean
   // on the card check above instead
@@ -340,7 +349,7 @@ describe("walkthrough steps", () => {
     tutorials.forEach((scenario) => {
       const steps = scenario.tutorialSteps as TutorialStepType[];
       targetsOf(steps).forEach((target) => {
-        target.split(/\s+/).forEach((simple) => {
+        (target.match(/\[[^\]]+\]|[^\s]+/g) || []).forEach((simple) => {
           expect([scenario.name, target, declares(simple)]).toEqual([
             scenario.name,
             target,

--- a/src/components/base/PowerExchangeSummary.tsx
+++ b/src/components/base/PowerExchangeSummary.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { Typography } from "@mui/material";
+import { GameType, TickPresentFutureType } from "../../Types";
+import { formatMoneyConcise, formatWatts } from "../../helpers/Format";
+
+export default function PowerExchangeSummary({
+  game,
+  now,
+}: {
+  game: GameType;
+  now: TickPresentFutureType;
+}) {
+  const flow = (now.importedW || 0) - (now.exportedW || 0);
+  const direction =
+    flow > 0 ? "Importing" : flow < 0 ? "Exporting" : "Standing by";
+  const available = now.transmissionCapacityW || 0;
+  const nameplate = (game.transmission?.lines || [])
+    .filter(({ yearsToBuildLeft }) => yearsToBuildLeft <= 0)
+    .reduce((sum, line) => sum + line.capacityW, 0);
+  const weatherLimited = available + 1 < nameplate;
+
+  return (
+    <div className="powerExchangeSummary">
+      <div className="powerExchangeHero">
+        <img src="/images/transmission-option-2.svg" alt="" />
+        <div>
+          <Typography variant="h6">{direction}</Typography>
+          <Typography color="textSecondary" variant="body2">
+            Power automatically follows your trading rule. Imports fill a
+            shortage; exports use only energy above demand and your reserve.
+          </Typography>
+        </div>
+      </div>
+      <dl className="powerExchangeMetrics">
+        <div>
+          <dt>Power flowing</dt>
+          <dd>{formatWatts(Math.abs(flow))}</dd>
+        </div>
+        <div>
+          <dt>Available capacity</dt>
+          <dd>{formatWatts(available)}</dd>
+        </div>
+        <div>
+          <dt>Neighbor price</dt>
+          <dd>{formatMoneyConcise(now.marketPricePerMWh || 0)}/MWh</dd>
+        </div>
+      </dl>
+      <Typography
+        className={weatherLimited ? "transmissionWeatherWarning" : undefined}
+        variant="body2"
+        color={weatherLimited ? "warning.main" : "textSecondary"}
+      >
+        {weatherLimited
+          ? `Hot, sunny weather has reduced the lines from ${formatWatts(nameplate)} nameplate capacity.`
+          : "Cooler, cloudier weather lets the lines carry their full rating."}
+      </Typography>
+    </div>
+  );
+}

--- a/src/components/base/PowerExchangeSummary.tsx
+++ b/src/components/base/PowerExchangeSummary.tsx
@@ -22,7 +22,7 @@ export default function PowerExchangeSummary({
   return (
     <div className="powerExchangeSummary">
       <div className="powerExchangeHero">
-        <img src="/images/transmission-option-2.svg" alt="" />
+        <img src="/images/transmission.svg" alt="" />
         <div>
           <Typography variant="h6">{direction}</Typography>
           <Typography color="textSecondary" variant="body2">

--- a/src/components/base/ScenarioDetailsDialog.tsx
+++ b/src/components/base/ScenarioDetailsDialog.tsx
@@ -187,6 +187,8 @@ export default function ScenarioDetailsDialog(props: Props): React.JSX.Element {
                 startingCustomers={scenario.startingCustomers}
                 minimumCustomerRetention={scenario.minimumCustomerRetention}
                 reliabilityObjective={scenario.reliabilityObjective}
+                difficulty={game.difficulty}
+                meaningfulDecisionCount={game.meaningfulDecisions.length}
               />
             </Box>
           </Box>

--- a/src/components/base/ScenarioDetailsDialog.tsx
+++ b/src/components/base/ScenarioDetailsDialog.tsx
@@ -188,7 +188,8 @@ export default function ScenarioDetailsDialog(props: Props): React.JSX.Element {
                 minimumCustomerRetention={scenario.minimumCustomerRetention}
                 reliabilityObjective={scenario.reliabilityObjective}
                 difficulty={game.difficulty}
-                meaningfulDecisionCount={game.meaningfulDecisions.length}
+                meaningfulDecisions={game.meaningfulDecisions}
+                meaningfulDecisionGateWaived={game.meaningfulDecisionGateWaived}
               />
             </Box>
           </Box>

--- a/src/components/base/VictoryConditions.test.tsx
+++ b/src/components/base/VictoryConditions.test.tsx
@@ -1,6 +1,46 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import VictoryConditions from "./VictoryConditions";
+import { MeaningfulDecisionType } from "../../Types";
+
+const decisions: MeaningfulDecisionType[] = [
+  {
+    key: "rate",
+    lever: "rate",
+    label: "Set the customer electricity rate",
+    month: 0,
+    kind: "rate",
+    before: "0.1",
+    after: "0.11",
+  },
+  {
+    key: "policy:solar",
+    lever: "policy:solar",
+    label: "Fund rooftop solar rebates",
+    month: 1,
+    kind: "policy",
+    before: "Off",
+    after: "Small",
+  },
+  {
+    key: "dispatch:1",
+    lever: "dispatch:1",
+    label: "Set Coal dispatch priority",
+    month: 2,
+    kind: "dispatch",
+    before: "0",
+    after: "1",
+  },
+  {
+    key: "asset-build:3",
+    lever: "asset-build:3",
+    label: "Build Natural Gas (100MW)",
+    month: 3,
+    kind: "asset",
+    before: "absent",
+    after: "Natural Gas:100000000:financed",
+  },
+];
 
 it("shows the absolute data-center customer threshold beside retention", () => {
   render(
@@ -22,11 +62,14 @@ it("makes the CEO meaningful-decision gate visible with live progress", () => {
       ownership="Public"
       dollarsPerkWh={0.1}
       difficulty="CEO"
-      meaningfulDecisionCount={4}
+      meaningfulDecisions={decisions}
     />,
   );
-  expect(screen.getByTestId("ceo-decision-progress")).toHaveTextContent(
-    "Progress: 4 of 10",
+  expect(screen.getByTestId("meaningful-decision-progress")).toHaveTextContent(
+    "Progress: 4 of 10 choices · 4 of 4 types",
+  );
+  expect(screen.getByTestId("meaningful-decision-history")).toHaveTextContent(
+    "Build Natural Gas (100MW) — grid investments",
   );
 });
 
@@ -36,8 +79,35 @@ it("does not add the CEO gate to lower difficulties", () => {
       ownership="Public"
       dollarsPerkWh={0.1}
       difficulty="VP"
-      meaningfulDecisionCount={9}
+      meaningfulDecisions={decisions}
     />,
   );
-  expect(screen.queryByTestId("ceo-decision-progress")).not.toBeInTheDocument();
+  expect(
+    screen.queryByTestId("meaningful-decision-progress"),
+  ).not.toBeInTheDocument();
+});
+
+it("shows the one-decision Intern objective and legacy waiver", () => {
+  const { rerender } = render(
+    <VictoryConditions
+      ownership="Public"
+      dollarsPerkWh={0.1}
+      difficulty="Intern"
+      meaningfulDecisions={[]}
+    />,
+  );
+  expect(screen.getByTestId("meaningful-decision-progress")).toHaveTextContent(
+    "Progress: 0 of 1",
+  );
+
+  rerender(
+    <VictoryConditions
+      ownership="Public"
+      dollarsPerkWh={0.1}
+      difficulty="Intern"
+      meaningfulDecisions={[]}
+      meaningfulDecisionGateWaived
+    />,
+  );
+  expect(screen.getByText(/original victory rules still apply/i)).toBeVisible();
 });

--- a/src/components/base/VictoryConditions.test.tsx
+++ b/src/components/base/VictoryConditions.test.tsx
@@ -15,3 +15,29 @@ it("shows the absolute data-center customer threshold beside retention", () => {
     "90% of starting customers (at least 14,850 customers, from 16,500 at the start)",
   );
 });
+
+it("makes the CEO meaningful-decision gate visible with live progress", () => {
+  render(
+    <VictoryConditions
+      ownership="Public"
+      dollarsPerkWh={0.1}
+      difficulty="CEO"
+      meaningfulDecisionCount={4}
+    />,
+  );
+  expect(screen.getByTestId("ceo-decision-progress")).toHaveTextContent(
+    "Progress: 4 of 10",
+  );
+});
+
+it("does not add the CEO gate to lower difficulties", () => {
+  render(
+    <VictoryConditions
+      ownership="Public"
+      dollarsPerkWh={0.1}
+      difficulty="VP"
+      meaningfulDecisionCount={9}
+    />,
+  );
+  expect(screen.queryByTestId("ceo-decision-progress")).not.toBeInTheDocument();
+});

--- a/src/components/base/VictoryConditions.tsx
+++ b/src/components/base/VictoryConditions.tsx
@@ -1,8 +1,16 @@
 import * as React from "react";
-import { DifficultyType, ScenarioType } from "../../Types";
+import {
+  DifficultyType,
+  MeaningfulDecisionType,
+  ScenarioType,
+} from "../../Types";
 import { formatLargeMassApprox, KG_PER_MEGATONNE } from "../../helpers/Units";
 import { useUnits } from "./UnitsContext";
-import { CEO_MEANINGFUL_DECISIONS_REQUIRED } from "../../helpers/MeaningfulDecisions";
+import {
+  meaningfulDecisionCategoryCount,
+  meaningfulDecisionRequirement,
+  MEANINGFUL_DECISION_CATEGORY_LABELS,
+} from "../../helpers/MeaningfulDecisions";
 
 export interface Props {
   ownership: ScenarioType["ownership"];
@@ -11,7 +19,8 @@ export interface Props {
   minimumCustomerRetention?: number;
   reliabilityObjective?: ScenarioType["reliabilityObjective"];
   difficulty?: DifficultyType;
-  meaningfulDecisionCount?: number;
+  meaningfulDecisions?: MeaningfulDecisionType[];
+  meaningfulDecisionGateWaived?: boolean;
 }
 
 /**
@@ -29,19 +38,50 @@ export default function VictoryConditions(props: Props): React.JSX.Element {
   } = props;
   const units = useUnits();
   const perEmissions = formatLargeMassApprox(KG_PER_MEGATONNE, units);
-  const ceoProgress =
-    props.difficulty === "CEO" ? (
-      <p data-testid="ceo-decision-progress">
-        Required: make {CEO_MEANINGFUL_DECISIONS_REQUIRED} meaningful decisions
-        that change the grid or its economics. Progress:{" "}
-        {props.meaningfulDecisionCount ?? 0} of{" "}
-        {CEO_MEANINGFUL_DECISIONS_REQUIRED}.
-      </p>
-    ) : null;
+  const decisions = props.meaningfulDecisions ?? [];
+  const requirement = props.difficulty
+    ? meaningfulDecisionRequirement(props.difficulty)
+    : null;
+  const decisionProgress = requirement ? (
+    <div data-testid="meaningful-decision-progress">
+      {props.meaningfulDecisionGateWaived ? (
+        <p>
+          This game began before decision tracking was added, so its original
+          victory rules still apply.
+        </p>
+      ) : (
+        <>
+          <p>
+            Required: make {requirement.count} meaningful decision
+            {requirement.count === 1 ? "" : "s"} that change the grid or its
+            economics
+            {requirement.categories > 1
+              ? ` across at least ${requirement.categories} decision types`
+              : ""}
+            . Progress: {decisions.length} of {requirement.count}
+            {requirement.categories > 1
+              ? ` choices · ${meaningfulDecisionCategoryCount(decisions)} of ${requirement.categories} types`
+              : ""}
+            .
+          </p>
+          {decisions.length > 0 && (
+            <ul data-testid="meaningful-decision-history">
+              {decisions.map((decision) => (
+                <li key={decision.key}>
+                  {decision.label} —{" "}
+                  {MEANINGFUL_DECISION_CATEGORY_LABELS[decision.kind]}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  ) : null;
   if (ownership === "Investor") {
     return (
       <div>
-        {ceoProgress}
+        {decisionProgress}
         <p>Earn 40 points per $1 billion of net worth at the end.</p>
         <p>Earn 2 points per 100,000 customers at the end.</p>
         <p>Earn 1 point per terawatt-hour (TWh) of electricity supplied.</p>
@@ -52,7 +92,7 @@ export default function VictoryConditions(props: Props): React.JSX.Element {
   }
   return (
     <div>
-      {ceoProgress}
+      {decisionProgress}
       {reliabilityObjective !== undefined && (
         <p>
           Required: serve at least{" "}

--- a/src/components/base/VictoryConditions.tsx
+++ b/src/components/base/VictoryConditions.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { ScenarioType } from "../../Types";
+import { DifficultyType, ScenarioType } from "../../Types";
 import { formatLargeMassApprox, KG_PER_MEGATONNE } from "../../helpers/Units";
 import { useUnits } from "./UnitsContext";
+import { CEO_MEANINGFUL_DECISIONS_REQUIRED } from "../../helpers/MeaningfulDecisions";
 
 export interface Props {
   ownership: ScenarioType["ownership"];
@@ -9,6 +10,8 @@ export interface Props {
   startingCustomers?: number;
   minimumCustomerRetention?: number;
   reliabilityObjective?: ScenarioType["reliabilityObjective"];
+  difficulty?: DifficultyType;
+  meaningfulDecisionCount?: number;
 }
 
 /**
@@ -26,9 +29,19 @@ export default function VictoryConditions(props: Props): React.JSX.Element {
   } = props;
   const units = useUnits();
   const perEmissions = formatLargeMassApprox(KG_PER_MEGATONNE, units);
+  const ceoProgress =
+    props.difficulty === "CEO" ? (
+      <p data-testid="ceo-decision-progress">
+        Required: make {CEO_MEANINGFUL_DECISIONS_REQUIRED} meaningful decisions
+        that change the grid or its economics. Progress:{" "}
+        {props.meaningfulDecisionCount ?? 0} of{" "}
+        {CEO_MEANINGFUL_DECISIONS_REQUIRED}.
+      </p>
+    ) : null;
   if (ownership === "Investor") {
     return (
       <div>
+        {ceoProgress}
         <p>Earn 40 points per $1 billion of net worth at the end.</p>
         <p>Earn 2 points per 100,000 customers at the end.</p>
         <p>Earn 1 point per terawatt-hour (TWh) of electricity supplied.</p>
@@ -39,6 +52,7 @@ export default function VictoryConditions(props: Props): React.JSX.Element {
   }
   return (
     <div>
+      {ceoProgress}
       {reliabilityObjective !== undefined && (
         <p>
           Required: serve at least{" "}

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -972,7 +972,8 @@ export default function CustomGame(props: Props): React.JSX.Element {
             minimumCustomerRetention={scenario.minimumCustomerRetention}
             reliabilityObjective={scenario.reliabilityObjective}
             difficulty={game.difficulty}
-            meaningfulDecisionCount={game.meaningfulDecisions.length}
+            meaningfulDecisions={game.meaningfulDecisions}
+            meaningfulDecisionGateWaived={game.meaningfulDecisionGateWaived}
           />
         </DialogContent>
         <DialogActions>

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -971,6 +971,8 @@ export default function CustomGame(props: Props): React.JSX.Element {
             startingCustomers={scenario.startingCustomers}
             minimumCustomerRetention={scenario.minimumCustomerRetention}
             reliabilityObjective={scenario.reliabilityObjective}
+            difficulty={game.difficulty}
+            meaningfulDecisionCount={game.meaningfulDecisions.length}
           />
         </DialogContent>
         <DialogActions>

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -55,6 +55,8 @@ function renderFacilities(
       selectedFacilityId={selectedFacilityId}
       onGeneratorBuild={() => undefined}
       onStorageBuild={() => undefined}
+      onTransmissionBuild={() => undefined}
+      onTradingPolicy={() => undefined}
       onSell={handlers.onSell}
       onTogglePause={() => undefined}
       onPause={handlers.onPause}
@@ -272,6 +274,8 @@ describe("the fleet list", () => {
       selectedFacilityId: null,
       onGeneratorBuild: () => undefined,
       onStorageBuild: () => undefined,
+      onTransmissionBuild: () => undefined,
+      onTradingPolicy: () => undefined,
       onSell: () => undefined,
       onTogglePause: () => undefined,
       onPause: () => undefined,
@@ -338,5 +342,18 @@ describe("the fleet list", () => {
         screen.queryByLabelText(`Move ${f.name} earlier in the dispatch order`),
       ).toBeNull();
     });
+  });
+});
+
+describe("the interties view", () => {
+  it("explains and offers California connection projects", async () => {
+    const game = playedGame(0);
+    renderFacilities(game, null);
+    await user.click(screen.getByRole("tab", { name: "Interties" }));
+    expect(
+      screen.getByText("Share power with nearby grids"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Pacific Northwest")).toBeInTheDocument();
+    expect(screen.getByLabelText("Trading rule")).toBeInTheDocument();
   });
 });

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -387,10 +387,23 @@ describe("the interties view", () => {
   });
 
   it("does not render an empty interties destination where no corridor exists", () => {
-    renderFacilities(createGame({ scenarioId: 103 }), null);
+    const game = createGame({ scenarioId: 103 });
+    game.location = { ...game.location, id: "HNL", name: "Honolulu, HI" };
+    renderFacilities(game, null);
 
     expect(screen.queryByRole("tablist")).toBeNull();
     expect(screen.queryByText(/Interties are coming/)).toBeNull();
+  });
+
+  it("shows researched local market names outside California", async () => {
+    const game = createGame({ scenarioId: 103 });
+    game.location = { ...game.location, id: "Dublin", name: "Dublin" };
+    renderFacilities(game, null);
+
+    await user.click(screen.getByRole("tab", { name: "Interties" }));
+
+    expect(screen.getByText("Great Britain")).toBeInTheDocument();
+    expect(screen.getByText("Continental Europe")).toBeInTheDocument();
   });
 
   it("gives the guided northern approval a stable target and specific name", async () => {
@@ -401,10 +414,9 @@ describe("the interties view", () => {
       name: "Approve Pacific Northwest intertie",
     });
     expect(approval).toHaveAttribute("id", "approve-intertie-california-north");
-    expect(approval.closest("article")).toHaveAttribute(
-      "data-corridor-id",
-      "california-north",
-    );
+    expect(
+      screen.getByTestId("transmission-project-california-north"),
+    ).toHaveAttribute("data-corridor-id", "california-north");
     expect(screen.queryByText("Desert Southwest")).toBeNull();
   });
 });

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Facilities from "./Facilities";
 import { tickState } from "../../reducers/Game";
@@ -356,11 +356,55 @@ describe("the interties view", () => {
     expect(screen.getByText("Pacific Northwest")).toBeInTheDocument();
     expect(screen.queryByLabelText("Trading rule")).toBeNull();
     expect(
-      screen.getAllByRole("button", { name: "Approve intertie" }),
+      screen.getAllByRole("button", { name: /Approve .* intertie/ }),
     ).not.toHaveLength(0);
     expect(screen.getAllByText("Total cost")).toHaveLength(2);
     expect(
       screen.getByText(/Pay \$36M now · finance \$144M/),
     ).toBeInTheDocument();
+  });
+
+  it("keeps every earlier tutorial focused on plants", () => {
+    for (const scenarioId of [0, 1, 2, 4, 3, 5]) {
+      renderFacilities(createGame({ scenarioId }), null);
+      expect(screen.queryByRole("tablist")).toBeNull();
+      expect(screen.queryByText("Interties")).toBeNull();
+      cleanup();
+    }
+  });
+
+  it("gives Mission 7 stable Plants and Interties tabs", () => {
+    renderFacilities(createGame({ scenarioId: 112 }), null);
+
+    expect(screen.getByRole("tab", { name: "Plants" })).toHaveAttribute(
+      "id",
+      "plantsTab",
+    );
+    expect(screen.getByRole("tab", { name: "Interties" })).toHaveAttribute(
+      "id",
+      "intertiesTab",
+    );
+  });
+
+  it("does not render an empty interties destination where no corridor exists", () => {
+    renderFacilities(createGame({ scenarioId: 103 }), null);
+
+    expect(screen.queryByRole("tablist")).toBeNull();
+    expect(screen.queryByText(/Interties are coming/)).toBeNull();
+  });
+
+  it("gives the guided northern approval a stable target and specific name", async () => {
+    renderFacilities(createGame({ scenarioId: 112 }), null);
+    await user.click(screen.getByRole("tab", { name: "Interties" }));
+
+    const approval = screen.getByRole("button", {
+      name: "Approve Pacific Northwest intertie",
+    });
+    expect(approval).toHaveAttribute("id", "approve-intertie-california-north");
+    expect(approval.closest("article")).toHaveAttribute(
+      "data-corridor-id",
+      "california-north",
+    );
+    expect(screen.queryByText("Desert Southwest")).toBeNull();
   });
 });

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -354,6 +354,13 @@ describe("the interties view", () => {
       screen.getByText("Share power with nearby grids"),
     ).toBeInTheDocument();
     expect(screen.getByText("Pacific Northwest")).toBeInTheDocument();
-    expect(screen.getByLabelText("Trading rule")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Trading rule")).toBeNull();
+    expect(
+      screen.getAllByRole("button", { name: "Approve intertie" }),
+    ).not.toHaveLength(0);
+    expect(screen.getAllByText("Total cost")).toHaveLength(2);
+    expect(
+      screen.getByText(/Pay \$36M now · finance \$144M/),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -57,6 +57,7 @@ import ConceptIcon from "../base/ConceptIcon";
 import { combineStoryEffects } from "../../data/WorldEvents";
 import TransmissionPanel from "./TransmissionPanel";
 import { TradingPolicyType } from "../../Types";
+import { corridorsForLocation } from "../../data/AdjacentMarkets";
 
 interface FacilityListItemProps {
   facility: FacilityOperatingType;
@@ -338,6 +339,7 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
           {...provided.draggableProps}
           {...provided.dragHandleProps}
           className={selected ? "facilityRow selected" : "facilityRow"}
+          data-fuel={fuel}
           role={provided.dragHandleProps ? undefined : "button"}
           tabIndex={provided.dragHandleProps ? undefined : 0}
           aria-expanded={selected}
@@ -565,8 +567,19 @@ export default class Facilities extends React.Component<
     return this.throttle.due(nextProps.game.date.minute, 4);
   }
 
-  public componentDidUpdate() {
+  public componentDidUpdate(previousProps: Props) {
     this.throttle.rendered(this.props.game.date.minute);
+    if (
+      this.props.game.scenarioId === 112 &&
+      this.props.game.tutorialStep !== previousProps.game.tutorialStep &&
+      [1, 6].includes(this.props.game.tutorialStep) &&
+      this.state.view !== "INTERTIES"
+    ) {
+      // If Next was tapped before opening the first tab, reveal the gated approval instead of
+      // stranding it off-screen. The same transition brings the live flow label into view after
+      // Natural Gas is paused, so "Importing" is something the learner can actually observe.
+      this.setState({ view: "INTERTIES" });
+    }
   }
 
   public onBeforeDragStart() {
@@ -600,6 +613,10 @@ export default class Facilities extends React.Component<
     } = this.props;
     const facilitiesCount = game.facilities.length;
     const readOnly = !!game.replayPlayback;
+    const intertiesAvailable = !!(
+      game.transmission && corridorsForLocation(game.location).length
+    );
+    const activeView = intertiesAvailable ? this.state.view : "PLANTS";
     const storyEffects = combineStoryEffects(
       game.worldEvents.active.filter(
         (event) =>
@@ -610,108 +627,114 @@ export default class Facilities extends React.Component<
 
     return (
       <GameCard className="facilities" id="facilitiesPane">
-        {/* The pane's own header rather than a row inside the list, so it lines up with the
+        <>
+          {/* The pane's own header rather than a row inside the list, so it lines up with the
             other panes' headers and the build buttons stay put as the fleet scrolls */}
-        <Toolbar className="paneHeader">
-          <Typography variant="h6">Facilities</Typography>
-          {!readOnly && this.state.view === "PLANTS" && (
-            <>
-              <Button
-                size="small"
-                variant="outlined"
-                color="primary"
-                onClick={onGeneratorBuild}
-                className="button-buildGenerator"
-                startIcon={<ConceptIcon concept="generator" fontSize="small" />}
-              >
-                Generator
-              </Button>
-              <Button
-                size="small"
-                variant="outlined"
-                color="primary"
-                onClick={onStorageBuild}
-                className="button-buildStorage"
-                startIcon={<ConceptIcon concept="storage" fontSize="small" />}
-              >
-                Storage
-              </Button>
-            </>
-          )}
-        </Toolbar>
-        <Tabs
-          value={this.state.view}
-          onChange={(_event, view) => this.setState({ view })}
-          aria-label="Facility type"
-          className="facilityTabs"
-          variant="fullWidth"
-        >
-          <Tab value="PLANTS" label="Plants" />
-          <Tab value="INTERTIES" label="Interties" />
-        </Tabs>
-        {this.state.view === "PLANTS" ? (
-          <>
-            <ChartSupplyDemand
-              height={180}
-              timeline={game.timeline}
-              currentMinute={game.date.minute}
-              location={game.location}
-              legend={game.speed === "PAUSED"}
-              startingYear={game.startingYear}
-            />
-            <List dense className="scrollable">
-              <DragDropContext
-                onBeforeDragStart={this.onBeforeDragStart}
-                onDragEnd={this.onDragEnd}
-              >
-                <Droppable droppableId="droppable">
-                  {(provided) => (
-                    <div {...provided.droppableProps} ref={provided.innerRef}>
-                      {game.facilities.map(
-                        (g: FacilityOperatingType, i: number) => (
-                          <FacilityListItem
-                            facility={g}
-                            game={game}
-                            key={g.id}
-                            onSell={onSell}
-                            onTogglePause={onTogglePause}
-                            onPause={onPause}
-                            onReprioritize={onReprioritize}
-                            onSelect={onSelect}
-                            selected={selectedFacilityId === g.id}
-                            storyOutputMultiplier={storyOutputMultiplierForFacility(
-                              g,
-                              storyEffects,
-                            )}
-                            spotInList={i}
-                            listLength={facilitiesCount}
-                            readOnly={readOnly}
-                          />
-                        ),
-                      )}
-                      {provided.placeholder}
-                    </div>
-                  )}
-                </Droppable>
-              </DragDropContext>
-              {facilitiesCount < 2 && !readOnly && (
-                <Typography
-                  color="textSecondary"
-                  variant="body2"
-                  style={{ textAlign: "center", marginTop: "12px" }}
+          <Toolbar className="paneHeader">
+            <Typography variant="h6">Facilities</Typography>
+            {!readOnly && activeView === "PLANTS" && (
+              <>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="primary"
+                  onClick={onGeneratorBuild}
+                  className="button-buildGenerator"
+                  startIcon={
+                    <ConceptIcon concept="generator" fontSize="small" />
+                  }
                 >
-                  (click "Generator" or "Storage" to build more)
-                </Typography>
-              )}
-            </List>
-          </>
-        ) : (
-          <TransmissionPanel
-            game={game}
-            onBuild={onTransmissionBuild}
-            onPolicy={onTradingPolicy}
-          />
-        )}
+                  Generator
+                </Button>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="primary"
+                  onClick={onStorageBuild}
+                  className="button-buildStorage"
+                  startIcon={<ConceptIcon concept="storage" fontSize="small" />}
+                >
+                  Storage
+                </Button>
+              </>
+            )}
+          </Toolbar>
+          {intertiesAvailable && (
+            <Tabs
+              value={activeView}
+              onChange={(_event, view) => this.setState({ view })}
+              aria-label="Facility type"
+              className="facilityTabs"
+              variant="fullWidth"
+            >
+              <Tab id="plantsTab" value="PLANTS" label="Plants" />
+              <Tab id="intertiesTab" value="INTERTIES" label="Interties" />
+            </Tabs>
+          )}
+          {activeView === "PLANTS" ? (
+            <>
+              <ChartSupplyDemand
+                height={180}
+                timeline={game.timeline}
+                currentMinute={game.date.minute}
+                location={game.location}
+                legend={game.speed === "PAUSED"}
+                startingYear={game.startingYear}
+              />
+              <List dense className="scrollable">
+                <DragDropContext
+                  onBeforeDragStart={this.onBeforeDragStart}
+                  onDragEnd={this.onDragEnd}
+                >
+                  <Droppable droppableId="droppable">
+                    {(provided) => (
+                      <div {...provided.droppableProps} ref={provided.innerRef}>
+                        {game.facilities.map(
+                          (g: FacilityOperatingType, i: number) => (
+                            <FacilityListItem
+                              facility={g}
+                              game={game}
+                              key={g.id}
+                              onSell={onSell}
+                              onTogglePause={onTogglePause}
+                              onPause={onPause}
+                              onReprioritize={onReprioritize}
+                              onSelect={onSelect}
+                              selected={selectedFacilityId === g.id}
+                              storyOutputMultiplier={storyOutputMultiplierForFacility(
+                                g,
+                                storyEffects,
+                              )}
+                              spotInList={i}
+                              listLength={facilitiesCount}
+                              readOnly={readOnly}
+                            />
+                          ),
+                        )}
+                        {provided.placeholder}
+                      </div>
+                    )}
+                  </Droppable>
+                </DragDropContext>
+                {facilitiesCount < 2 && !readOnly && (
+                  <Typography
+                    color="textSecondary"
+                    variant="body2"
+                    style={{ textAlign: "center", marginTop: "12px" }}
+                  >
+                    (click "Generator" or "Storage" to build more)
+                  </Typography>
+                )}
+              </List>
+            </>
+          ) : (
+            <TransmissionPanel
+              game={game}
+              onBuild={onTransmissionBuild}
+              onPolicy={onTradingPolicy}
+            />
+          )}
+        </>
       </GameCard>
     );
   }

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -14,6 +14,8 @@ import {
   ListItemAvatar,
   ListItemText,
   Toolbar,
+  Tab,
+  Tabs,
   Typography,
 } from "@mui/material";
 import CancelIcon from "@mui/icons-material/Cancel";
@@ -53,6 +55,8 @@ import FacilityDetails from "../base/FacilityDetails";
 import GameCard from "../base/GameCard";
 import ConceptIcon from "../base/ConceptIcon";
 import { combineStoryEffects } from "../../data/WorldEvents";
+import TransmissionPanel from "./TransmissionPanel";
+import { TradingPolicyType } from "../../Types";
 
 interface FacilityListItemProps {
   facility: FacilityOperatingType;
@@ -516,13 +520,19 @@ export interface DispatchProps {
   ) => void;
   onSelect: (id: FacilityOperatingType["id"] | null) => void;
   onStorageBuild: () => void;
+  onTransmissionBuild: (corridorId: string, financed: boolean) => void;
+  onTradingPolicy: (policy: TradingPolicyType) => void;
 }
 
 export interface Props extends StateProps, DispatchProps {}
 
-export default class Facilities extends React.Component<Props, {}> {
+export default class Facilities extends React.Component<
+  Props,
+  { view: "PLANTS" | "INTERTIES" }
+> {
   constructor(props: Props) {
     super(props);
+    this.state = { view: "PLANTS" };
     this.onBeforeDragStart = this.onBeforeDragStart.bind(this);
     this.onDragEnd = this.onDragEnd.bind(this);
   }
@@ -584,6 +594,8 @@ export default class Facilities extends React.Component<Props, {}> {
       onReprioritize,
       onSelect,
       onStorageBuild,
+      onTransmissionBuild,
+      onTradingPolicy,
       selectedFacilityId,
     } = this.props;
     const facilitiesCount = game.facilities.length;
@@ -602,7 +614,7 @@ export default class Facilities extends React.Component<Props, {}> {
             other panes' headers and the build buttons stay put as the fleet scrolls */}
         <Toolbar className="paneHeader">
           <Typography variant="h6">Facilities</Typography>
-          {!readOnly && (
+          {!readOnly && this.state.view === "PLANTS" && (
             <>
               <Button
                 size="small"
@@ -627,59 +639,79 @@ export default class Facilities extends React.Component<Props, {}> {
             </>
           )}
         </Toolbar>
-        <ChartSupplyDemand
-          height={180}
-          timeline={game.timeline}
-          currentMinute={game.date.minute}
-          location={game.location}
-          legend={game.speed === "PAUSED"}
-          startingYear={game.startingYear}
-        />
-        <List dense className="scrollable">
-          <DragDropContext
-            onBeforeDragStart={this.onBeforeDragStart}
-            onDragEnd={this.onDragEnd}
-          >
-            <Droppable droppableId="droppable">
-              {(provided) => (
-                <div {...provided.droppableProps} ref={provided.innerRef}>
-                  {game.facilities.map(
-                    (g: FacilityOperatingType, i: number) => (
-                      <FacilityListItem
-                        facility={g}
-                        game={game}
-                        key={g.id}
-                        onSell={onSell}
-                        onTogglePause={onTogglePause}
-                        onPause={onPause}
-                        onReprioritize={onReprioritize}
-                        onSelect={onSelect}
-                        selected={selectedFacilityId === g.id}
-                        storyOutputMultiplier={storyOutputMultiplierForFacility(
-                          g,
-                          storyEffects,
-                        )}
-                        spotInList={i}
-                        listLength={facilitiesCount}
-                        readOnly={readOnly}
-                      />
-                    ),
+        <Tabs
+          value={this.state.view}
+          onChange={(_event, view) => this.setState({ view })}
+          aria-label="Facility type"
+          className="facilityTabs"
+          variant="fullWidth"
+        >
+          <Tab value="PLANTS" label="Plants" />
+          <Tab value="INTERTIES" label="Interties" />
+        </Tabs>
+        {this.state.view === "PLANTS" ? (
+          <>
+            <ChartSupplyDemand
+              height={180}
+              timeline={game.timeline}
+              currentMinute={game.date.minute}
+              location={game.location}
+              legend={game.speed === "PAUSED"}
+              startingYear={game.startingYear}
+            />
+            <List dense className="scrollable">
+              <DragDropContext
+                onBeforeDragStart={this.onBeforeDragStart}
+                onDragEnd={this.onDragEnd}
+              >
+                <Droppable droppableId="droppable">
+                  {(provided) => (
+                    <div {...provided.droppableProps} ref={provided.innerRef}>
+                      {game.facilities.map(
+                        (g: FacilityOperatingType, i: number) => (
+                          <FacilityListItem
+                            facility={g}
+                            game={game}
+                            key={g.id}
+                            onSell={onSell}
+                            onTogglePause={onTogglePause}
+                            onPause={onPause}
+                            onReprioritize={onReprioritize}
+                            onSelect={onSelect}
+                            selected={selectedFacilityId === g.id}
+                            storyOutputMultiplier={storyOutputMultiplierForFacility(
+                              g,
+                              storyEffects,
+                            )}
+                            spotInList={i}
+                            listLength={facilitiesCount}
+                            readOnly={readOnly}
+                          />
+                        ),
+                      )}
+                      {provided.placeholder}
+                    </div>
                   )}
-                  {provided.placeholder}
-                </div>
+                </Droppable>
+              </DragDropContext>
+              {facilitiesCount < 2 && !readOnly && (
+                <Typography
+                  color="textSecondary"
+                  variant="body2"
+                  style={{ textAlign: "center", marginTop: "12px" }}
+                >
+                  (click "Generator" or "Storage" to build more)
+                </Typography>
               )}
-            </Droppable>
-          </DragDropContext>
-          {facilitiesCount < 2 && !readOnly && (
-            <Typography
-              color="textSecondary"
-              variant="body2"
-              style={{ textAlign: "center", marginTop: "12px" }}
-            >
-              (click "Generator" or "Storage" to build more)
-            </Typography>
-          )}
-        </List>
+            </List>
+          </>
+        ) : (
+          <TransmissionPanel
+            game={game}
+            onBuild={onTransmissionBuild}
+            onPolicy={onTradingPolicy}
+          />
+        )}
       </GameCard>
     );
   }

--- a/src/components/views/FacilitiesContainer.tsx
+++ b/src/components/views/FacilitiesContainer.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../reducers/UI";
 import { AppStateType } from "../../Types";
 import Facilities, { DispatchProps, StateProps } from "./Facilities";
+import { TRANSMISSION_CORRIDORS } from "../../data/AdjacentMarkets";
 
 const mapStateToProps = (state: AppStateType): StateProps => {
   return {
@@ -81,6 +82,16 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     },
     onTransmissionBuild: (corridorId, financed) => {
       dispatch(buildTransmissionLine({ corridorId, financed }));
+      const corridor = TRANSMISSION_CORRIDORS.find(
+        ({ id }) => id === corridorId,
+      );
+      if (corridor) {
+        dispatch(
+          snackbarOpen(
+            `Intertie approved — power can flow in ${corridor.yearsToBuild} year${corridor.yearsToBuild === 1 ? "" : "s"}.`,
+          ),
+        );
+      }
     },
     onTradingPolicy: (policy) => {
       dispatch(setTradingPolicy(policy));

--- a/src/components/views/FacilitiesContainer.tsx
+++ b/src/components/views/FacilitiesContainer.tsx
@@ -6,6 +6,8 @@ import {
   setSpeed,
   togglePauseFacility,
   reprioritizeFacility,
+  buildTransmissionLine,
+  setTradingPolicy,
 } from "../../reducers/Game";
 import {
   selectFacility,
@@ -76,6 +78,12 @@ const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
     },
     onStorageBuild: () => {
       dispatch(navigate({ name: "BUILD_STORAGE", dontRemember: true }));
+    },
+    onTransmissionBuild: (corridorId, financed) => {
+      dispatch(buildTransmissionLine({ corridorId, financed }));
+    },
+    onTradingPolicy: (policy) => {
+      dispatch(setTradingPolicy(policy));
     },
   };
 };

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -229,6 +229,7 @@ describe("Insights layers", () => {
     ]);
     expect(INSIGHT_PRESETS.reliability.layers).toEqual([
       "supplyDemand",
+      "powerExchange",
       "supplyByFuel",
       "storage",
       "weather",

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -567,6 +567,37 @@ describe("Insights layers", () => {
       "profit",
       "financeDetails",
     ]);
+    expect(withRequiredLayers(["cash", "powerExchange"], 112)).toEqual([
+      "powerExchange",
+      "cash",
+    ]);
+  });
+
+  it("puts Mission 7's required exchange track first once its line opens", () => {
+    localStorage.setItem(
+      "insightsLayers",
+      JSON.stringify(["cash", "supplyDemand"]),
+    );
+    const game = cloneDeep(
+      gameReducer(
+        createGame({ scenarioId: 112 }),
+        buildTransmissionLine({
+          corridorId: "california-north",
+          financed: true,
+        }),
+      ),
+    );
+    game.transmission!.lines[0].yearsToBuildLeft = 0;
+
+    renderInsights(112, game);
+
+    expect(document.querySelector(".insightsTrack")).toHaveAttribute(
+      "data-layer",
+      "powerExchange",
+    );
+    expect(localStorage.getItem("insightsLayers")).toBe(
+      JSON.stringify(["cash", "supplyDemand"]),
+    );
   });
 
   it("applies presets and gives every chart the shared cursor key", async () => {

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -591,9 +591,8 @@ describe("Insights layers", () => {
 
     renderInsights(112, game);
 
-    expect(document.querySelector(".insightsTrack")).toHaveAttribute(
-      "data-layer",
-      "powerExchange",
+    expect(screen.getAllByRole("heading", { level: 6 })[1]).toHaveTextContent(
+      "Power exchange",
     );
     expect(localStorage.getItem("insightsLayers")).toBe(
       JSON.stringify(["cash", "supplyDemand"]),
@@ -872,5 +871,27 @@ describe("Insights layers", () => {
         ref.current!.state,
       ),
     ).toBe(true);
+  });
+
+  it("does not offer the power-exchange layer for an explicitly islanded grid", async () => {
+    const game = cloneDeep(
+      gameReducer(
+        createGame({ scenarioId: 100, seed: 61 }),
+        buildTransmissionLine({
+          corridorId: "california-north",
+          financed: true,
+        }),
+      ),
+    );
+    game.transmission!.lines[0].yearsToBuildLeft = 0;
+    game.location = { ...game.location, id: "HNL", name: "Honolulu, HI" };
+
+    renderInsights(100, game);
+    await user.click(screen.getByRole("button", { name: /Layers/ }));
+
+    expect(
+      screen.queryByRole("checkbox", { name: "Power exchange" }),
+    ).toBeNull();
+    expect(screen.queryByText("Power exchange", { selector: "h6" })).toBeNull();
   });
 });

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import cloneDeep from "lodash.clonedeep";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EMPTY_HISTORY, MINUTES_PER_MONTH } from "../../helpers/DateTime";
@@ -12,6 +13,7 @@ import Insights, {
   withRequiredLayers,
 } from "./Insights";
 import { UpcomingStoryEventType } from "./StoryEventSelectors";
+import gameReducer, { buildTransmissionLine } from "../../reducers/Game";
 
 jest.mock("../base/GameCard", () => ({
   __esModule: true,
@@ -804,5 +806,40 @@ describe("Insights layers", () => {
       <Insights {...props} game={nextGame} facilityDragActive={false} />,
     );
     expect(mockSupplyDemandPaints).toBeGreaterThan(chartCountBeforeDrag);
+  });
+
+  it("refreshes a visible power exchange on every simulation tick", () => {
+    localStorage.setItem("insightsLayers", JSON.stringify(["powerExchange"]));
+    const game = cloneDeep(
+      gameReducer(
+        createGame({ scenarioId: 100, seed: 61 }),
+        buildTransmissionLine({
+          corridorId: "california-north",
+          financed: true,
+        }),
+      ),
+    );
+    game.transmission!.lines[0].yearsToBuildLeft = 0;
+    const props: React.ComponentProps<typeof Insights> = {
+      game,
+      selectedFacilityId: null,
+      facilityDragActive: false,
+      onDelta: () => undefined,
+    };
+    const ref = React.createRef<Insights>();
+    render(<Insights {...props} ref={ref} />);
+
+    expect(
+      ref.current!.shouldComponentUpdate(
+        {
+          ...props,
+          game: {
+            ...game,
+            date: { ...game.date, minute: game.date.minute + 600 },
+          },
+        },
+        ref.current!.state,
+      ),
+    ).toBe(true);
   });
 });

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -556,6 +556,8 @@ function requiredTutorialLayers(scenarioId: number): InsightLayerId[] {
       return ["customers"];
     case 5:
       return ["supplyDemand", "fuelPrices", "weather"];
+    case 112:
+      return ["powerExchange"];
     default:
       return [];
   }
@@ -565,6 +567,9 @@ export function withRequiredLayers(
   layers: InsightLayerId[],
   scenarioId: number,
 ): InsightLayerId[] {
+  if (scenarioId === 112) {
+    return ["powerExchange", ...layers.filter((id) => id !== "powerExchange")];
+  }
   const next = [...layers];
   for (const id of requiredTutorialLayers(scenarioId)) {
     if (!next.includes(id)) {
@@ -715,6 +720,7 @@ export default class Insights extends React.Component<Props, State> {
     }
     return (
       nextState !== this.state ||
+      nextProps.game.tutorialStep !== this.props.game.tutorialStep ||
       nextProps.game.date.monthsElapsed !==
         this.props.game.date.monthsElapsed ||
       (this.state.layers.includes("powerExchange") &&
@@ -728,7 +734,14 @@ export default class Insights extends React.Component<Props, State> {
     );
   }
 
+  public componentDidMount() {
+    this.scrollTutorialPowerExchangeIntoView();
+  }
+
   public componentDidUpdate(previousProps: Props) {
+    if (this.props.game.tutorialStep !== previousProps.game.tutorialStep) {
+      this.scrollTutorialPowerExchangeIntoView();
+    }
     if (
       this.props.game.date.monthsElapsed !==
       previousProps.game.date.monthsElapsed
@@ -766,6 +779,21 @@ export default class Insights extends React.Component<Props, State> {
     }
   }
 
+  private scrollTutorialPowerExchangeIntoView() {
+    if (
+      this.props.game.scenarioId !== 112 ||
+      this.props.game.tutorialStep !== 7 ||
+      window.innerWidth > 768
+    ) {
+      return;
+    }
+    window.setTimeout(() => {
+      document
+        .querySelector<HTMLElement>('[data-layer="powerExchange"]')
+        ?.scrollIntoView?.({ block: "nearest" });
+    }, 0);
+  }
+
   private setLayers(
     layers: InsightLayerId[],
     preset: InsightPresetId = this.state.preset,
@@ -775,8 +803,12 @@ export default class Insights extends React.Component<Props, State> {
       preset,
       this.state.presetLibrary,
     )?.layers;
-    setStorageKeyValue(LAYERS_KEY, required);
-    setStorageKeyValue(ACTIVE_PRESET_KEY, preset);
+    // Mission 7 temporarily puts its teaching track first. Keep that guided ordering out of the
+    // player's saved preset so finishing the mission does not rearrange their normal Insights.
+    if (this.props.game.scenarioId !== 112) {
+      setStorageKeyValue(LAYERS_KEY, required);
+      setStorageKeyValue(ACTIVE_PRESET_KEY, preset);
+    }
     this.setState({
       layers: required,
       preset,
@@ -804,8 +836,10 @@ export default class Insights extends React.Component<Props, State> {
       preset.layers,
       this.props.game.scenarioId,
     );
-    setStorageKeyValue(LAYERS_KEY, layers);
-    setStorageKeyValue(ACTIVE_PRESET_KEY, id);
+    if (this.props.game.scenarioId !== 112) {
+      setStorageKeyValue(LAYERS_KEY, layers);
+      setStorageKeyValue(ACTIVE_PRESET_KEY, id);
+    }
     this.setState({ layers, preset: id, presetDirty: false });
   }
 

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -717,6 +717,8 @@ export default class Insights extends React.Component<Props, State> {
       nextState !== this.state ||
       nextProps.game.date.monthsElapsed !==
         this.props.game.date.monthsElapsed ||
+      (this.state.layers.includes("powerExchange") &&
+        nextProps.game.date.minute !== this.props.game.date.minute) ||
       nextProps.game.dollarsPerkWh !== this.props.game.dollarsPerkWh ||
       nextProps.game.feePerKgCO2e !== this.props.game.feePerKgCO2e ||
       nextProps.selectedFacilityId !== this.props.selectedFacilityId ||
@@ -1140,7 +1142,9 @@ export default class Insights extends React.Component<Props, State> {
       (layer.availability === "storage" && projection.hasStorage) ||
       (layer.availability === "hydro" && projection.hasHydro) ||
       (layer.availability === "transmission" &&
-        !!this.props.game.transmission?.lines.length)
+        !!this.props.game.transmission?.lines.some(
+          ({ yearsToBuildLeft }) => yearsToBuildLeft <= 0,
+        ))
     );
   }
 

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -124,9 +124,11 @@ import {
   rangesEqual,
   zoomChartViewport,
 } from "../base/ChartViewportContext";
+import PowerExchangeSummary from "../base/PowerExchangeSummary";
 
 export type InsightLayerId =
   | "supplyDemand"
+  | "powerExchange"
   | "demandByType"
   | "supplyByFuel"
   | "storage"
@@ -149,11 +151,17 @@ export interface InsightLayerDefinition {
   id: InsightLayerId;
   label: string;
   group: LayerGroup;
-  availability?: "storage" | "hydro";
+  availability?: "storage" | "hydro" | "transmission";
 }
 
 export const INSIGHT_LAYERS: readonly InsightLayerDefinition[] = [
   { id: "supplyDemand", label: "Supply & Demand", group: "Grid" },
+  {
+    id: "powerExchange",
+    label: "Power exchange",
+    group: "Grid",
+    availability: "transmission",
+  },
   {
     id: "demandByType",
     label: "Demand by use",
@@ -222,7 +230,14 @@ export const INSIGHT_PRESETS: Record<
   },
   reliability: {
     label: "Reliability",
-    layers: ["supplyDemand", "supplyByFuel", "storage", "weather", "water"],
+    layers: [
+      "supplyDemand",
+      "powerExchange",
+      "supplyByFuel",
+      "storage",
+      "weather",
+      "water",
+    ],
   },
   profitability: {
     label: "Profitability",
@@ -636,7 +651,7 @@ function financeSeries(
 }
 
 function facilitySignature(game: GameType): string {
-  return game.facilities
+  const facilities = game.facilities
     .map((facility) =>
       [
         facility.id,
@@ -646,6 +661,10 @@ function facilitySignature(game: GameType): string {
       ].join(":"),
     )
     .join("|");
+  const transmission = (game.transmission?.lines || [])
+    .map((line) => [line.id, line.corridorId, line.yearsToBuildLeft].join(":"))
+    .join("|");
+  return `${facilities}/${game.transmission?.tradingPolicy || "BALANCED"}/${transmission}`;
 }
 
 export default class Insights extends React.Component<Props, State> {
@@ -1119,7 +1138,9 @@ export default class Insights extends React.Component<Props, State> {
     return (
       !layer.availability ||
       (layer.availability === "storage" && projection.hasStorage) ||
-      (layer.availability === "hydro" && projection.hasHydro)
+      (layer.availability === "hydro" && projection.hasHydro) ||
+      (layer.availability === "transmission" &&
+        !!this.props.game.transmission?.lines.length)
     );
   }
 
@@ -1609,6 +1630,14 @@ export default class Insights extends React.Component<Props, State> {
                 </Typography>
               )}
             </>
+          );
+          break;
+        case "powerExchange":
+          body = (
+            <PowerExchangeSummary
+              game={game}
+              now={getTimeFromTimeline(game.date.minute, game.timeline)!}
+            />
           );
           break;
         case "demandByType": {

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -125,6 +125,7 @@ import {
   zoomChartViewport,
 } from "../base/ChartViewportContext";
 import PowerExchangeSummary from "../base/PowerExchangeSummary";
+import { transmissionAvailable } from "../../data/AdjacentMarkets";
 
 export type InsightLayerId =
   | "supplyDemand"
@@ -1176,6 +1177,7 @@ export default class Insights extends React.Component<Props, State> {
       (layer.availability === "storage" && projection.hasStorage) ||
       (layer.availability === "hydro" && projection.hasHydro) ||
       (layer.availability === "transmission" &&
+        transmissionAvailable(this.props.game.location) &&
         !!this.props.game.transmission?.lines.some(
           ({ yearsToBuildLeft }) => yearsToBuildLeft <= 0,
         ))

--- a/src/components/views/NewGame.test.tsx
+++ b/src/components/views/NewGame.test.tsx
@@ -34,6 +34,8 @@ function challengeRows(): HTMLElement[] {
   );
 }
 
+const viewAllTutorialsName = `View all ${TUTORIALS.length}`;
+
 describe("NewGame", () => {
   beforeEach(() => localStorage.clear());
 
@@ -42,7 +44,9 @@ describe("NewGame", () => {
 
     expect(
       screen.getByTestId(`tutorial-spotlight-${TUTORIALS[0].id}`),
-    ).toHaveTextContent("Continue learning · 0 of 6 complete");
+    ).toHaveTextContent(
+      `Continue learning · 0 of ${TUTORIALS.length} complete`,
+    );
     expect(screen.queryByTestId(`mission-row-${TUTORIALS[0].id}`)).toBeNull();
     expect(challengeRows().map((row) => row.textContent)).toEqual([
       expect.stringContaining("Deep Freeze"),
@@ -54,10 +58,9 @@ describe("NewGame", () => {
       "true",
     );
     expect(screen.queryByLabelText("Deep Freeze themes")).toBeNull();
-    expect(screen.getByRole("button", { name: "View all 6" })).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
+    expect(
+      screen.getByRole("button", { name: viewAllTutorialsName }),
+    ).toHaveAttribute("aria-expanded", "false");
     expect(
       screen.getByTestId(`mission-row-${CUSTOM_SCENARIO_ID}`),
     ).toHaveTextContent("Custom Game");
@@ -66,7 +69,7 @@ describe("NewGame", () => {
   it("expands tutorials in authored order and shows all challenges by latest timeframe", () => {
     render(<NewGame {...props()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "View all 6" }));
+    fireEvent.click(screen.getByRole("button", { name: viewAllTutorialsName }));
     const tutorialCatalog = screen.getByRole("group", {
       name: "All tutorials",
     });
@@ -241,7 +244,9 @@ describe("NewGame", () => {
     render(<NewGame {...props()} />);
 
     const next = screen.getByTestId(`tutorial-spotlight-${TUTORIALS[1].id}`);
-    expect(next).toHaveTextContent("Continue learning · 1 of 6 complete");
+    expect(next).toHaveTextContent(
+      `Continue learning · 1 of ${TUTORIALS.length} complete`,
+    );
     expect(next).toHaveTextContent(TUTORIALS[1].summary as string);
     expect(within(next).getByRole("button")).toHaveAccessibleName(
       `Start ${TUTORIALS[1].name.replace(/^Mission \d+:\s*/, "")}`,
@@ -254,7 +259,7 @@ describe("NewGame", () => {
 
     expect(screen.getByText("Tutorials complete")).toBeInTheDocument();
     expect(screen.queryByTestId(/^tutorial-spotlight-/)).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "View all 6" }));
+    fireEvent.click(screen.getByRole("button", { name: viewAllTutorialsName }));
     expect(
       within(
         screen.getByRole("group", { name: "All tutorials" }),
@@ -269,7 +274,7 @@ describe("NewGame", () => {
     recordPlayed(TUTORIALS[0].id, regular.id);
     render(<NewGame {...props()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "View all 6" }));
+    fireEvent.click(screen.getByRole("button", { name: viewAllTutorialsName }));
     fireEvent.click(screen.getByRole("button", { name: "All challenges" }));
     expect(
       screen.getByTestId(`mission-complete-${TUTORIALS[0].id}`),

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -490,6 +490,8 @@ export default class NewGameDetails extends React.Component<Props, State> {
                 startingCustomers={scenario.startingCustomers}
                 minimumCustomerRetention={scenario.minimumCustomerRetention}
                 reliabilityObjective={scenario.reliabilityObjective}
+                difficulty={game.difficulty}
+                meaningfulDecisionCount={0}
               />
             </DialogContent>
             <DialogActions>

--- a/src/components/views/NewGameDetails.tsx
+++ b/src/components/views/NewGameDetails.tsx
@@ -491,7 +491,7 @@ export default class NewGameDetails extends React.Component<Props, State> {
                 minimumCustomerRetention={scenario.minimumCustomerRetention}
                 reliabilityObjective={scenario.reliabilityObjective}
                 difficulty={game.difficulty}
-                meaningfulDecisionCount={0}
+                meaningfulDecisions={[]}
               />
             </DialogContent>
             <DialogActions>

--- a/src/components/views/TransmissionPanel.tsx
+++ b/src/components/views/TransmissionPanel.tsx
@@ -44,6 +44,10 @@ export default function TransmissionPanel({
   const corridors = corridorsForLocation(game.location);
   const now = getTimeFromTimeline(game.date.minute, game.timeline);
   const readOnly = !!game.replayPlayback;
+  const unbuiltCorridors = corridors.filter(
+    (corridor) =>
+      !state.lines.some(({ corridorId }) => corridorId === corridor.id),
+  );
 
   if (!corridors.length) {
     return (
@@ -70,30 +74,11 @@ export default function TransmissionPanel({
         <div>
           <Typography variant="h6">Share power with nearby grids</Typography>
           <Typography variant="body2" color="textSecondary">
-            An intertie is a large power line between regions. It can import
-            energy during a shortage or sell energy you can safely spare.
+            An intertie links regional grids. Buy power during shortages or sell
+            safe surplus.
           </Typography>
         </div>
       </section>
-
-      <FormControl fullWidth size="small" className="tradingPolicy">
-        <InputLabel id="trading-policy-label">Trading rule</InputLabel>
-        <Select
-          labelId="trading-policy-label"
-          label="Trading rule"
-          value={state.tradingPolicy}
-          disabled={readOnly}
-          onChange={(event) =>
-            onPolicy(event.target.value as TradingPolicyType)
-          }
-        >
-          {Object.entries(POLICY_LABELS).map(([value, label]) => (
-            <MenuItem key={value} value={value}>
-              {label}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
 
       {!!state.lines.length && (
         <section aria-labelledby="your-interties-title">
@@ -120,7 +105,7 @@ export default function TransmissionPanel({
                     primary={line.name}
                     secondary={
                       building
-                        ? `${line.yearsToBuildLeft.toFixed(1)} years until power can flow`
+                        ? `${line.yearsToBuildLeft.toFixed(1)} ${line.yearsToBuildLeft <= 1 ? "year" : "years"} until power can flow`
                         : `${formatWatts(rating)} available now · ${market?.name}`
                     }
                   />
@@ -136,71 +121,98 @@ export default function TransmissionPanel({
         </section>
       )}
 
-      <section aria-labelledby="intertie-projects-title">
-        <Typography id="intertie-projects-title" variant="subtitle2">
-          Connection projects
-        </Typography>
-        <div className="transmissionProjects">
-          {corridors.map((corridor) => {
-            const market = adjacentMarketForCorridor(corridor.id);
-            const built = state.lines.some(
-              ({ corridorId }) => corridorId === corridor.id,
-            );
-            const downpayment = corridor.buildCost * DOWNPAYMENT_PERCENT;
-            return (
-              <article className="transmissionProject" key={corridor.id}>
-                <div className="transmissionProjectHeading">
-                  <div>
-                    <Typography variant="subtitle1">{market?.name}</Typography>
+      {!!state.lines.length && (
+        <FormControl fullWidth size="small" className="tradingPolicy">
+          <InputLabel id="trading-policy-label">Trading rule</InputLabel>
+          <Select
+            labelId="trading-policy-label"
+            label="Trading rule"
+            value={state.tradingPolicy}
+            disabled={readOnly}
+            onChange={(event) =>
+              onPolicy(event.target.value as TradingPolicyType)
+            }
+          >
+            {Object.entries(POLICY_LABELS).map(([value, label]) => (
+              <MenuItem key={value} value={value}>
+                {label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+
+      {!!unbuiltCorridors.length && (
+        <section aria-labelledby="intertie-projects-title">
+          <Typography id="intertie-projects-title" variant="subtitle2">
+            Connection projects
+          </Typography>
+          <div className="transmissionProjects">
+            {unbuiltCorridors.map((corridor) => {
+              const market = adjacentMarketForCorridor(corridor.id);
+              const downpayment = corridor.buildCost * DOWNPAYMENT_PERCENT;
+              const financed = corridor.buildCost - downpayment;
+              return (
+                <article className="transmissionProject" key={corridor.id}>
+                  <div className="transmissionProjectHeading">
+                    <div>
+                      <Typography variant="subtitle1">
+                        {market?.name}
+                      </Typography>
+                      <Typography variant="caption" color="textSecondary">
+                        {corridor.name}
+                      </Typography>
+                    </div>
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      label={
+                        corridor.routeType === "EXISTING"
+                          ? "Existing route"
+                          : "New route"
+                      }
+                    />
+                  </div>
+                  <Typography variant="body2">{market?.description}</Typography>
+                  <dl className="transmissionMetrics">
+                    <div>
+                      <dt>Capacity</dt>
+                      <dd>{formatWatts(corridor.capacityW)}</dd>
+                    </div>
+                    <div>
+                      <dt>Build time</dt>
+                      <dd>
+                        {corridor.yearsToBuild} year
+                        {corridor.yearsToBuild === 1 ? "" : "s"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Total cost</dt>
+                      <dd>{formatMoneyConcise(corridor.buildCost)}</dd>
+                    </div>
+                  </dl>
+                  {!readOnly && (
+                    <Button
+                      fullWidth
+                      variant="contained"
+                      disabled={!now || now.cash < downpayment}
+                      onClick={() => onBuild(corridor.id, true)}
+                    >
+                      Approve intertie
+                    </Button>
+                  )}
+                  {!readOnly && (
                     <Typography variant="caption" color="textSecondary">
-                      {corridor.name}
+                      Pay {formatMoneyConcise(downpayment)} now · finance{" "}
+                      {formatMoneyConcise(financed)}
                     </Typography>
-                  </div>
-                  <Chip
-                    size="small"
-                    variant="outlined"
-                    label={
-                      corridor.routeType === "EXISTING"
-                        ? "Existing route"
-                        : "New route"
-                    }
-                  />
-                </div>
-                <Typography variant="body2">{market?.description}</Typography>
-                <dl className="transmissionMetrics">
-                  <div>
-                    <dt>Capacity</dt>
-                    <dd>{formatWatts(corridor.capacityW)}</dd>
-                  </div>
-                  <div>
-                    <dt>Build time</dt>
-                    <dd>
-                      {corridor.yearsToBuild} year
-                      {corridor.yearsToBuild === 1 ? "" : "s"}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt>Cost</dt>
-                    <dd>{formatMoneyConcise(corridor.buildCost)}</dd>
-                  </div>
-                </dl>
-                {!readOnly && (
-                  <Button
-                    fullWidth
-                    variant="contained"
-                    disabled={built || !now || now.cash < downpayment}
-                    onClick={() => onBuild(corridor.id, true)}
-                  >
-                    {built
-                      ? "Project started"
-                      : `Build · ${formatMoneyConcise(downpayment)} down`}
-                  </Button>
-                )}
-              </article>
-            );
-          })}
-        </div>
-      </section>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/src/components/views/TransmissionPanel.tsx
+++ b/src/components/views/TransmissionPanel.tsx
@@ -64,10 +64,7 @@ export default function TransmissionPanel({
   return (
     <div className="transmissionPanel scrollable">
       <section className="transmissionIntro">
-        <img
-          src="/images/transmission-option-2.svg"
-          alt="Two grids exchanging power"
-        />
+        <img src="/images/transmission.svg" alt="Two grids exchanging power" />
         <div>
           <Typography variant="h6">Share power with nearby grids</Typography>
           <Typography variant="body2" color="textSecondary">
@@ -100,7 +97,7 @@ export default function TransmissionPanel({
                   <ListItemAvatar>
                     <img
                       className="transmissionListIcon"
-                      src="/images/transmission-option-2.svg"
+                      src="/images/transmission.svg"
                       alt=""
                     />
                   </ListItemAvatar>

--- a/src/components/views/TransmissionPanel.tsx
+++ b/src/components/views/TransmissionPanel.tsx
@@ -58,18 +58,7 @@ export default function TransmissionPanel({
   );
 
   if (!corridors.length) {
-    return (
-      <div className="transmissionEmpty">
-        <img src="/images/transmission-option-2.svg" alt="Power exchange" />
-        <Typography variant="h6">
-          Interties are coming to this region
-        </Typography>
-        <Typography color="textSecondary">
-          The first market connection is calibrated for California. Your grid
-          keeps running normally without one.
-        </Typography>
-      </div>
-    );
+    return null;
   }
 
   return (
@@ -170,6 +159,7 @@ export default function TransmissionPanel({
                 <article
                   className="transmissionProject"
                   data-corridor-id={corridor.id}
+                  data-testid={`transmission-project-${corridor.id}`}
                   key={corridor.id}
                 >
                   <div className="transmissionProjectHeading">

--- a/src/components/views/TransmissionPanel.tsx
+++ b/src/components/views/TransmissionPanel.tsx
@@ -41,9 +41,17 @@ export default function TransmissionPanel({
   onPolicy,
 }: TransmissionPanelProps) {
   const state = game.transmission ?? { tradingPolicy: "BALANCED", lines: [] };
-  const corridors = corridorsForLocation(game.location);
+  const availableCorridors = corridorsForLocation(game.location);
   const now = getTimeFromTimeline(game.date.minute, game.timeline);
   const readOnly = !!game.replayPlayback;
+  // The guided mission names the northern project. Showing only that choice until it is approved
+  // makes an exploratory tap recoverable instead of letting a much dearer three-year project
+  // consume the cash and time needed by the lesson.
+  const corridors =
+    game.scenarioId === 112 &&
+    !state.lines.some(({ corridorId }) => corridorId === "california-north")
+      ? availableCorridors.filter(({ id }) => id === "california-north")
+      : availableCorridors;
   const unbuiltCorridors = corridors.filter(
     (corridor) =>
       !state.lines.some(({ corridorId }) => corridorId === corridor.id),
@@ -92,6 +100,12 @@ export default function TransmissionPanel({
                 ? transmissionRatingW(line, now)
                 : line.capacityW;
               const building = line.yearsToBuildLeft > 0;
+              const direction =
+                (now?.importedW || 0) > (now?.exportedW || 0)
+                  ? "Importing"
+                  : (now?.exportedW || 0) > (now?.importedW || 0)
+                    ? "Exporting"
+                    : "Standing by";
               return (
                 <ListItem key={line.id} className="transmissionLine">
                   <ListItemAvatar>
@@ -105,14 +119,14 @@ export default function TransmissionPanel({
                     primary={line.name}
                     secondary={
                       building
-                        ? `${line.yearsToBuildLeft.toFixed(1)} ${line.yearsToBuildLeft <= 1 ? "year" : "years"} until power can flow`
+                        ? `${line.yearsToBuildLeft.toFixed(1)} ${line.yearsToBuildLeft <= 1 ? "year" : "years"} until power can flow · Monthly loan payments`
                         : `${formatWatts(rating)} available now · ${market?.name}`
                     }
                   />
                   <Chip
                     size="small"
                     color={building ? "default" : "success"}
-                    label={building ? "Building" : "Trading"}
+                    label={building ? "Building" : `Trading · ${direction}`}
                   />
                 </ListItem>
               );
@@ -153,7 +167,11 @@ export default function TransmissionPanel({
               const downpayment = corridor.buildCost * DOWNPAYMENT_PERCENT;
               const financed = corridor.buildCost - downpayment;
               return (
-                <article className="transmissionProject" key={corridor.id}>
+                <article
+                  className="transmissionProject"
+                  data-corridor-id={corridor.id}
+                  key={corridor.id}
+                >
                   <div className="transmissionProjectHeading">
                     <div>
                       <Typography variant="subtitle1">
@@ -193,6 +211,8 @@ export default function TransmissionPanel({
                   </dl>
                   {!readOnly && (
                     <Button
+                      id={`approve-intertie-${corridor.id}`}
+                      aria-label={`Approve ${market?.name} intertie`}
                       fullWidth
                       variant="contained"
                       disabled={!now || now.cash < downpayment}

--- a/src/components/views/TransmissionPanel.tsx
+++ b/src/components/views/TransmissionPanel.tsx
@@ -1,0 +1,206 @@
+import * as React from "react";
+import {
+  Button,
+  Chip,
+  FormControl,
+  InputLabel,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  MenuItem,
+  Select,
+  Typography,
+} from "@mui/material";
+import { DOWNPAYMENT_PERCENT } from "../../Constants";
+import {
+  adjacentMarketForCorridor,
+  corridorsForLocation,
+} from "../../data/AdjacentMarkets";
+import { getTimeFromTimeline } from "../../helpers/DateTime";
+import { formatMoneyConcise, formatWatts } from "../../helpers/Format";
+import { transmissionRatingW } from "../../helpers/Transmission";
+import { GameType, TradingPolicyType } from "../../Types";
+
+const POLICY_LABELS: Record<TradingPolicyType, string> = {
+  BALANCED: "Buy for shortages, sell extra",
+  RELIABILITY_FIRST: "Buy for shortages only",
+  SURPLUS_ONLY: "Sell extra only",
+  CLOSED: "No trading",
+};
+
+export interface TransmissionPanelProps {
+  game: GameType;
+  onBuild: (corridorId: string, financed: boolean) => void;
+  onPolicy: (policy: TradingPolicyType) => void;
+}
+
+export default function TransmissionPanel({
+  game,
+  onBuild,
+  onPolicy,
+}: TransmissionPanelProps) {
+  const state = game.transmission ?? { tradingPolicy: "BALANCED", lines: [] };
+  const corridors = corridorsForLocation(game.location);
+  const now = getTimeFromTimeline(game.date.minute, game.timeline);
+  const readOnly = !!game.replayPlayback;
+
+  if (!corridors.length) {
+    return (
+      <div className="transmissionEmpty">
+        <img src="/images/transmission-option-2.svg" alt="Power exchange" />
+        <Typography variant="h6">
+          Interties are coming to this region
+        </Typography>
+        <Typography color="textSecondary">
+          The first market connection is calibrated for California. Your grid
+          keeps running normally without one.
+        </Typography>
+      </div>
+    );
+  }
+
+  return (
+    <div className="transmissionPanel scrollable">
+      <section className="transmissionIntro">
+        <img
+          src="/images/transmission-option-2.svg"
+          alt="Two grids exchanging power"
+        />
+        <div>
+          <Typography variant="h6">Share power with nearby grids</Typography>
+          <Typography variant="body2" color="textSecondary">
+            An intertie is a large power line between regions. It can import
+            energy during a shortage or sell energy you can safely spare.
+          </Typography>
+        </div>
+      </section>
+
+      <FormControl fullWidth size="small" className="tradingPolicy">
+        <InputLabel id="trading-policy-label">Trading rule</InputLabel>
+        <Select
+          labelId="trading-policy-label"
+          label="Trading rule"
+          value={state.tradingPolicy}
+          disabled={readOnly}
+          onChange={(event) =>
+            onPolicy(event.target.value as TradingPolicyType)
+          }
+        >
+          {Object.entries(POLICY_LABELS).map(([value, label]) => (
+            <MenuItem key={value} value={value}>
+              {label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {!!state.lines.length && (
+        <section aria-labelledby="your-interties-title">
+          <Typography id="your-interties-title" variant="subtitle2">
+            Your interties
+          </Typography>
+          <List dense disablePadding>
+            {state.lines.map((line) => {
+              const market = adjacentMarketForCorridor(line.corridorId);
+              const rating = now
+                ? transmissionRatingW(line, now)
+                : line.capacityW;
+              const building = line.yearsToBuildLeft > 0;
+              return (
+                <ListItem key={line.id} className="transmissionLine">
+                  <ListItemAvatar>
+                    <img
+                      className="transmissionListIcon"
+                      src="/images/transmission-option-2.svg"
+                      alt=""
+                    />
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={line.name}
+                    secondary={
+                      building
+                        ? `${line.yearsToBuildLeft.toFixed(1)} years until power can flow`
+                        : `${formatWatts(rating)} available now · ${market?.name}`
+                    }
+                  />
+                  <Chip
+                    size="small"
+                    color={building ? "default" : "success"}
+                    label={building ? "Building" : "Trading"}
+                  />
+                </ListItem>
+              );
+            })}
+          </List>
+        </section>
+      )}
+
+      <section aria-labelledby="intertie-projects-title">
+        <Typography id="intertie-projects-title" variant="subtitle2">
+          Connection projects
+        </Typography>
+        <div className="transmissionProjects">
+          {corridors.map((corridor) => {
+            const market = adjacentMarketForCorridor(corridor.id);
+            const built = state.lines.some(
+              ({ corridorId }) => corridorId === corridor.id,
+            );
+            const downpayment = corridor.buildCost * DOWNPAYMENT_PERCENT;
+            return (
+              <article className="transmissionProject" key={corridor.id}>
+                <div className="transmissionProjectHeading">
+                  <div>
+                    <Typography variant="subtitle1">{market?.name}</Typography>
+                    <Typography variant="caption" color="textSecondary">
+                      {corridor.name}
+                    </Typography>
+                  </div>
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    label={
+                      corridor.routeType === "EXISTING"
+                        ? "Existing route"
+                        : "New route"
+                    }
+                  />
+                </div>
+                <Typography variant="body2">{market?.description}</Typography>
+                <dl className="transmissionMetrics">
+                  <div>
+                    <dt>Capacity</dt>
+                    <dd>{formatWatts(corridor.capacityW)}</dd>
+                  </div>
+                  <div>
+                    <dt>Build time</dt>
+                    <dd>
+                      {corridor.yearsToBuild} year
+                      {corridor.yearsToBuild === 1 ? "" : "s"}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Cost</dt>
+                    <dd>{formatMoneyConcise(corridor.buildCost)}</dd>
+                  </div>
+                </dl>
+                {!readOnly && (
+                  <Button
+                    fullWidth
+                    variant="contained"
+                    disabled={built || !now || now.cash < downpayment}
+                    onClick={() => onBuild(corridor.id, true)}
+                  >
+                    {built
+                      ? "Project started"
+                      : `Build · ${formatMoneyConcise(downpayment)} down`}
+                  </Button>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/data/AdjacentMarkets.test.ts
+++ b/src/data/AdjacentMarkets.test.ts
@@ -1,0 +1,183 @@
+import cityDocument from "../../scripts/cities.json";
+import weatherIndex from "../../public/data/weather/index.json";
+import {
+  ADJACENT_MARKETS,
+  LOCATION_TRANSMISSION_PROFILE_IDS,
+  TRANSMISSION_CORRIDORS,
+  adjacentMarketForCorridor,
+  adjacentMarketsForLocation,
+  corridorsForLocation,
+  transmissionAvailable,
+} from "./AdjacentMarkets";
+import {
+  NO_INTERTIE_LOCATION_IDS,
+  TRANSMISSION_PROFILE_DATA,
+  TRANSMISSION_PROFILE_LOCATION_IDS,
+} from "./TransmissionProfiles";
+
+const location = (id: string) => ({ id });
+
+describe("researched transmission profiles", () => {
+  it("explicitly covers every current and planned location exactly once", () => {
+    const plannedIds = cityDocument.cities.map(({ id }) => id);
+    const groupedIds = Object.values(TRANSMISSION_PROFILE_LOCATION_IDS).flat();
+    const mappedIds = [...groupedIds, ...NO_INTERTIE_LOCATION_IDS];
+
+    expect(plannedIds).toHaveLength(285);
+    expect(groupedIds).toHaveLength(254);
+    expect(NO_INTERTIE_LOCATION_IDS).toHaveLength(31);
+    expect(new Set(plannedIds).size).toBe(plannedIds.length);
+    expect(new Set(mappedIds).size).toBe(mappedIds.length);
+    expect([...mappedIds].sort()).toEqual([...plannedIds].sort());
+    expect(Object.keys(LOCATION_TRANSMISSION_PROFILE_IDS).sort()).toEqual(
+      [...plannedIds].sort(),
+    );
+
+    const downloadedIds = Object.keys(weatherIndex.cities);
+    expect(downloadedIds).toHaveLength(113);
+    expect(
+      downloadedIds.every((id) => id in LOCATION_TRANSMISSION_PROFILE_IDS),
+    ).toBe(true);
+  });
+
+  it("keeps profile records complete, finite, nonnegative, and internally linked", () => {
+    const corridorIds = new Set<string>();
+    const marketIds = new Set<string>();
+
+    for (const [profileId, [markets, corridors]] of Object.entries(
+      TRANSMISSION_PROFILE_DATA,
+    )) {
+      expect(markets.length).toBeGreaterThan(0);
+      expect(corridors.length).toBeGreaterThan(0);
+      const profileMarketIds = new Set(markets.map(([id]) => id));
+
+      for (const [id, , , price, supplyW, demandW] of markets) {
+        expect(marketIds.has(id)).toBe(false);
+        marketIds.add(id);
+        expect([price, supplyW, demandW]).toEqual(
+          expect.arrayContaining([expect.any(Number)]),
+        );
+        for (const value of [price, supplyW, demandW]) {
+          expect(Number.isFinite(value)).toBe(true);
+          expect(value).toBeGreaterThanOrEqual(0);
+        }
+      }
+
+      for (const corridor of corridors) {
+        const [
+          id,
+          adjacentMarketId,
+          ,
+          routeType,
+          capacityW,
+          buildCost,
+          annualOperatingCost,
+          yearsToBuild,
+          heatDerateStartsC,
+          heatDeratePerC,
+          solarDerateFraction,
+        ] = corridor;
+        expect(corridorIds.has(id)).toBe(false);
+        corridorIds.add(id);
+        expect(profileMarketIds.has(adjacentMarketId)).toBe(true);
+        expect(["EXISTING", "NEW"]).toContain(routeType);
+        for (const value of [
+          capacityW,
+          buildCost,
+          annualOperatingCost,
+          yearsToBuild,
+          heatDerateStartsC,
+          heatDeratePerC,
+          solarDerateFraction,
+        ]) {
+          expect(Number.isFinite(value)).toBe(true);
+          expect(value).toBeGreaterThanOrEqual(0);
+        }
+      }
+
+      expect(profileId in TRANSMISSION_PROFILE_LOCATION_IDS).toBe(true);
+    }
+
+    expect(TRANSMISSION_CORRIDORS).toHaveLength(corridorIds.size);
+    expect(ADJACENT_MARKETS).toHaveLength(marketIds.size);
+    for (const corridor of TRANSMISSION_CORRIDORS) {
+      expect(adjacentMarketForCorridor(corridor.id)?.id).toBe(
+        corridor.adjacentMarketId,
+      );
+    }
+  });
+
+  it("suppresses islanded and non-connected systems instead of inventing geography", () => {
+    const suppressed = [
+      "HNL",
+      "SJU",
+      "Reykjavik",
+      "Colombo",
+      "Male",
+      "Taipei",
+      "Seoul",
+      "Busan",
+      "Suva",
+      "PortMoresby",
+      "Noumea",
+      "Papeete",
+      "Honiara",
+    ];
+
+    for (const id of suppressed) {
+      expect(transmissionAvailable(location(id))).toBe(false);
+      expect(corridorsForLocation(location(id))).toEqual([]);
+      expect(adjacentMarketsForLocation(location(id))).toEqual([]);
+    }
+
+    expect(transmissionAvailable(location("custom-unknown"))).toBe(false);
+    expect(corridorsForLocation(location("custom-unknown"))).toEqual([]);
+  });
+
+  it("keeps connected islands enabled and proposed-only routes new", () => {
+    for (const id of ["Hobart", "Auckland", "Christchurch", "Dublin"]) {
+      expect(transmissionAvailable(location(id))).toBe(true);
+      expect(corridorsForLocation(location(id)).length).toBeGreaterThan(0);
+    }
+
+    for (const id of ["TelAviv", "Luanda", "Yangon", "BandarSeriBegawan"]) {
+      expect(corridorsForLocation(location(id))).not.toHaveLength(0);
+      expect(corridorsForLocation(location(id))).toEqual(
+        expect.arrayContaining([expect.objectContaining({ routeType: "NEW" })]),
+      );
+      expect(
+        corridorsForLocation(location(id)).every(
+          ({ routeType }) => routeType === "NEW",
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("preserves the saved California IDs and handles hidden support records", () => {
+    expect(corridorsForLocation(location("SF")).map(({ id }) => id)).toEqual([
+      "california-north",
+      "california-south",
+    ]);
+    expect(corridorsForLocation(location("CAMountains"))).toEqual(
+      corridorsForLocation(location("SF")),
+    );
+    expect(corridorsForLocation(location("AlleghenyUpper"))).toEqual(
+      corridorsForLocation(location("PIT")),
+    );
+  });
+
+  it("keeps location-specific regional proposals on the correct side of a shared grid", () => {
+    expect(
+      corridorsForLocation(location("GuatemalaCity")).map(({ id }) => id),
+    ).toContain("guatemala-mexico-upgrade");
+    expect(
+      corridorsForLocation(location("SanSalvador")).map(({ id }) => id),
+    ).toEqual(["siepac-honduras-upgrade"]);
+    expect(
+      corridorsForLocation(location("PanamaCity")).map(({ id }) => id),
+    ).toContain("panama-colombia-hvdc-new");
+    expect(
+      corridorsForLocation(location("SanJoseCR")).map(({ id }) => id),
+    ).toEqual(["siepac-panama-upgrade"]);
+  });
+});

--- a/src/data/AdjacentMarkets.ts
+++ b/src/data/AdjacentMarkets.ts
@@ -5,65 +5,113 @@ import {
   TransmissionCorridorDefinitionType,
   TransmissionStateType,
 } from "../Types";
+import {
+  NO_INTERTIE_LOCATION_IDS,
+  TRANSMISSION_PROFILE_DATA,
+  TRANSMISSION_PROFILE_LOCATION_IDS,
+  TransmissionProfileTuple,
+} from "./TransmissionProfiles";
 
-export const ADJACENT_MARKETS: readonly AdjacentMarketDefinitionType[] = [
-  {
-    id: "pacific-northwest",
-    name: "Pacific Northwest",
-    description:
-      "Hydropower often makes daytime imports affordable, but supply tightens in dry periods.",
-    basePricePerMWh: 48,
-    availableSupplyW: 1800000000,
-    availableDemandW: 1400000000,
-  },
-  {
-    id: "desert-southwest",
-    name: "Desert Southwest",
-    description:
-      "Solar power is plentiful near midday. Hot evenings raise prices and reduce line capacity.",
-    basePricePerMWh: 55,
-    availableSupplyW: 1500000000,
-    availableDemandW: 1700000000,
-  },
-] as const;
+interface TransmissionProfileDefinition {
+  markets: readonly AdjacentMarketDefinitionType[];
+  corridors: readonly TransmissionCorridorDefinitionType[];
+}
 
-export const TRANSMISSION_CORRIDORS: readonly TransmissionCorridorDefinitionType[] =
-  [
-    {
-      id: "california-north",
-      adjacentMarketId: "pacific-northwest",
-      name: "Northern intertie upgrade",
-      routeType: "EXISTING",
-      capacityW: 500000000,
-      buildCost: 180000000,
-      annualOperatingCost: 3600000,
-      yearsToBuild: 1,
-      heatDerateStartsC: 30,
-      heatDeratePerC: 0.012,
-      solarDerateFraction: 0.04,
-    },
-    {
-      id: "california-south",
-      adjacentMarketId: "desert-southwest",
-      name: "Desert connection",
-      routeType: "NEW",
-      capacityW: 750000000,
-      buildCost: 420000000,
-      annualOperatingCost: 7200000,
-      yearsToBuild: 3,
-      heatDerateStartsC: 32,
-      heatDeratePerC: 0.015,
-      solarDerateFraction: 0.06,
-    },
-  ] as const;
+function expandProfile(
+  tuple: TransmissionProfileTuple,
+): TransmissionProfileDefinition {
+  return {
+    markets: tuple[0].map(
+      ([
+        id,
+        name,
+        description,
+        basePricePerMWh,
+        availableSupplyW,
+        availableDemandW,
+      ]) => ({
+        id,
+        name,
+        description,
+        basePricePerMWh,
+        availableSupplyW,
+        availableDemandW,
+      }),
+    ),
+    corridors: tuple[1].map(
+      ([
+        id,
+        adjacentMarketId,
+        name,
+        routeType,
+        capacityW,
+        buildCost,
+        annualOperatingCost,
+        yearsToBuild,
+        heatDerateStartsC,
+        heatDeratePerC,
+        solarDerateFraction,
+      ]) => ({
+        id,
+        adjacentMarketId,
+        name,
+        routeType,
+        capacityW,
+        buildCost,
+        annualOperatingCost,
+        yearsToBuild,
+        heatDerateStartsC,
+        heatDeratePerC,
+        solarDerateFraction,
+      }),
+    ),
+  };
+}
+
+const TRANSMISSION_PROFILES = Object.fromEntries(
+  Object.entries(TRANSMISSION_PROFILE_DATA).map(([id, tuple]) => [
+    id,
+    expandProfile(tuple),
+  ]),
+) as Readonly<Record<string, TransmissionProfileDefinition>>;
+
+/** Every authored city is explicitly assigned either a researched profile or no interties. */
+export const LOCATION_TRANSMISSION_PROFILE_IDS: Readonly<
+  Record<string, string | null>
+> = Object.freeze({
+  ...Object.fromEntries(NO_INTERTIE_LOCATION_IDS.map((id) => [id, null])),
+  ...Object.fromEntries(
+    Object.entries(TRANSMISSION_PROFILE_LOCATION_IDS).flatMap(
+      ([profileId, ids]) => ids.map((id) => [id, profileId]),
+    ),
+  ),
+});
+
+const uniqueMarkets = new Map<string, AdjacentMarketDefinitionType>();
+const uniqueCorridors = new Map<string, TransmissionCorridorDefinitionType>();
+for (const profile of Object.values(TRANSMISSION_PROFILES)) {
+  for (const market of profile.markets) uniqueMarkets.set(market.id, market);
+  for (const corridor of profile.corridors) {
+    uniqueCorridors.set(corridor.id, corridor);
+  }
+}
+
+/** Complete catalog, retained for save/replay validation and built-line price/rating lookups. */
+export const ADJACENT_MARKETS = [...uniqueMarkets.values()] as const;
+export const TRANSMISSION_CORRIDORS = [...uniqueCorridors.values()] as const;
 
 export function emptyTransmissionState(): TransmissionStateType {
   return { tradingPolicy: "BALANCED", lines: [] };
 }
 
-/** The first release is deliberately calibrated only for the California market. */
-export function transmissionAvailable(location: LocationType): boolean {
-  return location.admin === "California" || location.id === "SF";
+export function transmissionProfileIdForLocation(
+  location: Pick<LocationType, "id">,
+): string | null {
+  return LOCATION_TRANSMISSION_PROFILE_IDS[location.id] ?? null;
+}
+
+export function transmissionAvailable(location: Pick<LocationType, "id">) {
+  return transmissionProfileIdForLocation(location) !== null;
 }
 
 /** Tutorials opt into this extra system deliberately; normal games follow physical availability. */
@@ -79,14 +127,22 @@ export function intertiesEnabledForScenario(
 }
 
 export function corridorsForLocation(
-  location: LocationType,
+  location: Pick<LocationType, "id">,
 ): readonly TransmissionCorridorDefinitionType[] {
-  return transmissionAvailable(location) ? TRANSMISSION_CORRIDORS : [];
+  const profileId = transmissionProfileIdForLocation(location);
+  return profileId ? (TRANSMISSION_PROFILES[profileId]?.corridors ?? []) : [];
+}
+
+export function adjacentMarketsForLocation(
+  location: Pick<LocationType, "id">,
+): readonly AdjacentMarketDefinitionType[] {
+  const profileId = transmissionProfileIdForLocation(location);
+  return profileId ? (TRANSMISSION_PROFILES[profileId]?.markets ?? []) : [];
 }
 
 export function adjacentMarketForCorridor(
   corridorId: string,
 ): AdjacentMarketDefinitionType | undefined {
-  const corridor = TRANSMISSION_CORRIDORS.find(({ id }) => id === corridorId);
-  return ADJACENT_MARKETS.find(({ id }) => id === corridor?.adjacentMarketId);
+  const corridor = uniqueCorridors.get(corridorId);
+  return corridor ? uniqueMarkets.get(corridor.adjacentMarketId) : undefined;
 }

--- a/src/data/AdjacentMarkets.ts
+++ b/src/data/AdjacentMarkets.ts
@@ -1,6 +1,7 @@
 import {
   AdjacentMarketDefinitionType,
   LocationType,
+  ScenarioType,
   TransmissionCorridorDefinitionType,
   TransmissionStateType,
 } from "../Types";
@@ -63,6 +64,18 @@ export function emptyTransmissionState(): TransmissionStateType {
 /** The first release is deliberately calibrated only for the California market. */
 export function transmissionAvailable(location: LocationType): boolean {
   return location.admin === "California" || location.id === "SF";
+}
+
+/** Tutorials opt into this extra system deliberately; normal games follow physical availability. */
+export function intertiesEnabledForScenario(
+  scenario: ScenarioType,
+  location: LocationType,
+): boolean {
+  if (!transmissionAvailable(location)) return false;
+  if (scenario.intertiesEnabled !== undefined) {
+    return scenario.intertiesEnabled;
+  }
+  return !scenario.tutorialSteps;
 }
 
 export function corridorsForLocation(

--- a/src/data/AdjacentMarkets.ts
+++ b/src/data/AdjacentMarkets.ts
@@ -1,0 +1,79 @@
+import {
+  AdjacentMarketDefinitionType,
+  LocationType,
+  TransmissionCorridorDefinitionType,
+  TransmissionStateType,
+} from "../Types";
+
+export const ADJACENT_MARKETS: readonly AdjacentMarketDefinitionType[] = [
+  {
+    id: "pacific-northwest",
+    name: "Pacific Northwest",
+    description:
+      "Hydropower often makes daytime imports affordable, but supply tightens in dry periods.",
+    basePricePerMWh: 48,
+    availableSupplyW: 1800000000,
+    availableDemandW: 1400000000,
+  },
+  {
+    id: "desert-southwest",
+    name: "Desert Southwest",
+    description:
+      "Solar power is plentiful near midday. Hot evenings raise prices and reduce line capacity.",
+    basePricePerMWh: 55,
+    availableSupplyW: 1500000000,
+    availableDemandW: 1700000000,
+  },
+] as const;
+
+export const TRANSMISSION_CORRIDORS: readonly TransmissionCorridorDefinitionType[] =
+  [
+    {
+      id: "california-north",
+      adjacentMarketId: "pacific-northwest",
+      name: "Northern intertie upgrade",
+      routeType: "EXISTING",
+      capacityW: 500000000,
+      buildCost: 180000000,
+      annualOperatingCost: 3600000,
+      yearsToBuild: 1,
+      heatDerateStartsC: 30,
+      heatDeratePerC: 0.012,
+      solarDerateFraction: 0.04,
+    },
+    {
+      id: "california-south",
+      adjacentMarketId: "desert-southwest",
+      name: "Desert connection",
+      routeType: "NEW",
+      capacityW: 750000000,
+      buildCost: 420000000,
+      annualOperatingCost: 7200000,
+      yearsToBuild: 3,
+      heatDerateStartsC: 32,
+      heatDeratePerC: 0.015,
+      solarDerateFraction: 0.06,
+    },
+  ] as const;
+
+export function emptyTransmissionState(): TransmissionStateType {
+  return { tradingPolicy: "BALANCED", lines: [] };
+}
+
+/** The first release is deliberately calibrated only for the California market. */
+export function transmissionAvailable(location: LocationType): boolean {
+  return location.admin === "California" || location.id === "SF";
+}
+
+export function corridorsForLocation(
+  location: LocationType,
+): readonly TransmissionCorridorDefinitionType[] {
+  return transmissionAvailable(location) ? TRANSMISSION_CORRIDORS : [];
+}
+
+export function adjacentMarketForCorridor(
+  corridorId: string,
+): AdjacentMarketDefinitionType | undefined {
+  const corridor = TRANSMISSION_CORRIDORS.find(({ id }) => id === corridorId);
+  return ADJACENT_MARKETS.find(({ id }) => id === corridor?.adjacentMarketId);
+}

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -9,6 +9,7 @@ import {
 import { AppStateType, ScenarioType } from "../Types";
 import { render, screen } from "@testing-library/react";
 import { getScenarioLocation } from "../helpers/Locations";
+import { intertiesEnabledForScenario } from "./AdjacentMarkets";
 
 describe("getScenario", () => {
   it("finds an authored scenario by id", () => {
@@ -53,6 +54,11 @@ describe("getNextTutorial", () => {
 
   it("finds nothing after the last tutorial", () => {
     expect(getNextTutorial(TUTORIALS[TUTORIALS.length - 1].id)).toBeUndefined();
+  });
+
+  it("places Mission 7 after Forecasting and keeps its append-only id", () => {
+    expect(getNextTutorial(5)?.id).toBe(112);
+    expect(getNextTutorial(112)).toBeUndefined();
   });
 
   // Which is what both callers rely on to decide whether to offer one at all
@@ -117,6 +123,48 @@ describe("tutorial mission metadata", () => {
     expect(steps[3].advanceOn).toBeDefined();
     expect(steps[4].advanceOn).toBeUndefined();
     expect(steps[4].capstone).toBeDefined();
+  });
+
+  it("authors the Interties mission as a fixed two-plant California lesson", () => {
+    const interties = getScenario(112)!;
+    expect(interties).toMatchObject({
+      name: "Mission 7: Interties",
+      seed: 249007,
+      startingYear: 2019,
+      durationMonths: 24,
+      intertiesEnabled: true,
+    });
+    expect(interties.facilities).toEqual([
+      expect.objectContaining({ fuel: "Sun", peakW: 800000000 }),
+      expect.objectContaining({ fuel: "Natural Gas", peakW: 500000000 }),
+    ]);
+    expect(interties.tutorialSteps).toHaveLength(10);
+  });
+
+  it("keeps interties out of earlier tutorials without disabling ordinary California games", () => {
+    for (const tutorial of TUTORIALS.filter(({ id }) => id !== 112)) {
+      expect(
+        intertiesEnabledForScenario(tutorial, getScenarioLocation(tutorial)!),
+      ).toBe(false);
+    }
+    const interties = getScenario(112)!;
+    expect(
+      intertiesEnabledForScenario(interties, getScenarioLocation(interties)!),
+    ).toBe(true);
+    const ordinaryCalifornia = getScenario(100)!;
+    expect(
+      intertiesEnabledForScenario(
+        ordinaryCalifornia,
+        getScenarioLocation(ordinaryCalifornia)!,
+      ),
+    ).toBe(true);
+    const noCorridor = getScenario(103)!;
+    expect(
+      intertiesEnabledForScenario(
+        { ...noCorridor, intertiesEnabled: true },
+        getScenarioLocation(noCorridor)!,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -159,10 +159,15 @@ describe("tutorial mission metadata", () => {
       ),
     ).toBe(true);
     const noCorridor = getScenario(103)!;
+    const islanded = {
+      ...getScenarioLocation(noCorridor)!,
+      id: "HNL",
+      name: "Honolulu, HI",
+    };
     expect(
       intertiesEnabledForScenario(
         { ...noCorridor, intertiesEnabled: true },
-        getScenarioLocation(noCorridor)!,
+        islanded,
       ),
     ).toBe(false);
   });

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -71,6 +71,30 @@ const forecastingCapstoneSucceeded = (state: AppStateType) => {
   );
 };
 
+const tutorialNorthernIntertie = (state: AppStateType) =>
+  state.game.transmission?.lines.find(
+    (line) => line.corridorId === "california-north",
+  );
+
+const tutorialSawImports = (state: AppStateType) =>
+  state.game.monthlyHistory.some(
+    (month) => (month.chartAverage?.importedW || 0) > 0,
+  );
+
+const tutorialSawSafeExport = (state: AppStateType) =>
+  state.game.monthlyHistory.some(
+    (month) =>
+      (month.chartAverage?.exportedW || 0) > 0 &&
+      (month.minimumSupplyMarginW ?? -1) >= 0,
+  );
+
+const intertiesCapstoneSucceeded = (state: AppStateType) =>
+  state.game.date.monthsElapsed >= 14 &&
+  tutorialNorthernIntertie(state)?.yearsToBuildLeft === 0 &&
+  state.game.transmission?.tradingPolicy === "BALANCED" &&
+  tutorialSawImports(state) &&
+  tutorialSawSafeExport(state);
+
 export const SCENARIOS = [
   {
     id: 0, // Avoid changing IDs, linked to scores / completion, and doesn't impact order
@@ -661,6 +685,160 @@ export const SCENARIOS = [
             "Final challenge complete—construction finished before peak demand, and the added generator prevented the predicted summer shortage.",
           failureMessage:
             "Demand exceeded available supply before the new generator was ready. Recheck the forecast shortage and start construction sooner.",
+        },
+      },
+    ],
+  },
+  {
+    id: 112, // Append-only persisted scenario id; tutorial order is its position in this array
+    name: "Mission 7: Interties",
+    icon: "transmission-option-2",
+    summary: "Share power with neighbors",
+    locationId: "SF",
+    ownership: "Investor",
+    seed: 249007,
+    startingYear: 2019,
+    cash: 220000000,
+    feePerKgCO2e: 0,
+    dollarsPerkWh: 0.07,
+    durationMonths: 24,
+    intertiesEnabled: true,
+    endTitle: "Mission complete!",
+    endMessage:
+      "You used a limited grid connection to cover shortages and sell only safe surplus.",
+    facilities: [
+      // Slightly above the design sketch's 650 MW calibration: the fixed weather seed needs this
+      // much nameplate to create observable daytime surplus after demand and the 5% reserve.
+      { fuel: "Sun", peakW: 800000000, initialAgeYears: 5 },
+      { fuel: "Natural Gas", peakW: 500000000, initialAgeYears: 12 },
+    ],
+    tutorialSteps: [
+      {
+        skipBeacon: true,
+        card: "FACILITIES",
+        target: "#intertiesTab",
+        content: (
+          <TutorialPrompt
+            concepts={["supply", "demand"]}
+            text="Tap Interties to see links to neighboring grids, then tap Next."
+          />
+        ),
+      },
+      {
+        card: "FACILITIES",
+        target: "#approve-intertie-california-north",
+        advanceOn: (s: AppStateType) => !!tutorialNorthernIntertie(s),
+        content: (
+          <TutorialPrompt
+            concepts={["money", "construction"]}
+            text="Approve the Pacific Northwest intertie with financing."
+          />
+        ),
+      },
+      {
+        card: "FACILITIES",
+        target: "#speedChangeButtons",
+        advanceOn: (s: AppStateType) =>
+          tutorialNorthernIntertie(s)?.yearsToBuildLeft === 0 &&
+          s.game.speed === "PAUSED",
+        content: (
+          <TutorialPrompt
+            concepts={["construction", "time"]}
+            text="Run time until the line says Trading, then pause."
+          />
+        ),
+        hint: "Tap 1× or fast speed, watch Building change to Trading, then tap pause.",
+      },
+      {
+        card: "FACILITIES",
+        target: ".tradingPolicy",
+        advanceOn: (s: AppStateType) =>
+          s.game.transmission?.tradingPolicy === "RELIABILITY_FIRST",
+        content: (
+          <TutorialPrompt
+            concepts={["demand", "supply"]}
+            text="Choose “Buy for shortages only” to use the neighboring grid as backup."
+          />
+        ),
+      },
+      {
+        card: "FACILITIES",
+        target: "#plantsTab",
+        content: (
+          <TutorialPrompt
+            concepts={["generator", "pause"]}
+            text="Tap Plants to return to your power plants, then tap Next."
+          />
+        ),
+      },
+      {
+        card: "FACILITIES",
+        target: '[data-fuel="Natural Gas"]',
+        advanceOn: (s: AppStateType) =>
+          s.game.facilities.some(
+            (facility) =>
+              "fuel" in facility &&
+              facility.fuel === "Natural Gas" &&
+              facility.paused,
+          ),
+        content: (
+          <TutorialPrompt
+            concepts={["pause", "demand"]}
+            text="Pause the natural-gas plant to create a shortage the intertie can cover."
+          />
+        ),
+      },
+      {
+        card: "FACILITIES",
+        target: "#speedChangeButtons",
+        advanceOn: (s: AppStateType) =>
+          s.game.date.monthsElapsed >= 13 &&
+          tutorialSawImports(s) &&
+          s.game.speed === "PAUSED",
+        content: (
+          <TutorialPrompt
+            concepts={["play", "supply"]}
+            text="Run until you see Importing, then pause; the line can cover only up to its available capacity."
+          />
+        ),
+        hint: "If time is paused, tap 1× or fast speed; the line must say Trading.",
+      },
+      {
+        card: "INSIGHTS",
+        target: '[data-layer="powerExchange"]',
+        content: (
+          <TutorialPrompt
+            concepts={["supply", "money"]}
+            text="Compare power flowing with available capacity; imports cost the neighbor price shown."
+          />
+        ),
+      },
+      {
+        card: "INSIGHTS",
+        target: ".powerExchangeSummary",
+        content: (
+          <TutorialPrompt
+            concepts={["weather", "supply"]}
+            text="Hot, sunny weather warms the line, so it may safely carry less than 500 MW."
+          />
+        ),
+      },
+      {
+        card: "FACILITIES",
+        content: (
+          <TutorialPrompt
+            concepts={["supply", "goal"]}
+            text="Your turn: choose “Buy for shortages, sell extra,” then run until the grid safely sends extra solar power out."
+          />
+        ),
+        hint: "An export starts only after local demand and the 5% reserve are covered. If flow stays at 0, make sure Solar is on.",
+        capstone: {
+          preserveProgress: true,
+          success: intertiesCapstoneSucceeded,
+          successMessage:
+            "You borrowed power at night and shared extra solar by day, while keeping your own grid safe.",
+          failureMessage:
+            "The grid has not safely used both directions yet. Choose the balanced rule, keep Solar on, and run time.",
         },
       },
     ],

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -690,7 +690,7 @@ export const SCENARIOS = [
   {
     id: 112, // Append-only persisted scenario id; tutorial order is its position in this array
     name: "Mission 7: Interties",
-    icon: "transmission-option-2",
+    icon: "transmission",
     summary: "Share power with neighbors",
     locationId: "SF",
     ownership: "Investor",

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -82,11 +82,9 @@ const tutorialSawImports = (state: AppStateType) =>
   );
 
 const tutorialSawSafeExport = (state: AppStateType) =>
-  state.game.monthlyHistory.some(
-    (month) =>
-      (month.chartAverage?.exportedW || 0) > 0 &&
-      (month.minimumSupplyMarginW ?? -1) >= 0,
-  );
+  !!state.game.monthlyHistory[0] &&
+  (state.game.monthlyHistory[0].chartAverage?.exportedW || 0) > 0 &&
+  (state.game.monthlyHistory[0].minimumSupplyMarginW ?? -1) >= 0;
 
 const intertiesCapstoneSucceeded = (state: AppStateType) =>
   state.game.date.monthsElapsed >= 14 &&

--- a/src/data/TransmissionProfiles.ts
+++ b/src/data/TransmissionProfiles.ts
@@ -1,0 +1,1791 @@
+// Generated from the five researched transmission reports for issue #61.
+// Gameplay values are calibrated abstractions; route status and descriptions preserve the cited research.
+
+export type AdjacentMarketTuple = readonly [
+  string,
+  string,
+  string,
+  number,
+  number,
+  number,
+];
+export type TransmissionCorridorTuple = readonly [
+  string,
+  string,
+  string,
+  "EXISTING" | "NEW",
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+];
+export type TransmissionProfileTuple = readonly [
+  readonly AdjacentMarketTuple[],
+  readonly TransmissionCorridorTuple[],
+];
+
+// prettier-ignore
+export const TRANSMISSION_PROFILE_DATA = {
+  "us-ca-wecc": [
+    [
+      ["pacific-northwest","Pacific Northwest","Hydropower often makes imports affordable, but dry years can tighten supply.",48,1800000000,1400000000],
+      ["desert-southwest","Desert Southwest","Midday solar can be cheap; hot evenings raise both demand and prices.",55,1500000000,1700000000]
+    ],
+    [
+      ["california-north","pacific-northwest","Northern intertie upgrade","EXISTING",500000000,180000000,3600000,1,30,0.012,0.04],
+      ["california-south","desert-southwest","Desert connection","NEW",750000000,420000000,7200000,3,32,0.015,0.06]
+    ]
+  ],
+  "us-pjm": [
+    [
+      ["pjm-miso-upgrade-market","Midcontinent market","A wide neighboring market can share wind, thermal, and hydro power across the western seam.",45,2200000000,2100000000],
+      ["pjm-nyiso-new-market","New York market","A stronger northeastern path can trade city demand and upstate hydro, but congestion can make power expensive.",58,1300000000,1600000000]
+    ],
+    [
+      ["pjm-miso-upgrade","pjm-miso-upgrade-market","Midcontinent market upgrade","EXISTING",600000000,240000000,4800000,2,31,0.012,0.04],
+      ["pjm-nyiso-new","pjm-nyiso-new-market","New York market connection","NEW",800000000,640000000,9600000,4,30,0.012,0.04]
+    ]
+  ],
+  "us-nyiso": [
+    [
+      ["ny-quebec-upgrade-market","Québec hydro market","Reservoir hydropower can answer quickly when New York needs energy.",42,2200000000,900000000],
+      ["ny-pjm-new-market","PJM market","A new controlled path links two large city-heavy markets, where peak prices often arrive together.",54,1800000000,2000000000]
+    ],
+    [
+      ["ny-quebec-upgrade","ny-quebec-upgrade-market","Québec hydro market upgrade","EXISTING",700000000,350000000,5600000,2,29,0.01,0.03],
+      ["ny-pjm-new","ny-pjm-new-market","PJM market connection","NEW",750000000,675000000,10100000,4,30,0.012,0.04]
+    ]
+  ],
+  "us-isone": [
+    [
+      ["newengland-quebec-upgrade-market","Québec hydro market","Stored water can supply steady power during cold snaps and summer peaks.",43,2100000000,800000000],
+      ["newengland-newyork-new-market","New York market","A stronger westward link adds another path when local gas or transmission is constrained.",57,1200000000,1500000000]
+    ],
+    [
+      ["newengland-quebec-upgrade","newengland-quebec-upgrade-market","Québec hydro market upgrade","EXISTING",700000000,315000000,5600000,2,28,0.01,0.03],
+      ["newengland-newyork-new","newengland-newyork-new-market","New York market connection","NEW",500000000,500000000,8000000,4,29,0.011,0.03]
+    ]
+  ],
+  "us-miso-north": [
+    [
+      ["miso-pjm-upgrade-market","PJM market","Upgrading the busy eastern seam lets two huge markets help each other when local plants are tight.",49,2200000000,2300000000],
+      ["miso-spp-new-market","Great Plains market","Plains wind can be abundant, while heat waves can make both regions compete for power.",41,2000000000,1500000000]
+    ],
+    [
+      ["miso-pjm-upgrade","miso-pjm-upgrade-market","PJM market upgrade","EXISTING",700000000,260000000,5200000,2,31,0.012,0.04],
+      ["miso-spp-new","miso-spp-new-market","Great Plains market connection","NEW",800000000,560000000,8400000,4,32,0.013,0.04]
+    ]
+  ],
+  "us-miso-south": [
+    [
+      ["miso-south-spp-upgrade-market","Southwest Power Pool","A western seam shares wind and gas power with the Gulf region.",44,1600000000,1500000000],
+      ["miso-south-southeast-new-market","Southeastern utilities","A new eastward route adds support during hurricanes and hot, still evenings.",51,1500000000,1800000000]
+    ],
+    [
+      ["miso-south-spp-upgrade","miso-south-spp-upgrade-market","Southwest Power Pool upgrade","EXISTING",500000000,220000000,4400000,2,32,0.014,0.05],
+      ["miso-south-southeast-new","miso-south-southeast-new-market","Southeastern utilities connection","NEW",600000000,510000000,7600000,4,32,0.015,0.05]
+    ]
+  ],
+  "us-spp": [
+    [
+      ["spp-miso-upgrade-market","Midcontinent market","A stronger eastern seam makes more Plains wind useful across a much larger region.",43,2100000000,1900000000],
+      ["spp-west-hvdc-new-market","Rocky Mountain grid","Converter stations let two grids trade without forcing their electrical rhythms to match.",46,1400000000,1300000000]
+    ],
+    [
+      ["spp-miso-upgrade","spp-miso-upgrade-market","Midcontinent market upgrade","EXISTING",700000000,245000000,4900000,2,32,0.013,0.04],
+      ["spp-west-hvdc-new","spp-west-hvdc-new-market","Rocky Mountain grid connection","NEW",600000000,720000000,10800000,5,31,0.012,0.05]
+    ]
+  ],
+  "us-tva": [
+    [
+      ["tva-pjm-upgrade-market","PJM market","A northern connection can supply power during a Valley shortage or buy surplus local energy.",50,1800000000,1900000000],
+      ["tva-midcontinent-new-market","Midcontinent market","A new Mississippi crossing opens a second regional path for trading and emergency help.",45,1700000000,1600000000]
+    ],
+    [
+      ["tva-pjm-upgrade","tva-pjm-upgrade-market","PJM market upgrade","EXISTING",500000000,210000000,4200000,2,31,0.013,0.04],
+      ["tva-midcontinent-new","tva-midcontinent-new-market","Midcontinent market connection","NEW",650000000,520000000,7800000,4,32,0.014,0.05]
+    ]
+  ],
+  "us-carolinas": [
+    [
+      ["carolinas-pjm-upgrade-market","PJM market","A stronger northern seam brings access to a large multi-state market.",51,1700000000,1800000000],
+      ["carolinas-southeast-new-market","Southern utility pool","A second route shares solar and gas power across the Southeast.",49,1500000000,1600000000]
+    ],
+    [
+      ["carolinas-pjm-upgrade","carolinas-pjm-upgrade-market","PJM market upgrade","EXISTING",500000000,225000000,4500000,2,31,0.013,0.04],
+      ["carolinas-southeast-new","carolinas-southeast-new-market","Southern utility pool connection","NEW",500000000,425000000,6400000,4,32,0.014,0.05]
+    ]
+  ],
+  "us-southeast": [
+    [
+      ["southeast-tva-upgrade-market","Tennessee Valley","An existing northern path can share nuclear, hydro, gas, and solar generation.",48,1600000000,1600000000],
+      ["southeast-miso-new-market","Lower Mississippi market","A new westward line adds choices when a storm or heat wave strains one side.",47,1700000000,1700000000]
+    ],
+    [
+      ["southeast-tva-upgrade","southeast-tva-upgrade-market","Tennessee Valley upgrade","EXISTING",500000000,205000000,4100000,2,32,0.014,0.05],
+      ["southeast-miso-new","southeast-miso-new-market","Lower Mississippi market connection","NEW",650000000,550000000,8300000,4,32,0.015,0.05]
+    ]
+  ],
+  "us-florida": [
+    [
+      ["florida-southeast-upgrade-market","Southeastern grid","Florida's main outside support comes from the north, so this upgrade adds room on an already important path.",50,1800000000,1900000000],
+      ["florida-gulf-new-market","Gulf Coast market","A new controlled Gulf route gives Florida another source when the northern path is crowded.",52,1500000000,1800000000]
+    ],
+    [
+      ["florida-southeast-upgrade","florida-southeast-upgrade-market","Southeastern grid upgrade","EXISTING",600000000,260000000,5200000,2,32,0.015,0.06],
+      ["florida-gulf-new","florida-gulf-new-market","Gulf Coast market connection","NEW",700000000,910000000,13700000,5,32,0.015,0.06]
+    ]
+  ],
+  "us-ercot": [
+    [
+      ["ercot-east-dc-upgrade-market","Eastern grid","DC converter stations let Texas trade while its AC grid keeps operating independently.",47,1600000000,1700000000],
+      ["ercot-southern-spirit-new-market","Southeastern grid","A major new DC line can move much more emergency and market power across the Texas seam.",51,2200000000,2200000000]
+    ],
+    [
+      ["ercot-east-dc-upgrade","ercot-east-dc-upgrade-market","Eastern grid upgrade","EXISTING",600000000,360000000,7200000,2,33,0.016,0.06],
+      ["ercot-southern-spirit-new","ercot-southern-spirit-new-market","Southeastern grid connection","NEW",1200000000,1500000000,22500000,6,33,0.016,0.06]
+    ]
+  ],
+  "us-pnw-wecc": [
+    [
+      ["pnw-california-upgrade-market","California market","A long north-south path trades hydropower, solar power, and evening demand.",56,1700000000,2100000000],
+      ["pnw-bc-upgrade-market","British Columbia hydro","Northern reservoirs can trade across the border when water and demand differ.",44,1500000000,900000000]
+    ],
+    [
+      ["pnw-california-upgrade","pnw-california-upgrade-market","California market upgrade","EXISTING",700000000,245000000,4900000,2,30,0.011,0.04],
+      ["pnw-bc-upgrade","pnw-bc-upgrade-market","British Columbia hydro upgrade","EXISTING",400000000,160000000,3200000,2,28,0.01,0.03]
+    ]
+  ],
+  "us-desert-wecc": [
+    [
+      ["desert-california-upgrade-market","California market","Desert solar can flow west by day, while California can help after sunset.",55,1500000000,1900000000],
+      ["desert-rockies-new-market","Rocky Mountain grid","A new inland route reaches wind and flexible generation with a different weather pattern.",45,1500000000,1300000000]
+    ],
+    [
+      ["desert-california-upgrade","desert-california-upgrade-market","California market upgrade","EXISTING",600000000,230000000,4600000,2,34,0.017,0.07],
+      ["desert-rockies-new","desert-rockies-new-market","Rocky Mountain grid connection","NEW",700000000,595000000,8900000,4,33,0.015,0.06]
+    ]
+  ],
+  "us-rockies-wecc": [
+    [
+      ["rockies-desert-upgrade-market","Desert Southwest","This route trades mountain wind and hydro for desert solar and peak support.",48,1500000000,1500000000],
+      ["rockies-eastern-hvdc-new-market","Great Plains market","A new HVDC seam link lets the Western and Eastern grids exchange much more power safely.",42,1800000000,1500000000]
+    ],
+    [
+      ["rockies-desert-upgrade","rockies-desert-upgrade-market","Desert Southwest upgrade","EXISTING",500000000,210000000,4200000,2,31,0.012,0.05],
+      ["rockies-eastern-hvdc-new","rockies-eastern-hvdc-new-market","Great Plains market connection","NEW",750000000,900000000,13500000,5,31,0.012,0.05]
+    ]
+  ],
+  "ca-ontario": [
+    [
+      ["ontario-quebec-upgrade-market","Québec hydro market","Flexible reservoir power complements Ontario's nuclear-heavy supply.",42,2000000000,1000000000],
+      ["ontario-us-upgrade-market","Great Lakes U.S. market","Several border paths link Ontario to New York and Midcontinent neighbors.",50,1700000000,1900000000]
+    ],
+    [
+      ["ontario-quebec-upgrade","ontario-quebec-upgrade-market","Québec hydro market upgrade","EXISTING",700000000,280000000,5600000,2,29,0.01,0.03],
+      ["ontario-us-upgrade","ontario-us-upgrade-market","Great Lakes U.S. market upgrade","EXISTING",600000000,270000000,5400000,2,30,0.011,0.03]
+    ]
+  ],
+  "ca-quebec": [
+    [
+      ["quebec-ontario-upgrade-market","Ontario market","Ontario can buy flexible hydro or sell steady nuclear power when Québec reservoirs are tight.",49,1700000000,1800000000],
+      ["quebec-northeast-upgrade-market","New York and New England","Controlled ties carry Québec hydro to large northeastern markets.",56,1500000000,2300000000]
+    ],
+    [
+      ["quebec-ontario-upgrade","quebec-ontario-upgrade-market","Ontario market upgrade","EXISTING",700000000,280000000,5600000,2,29,0.01,0.03],
+      ["quebec-northeast-upgrade","quebec-northeast-upgrade-market","New York and New England upgrade","EXISTING",900000000,405000000,7200000,2,29,0.01,0.03]
+    ]
+  ],
+  "ca-bc": [
+    [
+      ["bc-pnw-upgrade-market","Pacific Northwest","Hydro systems on both sides of the border can trade when rainfall, snowmelt, and demand differ.",47,1700000000,1400000000],
+      ["bc-alberta-upgrade-market","Alberta market","A mountain crossing trades flexible hydro for wind and gas power.",50,1300000000,1400000000]
+    ],
+    [
+      ["bc-pnw-upgrade","bc-pnw-upgrade-market","Pacific Northwest upgrade","EXISTING",600000000,230000000,4600000,2,28,0.01,0.03],
+      ["bc-alberta-upgrade","bc-alberta-upgrade-market","Alberta market upgrade","EXISTING",400000000,190000000,3800000,2,28,0.01,0.03]
+    ]
+  ],
+  "ca-alberta": [
+    [
+      ["alberta-bc-upgrade-market","British Columbia hydro","Reservoir power can balance Alberta's wind and demand swings.",45,1500000000,1000000000],
+      ["alberta-saskatchewan-new-market","Prairie eastern grid","A larger converter link reaches a grid that runs independently from the West.",47,900000000,900000000]
+    ],
+    [
+      ["alberta-bc-upgrade","alberta-bc-upgrade-market","British Columbia hydro upgrade","EXISTING",500000000,220000000,4400000,2,29,0.01,0.03],
+      ["alberta-saskatchewan-new","alberta-saskatchewan-new-market","Prairie eastern grid connection","NEW",300000000,390000000,5900000,4,30,0.011,0.03]
+    ]
+  ],
+  "ca-manitoba": [
+    [
+      ["manitoba-us-upgrade-market","U.S. Midcontinent","Large north-south lines trade Manitoba hydro with the Midwest.",46,1700000000,1800000000],
+      ["manitoba-saskatchewan-upgrade-market","Saskatchewan market","A prairie link shares hydro, wind, and thermal power across different peak conditions.",48,900000000,900000000]
+    ],
+    [
+      ["manitoba-us-upgrade","manitoba-us-upgrade-market","U.S. Midcontinent upgrade","EXISTING",700000000,280000000,5600000,2,29,0.01,0.03],
+      ["manitoba-saskatchewan-upgrade","manitoba-saskatchewan-upgrade-market","Saskatchewan market upgrade","EXISTING",300000000,135000000,2700000,2,30,0.011,0.03]
+    ]
+  ],
+  "ca-maritimes": [
+    [
+      ["novascotia-newbrunswick-upgrade-market","New Brunswick market","This is Nova Scotia's landward path to the wider Eastern grid.",51,900000000,1000000000],
+      ["novascotia-maritime-link-upgrade-market","Newfoundland hydro","A subsea cable brings renewable power across the Cabot Strait.",44,1100000000,700000000]
+    ],
+    [
+      ["novascotia-newbrunswick-upgrade","novascotia-newbrunswick-upgrade-market","New Brunswick market upgrade","EXISTING",350000000,160000000,3200000,2,27,0.009,0.03],
+      ["novascotia-maritime-link-upgrade","novascotia-maritime-link-upgrade-market","Newfoundland hydro upgrade","EXISTING",475000000,285000000,5700000,2,27,0.009,0.02]
+    ]
+  ],
+  "mx-sin-central-west": [
+    [
+      ["mexico-central-occidental-upgrade-market","Western Mexico","A stronger central-west path shares solar, hydro, geothermal, and city demand inside the national market.",53,1800000000,2000000000],
+      ["mexico-northeast-new-market","Northeast Mexico","A new long-distance line reaches industrial demand and gas generation in the northeast.",50,1900000000,2100000000]
+    ],
+    [
+      ["mexico-central-occidental-upgrade","mexico-central-occidental-upgrade-market","Western Mexico upgrade","EXISTING",700000000,245000000,4900000,2,31,0.013,0.05],
+      ["mexico-northeast-new","mexico-northeast-new-market","Northeast Mexico connection","NEW",800000000,760000000,11400000,5,33,0.015,0.06]
+    ]
+  ],
+  "mx-sin-northeast": [
+    [
+      ["monterrey-ercot-dc-upgrade-market","Texas market","Converters let Northeast Mexico and Texas trade without synchronizing their whole grids.",48,1000000000,1100000000],
+      ["monterrey-central-mexico-upgrade-market","Central Mexico","A stronger inland backbone links industrial demand with the national generation mix.",53,1700000000,1900000000]
+    ],
+    [
+      ["monterrey-ercot-dc-upgrade","monterrey-ercot-dc-upgrade-market","Texas market upgrade","EXISTING",300000000,195000000,3900000,2,34,0.016,0.06],
+      ["monterrey-central-mexico-upgrade","monterrey-central-mexico-upgrade-market","Central Mexico upgrade","EXISTING",600000000,250000000,5000000,2,33,0.015,0.05]
+    ]
+  ],
+  "mx-baja-wecc": [
+    [
+      ["tijuana-california-upgrade-market","Southern California","Two operating border paths let Baja California and California support each other.",57,1500000000,1900000000],
+      ["baja-sin-hvdc-new-market","Mexican national grid","A new HVDC line would connect Baja to the SIN without forcing the two AC systems to synchronize.",52,1900000000,1800000000]
+    ],
+    [
+      ["tijuana-california-upgrade","tijuana-california-upgrade-market","Southern California upgrade","EXISTING",600000000,210000000,4200000,2,32,0.014,0.06],
+      ["baja-sin-hvdc-new","baja-sin-hvdc-new-market","Mexican national grid connection","NEW",800000000,1040000000,15600000,6,33,0.015,0.06]
+    ]
+  ],
+  "mx-sin-yucatan": [
+    [
+      ["yucatan-sin-upgrade-market","Eastern Mexico","The peninsula's main connection carries power to and from the rest of Mexico.",52,1700000000,1800000000],
+      ["yucatan-belize-upgrade-market","Belize grid","A small border line offers useful emergency trade, but cannot power the whole peninsula.",59,120000000,140000000]
+    ],
+    [
+      ["yucatan-sin-upgrade","yucatan-sin-upgrade-market","Eastern Mexico upgrade","EXISTING",600000000,270000000,5400000,2,32,0.015,0.06],
+      ["yucatan-belize-upgrade","yucatan-belize-upgrade-market","Belize grid upgrade","EXISTING",50000000,35000000,700000,1,32,0.015,0.06]
+    ]
+  ],
+  "siepac-north": [
+    [
+      ["siepac-north-neighbor-upgrade-market","Neighboring SIEPAC market","The regional line trades power with the next country when rainfall, wind, or demand differs.",61,650000000,700000000],
+      ["guatemala-mexico-upgrade-market","Mexico market","A northern border line gives the regional market another source and buyer.",54,900000000,1000000000]
+    ],
+    [
+      ["siepac-north-neighbor-upgrade","siepac-north-neighbor-upgrade-market","Neighboring SIEPAC market upgrade","EXISTING",250000000,105000000,2100000,2,31,0.014,0.05],
+      ["guatemala-mexico-upgrade","guatemala-mexico-upgrade-market","Mexico market upgrade","EXISTING",240000000,110000000,2200000,2,32,0.014,0.05]
+    ]
+  ],
+  "siepac-central": [
+    [
+      ["siepac-central-north-upgrade-market","Northern SIEPAC market","Trade north toward Guatemala and El Salvador when their power is cheaper.",60,650000000,700000000],
+      ["siepac-central-south-upgrade-market","Southern SIEPAC market","Trade south toward Costa Rica and Panama, where rainfall and generation can follow a different pattern.",57,750000000,750000000]
+    ],
+    [
+      ["siepac-central-north-upgrade","siepac-central-north-upgrade-market","Northern SIEPAC market upgrade","EXISTING",250000000,100000000,2000000,2,32,0.014,0.05],
+      ["siepac-central-south-upgrade","siepac-central-south-upgrade-market","Southern SIEPAC market upgrade","EXISTING",300000000,120000000,2400000,2,32,0.014,0.05]
+    ]
+  ],
+  "siepac-south": [
+    [
+      ["siepac-south-north-upgrade-market","Northern SIEPAC market","The regional backbone reaches five neighboring national markets to the north.",59,800000000,800000000],
+      ["panama-colombia-hvdc-new-market","Colombia market","A planned HVDC line would join Central and South America's regional grids.",48,1000000000,900000000]
+    ],
+    [
+      ["siepac-south-north-upgrade","siepac-south-north-upgrade-market","Northern SIEPAC market upgrade","EXISTING",300000000,120000000,2400000,2,31,0.014,0.05],
+      ["panama-colombia-hvdc-new","panama-colombia-hvdc-new-market","Colombia market connection","NEW",400000000,800000000,12000000,6,32,0.015,0.05]
+    ]
+  ],
+  "siepac-san-salvador": [
+    [
+      ["siepac-honduras-market","Neighboring SIEPAC market","The regional line trades power with the next country when rainfall, wind, or demand differs.",61,650000000,700000000]
+    ],
+    [
+      ["siepac-honduras-upgrade","siepac-honduras-market","Honduras intertie upgrade","EXISTING",250000000,105000000,2100000,2,31,0.014,0.05]
+    ]
+  ],
+  "siepac-costa-rica": [
+    [
+      ["siepac-panama-market","Northern SIEPAC market","The regional backbone reaches five neighboring national markets to the north.",59,800000000,800000000]
+    ],
+    [
+      ["siepac-panama-upgrade","siepac-panama-market","Panama intertie upgrade","EXISTING",300000000,120000000,2400000,2,31,0.014,0.05]
+    ]
+  ],
+  "geo-london": [
+    [
+      ["geo-london-continental-core","Continental Europe","Nuclear, wind, and gas compete across the Channel; prices change when cables or power stations are busy.",62,2400000000,2200000000],
+      ["geo-london-norwegian-hydro","Norwegian hydropower","Reservoirs can send flexible low-carbon power, but dry years leave less to export.",49,1600000000,1200000000]
+    ],
+    [
+      ["gb-channel-upgrade","geo-london-continental-core","Channel cable upgrade","EXISTING",750000000,240000000,4800000,1,30,0.012,0.03],
+      ["gb-north-sea-upgrade","geo-london-norwegian-hydro","North Sea Link upgrade","EXISTING",500000000,260000000,5200000,2,27,0.01,0.02]
+    ]
+  ],
+  "geo-dublin": [
+    [
+      ["geo-dublin-great-britain-market","Great Britain","Windy hours can be cheap, while cold calm evenings can tighten supply.",64,1400000000,1600000000],
+      ["geo-dublin-continental-core","Continental Europe","A larger mix of nuclear, wind, hydro, and gas gives another source of power.",62,1500000000,1400000000]
+    ],
+    [
+      ["ireland-ewic-upgrade","geo-dublin-great-britain-market","Irish Sea cable upgrade","EXISTING",350000000,190000000,3800000,1,27,0.01,0.02],
+      ["ireland-celtic","geo-dublin-continental-core","Celtic Interconnector","NEW",700000000,620000000,10500000,4,28,0.01,0.02]
+    ]
+  ],
+  "geo-paris": [
+    [
+      ["geo-paris-continental-core","Core European market","Neighbouring grids share wind, solar, nuclear, hydro, and gas across many borders.",60,2800000000,2600000000],
+      ["geo-paris-iberian-market","Iberian renewables","Spanish and Portuguese wind, sun, and hydro can send surplus north, but the Pyrenees limit the flow.",51,1700000000,1400000000]
+    ],
+    [
+      ["france-core-upgrade","geo-paris-continental-core","Eastern border reinforcement","EXISTING",800000000,230000000,4600000,1,30,0.012,0.04],
+      ["france-biscay","geo-paris-iberian-market","Bay of Biscay cable","NEW",1000000000,780000000,13000000,4,31,0.012,0.03]
+    ]
+  ],
+  "geo-madrid": [
+    [
+      ["geo-madrid-portuguese-market","Portugal","Atlantic wind and hydro often complement Spanish solar.",49,1500000000,1200000000],
+      ["geo-madrid-continental-core","France and Continental Europe","The Pyrenees gateway reaches the larger European market, but it is often congested.",62,1800000000,2000000000]
+    ],
+    [
+      ["spain-portugal-upgrade","geo-madrid-portuguese-market","Iberian border upgrade","EXISTING",650000000,180000000,3600000,1,34,0.014,0.05],
+      ["spain-biscay","geo-madrid-continental-core","Bay of Biscay cable","NEW",1000000000,780000000,13000000,4,32,0.013,0.03]
+    ]
+  ],
+  "geo-lisbon": [
+    [
+      ["geo-lisbon-spanish-market","Spain","The combined Iberian market shares changing supplies of wind, solar, hydro, and gas.",52,2000000000,1900000000]
+    ],
+    [
+      ["portugal-spain-upgrade","geo-lisbon-spanish-market","Northern Iberian reinforcement","EXISTING",700000000,190000000,3800000,1,32,0.013,0.05]
+    ]
+  ],
+  "geo-rome": [
+    [
+      ["geo-rome-alpine-market","Alpine neighbours","French, Swiss, Austrian, and Slovenian power crosses mountain passes, with strong winter demand.",61,2200000000,2100000000],
+      ["geo-rome-adriatic-market","Adriatic and Balkan grids","Hydro, wind, and thermal power arrive by eastern land routes and undersea cables.",54,1600000000,1300000000]
+    ],
+    [
+      ["italy-alpine-upgrade","geo-rome-alpine-market","Alpine border reinforcement","EXISTING",750000000,260000000,5200000,2,31,0.012,0.04],
+      ["italy-mediterranean-link","geo-rome-adriatic-market","Mediterranean cable","NEW",600000000,690000000,11500000,4,34,0.013,0.03]
+    ]
+  ],
+  "geo-berlin": [
+    [
+      ["geo-berlin-western-core","Western Europe","Dense borders share French nuclear, Benelux wind and gas, and Alpine hydro.",61,2800000000,2700000000],
+      ["geo-berlin-nordic-market","Nordic and Danish market","Wind and reservoir hydro can absorb or fill Germany’s changing renewable supply.",48,2000000000,1700000000]
+    ],
+    [
+      ["germany-west-upgrade","geo-berlin-western-core","Western grid reinforcement","EXISTING",800000000,210000000,4200000,1,30,0.012,0.04],
+      ["germany-nordic-link","geo-berlin-nordic-market","North–south exchange link","NEW",700000000,440000000,7500000,3,28,0.01,0.03]
+    ]
+  ],
+  "geo-vienna": [
+    [
+      ["geo-vienna-north-core","Germany and Czechia","Large connected markets can trade wind, solar, coal, gas, and nuclear power.",59,1800000000,1800000000],
+      ["geo-vienna-alpine-balkan","Alps and Balkans","Hydro-rich neighbours can respond quickly, especially after rain and snowmelt.",55,1500000000,1300000000]
+    ],
+    [
+      ["austria-north-upgrade","geo-vienna-north-core","Danube border upgrade","EXISTING",500000000,155000000,3100000,1,31,0.012,0.04],
+      ["austria-south-upgrade","geo-vienna-alpine-balkan","Alpine exchange upgrade","EXISTING",450000000,180000000,3600000,2,30,0.012,0.04]
+    ]
+  ],
+  "geo-zurich": [
+    [
+      ["geo-zurich-northwest-core","France and Germany","Big neighbouring markets bring nuclear, wind, and thermal power.",61,1900000000,2000000000],
+      ["geo-zurich-italian-market","Italy","Italy often needs imports, while Alpine storage can earn money by exporting at busy hours.",66,1200000000,1800000000]
+    ],
+    [
+      ["swiss-north-upgrade","geo-zurich-northwest-core","Northern border upgrade","EXISTING",500000000,170000000,3400000,1,29,0.011,0.04],
+      ["swiss-south-upgrade","geo-zurich-italian-market","Alpine crossing upgrade","EXISTING",450000000,210000000,4200000,2,29,0.011,0.04]
+    ]
+  ],
+  "geo-amsterdam": [
+    [
+      ["geo-amsterdam-core-neighbours","Belgium and Germany","Short, strong borders connect to the heart of the European market.",60,2200000000,2100000000],
+      ["geo-amsterdam-north-sea-market","North Sea neighbours","Long DC cables reach Norwegian hydro, Danish wind, and Great Britain.",52,1600000000,1500000000]
+    ],
+    [
+      ["netherlands-core-upgrade","geo-amsterdam-core-neighbours","Core border upgrade","EXISTING",650000000,170000000,3400000,1,30,0.012,0.04],
+      ["netherlands-north-sea-upgrade","geo-amsterdam-north-sea-market","North Sea cable upgrade","EXISTING",500000000,270000000,5400000,2,28,0.01,0.02]
+    ]
+  ],
+  "geo-brussels": [
+    [
+      ["geo-brussels-france-market","France","A large nuclear fleet can export steadily, but outages can quickly tighten prices.",60,2000000000,1900000000],
+      ["geo-brussels-north-sea-core","Netherlands, Germany, and Great Britain","Several nearby grids offer a mix of wind, gas, coal, and imports.",62,1800000000,1900000000]
+    ],
+    [
+      ["belgium-france-upgrade","geo-brussels-france-market","Southern border upgrade","EXISTING",550000000,150000000,3000000,1,30,0.012,0.04],
+      ["belgium-north-upgrade","geo-brussels-north-sea-core","Northern exchange upgrade","EXISTING",500000000,170000000,3400000,1,29,0.011,0.03]
+    ]
+  ],
+  "geo-copenhagen": [
+    [
+      ["geo-copenhagen-nordic-market","Nordic grid","Swedish and Norwegian hydro can balance Denmark’s changing wind output.",47,1900000000,1500000000],
+      ["geo-copenhagen-continental-market","Continental and North Sea grid","Germany, the Netherlands, and Great Britain offer a much larger market for windy and calm hours.",61,2000000000,2100000000]
+    ],
+    [
+      ["denmark-nordic-upgrade","geo-copenhagen-nordic-market","Øresund and Skagerrak upgrade","EXISTING",550000000,210000000,4200000,2,27,0.01,0.03],
+      ["denmark-continent-upgrade","geo-copenhagen-continental-market","Continental cable upgrade","EXISTING",600000000,220000000,4400000,2,28,0.01,0.03]
+    ]
+  ],
+  "geo-lista": [
+    [
+      ["geo-lista-nordic-market","Sweden and Finland","A shared Nordic grid moves hydro, wind, and nuclear power between regions.",47,1900000000,1700000000],
+      ["geo-lista-north-sea-continent","North Sea and Continental Europe","Subsea cables reach Denmark, the Netherlands, Germany, and Great Britain.",61,2000000000,2300000000]
+    ],
+    [
+      ["norway-nordic-upgrade","geo-lista-nordic-market","Nordic border upgrade","EXISTING",550000000,180000000,3600000,1,26,0.01,0.03],
+      ["norway-north-sea-upgrade","geo-lista-north-sea-continent","North Sea converter upgrade","EXISTING",500000000,280000000,5600000,2,27,0.01,0.02]
+    ]
+  ],
+  "geo-stockholm": [
+    [
+      ["geo-stockholm-nordic-market","Norway, Finland, and Denmark","The synchronous Nordic grid shares hydro, nuclear, and wind power.",47,2000000000,1700000000],
+      ["geo-stockholm-baltic-continent","Baltic and Continental Europe","DC cables reach Lithuania, Poland, and Germany.",57,1600000000,1600000000]
+    ],
+    [
+      ["sweden-nordic-upgrade","geo-stockholm-nordic-market","Nordic AC upgrade","EXISTING",600000000,180000000,3600000,1,26,0.01,0.03],
+      ["sweden-baltic-upgrade","geo-stockholm-baltic-continent","Baltic cable upgrade","EXISTING",450000000,250000000,5000000,2,27,0.01,0.02]
+    ]
+  ],
+  "geo-helsinki": [
+    [
+      ["geo-helsinki-nordic-market","Sweden and Norway","Nordic hydro, wind, and nuclear power share one synchronous grid.",48,1700000000,1600000000],
+      ["geo-helsinki-baltic-market","Estonia and the Baltic states","Undersea DC cables connect Finland to Estonia and onward to Continental Europe.",56,1100000000,1200000000]
+    ],
+    [
+      ["finland-nordic-upgrade","geo-helsinki-nordic-market","Northern border upgrade","EXISTING",500000000,170000000,3400000,1,25,0.01,0.03],
+      ["finland-estlink-upgrade","geo-helsinki-baltic-market","Estlink upgrade","EXISTING",350000000,230000000,4600000,2,26,0.01,0.02]
+    ]
+  ],
+  "geo-warsaw": [
+    [
+      ["geo-warsaw-western-core","Germany and Czechia","Large neighbouring markets mix wind, solar, nuclear, coal, and gas.",59,2100000000,2000000000],
+      ["geo-warsaw-baltic-nordic","Baltic and Nordic market","Links through Lithuania and Sweden reach hydro, wind, and nuclear power.",54,1500000000,1400000000]
+    ],
+    [
+      ["poland-west-upgrade","geo-warsaw-western-core","Western border upgrade","EXISTING",600000000,175000000,3500000,1,30,0.012,0.04],
+      ["poland-baltic-upgrade","geo-warsaw-baltic-nordic","Baltic exchange upgrade","EXISTING",450000000,240000000,4800000,2,28,0.01,0.03]
+    ]
+  ],
+  "geo-prague": [
+    [
+      ["geo-prague-west-core","Germany and Austria","Dense neighbouring grids provide a broad mix of power.",59,1900000000,1900000000],
+      ["geo-prague-east-core","Poland and Slovakia","Industrial demand competes with coal, nuclear, wind, and hydro generation.",56,1500000000,1500000000]
+    ],
+    [
+      ["czech-west-upgrade","geo-prague-west-core","Western border upgrade","EXISTING",500000000,145000000,2900000,1,30,0.012,0.04],
+      ["czech-east-upgrade","geo-prague-east-core","Eastern border upgrade","EXISTING",450000000,150000000,3000000,1,30,0.012,0.04]
+    ]
+  ],
+  "geo-budapest": [
+    [
+      ["geo-budapest-northwest-core","Austria and Slovakia","Connections lead toward large Central European markets.",59,1700000000,1600000000],
+      ["geo-budapest-southern-balkan","Romania, Croatia, and Serbia","Hydro, nuclear, wind, and thermal power trade across several southern borders.",53,1500000000,1400000000]
+    ],
+    [
+      ["hungary-northwest-upgrade","geo-budapest-northwest-core","Northwest border upgrade","EXISTING",500000000,155000000,3100000,1,32,0.013,0.04],
+      ["hungary-south-upgrade","geo-budapest-southern-balkan","Southern border upgrade","EXISTING",450000000,150000000,3000000,1,33,0.013,0.05]
+    ]
+  ],
+  "geo-bucharest": [
+    [
+      ["geo-bucharest-central-market","Hungary and Serbia","Connected neighbours share nuclear, hydro, wind, coal, and gas power.",55,1600000000,1500000000],
+      ["geo-bucharest-black-sea-market","Bulgaria and Ukraine","A Black Sea corridor reaches hydro, nuclear, and thermal generators.",51,1500000000,1400000000]
+    ],
+    [
+      ["romania-west-upgrade","geo-bucharest-central-market","Western border upgrade","EXISTING",500000000,150000000,3000000,1,33,0.014,0.05],
+      ["romania-black-sea-upgrade","geo-bucharest-black-sea-market","Black Sea grid upgrade","EXISTING",450000000,165000000,3300000,2,33,0.014,0.05]
+    ]
+  ],
+  "geo-sofia": [
+    [
+      ["geo-sofia-northwest-balkan","Romania and Serbia","Nuclear, hydro, and thermal power move around the Balkan grid.",52,1500000000,1400000000],
+      ["geo-sofia-south-market","Greece and Türkiye","Southern demand, solar, gas, and hydro create strong daily price swings.",57,1600000000,1700000000]
+    ],
+    [
+      ["bulgaria-north-upgrade","geo-sofia-northwest-balkan","Danube border upgrade","EXISTING",500000000,155000000,3100000,1,34,0.014,0.05],
+      ["bulgaria-turkey-upgrade","geo-sofia-south-market","Türkiye border upgrade","EXISTING",550000000,190000000,3800000,2,35,0.014,0.05]
+    ]
+  ],
+  "geo-belgrade": [
+    [
+      ["geo-belgrade-northwest-market","Hungary and Croatia","Central European markets add wind, nuclear, hydro, and gas power.",56,1500000000,1500000000],
+      ["geo-belgrade-east-balkan","Romania and Bulgaria","Hydro, nuclear, and thermal fleets can trade at busy hours.",52,1400000000,1300000000]
+    ],
+    [
+      ["serbia-north-upgrade","geo-belgrade-northwest-market","Northern border upgrade","EXISTING",450000000,145000000,2900000,1,34,0.014,0.05],
+      ["serbia-east-upgrade","geo-belgrade-east-balkan","Danube exchange upgrade","EXISTING",450000000,150000000,3000000,1,34,0.014,0.05]
+    ]
+  ],
+  "geo-zagreb": [
+    [
+      ["geo-zagreb-alpine-market","Slovenia and Hungary","Connections lead into the larger Central European market.",57,1500000000,1500000000],
+      ["geo-zagreb-western-balkan","Serbia and Bosnia","Hydro and thermal systems can help each other when water or fuel conditions differ.",51,1300000000,1200000000]
+    ],
+    [
+      ["croatia-alpine-upgrade","geo-zagreb-alpine-market","Alpine gateway upgrade","EXISTING",450000000,145000000,2900000,1,33,0.014,0.05],
+      ["croatia-balkan-upgrade","geo-zagreb-western-balkan","Balkan border upgrade","EXISTING",400000000,140000000,2800000,1,34,0.014,0.05]
+    ]
+  ],
+  "geo-athens": [
+    [
+      ["geo-athens-balkan-market","Bulgaria and Türkiye","Land links reach Balkan hydro, nuclear, gas, coal, wind, and solar.",56,1600000000,1600000000],
+      ["geo-athens-italian-market","Italy","An undersea cable links two Mediterranean markets with different busy hours.",65,1200000000,1600000000]
+    ],
+    [
+      ["greece-balkan-upgrade","geo-athens-balkan-market","Northern border upgrade","EXISTING",500000000,170000000,3400000,1,35,0.014,0.05],
+      ["greece-italy-upgrade","geo-athens-italian-market","Adriatic cable upgrade","EXISTING",350000000,240000000,4800000,2,33,0.012,0.02]
+    ]
+  ],
+  "geo-kyiv": [
+    [
+      ["geo-kyiv-continental-west","Continental Europe","Poland, Slovakia, Hungary, and Romania connect Ukraine to Europe's coordinated grid.",57,1700000000,1900000000]
+    ],
+    [
+      ["ukraine-west-upgrade","geo-kyiv-continental-west","Western synchronization upgrade","EXISTING",500000000,220000000,4400000,2,31,0.012,0.04]
+    ]
+  ],
+  "geo-minsk": [
+    [
+      ["geo-minsk-russian-market","Russia","The two power systems still operate at one frequency and exchange power, while the former Baltic routes are closed.",46,1600000000,1500000000]
+    ],
+    [
+      ["belarus-russia-upgrade","geo-minsk-russian-market","Russia border upgrade","EXISTING",450000000,160000000,3200000,1,29,0.011,0.04]
+    ]
+  ],
+  "geo-tallinn": [
+    [
+      ["geo-tallinn-finnish-market","Finland","Two undersea DC links reach the Nordic market.",49,1100000000,1200000000],
+      ["geo-tallinn-baltic-market","Latvia and Continental Europe","The Baltic grids now share Continental Europe's frequency and reach Poland through Lithuania.",55,1300000000,1200000000]
+    ],
+    [
+      ["estonia-estlink-upgrade","geo-tallinn-finnish-market","Estlink upgrade","EXISTING",350000000,230000000,4600000,2,27,0.01,0.02],
+      ["estonia-latvia-upgrade","geo-tallinn-baltic-market","Baltic AC upgrade","EXISTING",350000000,125000000,2500000,1,28,0.011,0.03]
+    ]
+  ],
+  "geo-riga": [
+    [
+      ["geo-riga-baltic-market","Estonia and Lithuania","The three Baltic grids share power and one Continental European frequency.",54,1300000000,1200000000],
+      ["geo-riga-nordic-market","Nordic market","Power reaches Finland through Estonia and Sweden through Lithuania.",48,1100000000,1100000000]
+    ],
+    [
+      ["latvia-baltic-upgrade","geo-riga-baltic-market","Baltic corridor upgrade","EXISTING",400000000,135000000,2700000,1,28,0.011,0.03],
+      ["latvia-nordic-converter","geo-riga-nordic-market","Nordic converter reinforcement","NEW",300000000,260000000,4800000,3,27,0.01,0.02]
+    ]
+  ],
+  "geo-vilnius": [
+    [
+      ["geo-vilnius-polish-market","Poland and Continental Europe","LitPol Link is the Baltic land gateway to the larger Continental European grid.",57,1400000000,1500000000],
+      ["geo-vilnius-swedish-market","Sweden","NordBalt reaches Nordic hydro, nuclear, and wind across the sea.",48,1100000000,1100000000]
+    ],
+    [
+      ["lithuania-litpol-upgrade","geo-vilnius-polish-market","LitPol Link upgrade","EXISTING",450000000,175000000,3500000,2,29,0.011,0.03],
+      ["lithuania-nordbalt-upgrade","geo-vilnius-swedish-market","NordBalt upgrade","EXISTING",350000000,240000000,4800000,2,27,0.01,0.02]
+    ]
+  ],
+  "geo-moscow": [
+    [
+      ["geo-moscow-russian-regions","Russia's connected regions","High-voltage lines join the Central, North-West, Volga, Ural, Southern, and Siberian systems.",44,2600000000,2500000000],
+      ["geo-moscow-belarus-market","Belarus","Belarus and Russia remain synchronized and can exchange power.",46,1300000000,1200000000]
+    ],
+    [
+      ["russia-regional-upgrade","geo-moscow-russian-regions","Inter-regional grid upgrade","EXISTING",700000000,220000000,4400000,2,27,0.01,0.03],
+      ["russia-belarus-upgrade","geo-moscow-belarus-market","Belarus border upgrade","EXISTING",400000000,160000000,3200000,1,29,0.011,0.04]
+    ]
+  ],
+  "geo-istanbul": [
+    [
+      ["geo-istanbul-continental-europe","Continental Europe","Türkiye shares one frequency with Bulgaria and Greece, reaching Europe's large power market.",59,2000000000,2100000000],
+      ["geo-istanbul-caucasus-market","Georgia and the Caucasus","An asynchronous gateway reaches Georgian hydro and the wider Caucasus grid.",47,1300000000,1200000000]
+    ],
+    [
+      ["turkey-europe-upgrade","geo-istanbul-continental-europe","Thrace border upgrade","EXISTING",600000000,210000000,4200000,2,35,0.014,0.05],
+      ["turkey-georgia-upgrade","geo-istanbul-caucasus-market","Georgia converter upgrade","EXISTING",450000000,230000000,4600000,2,35,0.014,0.04]
+    ]
+  ],
+  "geo-dubai": [
+    [
+      ["geo-dubai-gcc-north","Saudi Arabia and the northern Gulf","The GCC backbone shares gas-fired power and emergency reserves across the Gulf.",53,1500000000,1500000000],
+      ["geo-dubai-oman-market","Oman","Oman's later afternoon peak can differ from the Emirates, creating time to trade.",51,900000000,1000000000]
+    ],
+    [
+      ["uae-gcc-upgrade","geo-dubai-gcc-north","GCC backbone upgrade","EXISTING",500000000,190000000,3800000,2,38,0.018,0.08],
+      ["uae-oman-upgrade","geo-dubai-oman-market","Oman gateway upgrade","EXISTING",300000000,140000000,2800000,1,38,0.018,0.08]
+    ]
+  ],
+  "geo-doha": [
+    [
+      ["geo-doha-gcc-backbone","GCC power market","A regional safety net lets Qatar exchange gas-fired power and reserves with its neighbours.",52,1100000000,1200000000]
+    ],
+    [
+      ["qatar-gcc-upgrade","geo-doha-gcc-backbone","Qatar–GCC upgrade","EXISTING",400000000,175000000,3500000,2,38,0.018,0.08]
+    ]
+  ],
+  "geo-manama": [
+    [
+      ["geo-manama-gcc-backbone","GCC power market","Two undersea cables connect Bahrain to a regional grid that can share reserves and energy.",52,900000000,1000000000]
+    ],
+    [
+      ["bahrain-cable-upgrade","geo-manama-gcc-backbone","Bahrain cable upgrade","EXISTING",300000000,210000000,4200000,2,38,0.016,0.03]
+    ]
+  ],
+  "geo-kuwaitcity": [
+    [
+      ["geo-kuwaitcity-gcc-backbone","Saudi Arabia and the GCC","A 400 kV backbone shares power and reserves across the Gulf.",52,1400000000,1500000000],
+      ["geo-kuwaitcity-iraq-market","Southern Iraq","A new route can send Gulf electricity to Iraq and create a new trading border.",58,700000000,1000000000]
+    ],
+    [
+      ["kuwait-gcc-upgrade","geo-kuwaitcity-gcc-backbone","Al-Fadhili corridor upgrade","EXISTING",500000000,190000000,3800000,2,39,0.018,0.08],
+      ["kuwait-iraq-link","geo-kuwaitcity-iraq-market","Al-Wafrah–Al-Faw link","NEW",500000000,390000000,7200000,3,39,0.018,0.08]
+    ]
+  ],
+  "geo-muscat": [
+    [
+      ["geo-muscat-uae-market","United Arab Emirates","Oman reaches the wider GCC grid through the Emirates.",53,1000000000,1100000000],
+      ["geo-muscat-gcc-direct","Direct GCC backbone","A planned direct route would reduce reliance on the single path through the UAE.",51,1300000000,1300000000]
+    ],
+    [
+      ["oman-uae-upgrade","geo-muscat-uae-market","Mahdha gateway upgrade","EXISTING",300000000,145000000,2900000,1,38,0.018,0.08],
+      ["oman-gcc-direct","geo-muscat-gcc-direct","Direct GCC connection","NEW",600000000,420000000,7800000,3,38,0.018,0.08]
+    ]
+  ],
+  "geo-riyadh": [
+    [
+      ["geo-riyadh-gcc-market","GCC neighbours","A frequency converter connects Saudi Arabia's 60 Hz grid to the GCC's 50 Hz backbone.",52,1700000000,1700000000],
+      ["geo-riyadh-egypt-market","Egypt","Different evening peak times across the Red Sea can help both grids share power.",55,1500000000,1600000000]
+    ],
+    [
+      ["saudi-gcc-upgrade","geo-riyadh-gcc-market","GCC converter upgrade","EXISTING",600000000,250000000,5000000,2,39,0.018,0.08],
+      ["saudi-egypt-link","geo-riyadh-egypt-market","Saudi–Egypt HVDC link","NEW",750000000,620000000,11000000,4,38,0.016,0.03]
+    ]
+  ],
+  "geo-baghdad": [
+    [
+      ["geo-baghdad-iran-market","Iran","Existing eastern links can import power, but availability and contracts can change.",54,900000000,1100000000],
+      ["geo-baghdad-gcc-jordan-market","GCC and Jordan","New western and southern routes can diversify Iraq's supply.",56,1200000000,1200000000]
+    ],
+    [
+      ["iraq-iran-upgrade","geo-baghdad-iran-market","Eastern intertie upgrade","EXISTING",350000000,175000000,3500000,2,40,0.018,0.08],
+      ["iraq-gcc-link","geo-baghdad-gcc-jordan-market","GCC–Iraq connection","NEW",500000000,410000000,7500000,3,40,0.018,0.08]
+    ]
+  ],
+  "geo-tehran": [
+    [
+      ["geo-tehran-caucasus-market","Armenia and Azerbaijan","Northern links exchange thermal, hydro, and seasonal power with the Caucasus.",47,1100000000,1000000000],
+      ["geo-tehran-western-market","Türkiye and Iraq","Western links can trade power, though transfer limits and operating agreements vary.",55,1100000000,1200000000]
+    ],
+    [
+      ["iran-armenia-upgrade","geo-tehran-caucasus-market","Armenia border upgrade","EXISTING",400000000,190000000,3800000,2,38,0.017,0.07],
+      ["iran-west-upgrade","geo-tehran-western-market","Western intertie upgrade","EXISTING",350000000,180000000,3600000,2,39,0.018,0.08]
+    ]
+  ],
+  "geo-amman": [
+    [
+      ["geo-amman-egypt-market","Egypt","A short cable under the Gulf of Aqaba connects two grids with different peak times.",54,1000000000,1100000000],
+      ["geo-amman-iraq-saudi-market","Iraq and Saudi Arabia","New desert routes can widen regional trade and emergency support.",55,900000000,1000000000]
+    ],
+    [
+      ["jordan-egypt-upgrade","geo-amman-egypt-market","Aqaba cable upgrade","EXISTING",350000000,220000000,4400000,2,38,0.016,0.03],
+      ["jordan-east-link","geo-amman-iraq-saudi-market","Eastern regional link","NEW",400000000,300000000,5800000,3,38,0.018,0.08]
+    ]
+  ],
+  "geo-beirut": [
+    [
+      ["geo-beirut-levant-market","Syria and Jordan","Physical links can bring regional power, but outages and contracts may leave little available.",59,250000000,450000000]
+    ],
+    [
+      ["lebanon-levant-repair","geo-beirut-levant-market","Levant intertie restoration","EXISTING",200000000,140000000,2800000,2,35,0.014,0.05]
+    ]
+  ],
+  "geo-damascus": [
+    [
+      ["geo-damascus-jordan-market","Jordan and Egypt","The southbound link reaches Jordan and Egypt, but transfers may be unavailable.",57,300000000,500000000],
+      ["geo-damascus-turkey-market","Türkiye","A northern 400 kV route exists, but it is not part of Türkiye's synchronous European trading border.",60,250000000,450000000]
+    ],
+    [
+      ["syria-jordan-restoration","geo-damascus-jordan-market","Jordan link restoration","EXISTING",200000000,150000000,3000000,2,38,0.017,0.07],
+      ["syria-turkey-restoration","geo-damascus-turkey-market","Türkiye link restoration","EXISTING",200000000,160000000,3200000,2,38,0.017,0.07]
+    ]
+  ],
+  "geo-telaviv": [
+    [
+      ["geo-telaviv-east-mediterranean","Cyprus and Greece","A planned long subsea cable could connect today's isolated market to Europe.",63,900000000,1000000000]
+    ],
+    [
+      ["israel-great-sea","geo-telaviv-east-mediterranean","Great Sea Interconnector","NEW",500000000,850000000,14000000,4,36,0.014,0.02]
+    ]
+  ],
+  "geo-baku": [
+    [
+      ["geo-baku-caucasus-market","Georgia and Russia","Azerbaijan shares a synchronous regional system and trades through Georgia.",46,1200000000,1100000000],
+      ["geo-baku-turkey-market","Türkiye via Nakhchivan","A smaller western route reaches Türkiye, with a wider green corridor planned through Georgia.",58,700000000,800000000]
+    ],
+    [
+      ["azerbaijan-georgia-upgrade","geo-baku-caucasus-market","Georgia border upgrade","EXISTING",400000000,165000000,3300000,2,37,0.016,0.06],
+      ["azerbaijan-turkey-upgrade","geo-baku-turkey-market","Nakhchivan link upgrade","EXISTING",200000000,150000000,3000000,2,38,0.017,0.07]
+    ]
+  ],
+  "geo-tbilisi": [
+    [
+      ["geo-tbilisi-caucasus-market","Russia, Azerbaijan, and Armenia","Georgia sits between hydro-rich and thermal systems and can exchange in several directions.",46,1300000000,1100000000],
+      ["geo-tbilisi-turkey-market","Türkiye","A converter lets asynchronous grids trade without sharing one frequency.",58,900000000,1000000000]
+    ],
+    [
+      ["georgia-caucasus-upgrade","geo-tbilisi-caucasus-market","Caucasus border upgrade","EXISTING",450000000,175000000,3500000,2,35,0.015,0.05],
+      ["georgia-turkey-link","geo-tbilisi-turkey-market","Akhaltsikhe–Tortum link","NEW",500000000,310000000,5800000,3,35,0.015,0.04]
+    ]
+  ],
+  "geo-yerevan": [
+    [
+      ["geo-yerevan-iran-market","Iran","Gas-for-electricity exchange and power lines make Iran an important southern partner.",49,900000000,900000000],
+      ["geo-yerevan-georgia-market","Georgia and the Caucasus","A northern link can reach Georgian hydro and wider regional trade.",46,800000000,850000000]
+    ],
+    [
+      ["armenia-iran-upgrade","geo-yerevan-iran-market","Iran 400 kV upgrade","NEW",500000000,280000000,5200000,3,37,0.016,0.06],
+      ["armenia-georgia-link","geo-yerevan-georgia-market","Caucasus transmission link","NEW",350000000,260000000,4800000,3,35,0.015,0.05]
+    ]
+  ],
+  "geo-tashkent": [
+    [
+      ["geo-tashkent-central-asian-market","Kazakhstan and Central Asia","A regional system shares hydro and thermal power across seasons.",40,1300000000,1200000000],
+      ["geo-tashkent-afghanistan-market","Afghanistan","Afghanistan buys power from Uzbekistan, creating export demand south of the border.",50,300000000,600000000]
+    ],
+    [
+      ["uzbekistan-central-upgrade","geo-tashkent-central-asian-market","Central Asian grid upgrade","EXISTING",450000000,150000000,3000000,2,39,0.017,0.07],
+      ["uzbekistan-afghan-upgrade","geo-tashkent-afghanistan-market","Surkhan–Pul-e-Khumri line","NEW",350000000,230000000,4600000,3,40,0.018,0.08]
+    ]
+  ],
+  "geo-almaty": [
+    [
+      ["geo-almaty-russian-market","Russia","Kazakhstan operates in parallel with Russia and settles changing cross-border flows.",44,1800000000,1700000000],
+      ["geo-almaty-central-asian-market","Uzbekistan and Central Asia","Southern links share thermal and hydro power across the region.",40,1400000000,1300000000]
+    ],
+    [
+      ["kazakhstan-russia-upgrade","geo-almaty-russian-market","Northern border upgrade","EXISTING",600000000,190000000,3800000,2,34,0.014,0.05],
+      ["kazakhstan-central-upgrade","geo-almaty-central-asian-market","Central Asian corridor upgrade","EXISTING",500000000,170000000,3400000,2,38,0.017,0.07]
+    ]
+  ],
+  "geo-kabul": [
+    [
+      ["geo-kabul-uzbek-market","Uzbekistan","Imported power travels south from Uzbekistan; Kabul depends on long transmission routes.",45,500000000,250000000],
+      ["geo-kabul-tajik-hydro","Tajik and Kyrgyz hydropower","CASA-1000 is designed to move summer hydro surplus through Afghanistan.",38,400000000,250000000]
+    ],
+    [
+      ["afghanistan-uzbek-upgrade","geo-kabul-uzbek-market","Northern import upgrade","EXISTING",250000000,170000000,3400000,2,40,0.018,0.08],
+      ["afghanistan-casa","geo-kabul-tajik-hydro","CASA-1000 corridor","NEW",300000000,300000000,5500000,4,39,0.017,0.07]
+    ]
+  ],
+  "geo-cairo": [
+    [
+      ["geo-cairo-libyan-coast","Libyan coast","A smaller neighbouring grid often needs imports, but the desert border line can also help during an Egyptian shortage.",76,300000000,500000000],
+      ["geo-cairo-jordan-levant","Jordan and the Levant","A Red Sea cable shares thermal and renewable power between two grids whose busiest hours do not always match.",68,550000000,600000000]
+    ],
+    [
+      ["egypt-libya-upgrade","geo-cairo-libyan-coast","Western desert line upgrade","EXISTING",200000000,120000000,2400000,1,39,0.018,0.08],
+      ["egypt-jordan-upgrade","geo-cairo-jordan-levant","Gulf of Aqaba cable upgrade","EXISTING",350000000,230000000,4600000,2,38,0.017,0.03]
+    ]
+  ],
+  "geo-casablanca": [
+    [
+      ["geo-casablanca-iberian-market","Spain and the Iberian market","Two undersea links reach a large market with wind, solar, hydro, nuclear, and gas.",58,1300000000,1500000000],
+      ["geo-casablanca-portuguese-atlantic","Portugal by Atlantic cable","A proposed cable would add another route to Atlantic wind and reservoir hydropower.",53,900000000,800000000]
+    ],
+    [
+      ["morocco-spain-upgrade","geo-casablanca-iberian-market","Strait of Gibraltar upgrade","EXISTING",600000000,300000000,5400000,2,34,0.014,0.03],
+      ["morocco-portugal-cable","geo-casablanca-portuguese-atlantic","Atlantic cable to Portugal","NEW",700000000,690000000,11500000,4,34,0.014,0.02]
+    ]
+  ],
+  "geo-algiers": [
+    [
+      ["geo-algiers-tunisian-market","Tunisia","The Maghreb backbone can exchange gas-fired and renewable power, although a hot regional evening tightens both grids.",64,650000000,700000000],
+      ["geo-algiers-spanish-market","Spain by Mediterranean cable","A proposed subsea link would reach the larger Iberian market without depending on a land border.",58,1000000000,1100000000]
+    ],
+    [
+      ["algeria-tunisia-upgrade","geo-algiers-tunisian-market","Maghreb line upgrade","EXISTING",300000000,150000000,3000000,1,39,0.018,0.08],
+      ["algeria-spain-cable","geo-algiers-spanish-market","Alboran Sea cable","NEW",700000000,720000000,12000000,4,36,0.015,0.02]
+    ]
+  ],
+  "geo-tunis": [
+    [
+      ["geo-tunis-algerian-market","Algeria","A larger gas-rich neighbour can send power west-to-east or buy Tunisian surplus when its own demand rises.",61,700000000,650000000],
+      ["geo-tunis-sicilian-market","Sicily and Italy","A new undersea cable would connect North African sun and Italian demand.",69,800000000,1000000000]
+    ],
+    [
+      ["tunisia-algeria-upgrade","geo-tunis-algerian-market","Western Maghreb upgrade","EXISTING",300000000,150000000,3000000,1,37,0.017,0.07],
+      ["tunisia-italy-elmed","geo-tunis-sicilian-market","ELMED cable","NEW",600000000,690000000,11500000,4,35,0.015,0.02]
+    ]
+  ],
+  "geo-tripoli": [
+    [
+      ["geo-tripoli-egyptian-market","Egypt","The eastern neighbour has a much larger grid, but a long desert line limits how much can arrive.",67,400000000,450000000],
+      ["geo-tripoli-tunisian-market","Tunisia","The western route can bring Maghreb power when Libya's local plants are short.",64,500000000,550000000]
+    ],
+    [
+      ["libya-egypt-upgrade","geo-tripoli-egyptian-market","Tobruk–Saloum upgrade","EXISTING",200000000,125000000,2500000,1,39,0.018,0.08],
+      ["libya-tunisia-upgrade","geo-tripoli-tunisian-market","Western coastal line upgrade","EXISTING",300000000,170000000,3400000,2,39,0.018,0.08]
+    ]
+  ],
+  "geo-lagos": [
+    [
+      ["geo-lagos-benin-togo-market","Benin and Togo","The coastal backbone lets Nigeria sell power west or buy help when local plants and fuel supplies are tight.",72,550000000,700000000],
+      ["geo-lagos-sahel-market","Niger and Burkina Faso","Northern neighbours have smaller grids and strong daytime solar, but very hot weather raises demand and line losses.",66,500000000,550000000]
+    ],
+    [
+      ["nigeria-benin-upgrade","geo-lagos-benin-togo-market","Lagos–Sakété upgrade","EXISTING",350000000,155000000,3100000,1,36,0.016,0.06],
+      ["wapp-north-core","geo-lagos-sahel-market","North Core line","NEW",500000000,390000000,7000000,3,40,0.019,0.08]
+    ]
+  ],
+  "geo-accra": [
+    [
+      ["geo-accra-ivorian-market","Côte d'Ivoire","Hydro and gas on the western grid can cover a shortage, while Ghanaian surplus can flow the other way.",61,700000000,700000000],
+      ["geo-accra-togo-benin-market","Togo and Benin","The coastal line reaches smaller importing grids and, beyond them, Nigeria.",70,500000000,650000000]
+    ],
+    [
+      ["ghana-ivory-coast-upgrade","geo-accra-ivorian-market","Western coastal upgrade","EXISTING",400000000,180000000,3600000,1,35,0.016,0.05],
+      ["ghana-togo-upgrade","geo-accra-togo-benin-market","Eastern coastal upgrade","EXISTING",300000000,145000000,2900000,1,35,0.016,0.05]
+    ]
+  ],
+  "geo-abidjan": [
+    [
+      ["geo-abidjan-ghanaian-market","Ghana","The coastal neighbour mixes hydro, gas, and growing solar, so either grid may have surplus at a different hour.",62,700000000,700000000],
+      ["geo-abidjan-sahel-west-market","Mali and Burkina Faso","Northern grids often need imports, while sunny hours can create a smaller solar surplus.",68,400000000,650000000]
+    ],
+    [
+      ["ivory-coast-ghana-upgrade","geo-abidjan-ghanaian-market","Aboadze–Riviera upgrade","EXISTING",400000000,180000000,3600000,1,35,0.016,0.05],
+      ["ivory-coast-mali-upgrade","geo-abidjan-sahel-west-market","Northern export route upgrade","EXISTING",250000000,150000000,3000000,2,38,0.018,0.07]
+    ]
+  ],
+  "geo-dakar": [
+    [
+      ["geo-dakar-mali-hydro-market","Mali and Senegal River hydropower","Shared river dams can provide low-cost power, but dry seasons leave less water to generate.",55,400000000,450000000],
+      ["geo-dakar-omvg-coastal-market","Gambia, Guinea, and Guinea-Bissau","A regional loop links several small grids so they can share hydro, solar, and thermal backup.",63,350000000,450000000]
+    ],
+    [
+      ["senegal-mali-upgrade","geo-dakar-mali-hydro-market","Eastern 225 kV upgrade","EXISTING",250000000,155000000,3100000,2,38,0.018,0.07],
+      ["senegal-omvg-upgrade","geo-dakar-omvg-coastal-market","Coastal power-loop upgrade","EXISTING",250000000,165000000,3300000,2,35,0.016,0.05]
+    ]
+  ],
+  "geo-bamako": [
+    [
+      ["geo-bamako-ivorian-market","Côte d'Ivoire","A larger coastal grid can send hydro and gas-fired power north when Mali's supply is tight.",62,450000000,500000000],
+      ["geo-bamako-senegal-river-market","Senegal River grid","Shared hydropower is flexible, but output changes with the wet and dry seasons.",55,350000000,350000000]
+    ],
+    [
+      ["mali-ivory-coast-upgrade","geo-bamako-ivorian-market","Southern 225 kV upgrade","EXISTING",250000000,150000000,3000000,2,40,0.019,0.08],
+      ["mali-senegal-upgrade","geo-bamako-senegal-river-market","Kayes–Tambacounda upgrade","EXISTING",250000000,155000000,3100000,2,40,0.019,0.08]
+    ]
+  ],
+  "geo-ouagadougou": [
+    [
+      ["geo-ouagadougou-ghanaian-market","Ghana","Power from Ghana's hydro and gas plants can travel north, while Burkina's midday solar can reduce imports.",62,450000000,550000000],
+      ["geo-ouagadougou-north-core-market","Niger, Benin, and Nigeria","A new high-voltage backbone would open a second direction for regional trade.",68,500000000,550000000]
+    ],
+    [
+      ["burkina-ghana-upgrade","geo-ouagadougou-ghanaian-market","Bolgatanga–Ouagadougou upgrade","EXISTING",250000000,145000000,2900000,2,40,0.019,0.08],
+      ["burkina-north-core","geo-ouagadougou-north-core-market","North Core completion","NEW",400000000,340000000,6100000,3,41,0.02,0.09]
+    ]
+  ],
+  "geo-niamey": [
+    [
+      ["geo-niamey-nigerian-market","Nigeria","Long-running northern lines import power from Nigeria, but supply may tighten when both countries need cooling.",70,450000000,550000000],
+      ["geo-niamey-north-core-market","Benin and Burkina Faso","The new North Core backbone would add more routes instead of depending mainly on one neighbour.",68,400000000,450000000]
+    ],
+    [
+      ["niger-nigeria-upgrade","geo-niamey-nigerian-market","Northern border upgrade","EXISTING",200000000,135000000,2700000,2,42,0.02,0.09],
+      ["niger-north-core","geo-niamey-north-core-market","Niamey North Core section","NEW",400000000,360000000,6500000,3,42,0.02,0.09]
+    ]
+  ],
+  "geo-khartoum": [
+    [
+      ["geo-khartoum-ethiopian-hydro","Ethiopian hydropower","Rainy-season hydro can be inexpensive, while dry years reduce the surplus available to export.",45,500000000,350000000],
+      ["geo-khartoum-egyptian-market","Egypt","The northern grid is much larger and can support emergencies, but the present border path is limited.",69,350000000,400000000]
+    ],
+    [
+      ["sudan-ethiopia-upgrade","geo-khartoum-ethiopian-hydro","Eastern 230 kV upgrade","EXISTING",250000000,150000000,3000000,2,41,0.019,0.08],
+      ["sudan-egypt-upgrade","geo-khartoum-egyptian-market","Nile Valley upgrade","EXISTING",200000000,145000000,2900000,2,41,0.019,0.08]
+    ]
+  ],
+  "geo-addisababa": [
+    [
+      ["geo-addisababa-kenyan-market","Kenya","A modern converter sends Ethiopian hydropower south to a grid with geothermal, wind, hydro, and thermal generation.",57,1000000000,1000000000],
+      ["geo-addisababa-sudan-djibouti-market","Sudan and Djibouti","Older regional lines serve smaller markets; dry weather can tighten hydropower exports.",62,500000000,550000000]
+    ],
+    [
+      ["ethiopia-kenya-upgrade","geo-addisababa-kenyan-market","Eastern Electricity Highway upgrade","EXISTING",600000000,260000000,5200000,2,34,0.012,0.03],
+      ["ethiopia-sudan-upgrade","geo-addisababa-sudan-djibouti-market","Metema border upgrade","EXISTING",250000000,150000000,3000000,2,38,0.016,0.06]
+    ]
+  ],
+  "geo-nairobi": [
+    [
+      ["geo-nairobi-ethiopian-hydro","Ethiopian hydropower","The long HVDC highway brings low-carbon power, though drought can reduce how much is offered.",45,1000000000,700000000],
+      ["geo-nairobi-tanzanian-market","Tanzania","A newly energized 400 kV line links hydro, gas, and growing solar resources on both sides of the border.",60,700000000,750000000]
+    ],
+    [
+      ["kenya-ethiopia-upgrade","geo-nairobi-ethiopian-hydro","Suswa converter upgrade","EXISTING",600000000,260000000,5200000,2,34,0.012,0.03],
+      ["kenya-tanzania-upgrade","geo-nairobi-tanzanian-market","Isinya–Arusha upgrade","EXISTING",400000000,190000000,3800000,2,35,0.015,0.05]
+    ]
+  ],
+  "geo-kampala": [
+    [
+      ["geo-kampala-kenyan-market","Kenya","Geothermal, wind, hydro, and imports from Ethiopia make Kenya a diverse eastern neighbour.",57,550000000,600000000],
+      ["geo-kampala-great-lakes-market","Rwanda and the Great Lakes grid","Smaller linked grids share river hydropower and support one another when a plant is unavailable.",61,350000000,400000000]
+    ],
+    [
+      ["uganda-kenya-upgrade","geo-kampala-kenyan-market","Tororo border upgrade","EXISTING",250000000,145000000,2900000,2,34,0.015,0.05],
+      ["uganda-rwanda-upgrade","geo-kampala-great-lakes-market","Mirama–Shango upgrade","EXISTING",200000000,135000000,2700000,2,33,0.015,0.05]
+    ]
+  ],
+  "geo-kigali": [
+    [
+      ["geo-kigali-uganda-market","Uganda","A northern connection gives access to Uganda's hydro grid and, through it, Kenya.",58,350000000,350000000],
+      ["geo-kigali-great-lakes-market","Burundi and eastern DR Congo","Shared river plants and short border lines connect several small Great Lakes grids.",61,300000000,350000000]
+    ],
+    [
+      ["rwanda-uganda-upgrade","geo-kigali-uganda-market","Shango–Mirama upgrade","EXISTING",200000000,135000000,2700000,2,31,0.012,0.04],
+      ["rwanda-great-lakes-upgrade","geo-kigali-great-lakes-market","Great Lakes network upgrade","EXISTING",180000000,130000000,2600000,2,31,0.012,0.04]
+    ]
+  ],
+  "geo-daressalaam": [
+    [
+      ["geo-daressalaam-kenyan-market","Kenya and Ethiopia","The northern route can bring Kenyan geothermal and Ethiopian hydro, with Kenya carrying power between markets.",55,750000000,700000000],
+      ["geo-daressalaam-southern-pool","Southern African Power Pool","A future southern gateway would connect Tanzania to Zambia and the larger SAPP market.",63,650000000,700000000]
+    ],
+    [
+      ["tanzania-kenya-upgrade","geo-daressalaam-kenyan-market","Arusha–Isinya upgrade","EXISTING",400000000,190000000,3800000,2,36,0.016,0.05],
+      ["tanzania-zambia-link","geo-daressalaam-southern-pool","Tanzania–Zambia gateway","NEW",450000000,370000000,6700000,3,38,0.017,0.06]
+    ]
+  ],
+  "geo-kinshasa": [
+    [
+      ["geo-kinshasa-zambian-market","Zambia and the southern pool","The southern link reaches copper-belt demand and a much wider power pool.",62,600000000,700000000],
+      ["geo-kinshasa-great-lakes-market","Rwanda and Burundi","Small eastern grids share river hydropower across the Great Lakes region.",60,300000000,350000000]
+    ],
+    [
+      ["drc-zambia-upgrade","geo-kinshasa-zambian-market","Copperbelt border upgrade","EXISTING",350000000,190000000,3800000,2,36,0.016,0.05],
+      ["drc-rwanda-upgrade","geo-kinshasa-great-lakes-market","Ruzizi network upgrade","EXISTING",180000000,130000000,2600000,2,33,0.014,0.04]
+    ]
+  ],
+  "geo-luanda": [
+    [
+      ["geo-luanda-southern-pool","Namibia and the southern pool","A first regional line would let Angola share hydropower with Namibia and reach the wider SAPP market.",61,550000000,600000000]
+    ],
+    [
+      ["angola-namibia-anna","geo-luanda-southern-pool","Angola–Namibia interconnector","NEW",400000000,390000000,7000000,4,39,0.018,0.07]
+    ]
+  ],
+  "geo-lusaka": [
+    [
+      ["geo-lusaka-congo-copperbelt","DR Congo Copperbelt","Hydropower and mining demand sit on both sides of the border, so flows can change direction.",62,600000000,650000000],
+      ["geo-lusaka-zimbabwe-market","Zimbabwe and the Kariba grid","Shared reservoir power and southern trade meet at a busy regional junction.",65,700000000,800000000]
+    ],
+    [
+      ["zambia-drc-upgrade","geo-lusaka-congo-copperbelt","Copperbelt intertie upgrade","EXISTING",350000000,190000000,3800000,2,36,0.016,0.05],
+      ["zambia-zimbabwe-upgrade","geo-lusaka-zimbabwe-market","Kariba corridor upgrade","EXISTING",450000000,210000000,4200000,2,37,0.016,0.06]
+    ]
+  ],
+  "geo-harare": [
+    [
+      ["geo-harare-zambian-market","Zambia","Hydropower crosses near Kariba, but drought can tighten both grids at the same time.",60,650000000,700000000],
+      ["geo-harare-mozambique-market","Mozambique","Cahora Bassa hydropower and southern lines give a second direction for imports and exports.",58,700000000,650000000]
+    ],
+    [
+      ["zimbabwe-zambia-upgrade","geo-harare-zambian-market","Kariba corridor upgrade","EXISTING",400000000,200000000,4000000,2,37,0.016,0.06],
+      ["zimbabwe-mozambique-upgrade","geo-harare-mozambique-market","Eastern border upgrade","EXISTING",350000000,190000000,3800000,2,36,0.016,0.05]
+    ]
+  ],
+  "geo-maputo": [
+    [
+      ["geo-maputo-south-african-market","South Africa","A very large neighbour can buy Cahora Bassa power or send emergency support, but its own system can also be stressed.",67,1100000000,1200000000],
+      ["geo-maputo-zimbabwe-zambia-market","Zimbabwe and Zambia","Northern routes connect reservoir hydro and mining demand across the pool.",61,650000000,700000000]
+    ],
+    [
+      ["mozambique-south-africa-upgrade","geo-maputo-south-african-market","MOTRACO corridor upgrade","EXISTING",600000000,250000000,5000000,2,35,0.015,0.05],
+      ["mozambique-zimbabwe-upgrade","geo-maputo-zimbabwe-zambia-market","Western border upgrade","EXISTING",350000000,190000000,3800000,2,36,0.016,0.05]
+    ]
+  ],
+  "geo-gaborone": [
+    [
+      ["geo-gaborone-south-african-market","South Africa","Several border lines reach a huge market, but imports become expensive when the southern grid is short.",68,800000000,900000000],
+      ["geo-gaborone-zimbabwe-market","Zimbabwe","A northern route adds diversity, though drought can reduce regional hydropower.",64,450000000,550000000]
+    ],
+    [
+      ["botswana-south-africa-upgrade","geo-gaborone-south-african-market","Gaborone border upgrade","EXISTING",300000000,155000000,3100000,1,39,0.018,0.08],
+      ["botswana-zimbabwe-upgrade","geo-gaborone-zimbabwe-market","Northern border upgrade","EXISTING",250000000,150000000,3000000,2,39,0.018,0.08]
+    ]
+  ],
+  "geo-windhoek": [
+    [
+      ["geo-windhoek-south-african-market","South Africa","The southern connection supports a small, dry grid, while Namibian solar can create daytime export opportunities.",67,750000000,800000000],
+      ["geo-windhoek-zambia-zimbabwe-market","Zambia and Zimbabwe","A northern path reaches reservoir hydropower, but long distances and drought limit dependable supply.",61,450000000,500000000]
+    ],
+    [
+      ["namibia-south-africa-upgrade","geo-windhoek-south-african-market","Kokerboom corridor upgrade","EXISTING",350000000,180000000,3600000,2,39,0.018,0.08],
+      ["namibia-north-upgrade","geo-windhoek-zambia-zimbabwe-market","Caprivi trading-path upgrade","EXISTING",250000000,175000000,3500000,2,40,0.019,0.08]
+    ]
+  ],
+  "geo-johannesburg": [
+    [
+      ["geo-johannesburg-mozambique-market","Mozambique","Cahora Bassa hydropower can move south, while South African surplus can support Maputo.",58,1200000000,900000000],
+      ["geo-johannesburg-northwest-pool","Botswana and Namibia","Smaller dry-climate neighbours often import, but daytime solar can sometimes reverse the flow.",65,750000000,950000000]
+    ],
+    [
+      ["south-africa-mozambique-upgrade","geo-johannesburg-mozambique-market","Mozambique corridor upgrade","EXISTING",650000000,260000000,5200000,2,34,0.014,0.04],
+      ["south-africa-northwest-upgrade","geo-johannesburg-northwest-pool","Northwest border upgrade","EXISTING",450000000,210000000,4200000,2,35,0.015,0.05]
+    ]
+  ],
+  "geo-delhi": [
+    [
+      ["geo-delhi-himalayan-hydro-market","Nepal and Bhutan hydropower","Mountain rivers can send low-carbon power in wet months; winter and dry-season flows can be smaller.",43,1200000000,700000000],
+      ["geo-delhi-bangladesh-market","Bangladesh","A fast-growing neighbouring grid usually buys power, but a two-way market can share reserves during an emergency.",67,700000000,1300000000]
+    ],
+    [
+      ["india-himalaya-upgrade","geo-delhi-himalayan-hydro-market","Himalayan border upgrade","EXISTING",700000000,280000000,5600000,2,35,0.014,0.05],
+      ["india-bangladesh-upgrade","geo-delhi-bangladesh-market","Eastern border upgrade","EXISTING",700000000,300000000,6000000,2,37,0.016,0.06]
+    ]
+  ],
+  "geo-karachi": [
+    [
+      ["geo-karachi-central-asian-hydro","Central Asian hydropower","CASA-1000 is designed to bring summer hydropower through Afghanistan when Pakistan's cooling demand is high.",46,1000000000,500000000]
+    ],
+    [
+      ["pakistan-casa","geo-karachi-central-asian-hydro","CASA-1000 connection","NEW",800000000,620000000,11000000,4,40,0.018,0.07]
+    ]
+  ],
+  "geo-dhaka": [
+    [
+      ["geo-dhaka-india-west-market","Eastern India","Large Indian power stations and exchanges can supply Bangladesh through the western border.",61,1100000000,900000000],
+      ["geo-dhaka-india-tripura-market","Tripura and northeast India","A smaller eastern connection provides another source, especially useful nearer Chittagong.",64,300000000,350000000]
+    ],
+    [
+      ["bangladesh-bheramara-upgrade","geo-dhaka-india-west-market","Bheramara border upgrade","EXISTING",600000000,260000000,5200000,2,35,0.015,0.05],
+      ["bangladesh-tripura-upgrade","geo-dhaka-india-tripura-market","Cumilla border upgrade","EXISTING",150000000,120000000,2400000,1,35,0.015,0.05]
+    ]
+  ],
+  "geo-kathmandu": [
+    [
+      ["geo-kathmandu-indian-market","India","India can supply Nepal in a dry-season shortage and buy Nepalese hydropower when rivers are high.",57,1100000000,1100000000],
+      ["geo-kathmandu-bangladesh-via-india","Bangladesh through India","A three-country trade route lets Nepalese hydropower reach Bangladesh using India's grid.",65,250000000,450000000]
+    ],
+    [
+      ["nepal-india-upgrade","geo-kathmandu-indian-market","Dhalkebar border upgrade","EXISTING",600000000,250000000,5000000,2,32,0.012,0.04],
+      ["nepal-bangladesh-upgrade","geo-kathmandu-bangladesh-via-india","Three-country trade upgrade","EXISTING",150000000,120000000,2400000,2,33,0.013,0.04]
+    ]
+  ],
+  "jp-east": [
+    [
+      ["jp-east-tohoku-grid","Tohoku","Northern wind and thermal power can support Tokyo when the regional tie has room.",54,1400000000,900000000],
+      ["jp-east-chubu-grid","Chubu (60 Hz)","Frequency converters bridge eastern Japan's 50 Hz grid and western Japan's 60 Hz grid.",60,1000000000,1100000000]
+    ],
+    [
+      ["tohoku-tokyo-upgrade","jp-east-tohoku-grid","Tohoku connection","EXISTING",900000000,280000000,5600000,2,28,0.01,0.03],
+      ["tokyo-chubu-frequency","jp-east-chubu-grid","Chubu (60 Hz) connection","EXISTING",650000000,440000000,7500000,3,30,0.012,0.04]
+    ]
+  ],
+  "jp-kansai": [
+    [
+      ["jp-kansai-chubu-grid","Chubu","Move power between two large 60 Hz regions when prices and reserves differ.",59,1100000000,1200000000],
+      ["jp-kansai-chugoku-grid","Chugoku","A western reinforcement opens another path for backup and surplus power.",56,900000000,700000000]
+    ],
+    [
+      ["kansai-chubu-reinforcement","jp-kansai-chubu-grid","Chubu connection","EXISTING",800000000,240000000,4800000,2,30,0.012,0.04],
+      ["kansai-chugoku-reinforcement","jp-kansai-chugoku-grid","Chugoku connection","EXISTING",600000000,210000000,4200000,2,30,0.012,0.04]
+    ]
+  ],
+  "jp-hokkaido": [
+    [
+      ["jp-hokkaido-tohoku-grid","Northern Honshu","Share Hokkaido wind and Honshu backup power through the undersea link.",52,900000000,700000000]
+    ],
+    [
+      ["hokkaido-honshu-reinforcement","jp-hokkaido-tohoku-grid","Northern Honshu connection","EXISTING",500000000,360000000,6000000,2,35,0.005,0.01]
+    ]
+  ],
+  "jp-kyushu": [
+    [
+      ["jp-kyushu-chugoku-grid","Chugoku","Strengthen Kyushu's existing connection across the Kanmon Strait.",57,850000000,750000000]
+    ],
+    [
+      ["kyushu-kanmon-reinforcement","jp-kyushu-chugoku-grid","Chugoku connection","EXISTING",500000000,220000000,4400000,2,30,0.012,0.04]
+    ]
+  ],
+  "jp-chubu": [
+    [
+      ["jp-chubu-tokyo-grid","Tokyo (50 Hz)","Converters make power exchange possible across Japan's frequency divide.",63,1200000000,1500000000],
+      ["jp-chubu-kansai-grid","Kansai","Reinforce the 60 Hz west-Japan backbone toward Osaka.",58,1000000000,1100000000]
+    ],
+    [
+      ["chubu-tokyo-frequency","jp-chubu-tokyo-grid","Tokyo (50 Hz) connection","EXISTING",650000000,440000000,7500000,3,30,0.012,0.04],
+      ["chubu-kansai-reinforcement","jp-chubu-kansai-grid","Kansai connection","EXISTING",800000000,240000000,4800000,2,30,0.012,0.04]
+    ]
+  ],
+  "cn-north": [
+    [
+      ["cn-north-northwest-energy","Northwest wind and solar","Long-distance UHV lines bring western wind and solar toward northern load centers.",43,2000000000,900000000],
+      ["cn-north-northeast-grid","Northeast China","A stronger regional seam shares winter reserves between northern systems.",49,1000000000,800000000]
+    ],
+    [
+      ["north-northwest-uhv","cn-north-northwest-energy","Northwest wind and solar connection","EXISTING",1200000000,520000000,9000000,3,28,0.01,0.03],
+      ["north-northeast-reinforcement","cn-north-northeast-grid","Northeast China connection","EXISTING",700000000,240000000,4800000,2,28,0.01,0.03]
+    ]
+  ],
+  "cn-east": [
+    [
+      ["cn-east-southwest-hydro","Southwest hydropower","UHVDC carries large blocks of western hydropower to the east-coast load center.",46,2400000000,800000000],
+      ["cn-east-central-china-grid","Central China","Reinforce the interregional AC/DC network that balances inland and coastal demand.",52,1200000000,1100000000]
+    ],
+    [
+      ["east-southwest-uhv","cn-east-southwest-hydro","Southwest hydropower connection","EXISTING",1500000000,620000000,10000000,3,30,0.012,0.04],
+      ["east-central-reinforcement","cn-east-central-china-grid","Central China connection","EXISTING",900000000,330000000,6200000,2,30,0.012,0.04]
+    ]
+  ],
+  "cn-south": [
+    [
+      ["cn-south-southwest-renewables","Yunnan and Guizhou","Hydro-rich western provinces can serve the Pearl River Delta through the Southern Grid.",45,2100000000,800000000],
+      ["cn-south-hong-kong-system","Hong Kong system","A limited cross-system link can exchange support with Hong Kong; it is not an international border.",68,600000000,900000000]
+    ],
+    [
+      ["south-yunnan-guizhou-reinforcement","cn-south-southwest-renewables","Yunnan and Guizhou connection","EXISTING",1300000000,430000000,8000000,3,33,0.015,0.06],
+      ["guangdong-hong-kong-upgrade","cn-south-hong-kong-system","Hong Kong system connection","EXISTING",500000000,260000000,5000000,2,33,0.015,0.06]
+    ]
+  ],
+  "cn-sichuan": [
+    [
+      ["cn-sichuan-east-china-grid","East China","Export southwest hydropower to the dense east-coast grid.",61,900000000,2200000000],
+      ["cn-sichuan-xinjiang-renewables","Xinjiang renewables","A long-distance HVDC route brings western wind and solar into Chongqing.",44,1800000000,700000000]
+    ],
+    [
+      ["sichuan-east-uhv","cn-sichuan-east-china-grid","East China connection","EXISTING",1500000000,620000000,10000000,3,30,0.012,0.04],
+      ["xinjiang-chongqing-uhv","cn-sichuan-xinjiang-renewables","Xinjiang renewables connection","EXISTING",1000000000,580000000,9500000,3,26,0.01,0.08]
+    ]
+  ],
+  "cn-central": [
+    [
+      ["cn-central-north-china-grid","North China","Use the interregional UHV mesh to share reserves north of Wuhan.",54,1100000000,1200000000],
+      ["cn-central-southwest-hydro","Southwest hydropower","Western hydro can cover central-China peaks when river conditions allow.",46,1800000000,700000000]
+    ],
+    [
+      ["central-north-uhv","cn-central-north-china-grid","North China connection","EXISTING",850000000,310000000,6000000,2,30,0.012,0.04],
+      ["central-southwest-uhv","cn-central-southwest-hydro","Southwest hydropower connection","EXISTING",1000000000,390000000,7000000,3,30,0.012,0.04]
+    ]
+  ],
+  "cn-northwest": [
+    [
+      ["cn-northwest-central-china-grid","Central China","Send northwest wind, solar, and thermal output toward inland demand centers.",58,800000000,1700000000]
+    ],
+    [
+      ["northwest-central-uhv","cn-northwest-central-china-grid","Central China connection","EXISTING",1100000000,480000000,8500000,3,28,0.01,0.03]
+    ]
+  ],
+  "cn-northeast": [
+    [
+      ["cn-northeast-north-china-grid","North China","Move northern winter reserves toward Beijing through the domestic regional seam.",55,800000000,1100000000],
+      ["cn-northeast-russian-far-east","Russian Far East","A converter-backed border route can import hydro and thermal power from the Russian Far East.",50,900000000,500000000]
+    ],
+    [
+      ["northeast-north-reinforcement","cn-northeast-north-china-grid","North China connection","EXISTING",700000000,260000000,5000000,2,28,0.01,0.03],
+      ["heilongjiang-russia-upgrade","cn-northeast-russian-far-east","Russian Far East connection","EXISTING",500000000,340000000,6000000,3,28,0.01,0.03]
+    ]
+  ],
+  "cn-xinjiang": [
+    [
+      ["cn-xinjiang-chongqing-grid","Chongqing","A very long UHVDC corridor exports desert wind and solar to southwest demand.",60,700000000,1700000000],
+      ["cn-xinjiang-east-china-grid","East China","Add another long-haul outlet for western renewable surpluses.",66,700000000,2000000000]
+    ],
+    [
+      ["xinjiang-chongqing-export","cn-xinjiang-chongqing-grid","Chongqing connection","EXISTING",1200000000,650000000,10500000,3,26,0.01,0.08],
+      ["xinjiang-east-expansion","cn-xinjiang-east-china-grid","East China connection","NEW",1500000000,950000000,14000000,5,26,0.01,0.08]
+    ]
+  ],
+  "cn-xizang": [
+    [
+      ["cn-xizang-qinghai-grid","Qinghai","Reinforce the high-altitude line linking the plateau to China's wider grid.",48,600000000,450000000],
+      ["cn-xizang-sichuan-grid","Sichuan","A second mountain route adds support from the east.",52,700000000,500000000]
+    ],
+    [
+      ["qinghai-xizang-reinforcement","cn-xizang-qinghai-grid","Qinghai connection","EXISTING",350000000,300000000,5200000,3,26,0.01,0.08],
+      ["sichuan-xizang-reinforcement","cn-xizang-sichuan-grid","Sichuan connection","EXISTING",300000000,340000000,5800000,4,26,0.01,0.08]
+    ]
+  ],
+  "hk-mainland": [
+    [
+      ["hk-mainland-guangdong-grid","Guangdong grid","Expand Hong Kong's limited mainland connection for cleaner imports and emergency support.",57,1200000000,700000000],
+      ["hk-mainland-mainland-clean-power","Mainland clean power","Build a dedicated new circuit for additional low-carbon electricity.",54,1500000000,500000000]
+    ],
+    [
+      ["hong-kong-guangdong-upgrade","hk-mainland-guangdong-grid","Guangdong grid connection","EXISTING",600000000,320000000,6000000,3,33,0.015,0.06],
+      ["hong-kong-mainland-new-link","hk-mainland-mainland-clean-power","Mainland clean power connection","NEW",800000000,780000000,10000000,5,35,0.005,0.01]
+    ]
+  ],
+  "mn-central": [
+    [
+      ["mn-central-russian-siberia","Russian Siberia","Imported Russian power covers winter peaks in Mongolia's Central Energy System.",50,500000000,350000000]
+    ],
+    [
+      ["mongolia-russia-reinforcement","mn-central-russian-siberia","Russian Siberia connection","EXISTING",300000000,190000000,3800000,2,28,0.01,0.03]
+    ]
+  ],
+  "ru-far-east": [
+    [
+      ["ru-far-east-northeast-china","Northeast China","A converter station links the Far East system with China without synchronizing both grids.",56,800000000,1200000000],
+      ["ru-far-east-siberia-grid","Siberia","Strengthen the constrained seam between Russia's separate East and Siberia synchronous zones.",49,1000000000,700000000]
+    ],
+    [
+      ["far-east-china-upgrade","ru-far-east-northeast-china","Northeast China connection","EXISTING",500000000,330000000,6000000,3,28,0.01,0.03],
+      ["far-east-siberia-converter","ru-far-east-siberia-grid","Siberia connection","NEW",600000000,620000000,9000000,4,28,0.01,0.03]
+    ]
+  ],
+  "ru-siberia": [
+    [
+      ["ru-siberia-urals-grid","Urals grid","Reinforce the westbound route that balances Siberian hydro with the wider unified system.",57,1100000000,1300000000],
+      ["ru-siberia-far-east-grid","Russian Far East","A controlled new seam can share reserves without assuming normal synchronous operation.",55,700000000,900000000]
+    ],
+    [
+      ["siberia-urals-reinforcement","ru-siberia-urals-grid","Urals grid connection","EXISTING",900000000,350000000,6500000,3,28,0.01,0.03],
+      ["siberia-far-east-converter","ru-siberia-far-east-grid","Russian Far East connection","NEW",600000000,620000000,9000000,4,28,0.01,0.03]
+    ]
+  ],
+  "ru-yakutia": [
+    [
+      ["ru-yakutia-south-yakutia","South Yakutia","Reinforce the long internal route joining central Yakutia to the Far East system.",58,450000000,350000000]
+    ],
+    [
+      ["yakutia-south-reinforcement","ru-yakutia-south-yakutia","South Yakutia connection","EXISTING",350000000,310000000,5500000,3,28,0.01,0.03]
+    ]
+  ],
+  "th-central": [
+    [
+      ["th-central-laos-hydro","Lao hydropower","Laos can export hydro to Thailand, while the same network supports wider regional trading.",45,1500000000,500000000],
+      ["th-central-peninsular-malaysia","Peninsular Malaysia","The controllable HVDC border link trades power south toward Malaysia.",59,500000000,600000000]
+    ],
+    [
+      ["thailand-laos-reinforcement","th-central-laos-hydro","Lao hydropower connection","EXISTING",900000000,280000000,5500000,2,33,0.015,0.06],
+      ["thailand-malaysia-hvdc","th-central-peninsular-malaysia","Peninsular Malaysia connection","EXISTING",300000000,220000000,4200000,2,33,0.015,0.06]
+    ]
+  ],
+  "th-north": [
+    [
+      ["th-north-northern-laos","Northern Laos","A nearby cross-border line exchanges hydro and dry-season backup.",47,500000000,300000000],
+      ["th-north-central-thailand","Central Thailand","Reinforce the domestic path from the northern region to Thailand's main load center.",61,400000000,700000000]
+    ],
+    [
+      ["north-thailand-laos","th-north-northern-laos","Northern Laos connection","EXISTING",300000000,150000000,3000000,2,33,0.015,0.06],
+      ["north-thailand-central-upgrade","th-north-central-thailand","Central Thailand connection","EXISTING",450000000,180000000,3600000,2,33,0.015,0.06]
+    ]
+  ],
+  "vn-south": [
+    [
+      ["vn-south-cambodia-grid","Cambodia","The Chau Doc-Takeo corridor mostly carries Vietnamese power toward Cambodia.",66,350000000,550000000],
+      ["vn-south-north-vietnam-grid","Northern Vietnam","Reinforce the long domestic 500 kV backbone between northern supply and southern demand.",58,900000000,1100000000]
+    ],
+    [
+      ["vietnam-cambodia-upgrade","vn-south-cambodia-grid","Cambodia connection","EXISTING",300000000,170000000,3200000,2,33,0.015,0.06],
+      ["vietnam-north-south-reinforcement","vn-south-north-vietnam-grid","Northern Vietnam connection","EXISTING",800000000,320000000,6000000,3,33,0.015,0.06]
+    ]
+  ],
+  "vn-north": [
+    [
+      ["vn-north-yunnan-grid","Yunnan grid","Existing northern border lines import power from China when Vietnam needs it.",53,800000000,600000000],
+      ["vn-north-northern-laos","Northern Laos","Mountain hydro and wind enter Vietnam through growing Laos interconnections.",47,700000000,350000000]
+    ],
+    [
+      ["vietnam-china-upgrade","vn-north-yunnan-grid","Yunnan grid connection","EXISTING",500000000,210000000,4000000,2,33,0.015,0.06],
+      ["north-vietnam-laos","vn-north-northern-laos","Northern Laos connection","EXISTING",450000000,230000000,4300000,3,33,0.015,0.06]
+    ]
+  ],
+  "kh-national": [
+    [
+      ["kh-national-southern-vietnam","Southern Vietnam","Vietnamese imports support Phnom Penh through the existing 230 kV route.",57,700000000,400000000],
+      ["kh-national-laos-hydro","Lao hydropower","A northern border route brings hydropower into Cambodia.",48,600000000,250000000]
+    ],
+    [
+      ["cambodia-vietnam-reinforcement","kh-national-southern-vietnam","Southern Vietnam connection","EXISTING",350000000,180000000,3400000,2,33,0.015,0.06],
+      ["cambodia-laos-reinforcement","kh-national-laos-hydro","Lao hydropower connection","EXISTING",300000000,190000000,3500000,2,33,0.015,0.06]
+    ]
+  ],
+  "la-national": [
+    [
+      ["la-national-thailand-grid","Thailand","Export hydropower in wet periods and import support during dry-season shortages.",60,650000000,1200000000],
+      ["la-national-vietnam-grid","Vietnam","Newer high-voltage routes carry Lao wind and hydro east to Vietnam.",58,600000000,1000000000]
+    ],
+    [
+      ["laos-thailand-reinforcement","la-national-thailand-grid","Thailand connection","EXISTING",800000000,260000000,5000000,2,33,0.015,0.06],
+      ["laos-vietnam-reinforcement","la-national-vietnam-grid","Vietnam connection","EXISTING",600000000,300000000,5600000,3,33,0.015,0.06]
+    ]
+  ],
+  "mm-national": [
+    [
+      ["mm-national-thailand-grid","Thailand","Build a first bulk grid-to-grid route toward Thailand; today this remains a regional plan.",59,800000000,700000000],
+      ["mm-national-central-myanmar","Central Myanmar","Strengthen the domestic 230 kV backbone before relying on cross-border trade.",54,500000000,600000000]
+    ],
+    [
+      ["myanmar-thailand-new-link","mm-national-thailand-grid","Thailand connection","NEW",500000000,720000000,9000000,5,33,0.015,0.06],
+      ["myanmar-central-backbone","mm-national-central-myanmar","Central Myanmar connection","NEW",400000000,280000000,5000000,3,33,0.015,0.06]
+    ]
+  ],
+  "my-peninsula": [
+    [
+      ["my-peninsula-thailand-grid","Thailand","A controllable HVDC link and a smaller AC line connect the peninsula northward.",55,650000000,600000000],
+      ["my-peninsula-singapore-market","Singapore","Submarine cables exchange emergency support and traded power with Singapore.",78,500000000,1000000000]
+    ],
+    [
+      ["malaysia-thailand-hvdc","my-peninsula-thailand-grid","Thailand connection","EXISTING",380000000,220000000,4200000,2,33,0.015,0.06],
+      ["malaysia-singapore-upgrade","my-peninsula-singapore-market","Singapore connection","EXISTING",700000000,330000000,6000000,3,35,0.005,0.01]
+    ]
+  ],
+  "sg-national": [
+    [
+      ["sg-national-peninsular-malaysia","Peninsular Malaysia","The island's physical interconnector can move power in either direction.",58,1000000000,650000000]
+    ],
+    [
+      ["singapore-malaysia-upgrade","sg-national-peninsular-malaysia","Peninsular Malaysia connection","EXISTING",700000000,330000000,6000000,3,35,0.005,0.01]
+    ]
+  ],
+  "id-java": [
+    [
+      ["id-java-bali-grid","Bali grid","Reinforce the domestic submarine cables that tie Bali into the Java-Bali system.",72,300000000,450000000],
+      ["id-java-sumatra-grid","Sumatra grid","Build the long-planned domestic HVDC bridge across the Sunda Strait.",49,1400000000,700000000]
+    ],
+    [
+      ["java-bali-reinforcement","id-java-bali-grid","Bali grid connection","EXISTING",350000000,260000000,4800000,3,35,0.005,0.01],
+      ["java-sumatra-hvdc","id-java-sumatra-grid","Sumatra grid connection","NEW",900000000,1200000000,16000000,6,35,0.005,0.01]
+    ]
+  ],
+  "id-bali": [
+    [
+      ["id-bali-java-grid","Java grid","Upgrade the existing domestic submarine connection that supplies part of Bali's demand.",54,900000000,500000000]
+    ],
+    [
+      ["bali-java-reinforcement","id-bali-java-grid","Java grid connection","EXISTING",350000000,260000000,4800000,3,35,0.005,0.01]
+    ]
+  ],
+  "id-sumatra": [
+    [
+      ["id-sumatra-south-sumatra-grid","South Sumatra","Reinforce the domestic 275 kV backbone moving power between southern resources and northern demand.",50,900000000,500000000],
+      ["id-sumatra-peninsular-malaysia","Peninsular Malaysia","Build the proposed cross-strait HVDC connection to Malaysia.",60,700000000,650000000]
+    ],
+    [
+      ["sumatra-backbone-reinforcement","id-sumatra-south-sumatra-grid","South Sumatra connection","EXISTING",600000000,280000000,5200000,3,33,0.015,0.06],
+      ["sumatra-malaysia-hvdc","id-sumatra-peninsular-malaysia","Peninsular Malaysia connection","NEW",600000000,920000000,12000000,5,35,0.005,0.01]
+    ]
+  ],
+  "ph-luzon": [
+    [
+      ["ph-luzon-visayas-grid","Visayas grid","Reinforce the domestic submarine path joining Luzon and the Visayas.",61,550000000,500000000]
+    ],
+    [
+      ["luzon-visayas-reinforcement","ph-luzon-visayas-grid","Visayas grid connection","EXISTING",450000000,330000000,6000000,3,35,0.005,0.01]
+    ]
+  ],
+  "ph-visayas": [
+    [
+      ["ph-visayas-luzon-grid","Luzon grid","Share generation and reserves with the country's largest demand center.",66,700000000,900000000],
+      ["ph-visayas-mindanao-grid","Mindanao grid","Expand the new domestic HVDC link between the Visayas and Mindanao.",55,650000000,450000000]
+    ],
+    [
+      ["visayas-luzon-reinforcement","ph-visayas-luzon-grid","Luzon grid connection","EXISTING",450000000,330000000,6000000,3,35,0.005,0.01],
+      ["visayas-mindanao-reinforcement","ph-visayas-mindanao-grid","Mindanao grid connection","EXISTING",450000000,300000000,5500000,3,35,0.005,0.01]
+    ]
+  ],
+  "ph-mindanao": [
+    [
+      ["ph-mindanao-visayas-grid","Visayas grid","Use the domestic HVDC link to share Mindanao power with the rest of the unified Philippine grid.",62,550000000,600000000],
+      ["ph-mindanao-sabah-grid","Sabah grid","Build a future international cable toward Malaysian Borneo.",58,650000000,500000000]
+    ],
+    [
+      ["mindanao-visayas-reinforcement","ph-mindanao-visayas-grid","Visayas grid connection","EXISTING",450000000,300000000,5500000,3,35,0.005,0.01],
+      ["mindanao-sabah-link","ph-mindanao-sabah-grid","Sabah grid connection","NEW",500000000,1050000000,13000000,6,35,0.005,0.01]
+    ]
+  ],
+  "bn-proposed": [
+    [
+      ["bn-proposed-sarawak-hydro","Sarawak hydropower","Build Brunei's planned first cross-border power connection to Sarawak.",50,500000000,250000000]
+    ],
+    [
+      ["brunei-sarawak-link","bn-proposed-sarawak-hydro","Sarawak hydropower connection","NEW",250000000,520000000,7000000,4,33,0.015,0.06]
+    ]
+  ],
+  "co-national": [
+    [
+      ["co-national-ecuador-market","Ecuador","Mountain hydropower can flow either way when rain and demand differ across the border.",58,650000000,550000000]
+    ],
+    [
+      ["co-ecuador-upgrade","co-national-ecuador-market","Ecuador mountain link","EXISTING",450000000,190000000,3800000,2,26,0.01,0.08]
+    ]
+  ],
+  "ve-reconnection": [
+    [
+      ["ve-reconnection-colombia-restart-market","Colombia (dormant connection)","The wires exist, but regular trading stopped. Reopening them creates a fragile new source of backup power.",66,300000000,350000000]
+    ],
+    [
+      ["ve-colombia-reactivation","ve-reconnection-colombia-restart-market","Restart the Colombia link","EXISTING",250000000,240000000,4800000,3,34,0.018,0.08]
+    ]
+  ],
+  "ec-national": [
+    [
+      ["ec-national-colombia-market","Colombia","A working Andean market can provide hydro backup or buy Ecuador's surplus.",60,600000000,650000000],
+      ["ec-national-peru-market","Peru","Peru's gas and hydro mix complements Ecuador's rain-driven system.",64,500000000,550000000]
+    ],
+    [
+      ["ec-colombia-upgrade","ec-national-colombia-market","Northern Andean upgrade","EXISTING",450000000,190000000,3800000,2,26,0.01,0.08],
+      ["ec-peru-500kv","ec-national-peru-market","Ecuador-Peru 500 kV backbone","NEW",500000000,520000000,9000000,4,33,0.015,0.06]
+    ]
+  ],
+  "pe-national": [
+    [
+      ["pe-national-ecuador-market-pe","Ecuador","Northern exchanges connect Peru to Ecuador today; a stronger Andean backbone can carry more.",59,450000000,500000000],
+      ["pe-national-bolivia-market-pe","Bolivia (proposed)","A new highland route could trade Bolivian gas and hydro power with Peru.",55,350000000,300000000]
+    ],
+    [
+      ["pe-ecuador-upgrade","pe-national-ecuador-market-pe","Northern border upgrade","EXISTING",250000000,210000000,4200000,2,33,0.015,0.06],
+      ["pe-bolivia-sinea","pe-national-bolivia-market-pe","Peru-Bolivia highland line","NEW",350000000,480000000,8000000,4,26,0.01,0.08]
+    ]
+  ],
+  "bo-national": [
+    [
+      ["bo-national-argentina-market-bo","Argentina","The Juana Azurduy line lets Bolivia export generation to northern Argentina.",57,300000000,450000000],
+      ["bo-national-peru-market-bo","Peru (proposed)","A future Andean connection could balance dry-season shortages between the two highland grids.",60,300000000,350000000]
+    ],
+    [
+      ["bo-argentina-upgrade","bo-national-argentina-market-bo","Juana Azurduy upgrade","EXISTING",200000000,150000000,3000000,2,26,0.01,0.08],
+      ["bo-peru-sinea","bo-national-peru-market-bo","Lake Titicaca connection","NEW",300000000,410000000,7000000,4,26,0.01,0.08]
+    ]
+  ],
+  "cl-national": [
+    [
+      ["cl-national-argentina-market-cl","Argentina","The Andes-Salta route can move power across the mountains when the two systems coordinate.",61,350000000,450000000],
+      ["cl-national-peru-market-cl","Peru (proposed)","A northern line would extend the Andean power corridor.",58,400000000,350000000]
+    ],
+    [
+      ["cl-argentina-andes","cl-national-argentina-market-cl","Andes-Salta reinforcement","EXISTING",300000000,250000000,5000000,3,26,0.01,0.08],
+      ["cl-peru-sinea","cl-national-peru-market-cl","Chile-Peru northern line","NEW",400000000,560000000,9500000,4,26,0.01,0.08]
+    ]
+  ],
+  "ar-east": [
+    [
+      ["ar-east-uruguay-market-ar","Uruguay","A tightly coordinated 50 Hz neighbour can buy surplus or provide fast regional backup.",56,800000000,700000000],
+      ["ar-east-brazil-market-ar","Southern Brazil","Frequency converters bridge Argentina's 50 Hz system and Brazil's 60 Hz grid.",59,900000000,850000000]
+    ],
+    [
+      ["ar-uruguay-upgrade","ar-east-uruguay-market-ar","Salto Grande corridor upgrade","EXISTING",600000000,220000000,4400000,2,30,0.012,0.04],
+      ["ar-brazil-garabi","ar-east-brazil-market-ar","Garabi converter upgrade","EXISTING",650000000,310000000,6200000,3,33,0.015,0.06]
+    ]
+  ],
+  "ar-west": [
+    [
+      ["ar-west-chile-market-ar","Chile","A mountain route links Argentina's gas-backed power with Chile's long north-south grid.",63,400000000,450000000],
+      ["ar-west-bolivia-market-ar","Bolivia","Northern Argentina can receive power over the Juana Azurduy line.",55,300000000,350000000]
+    ],
+    [
+      ["ar-chile-andes","ar-west-chile-market-ar","Andes-Salta reinforcement","EXISTING",300000000,250000000,5000000,3,26,0.01,0.08],
+      ["ar-bolivia-upgrade","ar-west-bolivia-market-ar","Bolivia border upgrade","EXISTING",200000000,150000000,3000000,2,26,0.01,0.08]
+    ]
+  ],
+  "uy-national": [
+    [
+      ["uy-national-argentina-market-uy","Argentina","Three connection points share reserves and energy with Argentina's much larger 50 Hz system.",58,800000000,900000000],
+      ["uy-national-brazil-market-uy","Southern Brazil","Converters let Uruguay's 50 Hz grid exchange power with Brazil's 60 Hz grid.",60,650000000,700000000]
+    ],
+    [
+      ["uy-argentina-upgrade","uy-national-argentina-market-uy","Argentina intertie upgrade","EXISTING",600000000,210000000,4200000,2,30,0.012,0.04],
+      ["uy-brazil-melo","uy-national-brazil-market-uy","Melo converter upgrade","EXISTING",450000000,260000000,5200000,2,33,0.015,0.06]
+    ]
+  ],
+  "py-national": [
+    [
+      ["py-national-brazil-market-py","Brazil","Itaipu's two frequencies physically join Paraguay and Brazil, with room for regional sales.",53,900000000,1000000000],
+      ["py-national-argentina-market-py","Argentina","Yacyreta links Paraguay's hydro system to Argentina.",55,700000000,850000000]
+    ],
+    [
+      ["py-brazil-itaipu","py-national-brazil-market-py","Itaipu connection upgrade","EXISTING",650000000,260000000,5200000,2,33,0.015,0.06],
+      ["py-argentina-yacyreta","py-national-argentina-market-py","Yacyreta connection upgrade","EXISTING",500000000,230000000,4600000,2,33,0.015,0.06]
+    ]
+  ],
+  "br-seco": [
+    [
+      ["br-seco-br-south-market","Southern Brazil","Wind, hydro, and demand differ across the South and Southeast, creating two-way trade.",57,1200000000,1300000000],
+      ["br-seco-br-northeast-market","Northeast Brazil","Strong wind and solar can flow south; dry or still weather can reverse the exchange.",54,1300000000,1100000000]
+    ],
+    [
+      ["br-seco-south-upgrade","br-seco-br-south-market","South-Southeast backbone","EXISTING",800000000,260000000,5200000,2,33,0.015,0.06],
+      ["br-seco-ne-upgrade","br-seco-br-northeast-market","Northeast-Southeast backbone","EXISTING",850000000,310000000,6200000,3,33,0.015,0.06]
+    ]
+  ],
+  "br-ne": [
+    [
+      ["br-ne-br-seco-market","Southeast and Centre-West Brazil","The country's largest demand centre can buy Northeast renewable surplus or send backup north.",61,1400000000,1500000000],
+      ["br-ne-br-north-market","Northern Brazil","Hydro and long-distance renewable flows connect the North and Northeast.",55,1000000000,900000000]
+    ],
+    [
+      ["br-ne-seco-upgrade","br-ne-br-seco-market","Northeast-Southeast reinforcement","EXISTING",850000000,310000000,6200000,3,33,0.015,0.06],
+      ["br-ne-north-upgrade","br-ne-br-north-market","North-Northeast reinforcement","EXISTING",650000000,250000000,5000000,2,34,0.018,0.08]
+    ]
+  ],
+  "br-north": [
+    [
+      ["br-north-br-seco-market-north","Southeast and Centre-West Brazil","Long transmission routes share northern hydro with the country's main demand centre.",60,1100000000,1400000000],
+      ["br-north-br-ne-market-north","Northeast Brazil","A regional seam balances Amazon hydro against Northeast wind, solar, and demand.",56,900000000,1000000000]
+    ],
+    [
+      ["br-north-seco-upgrade","br-north-br-seco-market-north","North-Southeast trunk upgrade","EXISTING",750000000,340000000,6800000,3,34,0.018,0.08],
+      ["br-north-ne-upgrade","br-north-br-ne-market-north","North-Northeast trunk upgrade","EXISTING",600000000,270000000,5400000,3,34,0.018,0.08]
+    ]
+  ],
+  "br-south": [
+    [
+      ["br-south-argentina-market-br","Argentina","Garabi and Uruguaiana converters bridge Brazil's 60 Hz grid and Argentina's 50 Hz system.",58,850000000,900000000],
+      ["br-south-uruguay-market-br","Uruguay","Melo and Rivera converters support two-way trade with Uruguay.",56,650000000,650000000]
+    ],
+    [
+      ["br-argentina-garabi","br-south-argentina-market-br","Garabi converter upgrade","EXISTING",650000000,310000000,6200000,3,33,0.015,0.06],
+      ["br-uruguay-melo","br-south-uruguay-market-br","Melo-Rivera upgrade","EXISTING",450000000,260000000,5200000,2,33,0.015,0.06]
+    ]
+  ],
+  "au-nsw": [
+    [
+      ["au-nsw-queensland-market","Queensland","Solar-rich Queensland and New South Wales share power over two northern links.",55,1200000000,1300000000],
+      ["au-nsw-victoria-market","Victoria","The Snowy and Murray network moves power between two large NEM regions.",58,1300000000,1400000000]
+    ],
+    [
+      ["au-nsw-qld-upgrade","au-nsw-queensland-market","Queensland-NSW upgrade","EXISTING",700000000,250000000,5000000,2,33,0.015,0.06],
+      ["au-nsw-vic-upgrade","au-nsw-victoria-market","Victoria-NSW upgrade","EXISTING",800000000,280000000,5600000,2,30,0.012,0.04]
+    ]
+  ],
+  "au-vic": [
+    [
+      ["au-vic-nsw-market-vic","New South Wales","Snowy hydro and large city demand make this a busy two-way NEM seam.",57,1300000000,1400000000],
+      ["au-vic-tasmania-market-vic","Tasmania","Basslink carries Tasmanian hydro north and mainland backup south.",53,550000000,500000000]
+    ],
+    [
+      ["au-vic-nsw-upgrade","au-vic-nsw-market-vic","Victoria-NSW upgrade","EXISTING",800000000,280000000,5600000,2,30,0.012,0.04],
+      ["au-vic-tas-basslink","au-vic-tasmania-market-vic","Basslink upgrade","EXISTING",450000000,390000000,6500000,3,35,0.005,0.01]
+    ]
+  ],
+  "au-qld": [
+    [
+      ["au-qld-nsw-market-qld","New South Wales","Two links let Queensland's solar and thermal fleet trade with New South Wales.",59,1300000000,1400000000]
+    ],
+    [
+      ["au-qld-nsw-qni","au-qld-nsw-market-qld","Queensland-NSW upgrade","EXISTING",700000000,250000000,5000000,2,33,0.015,0.06]
+    ]
+  ],
+  "au-sa": [
+    [
+      ["au-sa-victoria-market-sa","Victoria","Heywood and Murraylink connect South Australian wind and solar with Victoria.",58,800000000,900000000],
+      ["au-sa-nsw-market-sa","New South Wales","EnergyConnect adds another route for sharing renewable power and reserves.",57,700000000,850000000]
+    ],
+    [
+      ["au-sa-vic-upgrade","au-sa-victoria-market-sa","Victoria intertie upgrade","EXISTING",500000000,240000000,4800000,2,33,0.015,0.06],
+      ["au-sa-nsw-energyconnect","au-sa-nsw-market-sa","EnergyConnect expansion","EXISTING",500000000,310000000,6200000,3,33,0.015,0.06]
+    ]
+  ],
+  "au-tas": [
+    [
+      ["au-tas-victoria-market-tas","Victoria","Basslink exports hydro when Tasmania is wet and imports mainland power when local supply is tight.",60,500000000,550000000]
+    ],
+    [
+      ["au-tas-vic-basslink","au-tas-victoria-market-tas","Basslink upgrade","EXISTING",450000000,390000000,6500000,3,35,0.005,0.01]
+    ]
+  ],
+  "nz-north": [
+    [
+      ["nz-north-nz-south-market","South Island","South Island hydro often flows north; dry years can send North Island generation south.",51,900000000,700000000]
+    ],
+    [
+      ["nz-north-cook-strait","nz-north-nz-south-market","Cook Strait HVDC upgrade","EXISTING",650000000,430000000,7000000,3,35,0.005,0.01]
+    ]
+  ],
+  "nz-south": [
+    [
+      ["nz-south-nz-north-market","North Island","The larger northern market buys southern hydro and sends backup south in dry years.",59,800000000,1000000000]
+    ],
+    [
+      ["nz-south-cook-strait","nz-south-nz-north-market","Cook Strait HVDC upgrade","EXISTING",650000000,430000000,7000000,3,35,0.005,0.01]
+    ]
+  ]
+} as const satisfies Readonly<Record<string, TransmissionProfileTuple>>;
+
+// prettier-ignore
+export const TRANSMISSION_PROFILE_LOCATION_IDS = {
+  "us-ca-wecc": ["SF","LA","SanDiego","Fresno","Sacramento","CAMountains"],
+  "us-pjm": ["PIT","Philadelphia","Manassas","Columbus","Baltimore","Cleveland","Chicago","AlleghenyUpper"],
+  "us-nyiso": ["NewYork","Buffalo"],
+  "us-isone": ["Boston"],
+  "us-miso-north": ["Indianapolis","Detroit","Milwaukee","Minneapolis","StLouis"],
+  "us-miso-south": ["NewOrleans"],
+  "us-spp": ["KansasCity"],
+  "us-tva": ["Nashville","Memphis"],
+  "us-carolinas": ["Charlotte"],
+  "us-southeast": ["Atlanta"],
+  "us-florida": ["Jacksonville","Miami"],
+  "us-ercot": ["Houston","SanAntonio","Dallas","Austin"],
+  "us-pnw-wecc": ["Seattle","Portland"],
+  "us-desert-wecc": ["Phoenix","Tucson","LasVegas"],
+  "us-rockies-wecc": ["Denver","Albuquerque","SaltLakeCity"],
+  "ca-ontario": ["Toronto"],
+  "ca-quebec": ["Montreal"],
+  "ca-bc": ["Vancouver"],
+  "ca-alberta": ["Calgary"],
+  "ca-manitoba": ["Winnipeg"],
+  "ca-maritimes": ["Halifax"],
+  "mx-sin-central-west": ["MexicoCity","Guadalajara"],
+  "mx-sin-northeast": ["Monterrey"],
+  "mx-baja-wecc": ["Tijuana"],
+  "mx-sin-yucatan": ["Cancun"],
+  "siepac-north": ["GuatemalaCity"],
+  "siepac-central": ["Tegucigalpa","Managua"],
+  "siepac-south": ["PanamaCity"],
+  "siepac-san-salvador": ["SanSalvador"],
+  "siepac-costa-rica": ["SanJoseCR"],
+  "geo-london": ["London","Manchester","Edinburgh"],
+  "geo-dublin": ["Dublin"],
+  "geo-paris": ["Paris","Marseille","Lyon"],
+  "geo-madrid": ["Madrid","Barcelona","Seville"],
+  "geo-lisbon": ["Lisbon","Porto"],
+  "geo-rome": ["Rome","Milan","Naples","Palermo"],
+  "geo-berlin": ["Berlin","Munich","Hamburg","Frankfurt","Cologne"],
+  "geo-vienna": ["Vienna"],
+  "geo-zurich": ["Zurich","Geneva"],
+  "geo-amsterdam": ["Amsterdam","Rotterdam"],
+  "geo-brussels": ["Brussels"],
+  "geo-copenhagen": ["Copenhagen"],
+  "geo-lista": ["Lista","Oslo","Bergen","Tromso"],
+  "geo-stockholm": ["Stockholm","Gothenburg"],
+  "geo-helsinki": ["Helsinki"],
+  "geo-warsaw": ["Warsaw","Krakow"],
+  "geo-prague": ["Prague"],
+  "geo-budapest": ["Budapest"],
+  "geo-bucharest": ["Bucharest"],
+  "geo-sofia": ["Sofia"],
+  "geo-belgrade": ["Belgrade"],
+  "geo-zagreb": ["Zagreb"],
+  "geo-athens": ["Athens"],
+  "geo-kyiv": ["Kyiv"],
+  "geo-minsk": ["Minsk"],
+  "geo-tallinn": ["Tallinn"],
+  "geo-riga": ["Riga"],
+  "geo-vilnius": ["Vilnius"],
+  "geo-moscow": ["Moscow","StPetersburg","Murmansk"],
+  "geo-istanbul": ["Istanbul","Ankara"],
+  "geo-dubai": ["Dubai","AbuDhabi"],
+  "geo-doha": ["Doha"],
+  "geo-manama": ["Manama"],
+  "geo-kuwaitcity": ["KuwaitCity"],
+  "geo-muscat": ["Muscat"],
+  "geo-riyadh": ["Riyadh","Jeddah"],
+  "geo-baghdad": ["Baghdad"],
+  "geo-tehran": ["Tehran"],
+  "geo-amman": ["Amman"],
+  "geo-beirut": ["Beirut"],
+  "geo-damascus": ["Damascus"],
+  "geo-telaviv": ["TelAviv","Jerusalem"],
+  "geo-baku": ["Baku"],
+  "geo-tbilisi": ["Tbilisi"],
+  "geo-yerevan": ["Yerevan"],
+  "geo-tashkent": ["Tashkent"],
+  "geo-almaty": ["Almaty","Astana"],
+  "geo-kabul": ["Kabul"],
+  "geo-cairo": ["Cairo","Alexandria"],
+  "geo-casablanca": ["Casablanca","Marrakesh"],
+  "geo-algiers": ["Algiers"],
+  "geo-tunis": ["Tunis"],
+  "geo-tripoli": ["Tripoli"],
+  "geo-lagos": ["Lagos","Abuja","Kano"],
+  "geo-accra": ["Accra"],
+  "geo-abidjan": ["Abidjan"],
+  "geo-dakar": ["Dakar"],
+  "geo-bamako": ["Bamako"],
+  "geo-ouagadougou": ["Ouagadougou"],
+  "geo-niamey": ["Niamey"],
+  "geo-khartoum": ["Khartoum"],
+  "geo-addisababa": ["AddisAbaba"],
+  "geo-nairobi": ["Nairobi","Mombasa"],
+  "geo-kampala": ["Kampala"],
+  "geo-kigali": ["Kigali"],
+  "geo-daressalaam": ["DarEsSalaam"],
+  "geo-kinshasa": ["Kinshasa"],
+  "geo-luanda": ["Luanda"],
+  "geo-lusaka": ["Lusaka"],
+  "geo-harare": ["Harare"],
+  "geo-maputo": ["Maputo"],
+  "geo-gaborone": ["Gaborone"],
+  "geo-windhoek": ["Windhoek"],
+  "geo-johannesburg": ["Johannesburg","CapeTown","Durban"],
+  "geo-delhi": ["Delhi","Mumbai","Bengaluru","Chennai","Kolkata","Hyderabad","Ahmedabad","Pune","Jaipur","Lucknow"],
+  "geo-karachi": ["Karachi","Lahore","Islamabad"],
+  "geo-dhaka": ["Dhaka","Chittagong"],
+  "geo-kathmandu": ["Kathmandu"],
+  "jp-east": ["Tokyo"],
+  "jp-kansai": ["Osaka"],
+  "jp-hokkaido": ["Sapporo"],
+  "jp-kyushu": ["Fukuoka"],
+  "jp-chubu": ["Nagoya"],
+  "cn-north": ["Beijing"],
+  "cn-east": ["Shanghai"],
+  "cn-south": ["Guangzhou","Shenzhen"],
+  "cn-sichuan": ["Chengdu","Chongqing"],
+  "cn-central": ["Wuhan"],
+  "cn-northwest": ["Xian"],
+  "cn-northeast": ["Harbin"],
+  "cn-xinjiang": ["Urumqi"],
+  "cn-xizang": ["Lhasa"],
+  "hk-mainland": ["HongKong"],
+  "mn-central": ["Ulaanbaatar"],
+  "ru-far-east": ["Vladivostok"],
+  "ru-siberia": ["Novosibirsk"],
+  "ru-yakutia": ["Yakutsk"],
+  "th-central": ["Bangkok"],
+  "th-north": ["ChiangMai"],
+  "vn-south": ["HoChiMinhCity"],
+  "vn-north": ["Hanoi"],
+  "kh-national": ["PhnomPenh"],
+  "la-national": ["Vientiane"],
+  "mm-national": ["Yangon"],
+  "my-peninsula": ["KualaLumpur"],
+  "sg-national": ["Singapore"],
+  "id-java": ["Jakarta","Surabaya"],
+  "id-bali": ["Denpasar"],
+  "id-sumatra": ["Medan"],
+  "ph-luzon": ["Manila"],
+  "ph-visayas": ["Cebu"],
+  "ph-mindanao": ["Davao"],
+  "bn-proposed": ["BandarSeriBegawan"],
+  "co-national": ["Bogota","Medellin"],
+  "ve-reconnection": ["Caracas"],
+  "ec-national": ["Quito","Guayaquil"],
+  "pe-national": ["Lima"],
+  "bo-national": ["LaPaz"],
+  "cl-national": ["Santiago"],
+  "ar-east": ["BuenosAires","Cordoba"],
+  "ar-west": ["Mendoza"],
+  "uy-national": ["Montevideo"],
+  "py-national": ["Asuncion"],
+  "br-seco": ["SaoPaulo","RioDeJaneiro","Brasilia"],
+  "br-ne": ["Salvador","Fortaleza","Recife"],
+  "br-north": ["Manaus","Belem"],
+  "br-south": ["PortoAlegre"],
+  "au-nsw": ["Sydney","Canberra"],
+  "au-vic": ["Melbourne"],
+  "au-qld": ["Brisbane"],
+  "au-sa": ["Adelaide"],
+  "au-tas": ["Hobart"],
+  "nz-north": ["Auckland","Wellington"],
+  "nz-south": ["Christchurch","Queenstown"]
+} as const satisfies Readonly<Record<keyof typeof TRANSMISSION_PROFILE_DATA, readonly string[]>>;
+
+// prettier-ignore
+export const NO_INTERTIE_LOCATION_IDS = ["Anchorage","Fairbanks","HNL","SJU","Yellowknife","Iqaluit","Havana","SantoDomingo","PortAuPrince","Kingston","Nassau","Bridgetown","Reykjavik","Antananarivo","PortLouis","Colombo","Male","Seoul","Busan","Taipei","Ushuaia","Georgetown","Paramaribo","Perth","Darwin","AliceSprings","Suva","PortMoresby","Noumea","Papeete","Honiara"] as const;

--- a/src/data/TutorialCapstones.test.tsx
+++ b/src/data/TutorialCapstones.test.tsx
@@ -1,12 +1,21 @@
+import cloneDeep from "lodash.clonedeep";
 import { getStore } from "../StoreRegistry";
-import { AppStateType, GameType, ScenarioType } from "../Types";
+import {
+  AppStateType,
+  GameType,
+  MonthlyHistoryType,
+  ScenarioType,
+  TickPresentFutureType,
+} from "../Types";
 import gameReducer, {
   buildFacility,
+  buildTransmissionLine,
   delta,
   initGame,
   start,
   tickState,
 } from "../reducers/Game";
+import { summarizeTimeline } from "../helpers/DateTime";
 import { GENERATORS } from "./Facilities";
 import { createGame } from "../testing/Simulator";
 import { TUTORIALS } from "./Scenarios";
@@ -153,5 +162,46 @@ describe("authored tutorial capstones", () => {
     expect(objective.failure?.(appState(prepared))).toBe(false);
     expect(tickUntil(unprepared, objective.failure!, 800)).toBe(true);
     expect(objective.success(appState(unprepared))).toBe(false);
+  });
+
+  it("requires Mission 7 to settle a new safe-export month after observing imports", () => {
+    const objective = capstone(112);
+    const game = cloneDeep(
+      gameReducer(
+        createGame({ scenarioId: 112 }),
+        buildTransmissionLine({
+          corridorId: "california-north",
+          financed: true,
+        }),
+      ),
+    );
+    game.transmission!.lines[0].yearsToBuildLeft = 0;
+    game.transmission!.tradingPolicy = "BALANCED";
+    game.date.monthsElapsed = 15;
+    const month = summarizeTimeline(game.timeline, game.startingYear);
+    const imported: MonthlyHistoryType = {
+      ...month,
+      chartAverage: {
+        ...month.chartAverage,
+        importedW: 1,
+        exportedW: 0,
+      } as TickPresentFutureType,
+      minimumSupplyMarginW: 0,
+    };
+    const olderExport: MonthlyHistoryType = {
+      ...month,
+      chartAverage: {
+        ...month.chartAverage,
+        importedW: 0,
+        exportedW: 1,
+      } as TickPresentFutureType,
+      minimumSupplyMarginW: 1,
+    };
+    game.monthlyHistory = [imported, olderExport];
+
+    expect(objective.success(appState(game))).toBe(false);
+
+    game.monthlyHistory = [olderExport, imported];
+    expect(objective.success(appState(game))).toBe(true);
   });
 });

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -1080,7 +1080,7 @@ export const TEXAS_DEEP_FREEZE_DEMAND: Record<DifficultyType, number> = {
   // The joint FERC/NERC report measured actual ERCOT peak load 20% above the normal-weather
   // forecast and estimated unconstrained demand 33% above it. Difficulty spans that observed
   // range while leaving the researched Austin portfolio and plant availability anchors intact.
-  Intern: 1.21,
+  Intern: 1.2,
   Employee: 1.23,
   Manager: 1.27,
   VP: 1.3,
@@ -1121,9 +1121,7 @@ const TEXAS_DEEP_FREEZE_ARC: StoryArcDefinitionType = {
               "Natural Gas": 0.62,
               Coal: 0.73,
               Uranium: 0.77,
-              // Intern calibration makes preparation necessary across the standard seed set
-              // without inflating demand so far that the audited 1.8 GW backup stops working.
-              Wind: difficulty === "Intern" ? 0.3 : 0.44,
+              Wind: 0.44,
             },
           },
           turningPointPriority: 110,
@@ -1281,8 +1279,8 @@ export const CALIFORNIA_WILDFIRE_BALANCE: Record<
 > = {
   Intern: {
     disconnectedDemand: 0.02,
-    targetCapacityShare: 0.9,
-    outputMultiplier: 0.1,
+    targetCapacityShare: 0.3,
+    outputMultiplier: 0.65,
     restorationCostPerMonth: 1000000,
   },
   Employee: {
@@ -1341,12 +1339,7 @@ const CALIFORNIA_WILDFIRE_ARC: StoryArcDefinitionType = {
       describe: (context, random) => {
         const balance = CALIFORNIA_WILDFIRE_BALANCE[context.difficulty];
         const candidates = context.snapshot.facilities
-          // The warning gives the player a year to add new backup. Treat that new equipment as
-          // hardened for this emergency; the shutoffs target the older exposed portfolio.
-          .filter(
-            (facility) =>
-              facility.operational && !!facility.fuel && facility.ageYears >= 2,
-          )
+          .filter((facility) => facility.operational && !!facility.fuel)
           .map((facility) => ({
             ...facility,
             score: random(`facility|${facility.id}`),

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -1080,7 +1080,7 @@ export const TEXAS_DEEP_FREEZE_DEMAND: Record<DifficultyType, number> = {
   // The joint FERC/NERC report measured actual ERCOT peak load 20% above the normal-weather
   // forecast and estimated unconstrained demand 33% above it. Difficulty spans that observed
   // range while leaving the researched Austin portfolio and plant availability anchors intact.
-  Intern: 1.2,
+  Intern: 1.21,
   Employee: 1.23,
   Manager: 1.27,
   VP: 1.3,
@@ -1121,7 +1121,9 @@ const TEXAS_DEEP_FREEZE_ARC: StoryArcDefinitionType = {
               "Natural Gas": 0.62,
               Coal: 0.73,
               Uranium: 0.77,
-              Wind: 0.44,
+              // Intern calibration makes preparation necessary across the standard seed set
+              // without inflating demand so far that the audited 1.8 GW backup stops working.
+              Wind: difficulty === "Intern" ? 0.3 : 0.44,
             },
           },
           turningPointPriority: 110,
@@ -1279,8 +1281,8 @@ export const CALIFORNIA_WILDFIRE_BALANCE: Record<
 > = {
   Intern: {
     disconnectedDemand: 0.02,
-    targetCapacityShare: 0.3,
-    outputMultiplier: 0.65,
+    targetCapacityShare: 0.9,
+    outputMultiplier: 0.1,
     restorationCostPerMonth: 1000000,
   },
   Employee: {
@@ -1339,7 +1341,12 @@ const CALIFORNIA_WILDFIRE_ARC: StoryArcDefinitionType = {
       describe: (context, random) => {
         const balance = CALIFORNIA_WILDFIRE_BALANCE[context.difficulty];
         const candidates = context.snapshot.facilities
-          .filter((facility) => facility.operational && !!facility.fuel)
+          // The warning gives the player a year to add new backup. Treat that new equipment as
+          // hardened for this emergency; the shutoffs target the older exposed portfolio.
+          .filter(
+            (facility) =>
+              facility.operational && !!facility.fuel && facility.ageYears >= 2,
+          )
           .map((facility) => ({
             ...facility,
             score: random(`facility|${facility.id}`),

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -40,6 +40,8 @@ export const EMPTY_HISTORY = {
   expensesCarbonFee: 0,
   expensesInterest: 0,
   expensesPolicy: 0,
+  expensesImports: 0,
+  revenueExports: 0,
   netWorth: 0,
   interestRate: 0,
   inflationRate: 0,
@@ -80,6 +82,8 @@ export function reduceHistories(
   acc.expensesCarbonFee += t.expensesCarbonFee;
   acc.expensesInterest += t.expensesInterest;
   acc.expensesPolicy = (acc.expensesPolicy || 0) + (t.expensesPolicy || 0);
+  acc.expensesImports = (acc.expensesImports || 0) + (t.expensesImports || 0);
+  acc.revenueExports = (acc.revenueExports || 0) + (t.revenueExports || 0);
   acc.cash = t.cash;
   acc.customers = t.customers;
   acc.netWorth = t.netWorth;
@@ -101,13 +105,14 @@ export function deriveExpandedSummary(
     s.expensesCarbonFee +
     s.expensesInterest +
     (s.expensesPolicy || 0);
+  const expensesWithImports = expenses + (s.expensesImports || 0);
   const supplykWh = (s.supplyWh || 1) / 1000;
   return {
     ...s,
-    profit: s.revenue - expenses,
-    profitPerkWh: (s.revenue - expenses) / supplykWh,
+    profit: s.revenue - expensesWithImports,
+    profitPerkWh: (s.revenue - expensesWithImports) / supplykWh,
     revenuePerkWh: s.revenue / supplykWh,
-    expenses,
+    expenses: expensesWithImports,
     kgco2ePerMWh: s.kgco2e / (supplykWh / 1000),
   };
 }
@@ -210,6 +215,10 @@ function accumulateTick(
   summary.expensesInterest += t.expensesInterest;
   summary.expensesPolicy =
     (summary.expensesPolicy || 0) + (t.expensesPolicy || 0);
+  summary.expensesImports =
+    (summary.expensesImports || 0) + (t.expensesImports || 0);
+  summary.revenueExports =
+    (summary.revenueExports || 0) + (t.revenueExports || 0);
   summary.cash = t.cash;
   summary.customers = t.customers;
   summary.netWorth = t.netWorth;

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -369,6 +369,17 @@ describe("getCreditInputs", () => {
     ]);
     expect(inputs.debtToCapital).toBeCloseTo(0.5, 10);
   });
+
+  it("counts financed interties in company debt", () => {
+    const inputs = getCreditInputs(
+      [aMonth(100, 50)],
+      500,
+      1000,
+      [],
+      [{ loanAmountLeft: 1000 }],
+    );
+    expect(inputs.debtToCapital).toBeCloseTo(0.5, 10);
+  });
 });
 
 describe("facilityLifetime", () => {

--- a/src/helpers/Financials.tsx
+++ b/src/helpers/Financials.tsx
@@ -5,6 +5,7 @@ import {
   GeneratorShoppingType,
   LocationType,
   MonthlyHistoryType,
+  TransmissionLineOperatingType,
 } from "../Types";
 import { getFuelPricesPerMBTU } from "../data/FuelPrices";
 import {
@@ -54,11 +55,10 @@ const PREMIUM_PER_POINT = 0.05;
 // end of the scale stays a number rather than running away.
 export const MAX_CREDIT_POINTS = 40;
 
-export function getTotalDebt(facilities: FacilityOperatingType[]): number {
-  return facilities.reduce(
-    (debt: number, g: FacilityOperatingType) => debt + g.loanAmountLeft,
-    0,
-  );
+export function getTotalDebt(
+  assets: readonly Pick<FacilityOperatingType, "loanAmountLeft">[],
+): number {
+  return assets.reduce((debt: number, asset) => debt + asset.loanAmountLeft, 0);
 }
 
 export interface CreditInputsType {
@@ -106,6 +106,10 @@ export function getCreditInputs(
   cash: number,
   netWorth: number,
   facilities: FacilityOperatingType[],
+  transmissionLines: readonly Pick<
+    TransmissionLineOperatingType,
+    "loanAmountLeft"
+  >[] = [],
 ): CreditInputsType {
   const trailing = deriveExpandedSummary(
     monthlyHistory
@@ -114,7 +118,7 @@ export function getCreditInputs(
       .reverse()
       .reduce(reduceHistories, { ...EMPTY_HISTORY }),
   );
-  const debt = getTotalDebt(facilities);
+  const debt = getTotalDebt([...facilities, ...transmissionLines]);
   // Annualised, so that a company three months into its first year is judged on the rate it is
   // earning rather than on a quarter of a year's revenue
   const months = Math.min(TRAILING_MONTHS, monthlyHistory.length);

--- a/src/helpers/Math.tsx
+++ b/src/helpers/Math.tsx
@@ -44,6 +44,7 @@ export const RANDOM_STREAM = {
   worldEvents: 5, // randomAt only -- discrete occurrences and each occurrence's attributes
   // normalAt only -- separate so adding offshore wind cannot shift any existing weather field
   weatherOffshore: 6,
+  transmissionMarkets: 7, // normalAt only -- neighbouring wholesale-price variation
 };
 
 // https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript

--- a/src/helpers/MeaningfulDecisions.test.ts
+++ b/src/helpers/MeaningfulDecisions.test.ts
@@ -1,0 +1,152 @@
+import { SCENARIOS } from "../data/Scenarios";
+import { scenarioObjectiveFailure } from "../reducers/Game";
+import { GameType, MeaningfulDecisionKindType } from "../Types";
+import {
+  isMaterialCapacityDecision,
+  meaningfulDecisionCategoryCount,
+  recordMeaningfulDecision,
+  validMeaningfulDecisions,
+} from "./MeaningfulDecisions";
+
+function game(month = 0, peakDemandW = 100_000_000): GameType {
+  return {
+    date: { monthsElapsed: month },
+    meaningfulDecisions: [],
+    timeline: [{ demandW: peakDemandW }],
+  } as unknown as GameType;
+}
+
+function choices(
+  count: number,
+  kinds: MeaningfulDecisionKindType[] = ["asset"],
+) {
+  return Array.from({ length: count }, (_, index) => ({
+    key: `choice:${index}`,
+    lever: `choice:${index}`,
+    label: `Choice ${index + 1}`,
+    month: index,
+    kind: kinds[index % kinds.length],
+    before: "before",
+    after: "after",
+  }));
+}
+
+describe("meaningful decisions", () => {
+  it("keeps one lifetime record and removes a cross-month return to baseline", () => {
+    const state = game();
+    recordMeaningfulDecision(state, {
+      lever: "rate",
+      label: "Set customer rate",
+      kind: "rate",
+      before: "0.1",
+      after: "0.11",
+    });
+    state.date.monthsElapsed = 3;
+    recordMeaningfulDecision(state, {
+      lever: "rate",
+      label: "Set customer rate",
+      kind: "rate",
+      before: "0.11",
+      after: "0.12",
+    });
+
+    expect(state.meaningfulDecisions).toEqual([
+      expect.objectContaining({
+        key: "rate",
+        before: "0.1",
+        after: "0.12",
+        month: 3,
+      }),
+    ]);
+
+    state.date.monthsElapsed = 7;
+    recordMeaningfulDecision(state, {
+      lever: "rate",
+      label: "Set customer rate",
+      kind: "rate",
+      before: "0.12",
+      after: "0.1",
+    });
+    expect(state.meaningfulDecisions).toEqual([]);
+  });
+
+  it("ignores same-value writes but keeps separate asset commitments", () => {
+    const state = game();
+    recordMeaningfulDecision(state, {
+      lever: "rate",
+      label: "Set customer rate",
+      kind: "rate",
+      before: "0.1",
+      after: "0.1",
+    });
+    recordMeaningfulDecision(state, {
+      lever: "asset-build:3",
+      label: "Build gas plant",
+      kind: "asset",
+      before: "absent",
+      after: "gas:cash",
+    });
+    recordMeaningfulDecision(state, {
+      lever: "asset-build:4",
+      label: "Build wind farm",
+      kind: "asset",
+      before: "absent",
+      after: "wind:cash",
+    });
+
+    expect(state.meaningfulDecisions.map(({ key }) => key)).toEqual([
+      "asset-build:3",
+      "asset-build:4",
+    ]);
+  });
+
+  it("requires a build to be at least one percent of peak demand", () => {
+    const state = game(0, 2_000_000_000);
+    expect(isMaterialCapacityDecision(state, 19_999_999)).toBe(false);
+    expect(isMaterialCapacityDecision(state, 20_000_000)).toBe(true);
+    expect(isMaterialCapacityDecision(game(0, 50_000_000), 999_999)).toBe(
+      false,
+    );
+    expect(isMaterialCapacityDecision(game(0, 50_000_000), 1_000_000)).toBe(
+      true,
+    );
+  });
+
+  it("validates unique labeled lifetime keys", () => {
+    const valid = choices(2, ["asset", "rate"]);
+    expect(validMeaningfulDecisions(valid, 5)).toBe(true);
+    expect(
+      validMeaningfulDecisions(
+        [...valid, { ...valid[1], label: "Duplicate" }],
+        5,
+      ),
+    ).toBe(false);
+    expect(validMeaningfulDecisions([{ hepo: "bad" }], 5)).toBe(false);
+  });
+
+  it("makes the Intern and diverse CEO objectives explicit, with a legacy waiver", () => {
+    const scenario = SCENARIOS.find(({ id }) => id === 100)!;
+    const one = choices(1);
+    const nine = choices(9, ["asset", "rate", "policy", "dispatch"]);
+    const tenOneKind = choices(10);
+    const tenDiverse = choices(10, ["asset", "rate", "policy", "dispatch"]);
+
+    expect(scenarioObjectiveFailure(scenario, [], "Intern", [])).toContain(
+      "at least one",
+    );
+    expect(scenarioObjectiveFailure(scenario, [], "Intern", one)).toBeFalsy();
+    expect(scenarioObjectiveFailure(scenario, [], "CEO", nine)).toContain(
+      "9 of 10",
+    );
+    expect(scenarioObjectiveFailure(scenario, [], "CEO", tenOneKind)).toContain(
+      "1 of 4",
+    );
+    expect(meaningfulDecisionCategoryCount(tenDiverse)).toBeGreaterThanOrEqual(
+      4,
+    );
+    expect(
+      scenarioObjectiveFailure(scenario, [], "CEO", tenDiverse),
+    ).toBeFalsy();
+    expect(scenarioObjectiveFailure(scenario, [], "CEO", [], true)).toBeFalsy();
+  });
+});

--- a/src/helpers/MeaningfulDecisions.ts
+++ b/src/helpers/MeaningfulDecisions.ts
@@ -1,0 +1,75 @@
+import { GameType, MeaningfulDecisionType } from "../Types";
+
+export const CEO_MEANINGFUL_DECISIONS_REQUIRED = 10;
+export const MAX_MEANINGFUL_DECISIONS = 1000;
+
+export type DecisionChangeType = Omit<MeaningfulDecisionType, "key" | "month">;
+
+/**
+ * Records an accepted simulation change, coalescing one lever to its settled state for the month.
+ * Returning a lever to its opening value removes the entry, so slider churn and inverse toggles
+ * cannot pad the CEO objective.
+ */
+export function recordMeaningfulDecision(
+  game: GameType,
+  change: DecisionChangeType,
+): void {
+  if (change.before === change.after) return;
+  const month = game.date.monthsElapsed;
+  const key = `${change.lever}@${month}`;
+  const log = game.meaningfulDecisions;
+  const existingIndex = log.findIndex((entry) => entry.key === key);
+  if (existingIndex >= 0) {
+    const existing = log[existingIndex];
+    if (existing.before === change.after) log.splice(existingIndex, 1);
+    else existing.after = change.after;
+    return;
+  }
+  if (log.length >= MAX_MEANINGFUL_DECISIONS) return;
+  log.push({ ...change, key, month });
+}
+
+export function meaningfulDecisionCount(
+  game: Pick<GameType, "meaningfulDecisions">,
+): number {
+  return game.meaningfulDecisions.length;
+}
+
+export function validMeaningfulDecisions(
+  raw: unknown,
+  currentMonth: number,
+): raw is MeaningfulDecisionType[] {
+  if (!Array.isArray(raw) || raw.length > MAX_MEANINGFUL_DECISIONS)
+    return false;
+  const keys = new Set<string>();
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) return false;
+    const decision = entry as Partial<MeaningfulDecisionType>;
+    if (
+      typeof decision.key !== "string" ||
+      typeof decision.lever !== "string" ||
+      !/^[a-z][a-z0-9:-]*$/.test(decision.lever) ||
+      !Number.isInteger(decision.month) ||
+      decision.month! < 0 ||
+      decision.month! > currentMonth ||
+      decision.key !== `${decision.lever}@${decision.month}` ||
+      typeof decision.kind !== "string" ||
+      ![
+        "asset",
+        "sale",
+        "rate",
+        "policy",
+        "operation",
+        "dispatch",
+        "trading",
+      ].includes(decision.kind) ||
+      typeof decision.before !== "string" ||
+      typeof decision.after !== "string" ||
+      decision.before === decision.after ||
+      keys.has(decision.key)
+    )
+      return false;
+    keys.add(decision.key);
+  }
+  return true;
+}

--- a/src/helpers/MeaningfulDecisions.ts
+++ b/src/helpers/MeaningfulDecisions.ts
@@ -1,14 +1,34 @@
-import { GameType, MeaningfulDecisionType } from "../Types";
+import {
+  DifficultyType,
+  GameType,
+  MeaningfulDecisionKindType,
+  MeaningfulDecisionType,
+} from "../Types";
 
+export const INTERN_MEANINGFUL_DECISIONS_REQUIRED = 1;
 export const CEO_MEANINGFUL_DECISIONS_REQUIRED = 10;
+export const CEO_MEANINGFUL_CATEGORIES_REQUIRED = 4;
 export const MAX_MEANINGFUL_DECISIONS = 1000;
+
+export const MEANINGFUL_DECISION_CATEGORY_LABELS: Record<
+  MeaningfulDecisionKindType,
+  string
+> = {
+  asset: "grid investments",
+  sale: "retirements and sales",
+  rate: "customer pricing",
+  policy: "customer programs",
+  operation: "plant operations",
+  dispatch: "dispatch planning",
+  trading: "regional trading",
+};
 
 export type DecisionChangeType = Omit<MeaningfulDecisionType, "key" | "month">;
 
 /**
- * Records an accepted simulation change, coalescing one lever to its settled state for the month.
- * Returning a lever to its opening value removes the entry, so slider churn and inverse toggles
- * cannot pad the CEO objective.
+ * Records an accepted simulation change under one lifetime key for that lever or asset. Returning
+ * a lever to its original value removes the entry even in a later month, so slider, program,
+ * operating, dispatch, and trading churn cannot pad a victory objective.
  */
 export function recordMeaningfulDecision(
   game: GameType,
@@ -16,13 +36,17 @@ export function recordMeaningfulDecision(
 ): void {
   if (change.before === change.after) return;
   const month = game.date.monthsElapsed;
-  const key = `${change.lever}@${month}`;
+  const key = change.lever;
   const log = game.meaningfulDecisions;
   const existingIndex = log.findIndex((entry) => entry.key === key);
   if (existingIndex >= 0) {
     const existing = log[existingIndex];
     if (existing.before === change.after) log.splice(existingIndex, 1);
-    else existing.after = change.after;
+    else {
+      existing.after = change.after;
+      existing.label = change.label;
+      existing.month = month;
+    }
     return;
   }
   if (log.length >= MAX_MEANINGFUL_DECISIONS) return;
@@ -33,6 +57,38 @@ export function meaningfulDecisionCount(
   game: Pick<GameType, "meaningfulDecisions">,
 ): number {
   return game.meaningfulDecisions.length;
+}
+
+export function meaningfulDecisionCategoryCount(
+  decisions: MeaningfulDecisionType[],
+): number {
+  return new Set(decisions.map(({ kind }) => kind)).size;
+}
+
+export function meaningfulDecisionRequirement(difficulty: DifficultyType): {
+  count: number;
+  categories: number;
+} | null {
+  if (difficulty === "Intern")
+    return { count: INTERN_MEANINGFUL_DECISIONS_REQUIRED, categories: 1 };
+  if (difficulty === "CEO")
+    return {
+      count: CEO_MEANINGFUL_DECISIONS_REQUIRED,
+      categories: CEO_MEANINGFUL_CATEGORIES_REQUIRED,
+    };
+  return null;
+}
+
+/** One percent of current peak demand, with a 1 MW floor, is a material grid commitment. */
+export function isMaterialCapacityDecision(
+  game: GameType,
+  capacityW: number,
+): boolean {
+  const peakDemandW = game.timeline.reduce(
+    (peak, tick) => Math.max(peak, tick.demandW || 0),
+    0,
+  );
+  return capacityW >= Math.max(1_000_000, peakDemandW * 0.01);
 }
 
 export function validMeaningfulDecisions(
@@ -49,10 +105,13 @@ export function validMeaningfulDecisions(
       typeof decision.key !== "string" ||
       typeof decision.lever !== "string" ||
       !/^[a-z][a-z0-9:-]*$/.test(decision.lever) ||
+      typeof decision.label !== "string" ||
+      decision.label.trim().length === 0 ||
+      decision.label.length > 160 ||
       !Number.isInteger(decision.month) ||
       decision.month! < 0 ||
       decision.month! > currentMonth ||
-      decision.key !== `${decision.lever}@${decision.month}` ||
+      decision.key !== decision.lever ||
       typeof decision.kind !== "string" ||
       ![
         "asset",

--- a/src/helpers/Transmission.test.ts
+++ b/src/helpers/Transmission.test.ts
@@ -1,0 +1,82 @@
+import {
+  adjacentMarketPricePerMWh,
+  clearTransmissionMarket,
+  transmissionRatingW,
+} from "./Transmission";
+
+const line = { corridorId: "california-north", capacityW: 500000000 };
+
+describe("transmission ratings", () => {
+  it("uses full nameplate in cool shade and derates in hot sun", () => {
+    expect(
+      transmissionRatingW(line, {
+        temperatureC: 20,
+        solarIrradianceWM2: 0,
+      }),
+    ).toBe(500000000);
+    expect(
+      transmissionRatingW(line, {
+        temperatureC: 42,
+        solarIrradianceWM2: 1000,
+      }),
+    ).toBe(408000000);
+  });
+
+  it("produces a deterministic offline market price", () => {
+    const conditions = { temperatureC: 35, solarIrradianceWM2: 700 };
+    const first = adjacentMarketPricePerMWh(
+      "california-north",
+      1234,
+      600,
+      conditions,
+    );
+    expect(
+      adjacentMarketPricePerMWh("california-north", 1234, 600, conditions),
+    ).toBe(first);
+    expect(first).toBeGreaterThan(0);
+  });
+});
+
+describe("market clearing", () => {
+  it("imports only the shortage and respects line capacity", () => {
+    expect(
+      clearTransmissionMarket({
+        localSupplyW: 700,
+        demandW: 1000,
+        capacityW: 200,
+        importLimitW: 500,
+        exportLimitW: 500,
+        reserveMargin: 0.15,
+        policy: "BALANCED",
+      }),
+    ).toEqual({ importedW: 200, exportedW: 0, localAvailableSupplyW: 900 });
+  });
+
+  it("exports only above demand plus the reserve margin", () => {
+    expect(
+      clearTransmissionMarket({
+        localSupplyW: 1400,
+        demandW: 1000,
+        capacityW: 500,
+        importLimitW: 500,
+        exportLimitW: 500,
+        reserveMargin: 0.15,
+        policy: "SURPLUS_ONLY",
+      }),
+    ).toEqual({ importedW: 0, exportedW: 250, localAvailableSupplyW: 1150 });
+  });
+
+  it("keeps the line idle when trading is closed", () => {
+    expect(
+      clearTransmissionMarket({
+        localSupplyW: 500,
+        demandW: 1000,
+        capacityW: 500,
+        importLimitW: 500,
+        exportLimitW: 500,
+        reserveMargin: 0.15,
+        policy: "CLOSED",
+      }),
+    ).toEqual({ importedW: 0, exportedW: 0, localAvailableSupplyW: 500 });
+  });
+});

--- a/src/helpers/Transmission.ts
+++ b/src/helpers/Transmission.ts
@@ -1,0 +1,113 @@
+import { TICK_MINUTES } from "../Constants";
+import {
+  TRANSMISSION_CORRIDORS,
+  adjacentMarketForCorridor,
+} from "../data/AdjacentMarkets";
+import { normalAt, RANDOM_STREAM } from "./Math";
+import { TradingPolicyType, TransmissionLineOperatingType } from "../Types";
+
+export interface TransmissionConditions {
+  temperatureC: number;
+  solarIrradianceWM2: number;
+}
+
+/**
+ * A compact dynamic line rating: hot conductors shed less heat, while direct sun adds heat.
+ * It is intentionally bounded so weather changes capacity without making a built line vanish.
+ */
+export function transmissionRatingW(
+  line: Pick<TransmissionLineOperatingType, "corridorId" | "capacityW">,
+  conditions: TransmissionConditions,
+): number {
+  const corridor = TRANSMISSION_CORRIDORS.find(
+    ({ id }) => id === line.corridorId,
+  );
+  if (!corridor) return 0;
+  const heatDerate =
+    Math.max(0, conditions.temperatureC - corridor.heatDerateStartsC) *
+    corridor.heatDeratePerC;
+  const sunDerate =
+    Math.min(1, Math.max(0, conditions.solarIrradianceWM2) / 1000) *
+    corridor.solarDerateFraction;
+  return Math.round(line.capacityW * Math.max(0.6, 1 - heatDerate - sunDerate));
+}
+
+export function transmissionCapacityW(
+  lines: readonly TransmissionLineOperatingType[],
+  conditions: TransmissionConditions,
+): number {
+  return lines
+    .filter(({ yearsToBuildLeft }) => yearsToBuildLeft <= 0)
+    .reduce((sum, line) => sum + transmissionRatingW(line, conditions), 0);
+}
+
+/** Offline, seeded wholesale price in dollars per MWh. */
+export function adjacentMarketPricePerMWh(
+  corridorId: string,
+  seed: number,
+  minute: number,
+  conditions: TransmissionConditions,
+): number {
+  const market = adjacentMarketForCorridor(corridorId);
+  if (!market) return 0;
+  const tick = Math.floor(minute / TICK_MINUTES);
+  const hour = Math.floor((minute % 1440) / 60);
+  const eveningPeak = hour >= 17 && hour < 22 ? 18 : 0;
+  const solarDiscount =
+    (Math.min(1000, Math.max(0, conditions.solarIrradianceWM2)) / 1000) * 16;
+  const heatPremium = Math.max(0, conditions.temperatureC - 28) * 1.6;
+  const noise = normalAt(seed, RANDOM_STREAM.transmissionMarkets, tick) * 4;
+  return Math.max(
+    5,
+    Math.round(
+      (market.basePricePerMWh +
+        eveningPeak +
+        heatPremium -
+        solarDiscount +
+        noise) *
+        10,
+    ) / 10,
+  );
+}
+
+export function allowsImports(policy: TradingPolicyType): boolean {
+  return policy === "BALANCED" || policy === "RELIABILITY_FIRST";
+}
+
+export function allowsExports(policy: TradingPolicyType): boolean {
+  return policy === "BALANCED" || policy === "SURPLUS_ONLY";
+}
+
+export function clearTransmissionMarket({
+  localSupplyW,
+  demandW,
+  capacityW,
+  importLimitW,
+  exportLimitW,
+  reserveMargin,
+  policy,
+}: {
+  localSupplyW: number;
+  demandW: number;
+  capacityW: number;
+  importLimitW: number;
+  exportLimitW: number;
+  reserveMargin: number;
+  policy: TradingPolicyType;
+}): { importedW: number; exportedW: number; localAvailableSupplyW: number } {
+  const importedW = allowsImports(policy)
+    ? Math.min(Math.max(0, demandW - localSupplyW), capacityW, importLimitW)
+    : 0;
+  const exportedW = allowsExports(policy)
+    ? Math.min(
+        Math.max(0, localSupplyW + importedW - demandW * (1 + reserveMargin)),
+        capacityW - importedW,
+        exportLimitW,
+      )
+    : 0;
+  return {
+    importedW,
+    exportedW,
+    localAvailableSupplyW: localSupplyW + importedW - exportedW,
+  };
+}

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -55,6 +55,10 @@ import { buildStartedMessage } from "../helpers/BuildConsequences";
 import { buildVictoryDebrief } from "../helpers/Debrief";
 import { buildStoryPeriodSnapshot, buildStorySnapshot } from "../helpers/Story";
 import {
+  CEO_MEANINGFUL_DECISIONS_REQUIRED,
+  recordMeaningfulDecision,
+} from "../helpers/MeaningfulDecisions";
+import {
   getAirborneWindOutputFactor,
   getAirborneWindReferenceKph,
   getOffshoreWindOutputFactor,
@@ -141,6 +145,7 @@ import { clearSaveFor } from "../SaveGame";
 import { recordReplayAction, recordedDelta, serializeReplay } from "../Replay";
 import {
   DateType,
+  DifficultyType,
   FacilityOperatingType,
   FacilityShoppingType,
   FuelPricesType,
@@ -673,6 +678,7 @@ const initialGame: GameType = {
   eventLogReadThroughId: 0,
   worldEvents: { active: [], occurrences: [], checkedKeys: [] },
   transmission: emptyTransmissionState(),
+  meaningfulDecisions: [],
 };
 
 // Restarts the self-rescheduling tick() loop when leaving PAUSED, unless it's already running.
@@ -743,9 +749,16 @@ export const gameSlice = createSlice({
         policyPause: _policyPause,
         ...payload
       } = action.payload;
-      Object.assign(state, payload);
       const recorded = recordedDelta(action.payload);
-      if (recorded) {
+      const rateBefore = state.dollarsPerkWh;
+      Object.assign(state, payload);
+      if (recorded && recorded.dollarsPerkWh !== rateBefore) {
+        recordMeaningfulDecision(state, {
+          lever: "rate",
+          kind: "rate",
+          before: String(rateBefore),
+          after: String(recorded.dollarsPerkWh),
+        });
         recordReplayAction(state, "delta", recorded);
       }
     },
@@ -761,6 +774,7 @@ export const gameSlice = createSlice({
       state.eventLogReadThroughId = 0;
       state.worldEvents = { active: [], occurrences: [], checkedKeys: [] };
       state.fuelCostSnapshot = undefined;
+      state.meaningfulDecisions = [];
       state.transmission = undefined;
       state.timeline = [] as TickPresentFutureType[];
       // A game being watched is not a game being recorded; anything else starts an empty log,
@@ -918,8 +932,9 @@ export const gameSlice = createSlice({
       applyPendingReplayActions(state);
     },
     buildFacility: (state, action: PayloadAction<BuildFacilityAction>) => {
-      applyBuildFacility(state, action.payload);
-      recordReplayAction(state, "buildFacility", action.payload);
+      if (applyBuildFacility(state, action.payload)) {
+        recordReplayAction(state, "buildFacility", action.payload);
+      }
     },
     buildTransmissionLine: (
       state,
@@ -935,19 +950,22 @@ export const gameSlice = createSlice({
       }
     },
     sellFacility: (state, action: PayloadAction<number>) => {
-      applySellFacility(state, action.payload);
-      recordReplayAction(state, "sellFacility", action.payload);
+      if (applySellFacility(state, action.payload)) {
+        recordReplayAction(state, "sellFacility", action.payload);
+      }
     },
     togglePauseFacility: (state, action: PayloadAction<number>) => {
-      applyTogglePauseFacility(state, action.payload);
-      recordReplayAction(state, "togglePauseFacility", action.payload);
+      if (applyTogglePauseFacility(state, action.payload)) {
+        recordReplayAction(state, "togglePauseFacility", action.payload);
+      }
     },
     reprioritizeFacility: (
       state,
       action: PayloadAction<ReprioritizeFacilityAction>,
     ) => {
-      applyReprioritizeFacility(state, action.payload);
-      recordReplayAction(state, "reprioritizeFacility", action.payload);
+      if (applyReprioritizeFacility(state, action.payload)) {
+        recordReplayAction(state, "reprioritizeFacility", action.payload);
+      }
     },
     setSpeed: (state, action: PayloadAction<SpeedType>) => {
       delete state.policyPause;
@@ -1145,7 +1163,10 @@ function matchesFacilitySearch(
   );
 }
 
-function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
+function applyBuildFacility(
+  state: GameType,
+  payload: BuildFacilityAction,
+): boolean {
   const built = payload.facility;
   const now = getTimeFromTimeline(state.date.minute, state.timeline);
   const amountDue = payload.financed
@@ -1154,7 +1175,7 @@ function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
   // The dialog's quote can be stale by the time an action lands (or a replay/import can be
   // malformed). Never let a purchase drive cash below zero merely because the UI once enabled it.
   if (!now || now.cash < amountDue) {
-    return;
+    return false;
   }
   const viableLocationsRemaining = getViableLocationsRemaining(
     state.location,
@@ -1164,29 +1185,39 @@ function applyBuildFacility(state: GameType, payload: BuildFacilityAction) {
   // Recheck current state instead of trusting the shopping-card snapshot in the action. It keeps
   // a stale dialog or replay action from claiming one more site after the last one was used.
   if (viableLocationsRemaining !== undefined && viableLocationsRemaining <= 0) {
-    return;
+    return false;
   }
+  const existingIds = new Set(state.facilities.map(({ id }) => id));
   logGameEvent(state, "BUILD", buildStartedMessage(built), {
     importance: "NOTABLE",
     actionTarget: { card: "FACILITIES", view: "FLEET" },
   });
   state = buildFacilityHelper(state, built, payload.financed);
+  const added = state.facilities.find(({ id }) => !existingIds.has(id));
+  if (!added) return false;
+  recordMeaningfulDecision(state, {
+    lever: `facility:${added.id}`,
+    kind: "asset",
+    before: "absent",
+    after: `${added.name}:${added.peakWh ?? added.peakW}:${payload.financed ? "financed" : "cash"}`,
+  });
   // Assigned rather than spread into a new object: this is an immer draft, so a fresh object
   // assigned to the parameter is discarded and the forecast would never reach state
   state.timeline = reforecastSupply(state);
+  return true;
 }
 
-function applySellFacility(state: GameType, id: number) {
+function applySellFacility(state: GameType, id: number): boolean {
   const sold = state.facilities.find((g: FacilityOperatingType) => g.id === id);
-  if (sold) {
-    logGameEvent(
-      state,
-      sold.yearsToBuildLeft > 0 ? "BUILD" : "SELL",
-      sold.yearsToBuildLeft > 0
-        ? `Cancelled construction of ${sold.name}`
-        : `Sold ${sold.name}, ${sold.peakWh ? formatWattHours(sold.peakWh) : formatWatts(sold.peakW)} for ${formatMoneyConcise(facilityCashBack(sold, state.date.minute))}`,
-    );
-  }
+  if (!sold) return false;
+  logGameEvent(
+    state,
+    sold.yearsToBuildLeft > 0 ? "BUILD" : "SELL",
+    sold.yearsToBuildLeft > 0
+      ? `Cancelled construction of ${sold.name}`
+      : `Sold ${sold.name}, ${sold.peakWh ? formatWattHours(sold.peakWh) : formatWatts(sold.peakW)} for ${formatMoneyConcise(facilityCashBack(sold, state.date.minute))}`,
+  );
+  const ownedState = `${sold.name}:${sold.peakWh ?? sold.peakW}:${sold.financed ? "financed" : "cash"}`;
   // in one loop, refund cash from selling + remove from list
   state.facilities = state.facilities.filter(
     (g: GeneratorOperatingType | StorageOperatingType) => {
@@ -1200,30 +1231,60 @@ function applySellFacility(state: GameType, id: number) {
       return true;
     },
   );
+  recordMeaningfulDecision(state, {
+    lever: `facility:${id}`,
+    kind: "sale",
+    before: ownedState,
+    after: "absent",
+  });
   state.timeline = reforecastSupply(state);
+  return true;
 }
 
-function applyTogglePauseFacility(state: GameType, id: number) {
-  state.facilities.forEach(
-    (g: GeneratorOperatingType | StorageOperatingType) => {
-      if (g.id === id) {
-        g.paused = !g.paused;
-      }
-    },
-  );
+function applyTogglePauseFacility(state: GameType, id: number): boolean {
+  const facility = state.facilities.find((item) => item.id === id);
+  if (!facility) return false;
+  const before = facility.paused ? "paused" : "operating";
+  facility.paused = !facility.paused;
+  recordMeaningfulDecision(state, {
+    lever: `operation:${id}`,
+    kind: "operation",
+    before,
+    after: facility.paused ? "paused" : "operating",
+  });
   state.timeline = reforecastSupply(state);
+  return true;
 }
 
 function applyReprioritizeFacility(
   state: GameType,
   payload: ReprioritizeFacilityAction,
-) {
+): boolean {
+  const destination = payload.spotInList + payload.delta;
+  if (
+    !Number.isInteger(payload.spotInList) ||
+    !Number.isInteger(payload.delta) ||
+    payload.delta === 0 ||
+    payload.spotInList < 0 ||
+    payload.spotInList >= state.facilities.length ||
+    destination < 0 ||
+    destination >= state.facilities.length
+  )
+    return false;
+  const movedId = state.facilities[payload.spotInList].id;
   arrayMove(
     state.facilities,
     payload.spotInList,
     payload.spotInList + payload.delta,
   );
+  recordMeaningfulDecision(state, {
+    lever: `dispatch:${movedId}`,
+    kind: "dispatch",
+    before: String(payload.spotInList),
+    after: String(destination),
+  });
   state.timeline = reforecastSupply(state);
+  return true;
 }
 
 const TRADING_POLICIES: readonly TradingPolicyType[] = [
@@ -1237,7 +1298,14 @@ function applyTradingPolicy(state: GameType, policy: unknown): boolean {
   if (!TRADING_POLICIES.includes(policy as TradingPolicyType)) return false;
   if (!state.transmission) return false;
   if (state.transmission.tradingPolicy === policy) return false;
+  const before = state.transmission.tradingPolicy;
   state.transmission.tradingPolicy = policy as TradingPolicyType;
+  recordMeaningfulDecision(state, {
+    lever: "trading",
+    kind: "trading",
+    before,
+    after: policy as TradingPolicyType,
+  });
   state.timeline = reforecastSupply(state, true);
   return true;
 }
@@ -1289,6 +1357,12 @@ function applyBuildTransmissionLine(
     interestRate: financed ? state.interestRate : 0,
   };
   state.transmission.lines.push(line);
+  recordMeaningfulDecision(state, {
+    lever: `intertie:${line.id}`,
+    kind: "asset",
+    before: "absent",
+    after: `${line.corridorId}:${financed ? "financed" : "cash"}`,
+  });
   logGameEvent(
     state,
     "BUILD",
@@ -1325,6 +1399,7 @@ function applyPolicyEdit(
   )
     return false;
   const existing = state.policies?.programs[payload.id];
+  const before = existing?.pending?.tier ?? existing?.tier ?? "Off";
   if (cancel) {
     if (
       !existing?.pending ||
@@ -1341,6 +1416,16 @@ function applyPolicyEdit(
     if (payload.tier === program.tier) delete program.pending;
     else program.pending = { tier: payload.tier, month: payload.month };
   }
+  const after = cancel
+    ? (existing?.tier ?? "Off")
+    : (state.policies!.programs[payload.id].pending?.tier ??
+      state.policies!.programs[payload.id].tier);
+  recordMeaningfulDecision(state, {
+    lever: `policy:${payload.id}`,
+    kind: "policy",
+    before,
+    after,
+  });
   // Accepted changes start next month; the current month's demand and customer balance
   // already happened. Long-range callers project the new pending state independently.
   state.timeline = reforecastSupply(state, true);
@@ -1391,8 +1476,18 @@ function applyReplayAction(state: GameType, entry: ReplayActionType) {
     }
     case "delta": {
       const recorded = recordedDelta((payload || {}) as Partial<GameType>);
-      if (recorded) {
+      if (
+        recorded?.dollarsPerkWh !== undefined &&
+        recorded.dollarsPerkWh !== state.dollarsPerkWh
+      ) {
+        const before = state.dollarsPerkWh;
         Object.assign(state, recorded);
+        recordMeaningfulDecision(state, {
+          lever: "rate",
+          kind: "rate",
+          before: String(before),
+          after: String(recorded.dollarsPerkWh),
+        });
       }
       break;
     }
@@ -1697,7 +1792,12 @@ export function tickState(state: GameType) {
       const chronicBlackouts = hasChronicBlackouts(history);
       const objectiveFailure =
         state.date.monthsElapsed === (scenario.durationMonths || 12 * 20)
-          ? scenarioObjectiveFailure(scenario, history)
+          ? scenarioObjectiveFailure(
+              scenario,
+              history,
+              state.difficulty,
+              state.meaningfulDecisions.length,
+            )
           : undefined;
       const failure =
         now.cash < 0
@@ -1844,6 +1944,8 @@ export function hasChronicBlackouts(history: MonthlyHistoryType[]): boolean {
 export function scenarioObjectiveFailure(
   scenario: ScenarioType,
   history: MonthlyHistoryType[],
+  difficulty?: DifficultyType,
+  meaningfulDecisions = 0,
 ): string | undefined {
   const reliabilityObjective = scenario.reliabilityObjective;
   if (reliabilityObjective) {
@@ -1875,6 +1977,13 @@ export function scenarioObjectiveFailure(
     if (retained < scenario.minimumCustomerRetention) {
       return `Customer attrition left you with only ${Math.round(retained * 100)}% of the community you started with; this mission requires retaining at least ${Math.round(scenario.minimumCustomerRetention * 100)}%.`;
     }
+  }
+  if (
+    !scenario.tutorialSteps &&
+    difficulty === "CEO" &&
+    meaningfulDecisions < CEO_MEANINGFUL_DECISIONS_REQUIRED
+  ) {
+    return `You made ${meaningfulDecisions} of ${CEO_MEANINGFUL_DECISIONS_REQUIRED} meaningful decisions; CEO difficulty requires choices that change the grid or its economics.`;
   }
   return undefined;
 }

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -2759,7 +2759,10 @@ function supplyForecastPass(
           newState.facilities,
           t.cash,
           t.minute,
-          newState.transmission?.lines,
+          // Just like currentCash, the live transmission balance already represents this tick.
+          // The cloned line has made one forecast payment, so using it here would grant project
+          // equity before the matching principal has actually left cash.
+          state.transmission?.lines,
         );
       }
     }
@@ -3029,10 +3032,11 @@ function getNetWorth(
     }
   });
   transmissionLines.forEach((line) => {
-    netWorth +=
-      line.yearsToBuildLeft > 0
-        ? line.buildCost * DOWNPAYMENT_PERCENT
-        : line.buildCost - line.loanAmountLeft;
+    // The project is worth what has been paid for it at every construction stage. At purchase,
+    // cost less the new loan is exactly the down payment, keeping net worth neutral. Each later
+    // principal payment then moves value from cash into project equity instead of disappearing
+    // from the balance sheet before the line opens.
+    netWorth += line.buildCost - line.loanAmountLeft;
   });
   return netWorth;
 }

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1551,7 +1551,13 @@ export function tickState(state: GameType) {
       // against it. Once a month, not once a tick: a lender looks at a year of results, and a
       // rate that moved every tick would be unplannable.
       state.creditPremium = getCreditPremium(
-        getCreditInputs(history, cash, now.netWorth, state.facilities),
+        getCreditInputs(
+          history,
+          cash,
+          now.netWorth,
+          state.facilities,
+          state.transmission?.lines,
+        ),
       );
       state.interestRate =
         getPrimeRate(state.date, state.seed) * state.creditPremium;
@@ -3024,9 +3030,9 @@ function getNetWorth(
   });
   transmissionLines.forEach((line) => {
     netWorth +=
-      (line.yearsToBuildLeft > 0
+      line.yearsToBuildLeft > 0
         ? line.buildCost * DOWNPAYMENT_PERCENT
-        : line.buildCost) - line.loanAmountLeft;
+        : line.buildCost - line.loanAmountLeft;
   });
   return netWorth;
 }

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -66,6 +66,7 @@ import {
   adjacentMarketForCorridor,
   corridorsForLocation,
   emptyTransmissionState,
+  intertiesEnabledForScenario,
 } from "../data/AdjacentMarkets";
 import {
   adjacentMarketPricePerMWh,
@@ -760,7 +761,7 @@ export const gameSlice = createSlice({
       state.eventLogReadThroughId = 0;
       state.worldEvents = { active: [], occurrences: [], checkedKeys: [] };
       state.fuelCostSnapshot = undefined;
-      state.transmission = emptyTransmissionState();
+      state.transmission = undefined;
       state.timeline = [] as TickPresentFutureType[];
       // A game being watched is not a game being recorded; anything else starts an empty log,
       // which is also what tells serializeReplay the run was recorded from its very first minute
@@ -793,6 +794,9 @@ export const gameSlice = createSlice({
       state.startingDemandScale = scenario.startingDemandScale ?? 1;
       state.loadAdditions = cloneDeep(scenario.loadAdditions || []);
       state.location = a.location;
+      state.transmission = intertiesEnabledForScenario(scenario, a.location)
+        ? emptyTransmissionState()
+        : undefined;
       state.timeline = generateNewTimeline(
         state,
         startingCash,
@@ -875,7 +879,7 @@ export const gameSlice = createSlice({
         }
       });
 
-      if (!scenario.tutorialSteps) {
+      if (!scenario.tutorialSteps || scenario.intertiesEnabled) {
         // buildFacilityHelper prepends generators because player-built capacity should dispatch
         // by default. For authored starting fleets, however, the scenario order is deliberate:
         // reverse just the resulting generator block back into that order while storage remains
@@ -1231,7 +1235,7 @@ const TRADING_POLICIES: readonly TradingPolicyType[] = [
 
 function applyTradingPolicy(state: GameType, policy: unknown): boolean {
   if (!TRADING_POLICIES.includes(policy as TradingPolicyType)) return false;
-  state.transmission ??= emptyTransmissionState();
+  if (!state.transmission) return false;
   if (state.transmission.tradingPolicy === policy) return false;
   state.transmission.tradingPolicy = policy as TradingPolicyType;
   state.timeline = reforecastSupply(state, true);
@@ -1247,7 +1251,7 @@ function applyBuildTransmissionLine(
     ({ id }) => id === payload.corridorId,
   );
   const now = getTimeFromTimeline(state.date.minute, state.timeline);
-  state.transmission ??= emptyTransmissionState();
+  if (!state.transmission) return false;
   if (
     !corridor ||
     !now ||
@@ -2162,7 +2166,9 @@ function updateSupplyFacilitiesFinances(
 
   const transmission = state.transmission ?? emptyTransmissionState();
   transmission.lines.forEach((line) => {
-    if (line.yearsToBuildLeft <= 0) return;
+    // Month-boundary pre-roll stabilizes generator output against the new weather frame. It is
+    // not elapsed game time and must not quietly shorten an intertie's authored build schedule.
+    if (preRoll || line.yearsToBuildLeft <= 0) return;
     line.yearsToBuildLeft = Math.max(
       0,
       line.yearsToBuildLeft - YEARS_PER_TICK * tickScale,

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -62,6 +62,16 @@ import {
   getWindOutputFactor,
 } from "../helpers/Energy";
 import { getFuelPricesPerMBTU } from "../data/FuelPrices";
+import {
+  adjacentMarketForCorridor,
+  corridorsForLocation,
+  emptyTransmissionState,
+} from "../data/AdjacentMarkets";
+import {
+  adjacentMarketPricePerMWh,
+  clearTransmissionMarket,
+  transmissionRatingW,
+} from "../helpers/Transmission";
 import { DEMAND_TYPES, demandByTypeAt } from "../data/DemandProfiles";
 import {
   combineStoryEffects,
@@ -149,6 +159,8 @@ import {
   TickPresentFutureType,
   FuelProductionType,
   ReplayActionType,
+  TradingPolicyType,
+  TransmissionLineOperatingType,
   VictoryType,
   WorldEventEffectsType,
 } from "../Types";
@@ -161,6 +173,11 @@ interface BuildFacilityAction {
 interface ReprioritizeFacilityAction {
   spotInList: number;
   delta: number;
+}
+
+interface BuildTransmissionLineAction {
+  corridorId: string;
+  financed: boolean;
 }
 
 interface NewGameAction {
@@ -654,6 +671,7 @@ const initialGame: GameType = {
   reportedEventKeys: [],
   eventLogReadThroughId: 0,
   worldEvents: { active: [], occurrences: [], checkedKeys: [] },
+  transmission: emptyTransmissionState(),
 };
 
 // Restarts the self-rescheduling tick() loop when leaving PAUSED, unless it's already running.
@@ -742,6 +760,7 @@ export const gameSlice = createSlice({
       state.eventLogReadThroughId = 0;
       state.worldEvents = { active: [], occurrences: [], checkedKeys: [] };
       state.fuelCostSnapshot = undefined;
+      state.transmission = emptyTransmissionState();
       state.timeline = [] as TickPresentFutureType[];
       // A game being watched is not a game being recorded; anything else starts an empty log,
       // which is also what tells serializeReplay the run was recorded from its very first minute
@@ -897,6 +916,19 @@ export const gameSlice = createSlice({
     buildFacility: (state, action: PayloadAction<BuildFacilityAction>) => {
       applyBuildFacility(state, action.payload);
       recordReplayAction(state, "buildFacility", action.payload);
+    },
+    buildTransmissionLine: (
+      state,
+      action: PayloadAction<BuildTransmissionLineAction>,
+    ) => {
+      if (applyBuildTransmissionLine(state, action.payload)) {
+        recordReplayAction(state, "buildTransmissionLine", action.payload);
+      }
+    },
+    setTradingPolicy: (state, action: PayloadAction<TradingPolicyType>) => {
+      if (applyTradingPolicy(state, action.payload)) {
+        recordReplayAction(state, "setTradingPolicy", action.payload);
+      }
     },
     sellFacility: (state, action: PayloadAction<number>) => {
       applySellFacility(state, action.payload);
@@ -1074,9 +1106,11 @@ export const {
   delta,
   initGame,
   buildFacility,
+  buildTransmissionLine,
   sellFacility,
   togglePauseFacility,
   reprioritizeFacility,
+  setTradingPolicy,
   setSpeed,
   markEventsRead,
 } = gameSlice.actions;
@@ -1188,6 +1222,82 @@ function applyReprioritizeFacility(
   state.timeline = reforecastSupply(state);
 }
 
+const TRADING_POLICIES: readonly TradingPolicyType[] = [
+  "BALANCED",
+  "RELIABILITY_FIRST",
+  "SURPLUS_ONLY",
+  "CLOSED",
+];
+
+function applyTradingPolicy(state: GameType, policy: unknown): boolean {
+  if (!TRADING_POLICIES.includes(policy as TradingPolicyType)) return false;
+  state.transmission ??= emptyTransmissionState();
+  if (state.transmission.tradingPolicy === policy) return false;
+  state.transmission.tradingPolicy = policy as TradingPolicyType;
+  state.timeline = reforecastSupply(state, true);
+  return true;
+}
+
+function applyBuildTransmissionLine(
+  state: GameType,
+  payload: Partial<BuildTransmissionLineAction>,
+): boolean {
+  if (typeof payload.corridorId !== "string") return false;
+  const corridor = corridorsForLocation(state.location).find(
+    ({ id }) => id === payload.corridorId,
+  );
+  const now = getTimeFromTimeline(state.date.minute, state.timeline);
+  state.transmission ??= emptyTransmissionState();
+  if (
+    !corridor ||
+    !now ||
+    state.transmission.lines.some(
+      ({ corridorId }) => corridorId === corridor.id,
+    )
+  ) {
+    return false;
+  }
+  const financed = !!payload.financed;
+  const amountDue = financed
+    ? corridor.buildCost * DOWNPAYMENT_PERCENT
+    : corridor.buildCost;
+  if (now.cash < amountDue) return false;
+  now.cash -= amountDue;
+  const loanAmount = financed ? corridor.buildCost - amountDue : 0;
+  const line: TransmissionLineOperatingType = {
+    id:
+      state.transmission.lines.reduce(
+        (largest, item) => Math.max(largest, item.id),
+        0,
+      ) + 1,
+    corridorId: corridor.id,
+    name: corridor.name,
+    capacityW: corridor.capacityW,
+    buildCost: corridor.buildCost,
+    annualOperatingCost: corridor.annualOperatingCost,
+    yearsToBuildLeft: corridor.yearsToBuild,
+    minuteCreated: state.date.minute,
+    financed,
+    loanAmountLeft: loanAmount,
+    loanMonthlyPayment: financed
+      ? getMonthlyPayment(loanAmount, state.interestRate, LOAN_MONTHS)
+      : 0,
+    interestRate: financed ? state.interestRate : 0,
+  };
+  state.transmission.lines.push(line);
+  logGameEvent(
+    state,
+    "BUILD",
+    `Started ${corridor.name}: ${formatWatts(corridor.capacityW)} to ${adjacentMarketForCorridor(corridor.id)?.name}`,
+    {
+      importance: "NOTABLE",
+      actionTarget: { card: "FACILITIES", view: "FLEET" },
+    },
+  );
+  state.timeline = reforecastSupply(state, true);
+  return true;
+}
+
 /**
  * Replays one recorded action. The payload came off the network, so anything shaped wrong is
  * skipped rather than allowed to crash the sim mid-tick -- a replay that plays back slightly
@@ -1250,6 +1360,14 @@ function applyReplayAction(state: GameType, entry: ReplayActionType) {
       }
       break;
     }
+    case "buildTransmissionLine": {
+      const build = payload as Partial<BuildTransmissionLineAction>;
+      applyBuildTransmissionLine(state, build);
+      break;
+    }
+    case "setTradingPolicy":
+      applyTradingPolicy(state, payload);
+      break;
     case "sellFacility":
       if (typeof payload === "number") {
         applySellFacility(state, payload);
@@ -2036,6 +2154,18 @@ function updateSupplyFacilitiesFinances(
     }
   });
 
+  const transmission = state.transmission ?? emptyTransmissionState();
+  transmission.lines.forEach((line) => {
+    if (line.yearsToBuildLeft <= 0) return;
+    line.yearsToBuildLeft = Math.max(
+      0,
+      line.yearsToBuildLeft - YEARS_PER_TICK * tickScale,
+    );
+    if (line.yearsToBuildLeft === 0 && !simulated) {
+      logGameEvent(state, "CONSTRUCTION", `Intertie open: ${line.name}`);
+    }
+  });
+
   const windOutputFactor = getWindOutputFactor(now.windKph);
   const offshoreWindOutputFactor = getOffshoreWindOutputFactor(
     now.windOffshoreKph || 0,
@@ -2306,6 +2436,46 @@ function updateSupplyFacilitiesFinances(
       }
     }
   });
+  const operatingLines = transmission.lines.filter(
+    ({ yearsToBuildLeft }) => yearsToBuildLeft <= 0,
+  );
+  let transmissionCapacity = 0;
+  let weightedMarketPrice = 0;
+  let marketImportLimitW = 0;
+  let marketExportLimitW = 0;
+  for (const line of operatingLines) {
+    const rating = transmissionRatingW(line, now);
+    const market = adjacentMarketForCorridor(line.corridorId);
+    const price = adjacentMarketPricePerMWh(
+      line.corridorId,
+      state.seed,
+      now.minute,
+      now,
+    );
+    transmissionCapacity += rating;
+    weightedMarketPrice += rating * price;
+    marketImportLimitW += Math.min(rating, market?.availableSupplyW || 0);
+    marketExportLimitW += Math.min(rating, market?.availableDemandW || 0);
+  }
+  const marketPricePerMWh =
+    transmissionCapacity > 0 ? weightedMarketPrice / transmissionCapacity : 0;
+  // Exports use only energy above demand plus the reserve margin. Trading can earn money, but it
+  // must never create a local shortage or sell the reliability buffer the dispatch stack built.
+  const clearing = clearTransmissionMarket({
+    localSupplyW: supply,
+    demandW: now.demandW,
+    capacityW: transmissionCapacity,
+    importLimitW: marketImportLimitW,
+    exportLimitW: marketExportLimitW,
+    reserveMargin: RESERVE_MARGIN,
+    policy: transmission.tradingPolicy,
+  });
+  const { importedW, exportedW } = clearing;
+  supply = clearing.localAvailableSupplyW;
+  now.importedW = importedW;
+  now.exportedW = exportedW;
+  now.transmissionCapacityW = transmissionCapacity;
+  now.marketPricePerMWh = marketPricePerMWh;
   now.supplyW = supply;
   now.supplyByFuel = supplyByFuel;
   now.storedWh = storedWh;
@@ -2320,7 +2490,12 @@ function updateSupplyFacilitiesFinances(
     (Math.min(now.supplyW, now.demandW) / ticksPerHour) * GAME_TO_REAL_YEARS;
   // Scale the representative simulated day to the real month it stands for.
   const demandWh = (now.demandW / ticksPerHour) * GAME_TO_REAL_YEARS;
-  const revenue = (supplyWh / 1000) * state.dollarsPerkWh;
+  const customerRevenue = (supplyWh / 1000) * state.dollarsPerkWh;
+  const importedWh = (importedW / ticksPerHour) * GAME_TO_REAL_YEARS;
+  const exportedWh = (exportedW / ticksPerHour) * GAME_TO_REAL_YEARS;
+  const expensesImports = (importedWh / 1000000) * marketPricePerMWh;
+  const revenueExports = (exportedWh / 1000000) * marketPricePerMWh;
+  const revenue = customerRevenue + revenueExports;
 
   // Facilities expenses
   let kgco2e = 0;
@@ -2337,7 +2512,7 @@ function updateSupplyFacilitiesFinances(
   // What one facility earns is its share of what the company actually sold, so the row can say
   // whether it has paid for itself. Curtailed output earns nothing, which pro-rating against the
   // served total is exactly what expresses
-  const revenuePerSuppliedW = supply > 0 ? revenue / supply : 0;
+  const revenuePerSuppliedW = supply > 0 ? customerRevenue / supply : 0;
   facilities.forEach((g: FacilityOperatingType) => {
     // Everything this facility costs the company this tick, so it can be booked against the
     // facility as well as into the company's own totals below
@@ -2436,6 +2611,24 @@ function updateSupplyFacilitiesFinances(
       }
     }
   });
+  let transmissionPrincipalRepayment = 0;
+  operatingLines.forEach((line) => {
+    expensesOM += line.annualOperatingCost / ticksPerYear;
+  });
+  transmission.lines.forEach((line) => {
+    if (line.loanAmountLeft <= 0) return;
+    const paymentInterest = getPaymentInterest(
+      line.loanAmountLeft,
+      line.interestRate,
+    );
+    const paymentPrincipal = Math.min(
+      (line.loanMonthlyPayment - paymentInterest) / ticksPerMonth,
+      line.loanAmountLeft,
+    );
+    expensesInterest += paymentInterest / ticksPerMonth;
+    transmissionPrincipalRepayment += paymentPrincipal;
+    line.loanAmountLeft -= paymentPrincipal;
+  });
   const expensesCarbonFee = effectiveCarbonFee(tickDate, state) * kgco2e;
 
   // Customers
@@ -2469,15 +2662,24 @@ function updateSupplyFacilitiesFinances(
   now.cash = Math.round(
     prev.cash +
       revenue -
+      expensesImports -
       expensesOM -
       expensesFuel -
       expensesCarbonFee -
       expensesInterest -
       (now.expensesPolicy || 0) -
-      principalRepayment,
+      principalRepayment -
+      transmissionPrincipalRepayment,
   );
-  now.netWorth = getNetWorth(facilities, now.cash, now.minute);
+  now.netWorth = getNetWorth(
+    facilities,
+    now.cash,
+    now.minute,
+    transmission.lines,
+  );
   now.revenue = revenue;
+  now.revenueExports = revenueExports;
+  now.expensesImports = expensesImports;
   now.expensesOM = expensesOM;
   now.expensesFuel = expensesFuel;
   now.expensesCarbonFee = expensesCarbonFee;
@@ -2507,7 +2709,11 @@ function supplyForecastPass(
   // spread shares the same facility objects, which let a forecast leave the real fleet sitting at
   // its end-of-horizon state -- resuming a paused nuclear plant snapped straight to full output
   // instead of ramping, and every reforecast silently aged construction and loans by a whole day.
-  const newState = { ...state, facilities: cloneDeep(state.facilities) };
+  const newState = {
+    ...state,
+    facilities: cloneDeep(state.facilities),
+    transmission: cloneDeep(state.transmission ?? emptyTransmissionState()),
+  };
   if (withoutMinimumStableOutput) {
     newState.facilities.forEach((facility) => {
       if (!facility.peakWh) {
@@ -2543,7 +2749,12 @@ function supplyForecastPass(
         if (currentCustomers !== undefined) {
           t.customers = currentCustomers;
         }
-        t.netWorth = getNetWorth(newState.facilities, t.cash, t.minute);
+        t.netWorth = getNetWorth(
+          newState.facilities,
+          t.cash,
+          t.minute,
+          newState.transmission?.lines,
+        );
       }
     }
     prev = t;
@@ -2603,6 +2814,9 @@ export function generateNewTimeline(
   const state = {
     ...readOnlyState,
     facilities: cloneDeep(readOnlyState.facilities),
+    transmission: cloneDeep(
+      readOnlyState.transmission ?? emptyTransmissionState(),
+    ),
     // Story checkpoints only need the trailing year, and scheduled forecast effects resolve from
     // the same immutable facts as live play. Keeping twelve entries is cheap and avoids a second
     // forecast-only narrative state.
@@ -2614,7 +2828,12 @@ export function generateNewTimeline(
   );
   // Loop invariant: the fleet is fixed across the horizon and the cash is a parameter, so this
   // was the same number recomputed for every one of up to a year's worth of ticks
-  const netWorth = getNetWorth(state.facilities, cash, state.date.minute);
+  const netWorth = getNetWorth(
+    state.facilities,
+    cash,
+    state.date.minute,
+    state.transmission?.lines,
+  );
   const currentCustomerRate =
     getTimeFromTimeline(readOnlyState.date.minute, readOnlyState.timeline)
       ?.customerRate || readOnlyState.customerRate;
@@ -2644,6 +2863,12 @@ export function generateNewTimeline(
       expensesCarbonFee: 0,
       expensesInterest: 0,
       expensesPolicy: 0,
+      expensesImports: 0,
+      revenueExports: 0,
+      importedW: 0,
+      exportedW: 0,
+      transmissionCapacityW: 0,
+      marketPricePerMWh: 0,
       kgco2e: 0,
       // Both overwritten by updateSupplyFacilitiesFinances, from each tick's own date
       interestRate: 0,
@@ -2787,6 +3012,7 @@ function getNetWorth(
   facilities: FacilityOperatingType[],
   cash: number,
   currentMinute: number,
+  transmissionLines: readonly TransmissionLineOperatingType[] = [],
 ): number {
   let netWorth = cash;
   facilities.forEach((g: FacilityOperatingType) => {
@@ -2795,6 +3021,12 @@ function getNetWorth(
     } else {
       netWorth += facilityCashBack(g, currentMinute);
     }
+  });
+  transmissionLines.forEach((line) => {
+    netWorth +=
+      (line.yearsToBuildLeft > 0
+        ? line.buildCost * DOWNPAYMENT_PERCENT
+        : line.buildCost) - line.loanAmountLeft;
   });
   return netWorth;
 }

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -55,7 +55,11 @@ import { buildStartedMessage } from "../helpers/BuildConsequences";
 import { buildVictoryDebrief } from "../helpers/Debrief";
 import { buildStoryPeriodSnapshot, buildStorySnapshot } from "../helpers/Story";
 import {
+  CEO_MEANINGFUL_CATEGORIES_REQUIRED,
   CEO_MEANINGFUL_DECISIONS_REQUIRED,
+  INTERN_MEANINGFUL_DECISIONS_REQUIRED,
+  isMaterialCapacityDecision,
+  meaningfulDecisionCategoryCount,
   recordMeaningfulDecision,
 } from "../helpers/MeaningfulDecisions";
 import {
@@ -156,6 +160,7 @@ import {
   LocationType,
   GameType,
   GeneratorOperatingType,
+  MeaningfulDecisionType,
   MonthlyHistoryType,
   ScenarioFacilityType,
   ScenarioType,
@@ -679,6 +684,7 @@ const initialGame: GameType = {
   worldEvents: { active: [], occurrences: [], checkedKeys: [] },
   transmission: emptyTransmissionState(),
   meaningfulDecisions: [],
+  meaningfulDecisionGateWaived: false,
 };
 
 // Restarts the self-rescheduling tick() loop when leaving PAUSED, unless it's already running.
@@ -755,6 +761,7 @@ export const gameSlice = createSlice({
       if (recorded && recorded.dollarsPerkWh !== rateBefore) {
         recordMeaningfulDecision(state, {
           lever: "rate",
+          label: "Set the customer electricity rate",
           kind: "rate",
           before: String(rateBefore),
           after: String(recorded.dollarsPerkWh),
@@ -1029,6 +1036,7 @@ export const gameSlice = createSlice({
         // The loading screen reads this back rather than looking the scenario's location up,
         // which is what makes the replay run against the weather the original player saw
         location: cloneDeep(replay.location),
+        meaningfulDecisionGateWaived: !!replay.meaningfulDecisionGateWaived,
         replayPlayback: { actions: cloneDeep(replay.actions), index: 0 },
       };
     });
@@ -1195,12 +1203,15 @@ function applyBuildFacility(
   state = buildFacilityHelper(state, built, payload.financed);
   const added = state.facilities.find(({ id }) => !existingIds.has(id));
   if (!added) return false;
-  recordMeaningfulDecision(state, {
-    lever: `facility:${added.id}`,
-    kind: "asset",
-    before: "absent",
-    after: `${added.name}:${added.peakWh ?? added.peakW}:${payload.financed ? "financed" : "cash"}`,
-  });
+  if (isMaterialCapacityDecision(state, added.peakW)) {
+    recordMeaningfulDecision(state, {
+      lever: `asset-build:${added.id}`,
+      label: `Build ${added.name} (${formatWatts(added.peakW)})`,
+      kind: "asset",
+      before: "absent",
+      after: `${added.name}:${added.peakWh ?? added.peakW}:${payload.financed ? "financed" : "cash"}`,
+    });
+  }
   // Assigned rather than spread into a new object: this is an immer draft, so a fresh object
   // assigned to the parameter is discarded and the forecast would never reach state
   state.timeline = reforecastSupply(state);
@@ -1231,12 +1242,15 @@ function applySellFacility(state: GameType, id: number): boolean {
       return true;
     },
   );
-  recordMeaningfulDecision(state, {
-    lever: `facility:${id}`,
-    kind: "sale",
-    before: ownedState,
-    after: "absent",
-  });
+  if (isMaterialCapacityDecision(state, sold.peakW)) {
+    recordMeaningfulDecision(state, {
+      lever: `asset-sale:${id}`,
+      label: `Sell ${sold.name} (${formatWatts(sold.peakW)})`,
+      kind: "sale",
+      before: ownedState,
+      after: "absent",
+    });
+  }
   state.timeline = reforecastSupply(state);
   return true;
 }
@@ -1248,6 +1262,7 @@ function applyTogglePauseFacility(state: GameType, id: number): boolean {
   facility.paused = !facility.paused;
   recordMeaningfulDecision(state, {
     lever: `operation:${id}`,
+    label: `${facility.paused ? "Pause" : "Run"} ${facility.name}`,
     kind: "operation",
     before,
     after: facility.paused ? "paused" : "operating",
@@ -1279,6 +1294,7 @@ function applyReprioritizeFacility(
   );
   recordMeaningfulDecision(state, {
     lever: `dispatch:${movedId}`,
+    label: `Set ${state.facilities[destination].name} dispatch priority`,
     kind: "dispatch",
     before: String(payload.spotInList),
     after: String(destination),
@@ -1297,11 +1313,14 @@ const TRADING_POLICIES: readonly TradingPolicyType[] = [
 function applyTradingPolicy(state: GameType, policy: unknown): boolean {
   if (!TRADING_POLICIES.includes(policy as TradingPolicyType)) return false;
   if (!state.transmission) return false;
+  // A trading rule is only an actionable grid choice once there is a corridor to govern.
+  if (state.transmission.lines.length === 0) return false;
   if (state.transmission.tradingPolicy === policy) return false;
   const before = state.transmission.tradingPolicy;
   state.transmission.tradingPolicy = policy as TradingPolicyType;
   recordMeaningfulDecision(state, {
     lever: "trading",
+    label: "Set the regional trading rule",
     kind: "trading",
     before,
     after: policy as TradingPolicyType,
@@ -1359,6 +1378,7 @@ function applyBuildTransmissionLine(
   state.transmission.lines.push(line);
   recordMeaningfulDecision(state, {
     lever: `intertie:${line.id}`,
+    label: `Build ${line.name}`,
     kind: "asset",
     before: "absent",
     after: `${line.corridorId}:${financed ? "financed" : "cash"}`,
@@ -1422,6 +1442,10 @@ function applyPolicyEdit(
       state.policies!.programs[payload.id].tier);
   recordMeaningfulDecision(state, {
     lever: `policy:${payload.id}`,
+    label:
+      payload.id === "efficiency"
+        ? "Fund efficiency rebates"
+        : "Fund rooftop solar rebates",
     kind: "policy",
     before,
     after,
@@ -1484,6 +1508,7 @@ function applyReplayAction(state: GameType, entry: ReplayActionType) {
         Object.assign(state, recorded);
         recordMeaningfulDecision(state, {
           lever: "rate",
+          label: "Set the customer electricity rate",
           kind: "rate",
           before: String(before),
           after: String(recorded.dollarsPerkWh),
@@ -1796,7 +1821,8 @@ export function tickState(state: GameType) {
               scenario,
               history,
               state.difficulty,
-              state.meaningfulDecisions.length,
+              state.meaningfulDecisions,
+              !!state.meaningfulDecisionGateWaived,
             )
           : undefined;
       const failure =
@@ -1945,7 +1971,8 @@ export function scenarioObjectiveFailure(
   scenario: ScenarioType,
   history: MonthlyHistoryType[],
   difficulty?: DifficultyType,
-  meaningfulDecisions = 0,
+  meaningfulDecisions: MeaningfulDecisionType[] = [],
+  decisionGateWaived = false,
 ): string | undefined {
   const reliabilityObjective = scenario.reliabilityObjective;
   if (reliabilityObjective) {
@@ -1978,12 +2005,21 @@ export function scenarioObjectiveFailure(
       return `Customer attrition left you with only ${Math.round(retained * 100)}% of the community you started with; this mission requires retaining at least ${Math.round(scenario.minimumCustomerRetention * 100)}%.`;
     }
   }
-  if (
-    !scenario.tutorialSteps &&
-    difficulty === "CEO" &&
-    meaningfulDecisions < CEO_MEANINGFUL_DECISIONS_REQUIRED
-  ) {
-    return `You made ${meaningfulDecisions} of ${CEO_MEANINGFUL_DECISIONS_REQUIRED} meaningful decisions; CEO difficulty requires choices that change the grid or its economics.`;
+  if (!scenario.tutorialSteps && !decisionGateWaived) {
+    if (
+      difficulty === "Intern" &&
+      meaningfulDecisions.length < INTERN_MEANINGFUL_DECISIONS_REQUIRED
+    ) {
+      return "Make at least one meaningful decision that changes the grid or its economics.";
+    }
+    if (
+      difficulty === "CEO" &&
+      (meaningfulDecisions.length < CEO_MEANINGFUL_DECISIONS_REQUIRED ||
+        meaningfulDecisionCategoryCount(meaningfulDecisions) <
+          CEO_MEANINGFUL_CATEGORIES_REQUIRED)
+    ) {
+      return `You made ${meaningfulDecisions.length} of ${CEO_MEANINGFUL_DECISIONS_REQUIRED} meaningful decisions across ${meaningfulDecisionCategoryCount(meaningfulDecisions)} of ${CEO_MEANINGFUL_CATEGORIES_REQUIRED} decision types; CEO difficulty requires a varied operating plan.`;
+    }
   }
   return undefined;
 }

--- a/src/reducers/Replay.test.tsx
+++ b/src/reducers/Replay.test.tsx
@@ -90,7 +90,7 @@ describe("recording a run", () => {
     played = playAScriptedGame();
   });
 
-  it("logs every simulation-affecting action the player took", () => {
+  it("logs every action while the decision ledger cancels lifetime churn", () => {
     const types = played.replayLog!.map((a) => a.type);
     expect(types).toEqual([
       "buildFacility",
@@ -100,25 +100,30 @@ describe("recording a run", () => {
       "togglePauseFacility",
       "sellFacility",
     ]);
-    expect(played.meaningfulDecisions).toHaveLength(6);
+    // The two pause clicks ultimately return the same plant to its baseline state, so they remain
+    // in the replay but correctly disappear from persistent decision progress.
+    expect(played.meaningfulDecisions).toHaveLength(4);
     expect(new Set(played.meaningfulDecisions.map(({ key }) => key)).size).toBe(
-      6,
+      4,
     );
   });
 
-  it("counts only accepted settled changes, not rejected targets or same-month churn", () => {
+  it("counts only accepted settled changes, not rejected targets or lifetime churn", () => {
     let state = createGame(OPTIONS);
     const startingRate = state.dollarsPerkWh;
 
     state = dispatch(state, delta({ dollarsPerkWh: startingRate + 0.001 }));
+    runMonths(state, 1);
     state = dispatch(state, delta({ dollarsPerkWh: startingRate + 0.002 }));
     expect(state.meaningfulDecisions).toHaveLength(1);
     expect(state.meaningfulDecisions[0]).toMatchObject({
       lever: "rate",
       before: String(startingRate),
       after: String(startingRate + 0.002),
+      month: 1,
     });
 
+    runMonths(state, 1);
     state = dispatch(state, delta({ dollarsPerkWh: startingRate }));
     expect(state.meaningfulDecisions).toHaveLength(0);
 
@@ -192,6 +197,19 @@ describe("watching a replay", () => {
   beforeAll(() => {
     played = playAScriptedGame();
     replay = roundTripped(serializeReplay(played)!);
+  });
+
+  it("preserves the visible legacy decision-gate waiver during playback", () => {
+    const doc = encodeReplay(serializeReplay(played)!) as unknown as Record<
+      string,
+      unknown
+    >;
+    doc.version = 5;
+    const legacy = decodeReplay(doc)!;
+    const watched = createGameFromReplay(legacy);
+
+    expect(legacy.meaningfulDecisionGateWaived).toBe(true);
+    expect(watched.meaningfulDecisionGateWaived).toBe(true);
   });
 
   /**

--- a/src/reducers/Replay.test.tsx
+++ b/src/reducers/Replay.test.tsx
@@ -100,6 +100,35 @@ describe("recording a run", () => {
       "togglePauseFacility",
       "sellFacility",
     ]);
+    expect(played.meaningfulDecisions).toHaveLength(6);
+    expect(new Set(played.meaningfulDecisions.map(({ key }) => key)).size).toBe(
+      6,
+    );
+  });
+
+  it("counts only accepted settled changes, not rejected targets or same-month churn", () => {
+    let state = createGame(OPTIONS);
+    const startingRate = state.dollarsPerkWh;
+
+    state = dispatch(state, delta({ dollarsPerkWh: startingRate + 0.001 }));
+    state = dispatch(state, delta({ dollarsPerkWh: startingRate + 0.002 }));
+    expect(state.meaningfulDecisions).toHaveLength(1);
+    expect(state.meaningfulDecisions[0]).toMatchObject({
+      lever: "rate",
+      before: String(startingRate),
+      after: String(startingRate + 0.002),
+    });
+
+    state = dispatch(state, delta({ dollarsPerkWh: startingRate }));
+    expect(state.meaningfulDecisions).toHaveLength(0);
+
+    state = dispatch(state, sellFacility(999999));
+    state = dispatch(state, togglePauseFacility(999999));
+    state = dispatch(
+      state,
+      reprioritizeFacility({ spotInList: 999999, delta: 1 }),
+    );
+    expect(state.meaningfulDecisions).toHaveLength(0);
   });
 
   it("merges the deltas fired within one minute into the value that stuck", () => {
@@ -176,6 +205,7 @@ describe("watching a replay", () => {
     expect(watched.date.minute).toBe(played.date.minute);
     expect(watched.monthlyHistory).toEqual(played.monthlyHistory);
     expect(watched.facilities).toEqual(played.facilities);
+    expect(watched.meaningfulDecisions).toEqual(played.meaningfulDecisions);
   });
 
   it("applies each action at the minute it was taken", () => {

--- a/src/reducers/Transmission.test.tsx
+++ b/src/reducers/Transmission.test.tsx
@@ -1,6 +1,28 @@
-import gameReducer, { buildTransmissionLine, setTradingPolicy } from "./Game";
+import cloneDeep from "lodash.clonedeep";
+import { TICKS_PER_YEAR, YEARS_PER_TICK } from "../Constants";
 import { getTimeFromTimeline } from "../helpers/DateTime";
-import { createGame } from "../testing/Simulator";
+import { serializeReplay } from "../Replay";
+import { createGame, createGameFromReplay } from "../testing/Simulator";
+import gameReducer, {
+  buildTransmissionLine,
+  generateNewTimeline,
+  setTradingPolicy,
+  tickState,
+} from "./Game";
+
+function buildNorthernIntertie() {
+  const game = createGame({ scenarioId: 100, seed: 61 });
+  getTimeFromTimeline(game.date.minute, game.timeline)!.cash = 1000000000;
+  return cloneDeep(
+    gameReducer(
+      game,
+      buildTransmissionLine({
+        corridorId: "california-north",
+        financed: true,
+      }),
+    ),
+  );
+}
 
 describe("transmission actions", () => {
   it("builds one valid California corridor and charges the down payment", () => {
@@ -38,5 +60,104 @@ describe("transmission actions", () => {
     const game = createGame({ scenarioId: 100, seed: 61 });
     const next = gameReducer(game, setTradingPolicy("RELIABILITY_FIRST"));
     expect(next.transmission?.tradingPolicy).toBe("RELIABILITY_FIRST");
+  });
+
+  it("keeps construction equity neutral instead of counting the intertie loan twice", () => {
+    const game = createGame({ scenarioId: 100, seed: 61 });
+    const now = getTimeFromTimeline(game.date.minute, game.timeline)!;
+    now.cash = 1000000000;
+    const netWorthBefore = generateNewTimeline(
+      game,
+      now.cash,
+      now.customers,
+      1,
+    )[0].netWorth;
+
+    const next = gameReducer(
+      game,
+      buildTransmissionLine({
+        corridorId: "california-north",
+        financed: true,
+      }),
+    );
+    const after = getTimeFromTimeline(next.date.minute, next.timeline)!;
+
+    expect(after.netWorth).toBe(netWorthBefore);
+  });
+
+  it("commissions an intertie, imports a shortage, and books its full cash costs", () => {
+    const state = buildNorthernIntertie();
+    const line = state.transmission!.lines[0];
+    line.yearsToBuildLeft = YEARS_PER_TICK;
+    state.facilities = [];
+    const opening = getTimeFromTimeline(state.date.minute, state.timeline)!;
+    state.timeline = generateNewTimeline(
+      state,
+      opening.cash,
+      opening.customers,
+      3,
+    );
+    const cashBefore = state.timeline[0].cash;
+    const debtBefore = line.loanAmountLeft;
+
+    tickState(state);
+
+    const now = getTimeFromTimeline(state.date.minute, state.timeline)!;
+    const principalPaid = debtBefore - line.loanAmountLeft;
+    expect(line.yearsToBuildLeft).toBe(0);
+    expect(now.importedW).toBeGreaterThan(0);
+    expect(now.exportedW).toBe(0);
+    expect(now.supplyW).toBe(now.demandW);
+    expect(now.expensesImports).toBeGreaterThan(0);
+    expect(now.expensesOM).toBeCloseTo(3600000 / TICKS_PER_YEAR, 5);
+    expect(now.expensesInterest).toBeGreaterThan(0);
+    expect(line.loanAmountLeft).toBeLessThan(debtBefore);
+    expect(now.cash).toBe(
+      Math.round(
+        cashBefore +
+          now.revenue -
+          now.expensesImports! -
+          now.expensesOM -
+          now.expensesInterest -
+          principalPaid,
+      ),
+    );
+    expect(
+      state.eventLog.some(({ message }) => message.includes("Intertie open")),
+    ).toBe(true);
+  });
+
+  it("does not mutate live intertie construction or debt while forecasting", () => {
+    const state = buildNorthernIntertie();
+    const before = cloneDeep(state.transmission);
+    const now = getTimeFromTimeline(state.date.minute, state.timeline)!;
+
+    generateNewTimeline(state, now.cash, now.customers, 8);
+
+    expect(state.transmission).toEqual(before);
+  });
+
+  it("replays intertie builds and trading policy changes", () => {
+    let game = createGame({ scenarioId: 100, seed: 61 });
+    game = gameReducer(
+      game,
+      buildTransmissionLine({
+        corridorId: "california-north",
+        financed: true,
+      }),
+    );
+    game = gameReducer(game, setTradingPolicy("RELIABILITY_FIRST"));
+
+    const replayed = createGameFromReplay(serializeReplay(game)!);
+
+    expect(replayed.transmission).toMatchObject({
+      tradingPolicy: "RELIABILITY_FIRST",
+      lines: [
+        expect.objectContaining({
+          corridorId: "california-north",
+          financed: true,
+        }),
+      ],
+    });
   });
 });

--- a/src/reducers/Transmission.test.tsx
+++ b/src/reducers/Transmission.test.tsx
@@ -8,7 +8,10 @@ import gameReducer, {
   generateNewTimeline,
   setTradingPolicy,
   tickState,
+  togglePauseFacility,
 } from "./Game";
+import { AppStateType } from "../Types";
+import { getScenario } from "../data/Scenarios";
 
 function buildNorthernIntertie() {
   const game = createGame({ scenarioId: 100, seed: 61 });
@@ -25,6 +28,25 @@ function buildNorthernIntertie() {
 }
 
 describe("transmission actions", () => {
+  it("cannot enable transmission inside earlier tutorials", () => {
+    for (const scenarioId of [0, 1, 2, 4, 3, 5]) {
+      const game = createGame({ scenarioId });
+      expect(game.transmission).toBeUndefined();
+      expect(
+        gameReducer(
+          game,
+          buildTransmissionLine({
+            corridorId: "california-north",
+            financed: true,
+          }),
+        ).transmission,
+      ).toBeUndefined();
+      expect(
+        gameReducer(game, setTradingPolicy("RELIABILITY_FIRST")).transmission,
+      ).toBeUndefined();
+    }
+  });
+
   it("builds one valid California corridor and charges the down payment", () => {
     const game = createGame({ scenarioId: 100, seed: 61 });
     const before = getTimeFromTimeline(game.date.minute, game.timeline)!.cash;
@@ -185,5 +207,136 @@ describe("transmission actions", () => {
         }),
       ],
     });
+  });
+
+  it("runs Mission 7 from financed build through imports and a later safe export", () => {
+    jest.useFakeTimers();
+    try {
+      const scenario = getScenario(112)!;
+      const steps = scenario.tutorialSteps!;
+      let state = createGame({ scenarioId: 112 });
+      const appState = () => ({ game: state }) as AppStateType;
+      expect(state.transmission).toEqual({
+        tradingPolicy: "BALANCED",
+        lines: [],
+      });
+      expect(state.facilities.map(({ fuel }) => fuel)).toEqual([
+        "Sun",
+        "Natural Gas",
+      ]);
+
+      const startingCash = getTimeFromTimeline(
+        state.date.minute,
+        state.timeline,
+      )!.cash;
+      state = cloneDeep(
+        gameReducer(
+          state,
+          buildTransmissionLine({
+            corridorId: "california-north",
+            financed: true,
+          }),
+        ),
+      );
+      expect(getTimeFromTimeline(state.date.minute, state.timeline)!.cash).toBe(
+        startingCash - 36000000,
+      );
+      expect(steps[1].advanceOn?.(appState())).toBe(true);
+
+      let constructionTicks = 0;
+      while (state.transmission!.lines[0].yearsToBuildLeft > 0) {
+        tickState(state);
+        constructionTicks++;
+      }
+      state.speed = "NORMAL";
+      expect(constructionTicks).toBeGreaterThanOrEqual(TICKS_PER_YEAR - 1);
+      expect(constructionTicks).toBeLessThanOrEqual(TICKS_PER_YEAR + 1);
+      expect(steps[2].advanceOn?.(appState())).toBe(false);
+      state.speed = "PAUSED";
+      expect(steps[2].advanceOn?.(appState())).toBe(true);
+
+      state = cloneDeep(
+        gameReducer(state, setTradingPolicy("RELIABILITY_FIRST")),
+      );
+      const gas = state.facilities.find(({ fuel }) => fuel === "Natural Gas")!;
+      state = cloneDeep(gameReducer(state, togglePauseFacility(gas.id)));
+      expect(steps[3].advanceOn?.(appState())).toBe(true);
+      expect(steps[5].advanceOn?.(appState())).toBe(true);
+
+      const operatingTicks = [] as Array<{
+        importedW: number;
+        exportedW: number;
+        capacityW: number;
+      }>;
+      while (state.date.monthsElapsed < 13) {
+        tickState(state);
+        const now = getTimeFromTimeline(state.date.minute, state.timeline)!;
+        operatingTicks.push({
+          importedW: now.importedW || 0,
+          exportedW: now.exportedW || 0,
+          capacityW: now.transmissionCapacityW || 0,
+        });
+      }
+      state.speed = "PAUSED";
+      expect(steps[6].advanceOn?.(appState())).toBe(true);
+      expect(
+        state.monthlyHistory.some(
+          (month) => (month.chartAverage?.importedW || 0) > 0,
+        ),
+      ).toBe(true);
+      expect(state.eventLog.some(({ kind }) => kind === "BLACKOUT")).toBe(
+        false,
+      );
+
+      const capstone = steps[9].capstone!;
+      state = cloneDeep(gameReducer(state, setTradingPolicy("CLOSED")));
+      const solar = state.facilities.find(({ fuel }) => fuel === "Sun")!;
+      state = cloneDeep(gameReducer(state, togglePauseFacility(solar.id)));
+      state.eventLog.push({
+        id: 999,
+        kind: "BLACKOUT",
+        label: "Recovered",
+        message: "Recovered test blackout",
+        importance: "CRITICAL",
+      });
+      while (state.date.monthsElapsed < 14) tickState(state);
+      expect(capstone.success(appState())).toBe(false);
+
+      state = cloneDeep(gameReducer(state, setTradingPolicy("BALANCED")));
+      state = cloneDeep(gameReducer(state, togglePauseFacility(solar.id)));
+      while (state.date.monthsElapsed < 15) {
+        tickState(state);
+        const now = getTimeFromTimeline(state.date.minute, state.timeline)!;
+        operatingTicks.push({
+          importedW: now.importedW || 0,
+          exportedW: now.exportedW || 0,
+          capacityW: now.transmissionCapacityW || 0,
+        });
+      }
+      expect(capstone.success(appState())).toBe(true);
+      expect(
+        state.monthlyHistory.some(
+          (month) =>
+            (month.chartAverage?.exportedW || 0) > 0 &&
+            (month.minimumSupplyMarginW ?? -1) >= 0,
+        ),
+      ).toBe(true);
+      expect(
+        operatingTicks.every(
+          ({ importedW, exportedW, capacityW }) =>
+            importedW + exportedW <= capacityW,
+        ),
+      ).toBe(true);
+      expect(
+        state.timeline.some(
+          ({ transmissionCapacityW }) =>
+            (transmissionCapacityW || 0) > 0 &&
+            (transmissionCapacityW || 0) < 500000000,
+        ),
+      ).toBe(true);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/reducers/Transmission.test.tsx
+++ b/src/reducers/Transmission.test.tsx
@@ -85,6 +85,32 @@ describe("transmission actions", () => {
     expect(after.netWorth).toBe(netWorthBefore);
   });
 
+  it("turns construction principal payments into project equity", () => {
+    const state = buildNorthernIntertie();
+    const line = state.transmission!.lines[0];
+    line.yearsToBuildLeft = 0.5;
+    state.facilities = [];
+    const opening = getTimeFromTimeline(state.date.minute, state.timeline)!;
+    state.timeline = generateNewTimeline(
+      state,
+      opening.cash,
+      opening.customers,
+      3,
+    );
+    const debtBefore = line.loanAmountLeft;
+
+    tickState(state);
+
+    const now = getTimeFromTimeline(state.date.minute, state.timeline)!;
+    const principalPaid = debtBefore - line.loanAmountLeft;
+    expect(line.yearsToBuildLeft).toBeGreaterThan(0);
+    expect(principalPaid).toBeGreaterThan(0);
+    expect(now.netWorth - now.cash).toBeCloseTo(
+      180000000 - debtBefore + principalPaid,
+      5,
+    );
+  });
+
   it("commissions an intertie, imports a shortage, and books its full cash costs", () => {
     const state = buildNorthernIntertie();
     const line = state.transmission!.lines[0];

--- a/src/reducers/Transmission.test.tsx
+++ b/src/reducers/Transmission.test.tsx
@@ -78,10 +78,28 @@ describe("transmission actions", () => {
     expect(Number.isFinite(before)).toBe(true);
   });
 
-  it("updates the trading rule", () => {
+  it("rejects an ineffective trading rule until an intertie exists", () => {
     const game = createGame({ scenarioId: 100, seed: 61 });
     const next = gameReducer(game, setTradingPolicy("RELIABILITY_FIRST"));
+    expect(next.transmission?.tradingPolicy).toBe("BALANCED");
+    expect(next.meaningfulDecisions).toEqual([]);
+  });
+
+  it("updates and records the trading rule once it governs an intertie", () => {
+    const next = gameReducer(
+      buildNorthernIntertie(),
+      setTradingPolicy("RELIABILITY_FIRST"),
+    );
     expect(next.transmission?.tradingPolicy).toBe("RELIABILITY_FIRST");
+    expect(next.meaningfulDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "trading",
+          kind: "trading",
+          label: "Set the regional trading rule",
+        }),
+      ]),
+    );
   });
 
   it("keeps construction equity neutral instead of counting the intertie loan twice", () => {

--- a/src/reducers/Transmission.test.tsx
+++ b/src/reducers/Transmission.test.tsx
@@ -1,0 +1,42 @@
+import gameReducer, { buildTransmissionLine, setTradingPolicy } from "./Game";
+import { getTimeFromTimeline } from "../helpers/DateTime";
+import { createGame } from "../testing/Simulator";
+
+describe("transmission actions", () => {
+  it("builds one valid California corridor and charges the down payment", () => {
+    const game = createGame({ scenarioId: 100, seed: 61 });
+    const before = getTimeFromTimeline(game.date.minute, game.timeline)!.cash;
+    getTimeFromTimeline(game.date.minute, game.timeline)!.cash = 1000000000;
+    const next = gameReducer(
+      game,
+      buildTransmissionLine({
+        corridorId: "california-north",
+        financed: true,
+      }),
+    );
+    expect(next.transmission?.lines).toHaveLength(1);
+    expect(next.transmission?.lines[0]).toMatchObject({
+      corridorId: "california-north",
+      yearsToBuildLeft: 1,
+      financed: true,
+    });
+    expect(getTimeFromTimeline(next.date.minute, next.timeline)!.cash).toBe(
+      1000000000 - 180000000 * 0.2,
+    );
+    const duplicate = gameReducer(
+      next,
+      buildTransmissionLine({
+        corridorId: "california-north",
+        financed: true,
+      }),
+    );
+    expect(duplicate.transmission?.lines).toHaveLength(1);
+    expect(Number.isFinite(before)).toBe(true);
+  });
+
+  it("updates the trading rule", () => {
+    const game = createGame({ scenarioId: 100, seed: 61 });
+    const next = gameReducer(game, setTradingPolicy("RELIABILITY_FIRST"));
+    expect(next.transmission?.tradingPolicy).toBe("RELIABILITY_FIRST");
+  });
+});

--- a/src/testing/BalancePlaybooks.ts
+++ b/src/testing/BalancePlaybooks.ts
@@ -1,4 +1,23 @@
-import { SimOptionsType } from "./Simulator";
+import { ScheduledSimActionType, SimOptionsType } from "./Simulator";
+
+function rateSteps(
+  startingRate: number,
+  count: number,
+): ScheduledSimActionType[] {
+  return Array.from({ length: count }, (_, index) => ({
+    month: index * 2,
+    type: "rate" as const,
+    // A small, staged tariff plan: each setting remains in force for two settlements.
+    dollarsPerkWh: startingRate + index * 0.00025,
+  }));
+}
+
+function modernDecisionPlan(
+  startingRate: number,
+  count: 8 | 9,
+): ScheduledSimActionType[] {
+  return rateSteps(startingRate, count);
+}
 
 /**
  * Reproducible, UI-legal playthroughs used by both the CEO economics gates and the seeded story
@@ -7,7 +26,6 @@ import { SimOptionsType } from "./Simulator";
 export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
   100: {
     // The announced carbon-fee step makes the old $0.055/kWh gas-heavy play insolvent.
-    dollarsPerkWh: 0.08,
     initialBuild: {
       name: "Natural Gas",
       peakW: 150000000,
@@ -15,9 +33,9 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
     },
     sellFacilityId: 2,
     sellAtMonth: 37,
+    scheduledActions: modernDecisionPlan(0.08, 8),
   },
   101: {
-    dollarsPerkWh: 0.1,
     initialBuild: {
       name: "Natural Gas",
       peakW: 300000000,
@@ -25,9 +43,9 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
     },
     sellFacilityId: 2,
     sellAtMonth: 39,
+    scheduledActions: modernDecisionPlan(0.1, 8),
   },
   102: {
-    dollarsPerkWh: 0.15,
     initialBuild: {
       name: "Natural Gas",
       peakW: 300000000,
@@ -35,10 +53,10 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
     },
     sellFacilityId: 1,
     sellAtMonth: 39,
+    scheduledActions: rateSteps(0.15, 8),
   },
   103: {
     // This control must remain viable without the shale discount as well as with it.
-    dollarsPerkWh: 0.08,
     initialBuild: {
       name: "Natural Gas",
       peakW: 600000000,
@@ -46,9 +64,9 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
     },
     sellFacilityId: 1,
     sellAtMonth: 39,
+    scheduledActions: rateSteps(0.08, 8),
   },
   104: {
-    dollarsPerkWh: 0.08,
     initialBuild: {
       name: "Natural Gas",
       peakW: 300000000,
@@ -56,10 +74,10 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
     },
     sellFacilityId: 1,
     sellAtMonth: 110,
+    scheduledActions: modernDecisionPlan(0.08, 8),
   },
   105: {
     // Oil's output-dependent O&M makes the old $0.08/kWh play run out of cash in 2007.
-    dollarsPerkWh: 0.085,
     initialBuild: {
       name: "Natural Gas",
       peakW: 300000000,
@@ -67,6 +85,36 @@ export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
     },
     sellFacilityId: 3,
     sellAtMonth: 39,
+    scheduledActions: modernDecisionPlan(0.085, 8),
+  },
+  106: {
+    initialBuild: { name: "Natural Gas", peakW: 50000000, financed: true },
+    scheduledActions: modernDecisionPlan(0.101, 9),
+  },
+  107: {
+    initialBuild: { name: "Natural Gas", peakW: 1800000000, financed: true },
+    scheduledActions: modernDecisionPlan(0.091, 9),
+  },
+  108: {
+    initialBuild: { name: "Oil", peakW: 250000000, financed: true },
+    scheduledActions: modernDecisionPlan(0.241, 9),
+  },
+  110: {
+    initialBuild: { name: "Oil", peakW: 400000000, financed: true },
+    scheduledActions: modernDecisionPlan(0.141, 9),
+  },
+  111: {
+    // The one-year northern intertie is the only new firm resource that can be commissioned
+    // between the warning and the firestorm on full CEO construction times.
+    scheduledActions: [
+      {
+        month: 0,
+        type: "intertie",
+        corridorId: "california-north",
+        financed: true,
+      },
+      ...modernDecisionPlan(0.171, 9),
+    ],
   },
 };
 
@@ -96,10 +144,19 @@ export const INTERN_ONE_BUILD_PLAYS: Record<
   105: {
     initialBuild: { name: "Natural Gas", peakW: 525000000, financed: true },
   },
+  106: {
+    initialBuild: { name: "Natural Gas", peakW: 50000000, financed: true },
+  },
+  107: {
+    initialBuild: { name: "Natural Gas", peakW: 1800000000, financed: true },
+  },
   108: {
     initialBuild: { name: "Natural Gas", peakW: 250000000, financed: true },
   },
   110: {
     initialBuild: { name: "Natural Gas", peakW: 400000000, financed: true },
+  },
+  111: {
+    initialBuild: { name: "Natural Gas", peakW: 20000000, financed: true },
   },
 };

--- a/src/testing/BalancePlaybooks.ts
+++ b/src/testing/BalancePlaybooks.ts
@@ -1,127 +1,183 @@
 import { ScheduledSimActionType, SimOptionsType } from "./Simulator";
 
-function rateSteps(
-  startingRate: number,
-  count: number,
-): ScheduledSimActionType[] {
-  return Array.from({ length: count }, (_, index) => ({
-    month: index * 2,
-    type: "rate" as const,
-    // A small, staged tariff plan: each setting remains in force for two settlements.
-    dollarsPerkWh: startingRate + index * 0.00025,
-  }));
-}
+const rate = (dollarsPerkWh: number): ScheduledSimActionType => ({
+  month: 0,
+  type: "rate",
+  dollarsPerkWh,
+});
 
-function modernDecisionPlan(
-  startingRate: number,
-  count: 8 | 9,
-): ScheduledSimActionType[] {
-  return rateSteps(startingRate, count);
-}
+const programs = (month: number): ScheduledSimActionType[] => [
+  { month, type: "policy", id: "efficiency", tier: "Small" },
+  { month, type: "policy", id: "solar", tier: "Small" },
+];
+
+const dispatch = (
+  facilityIds: number[],
+  startingMonth = 2,
+): ScheduledSimActionType[] =>
+  facilityIds.map((facilityId, index) => ({
+    month: startingMonth + index,
+    type: "reprioritize",
+    facilityId,
+  }));
+
+const line = (
+  corridorId: string,
+  tradingMonth = 1,
+  buildMonth = 0,
+): ScheduledSimActionType[] => [
+  { month: buildMonth, type: "intertie", corridorId, financed: true },
+  {
+    month: tradingMonth,
+    type: "trading",
+    policy: "RELIABILITY_FIRST",
+  },
+];
 
 /**
- * Reproducible, UI-legal playthroughs used by both the CEO economics gates and the seeded story
- * matrix. They deliberately contain only actions the headless simulator records as player input.
+ * Reproducible CEO plans made from persistent, UI-legal commitments. Every plan contains exactly
+ * ten material choices across at least four categories, no more than one rate setting, and no
+ * inverse action. Late operating/program changes still remain in force through a settlement.
  */
 export const STANDARD_BALANCE_PLAYS: Record<number, Partial<SimOptionsType>> = {
   100: {
-    // The announced carbon-fee step makes the old $0.055/kWh gas-heavy play insolvent.
-    initialBuild: {
-      name: "Natural Gas",
-      peakW: 150000000,
-      financed: true,
-    },
+    initialBuild: { name: "Natural Gas", peakW: 150000000, financed: true },
     sellFacilityId: 2,
     sellAtMonth: 37,
-    scheduledActions: modernDecisionPlan(0.08, 8),
+    scheduledActions: [
+      rate(0.08),
+      ...line("california-north"),
+      ...dispatch([1, 3]),
+      { month: 36, type: "toggle", facilityId: 2 },
+      ...programs(142),
+    ],
   },
   101: {
-    initialBuild: {
-      name: "Natural Gas",
-      peakW: 300000000,
-      financed: true,
-    },
+    initialBuild: { name: "Natural Gas", peakW: 300000000, financed: true },
     sellFacilityId: 2,
-    sellAtMonth: 39,
-    scheduledActions: modernDecisionPlan(0.1, 8),
+    sellAtMonth: 143,
+    scheduledActions: [
+      rate(0.1),
+      {
+        month: 1,
+        type: "build",
+        build: { name: "Natural Gas", peakW: 20000000, financed: true },
+      },
+      ...dispatch([1, 2, 3, 4]),
+      { month: 141, type: "toggle", facilityId: 1 },
+      { month: 142, type: "toggle", facilityId: 2 },
+    ],
   },
   102: {
-    initialBuild: {
-      name: "Natural Gas",
-      peakW: 300000000,
-      financed: true,
-    },
+    initialBuild: { name: "Natural Gas", peakW: 300000000, financed: true },
     sellFacilityId: 1,
     sellAtMonth: 39,
-    scheduledActions: rateSteps(0.15, 8),
+    scheduledActions: [
+      rate(0.15),
+      {
+        month: 1,
+        type: "build",
+        build: { name: "Natural Gas", peakW: 20000000, financed: true },
+      },
+      ...dispatch([1, 2, 3, 4], 3),
+      { month: 38, type: "toggle", facilityId: 1 },
+      { month: 38, type: "toggle", facilityId: 2 },
+    ],
   },
   103: {
-    // This control must remain viable without the shale discount as well as with it.
-    initialBuild: {
-      name: "Natural Gas",
-      peakW: 600000000,
-      financed: true,
-    },
+    initialBuild: { name: "Natural Gas", peakW: 600000000, financed: true },
     sellFacilityId: 1,
     sellAtMonth: 39,
-    scheduledActions: rateSteps(0.08, 8),
+    scheduledActions: [
+      rate(0.08),
+      {
+        month: 1,
+        type: "build",
+        build: { name: "Natural Gas", peakW: 10000000, financed: true },
+      },
+      {
+        month: 2,
+        type: "build",
+        build: { name: "Natural Gas", peakW: 10000000, financed: true },
+      },
+      ...dispatch([1, 2, 3, 4], 3),
+      { month: 38, type: "toggle", facilityId: 1 },
+    ],
   },
   104: {
-    initialBuild: {
-      name: "Natural Gas",
-      peakW: 300000000,
-      financed: true,
-    },
+    initialBuild: { name: "Natural Gas", peakW: 300000000, financed: true },
     sellFacilityId: 1,
     sellAtMonth: 110,
-    scheduledActions: modernDecisionPlan(0.08, 8),
+    scheduledActions: [
+      rate(0.08),
+      ...dispatch([1, 2, 3, 4]),
+      { month: 109, type: "toggle", facilityId: 1 },
+      ...programs(238),
+    ],
   },
   105: {
-    // Oil's output-dependent O&M makes the old $0.08/kWh play run out of cash in 2007.
-    initialBuild: {
-      name: "Natural Gas",
-      peakW: 300000000,
-      financed: true,
-    },
+    initialBuild: { name: "Natural Gas", peakW: 300000000, financed: true },
     sellFacilityId: 3,
     sellAtMonth: 39,
-    scheduledActions: modernDecisionPlan(0.085, 8),
+    scheduledActions: [
+      rate(0.085),
+      ...dispatch([1, 2, 3, 4]),
+      { month: 38, type: "toggle", facilityId: 3 },
+      ...programs(142),
+    ],
   },
   106: {
     initialBuild: { name: "Natural Gas", peakW: 50000000, financed: true },
-    scheduledActions: modernDecisionPlan(0.101, 9),
+    sellFacilityId: 2,
+    sellAtMonth: 191,
+    scheduledActions: [
+      rate(0.101),
+      ...dispatch([1, 2, 3]),
+      ...line("pjm-miso-upgrade", 189, 188),
+      ...programs(190),
+    ],
   },
   107: {
     initialBuild: { name: "Natural Gas", peakW: 1800000000, financed: true },
-    scheduledActions: modernDecisionPlan(0.091, 9),
+    scheduledActions: [
+      rate(0.091),
+      ...dispatch([1, 2, 3, 4, 5]),
+      { month: 82, type: "toggle", facilityId: 4 },
+      ...programs(82),
+    ],
   },
   108: {
     initialBuild: { name: "Oil", peakW: 250000000, financed: true },
-    scheduledActions: modernDecisionPlan(0.241, 9),
+    scheduledActions: [
+      rate(0.241),
+      ...line("spain-portugal-upgrade"),
+      ...dispatch([1, 2, 7]),
+      { month: 35, type: "toggle", facilityId: 1 },
+      ...programs(34),
+    ],
   },
   110: {
     initialBuild: { name: "Oil", peakW: 400000000, financed: true },
-    scheduledActions: modernDecisionPlan(0.141, 9),
+    scheduledActions: [
+      rate(0.141),
+      ...line("france-core-upgrade"),
+      ...dispatch([2, 3, 6]),
+      { month: 47, type: "toggle", facilityId: 2 },
+      ...programs(46),
+    ],
   },
   111: {
-    // The one-year northern intertie is the only new firm resource that can be commissioned
-    // between the warning and the firestorm on full CEO construction times.
     scheduledActions: [
-      {
-        month: 0,
-        type: "intertie",
-        corridorId: "california-north",
-        financed: true,
-      },
-      ...modernDecisionPlan(0.171, 9),
+      rate(0.171),
+      ...line("california-north"),
+      ...dispatch([1, 2, 3, 4]),
+      { month: 35, type: "toggle", facilityId: 5 },
+      ...programs(34),
     ],
   },
 };
 
-/**
- * The single commitment that teaches each Intern scenario's intended first lesson. These use no
- * tariff change, sale, or reactive strategy: passive play must fail, while this one build wins.
- */
+/** The single material commitment that teaches each Intern scenario's intended first lesson. */
 export const INTERN_ONE_BUILD_PLAYS: Record<
   number,
   Pick<SimOptionsType, "initialBuild">

--- a/src/testing/Invariants.tsx
+++ b/src/testing/Invariants.tsx
@@ -55,6 +55,12 @@ const FINITE_TICK_FIELDS: TickFieldType[] = [
   "kgco2e",
   "interestRate",
   "inflationRate",
+  "importedW",
+  "exportedW",
+  "transmissionCapacityW",
+  "marketPricePerMWh",
+  "revenueExports",
+  "expensesImports",
 ];
 
 // Tick fields that are physically incapable of going negative (cash and netWorth can, by design)
@@ -82,6 +88,12 @@ const NON_NEGATIVE_TICK_FIELDS: TickFieldType[] = [
   "kgco2e",
   // A lender can quote any rate it likes, but never a negative one
   "interestRate",
+  "importedW",
+  "exportedW",
+  "transmissionCapacityW",
+  "marketPricePerMWh",
+  "revenueExports",
+  "expensesImports",
 ];
 
 const FINITE_MONTH_FIELDS: MonthFieldType[] = [
@@ -98,6 +110,8 @@ const FINITE_MONTH_FIELDS: MonthFieldType[] = [
   "kgco2e",
   "interestRate",
   "inflationRate",
+  "revenueExports",
+  "expensesImports",
 ];
 
 /**
@@ -211,7 +225,8 @@ export function checkTick(
   });
   if (
     isFinite_(now.supplyW) &&
-    supplyByFuelTotal > now.supplyW * (1 + RELATIVE_TOLERANCE) + 1
+    supplyByFuelTotal >
+      (now.supplyW + (now.exportedW || 0)) * (1 + RELATIVE_TOLERANCE) + 1
   ) {
     collector.add(
       "supplyByFuel sums to at most supplyW",
@@ -228,13 +243,23 @@ export function checkTick(
       now.expensesOM +
       now.expensesCarbonFee +
       now.expensesInterest +
+      (now.expensesImports || 0) +
       (now.expensesPolicy || 0);
-    const maxPrincipal = state.facilities.reduce(
-      (acc: number, f: FacilityOperatingType) =>
-        acc +
-        (f.loanAmountLeft > 0 ? f.loanMonthlyPayment / TICKS_PER_MONTH : 0),
-      0,
-    );
+    const maxPrincipal =
+      state.facilities.reduce(
+        (acc: number, f: FacilityOperatingType) =>
+          acc +
+          (f.loanAmountLeft > 0 ? f.loanMonthlyPayment / TICKS_PER_MONTH : 0),
+        0,
+      ) +
+      (state.transmission?.lines || []).reduce(
+        (acc, line) =>
+          acc +
+          (line.loanAmountLeft > 0
+            ? line.loanMonthlyPayment / TICKS_PER_MONTH
+            : 0),
+        0,
+      );
     const upperBound = prev.cash + now.revenue - expenses;
     const lowerBound = upperBound - maxPrincipal;
     if (
@@ -336,6 +361,24 @@ export function checkTick(
         "loan balance stays within 0..original",
         when,
         `${label} loanAmountLeft = ${Math.round(f.loanAmountLeft)} of ${Math.round(f.loanAmountTotal)}`,
+      );
+    }
+  });
+
+  (state.transmission?.lines || []).forEach((line) => {
+    const label = `${line.name} #${line.id}`;
+    if (!isFinite_(line.yearsToBuildLeft) || line.yearsToBuildLeft < 0) {
+      collector.add(
+        "transmission construction time remaining is non-negative",
+        when,
+        `${label} yearsToBuildLeft = ${line.yearsToBuildLeft}`,
+      );
+    }
+    if (!isFinite_(line.loanAmountLeft) || line.loanAmountLeft < 0) {
+      collector.add(
+        "transmission loan balance is finite and non-negative",
+        when,
+        `${label} loanAmountLeft = ${line.loanAmountLeft}`,
       );
     }
   });

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -1,9 +1,15 @@
 import { CUSTOM_SCENARIO_ID, SCENARIOS } from "../data/Scenarios";
-import { DifficultyType, GameType, ScenarioType } from "../Types";
+import {
+  DifficultyType,
+  GameType,
+  MeaningfulDecisionKindType,
+  ScenarioType,
+} from "../Types";
 import {
   createGame,
   createGameFromReplay,
   runSimulation,
+  SimOptionsType,
   SimResultType,
 } from "./Simulator";
 import {
@@ -13,7 +19,7 @@ import {
 import { loadSimData } from "./SimData";
 import { LOCATIONS, TICKS_PER_MONTH } from "../Constants";
 import { getTimeFromTimeline } from "../helpers/DateTime";
-import { scenarioObjectiveFailure, tickState } from "../reducers/Game";
+import { tickState } from "../reducers/Game";
 import { parseSave, serializeSave } from "../SaveGame";
 import { serializeReplay } from "../Replay";
 import { getAirborneWindOutputFactor } from "../helpers/Energy";
@@ -619,6 +625,27 @@ describe("airborne wind dispatch", () => {
 
 describe("simulation economics", () => {
   const scenarios = SCENARIOS.filter((scenario) => !scenario.tutorialSteps);
+  const expectedCeoCategories: Record<number, MeaningfulDecisionKindType[]> = {
+    100: [
+      "asset",
+      "dispatch",
+      "operation",
+      "policy",
+      "rate",
+      "sale",
+      "trading",
+    ],
+    101: ["asset", "dispatch", "operation", "rate", "sale"],
+    102: ["asset", "dispatch", "operation", "rate", "sale"],
+    103: ["asset", "dispatch", "operation", "rate", "sale"],
+    104: ["asset", "dispatch", "operation", "policy", "rate", "sale"],
+    105: ["asset", "dispatch", "operation", "policy", "rate", "sale"],
+    106: ["asset", "dispatch", "policy", "rate", "sale", "trading"],
+    107: ["asset", "dispatch", "operation", "policy", "rate"],
+    108: ["asset", "dispatch", "operation", "policy", "rate", "trading"],
+    110: ["asset", "dispatch", "operation", "policy", "rate", "trading"],
+    111: ["asset", "dispatch", "operation", "policy", "rate", "trading"],
+  };
   scenarios.forEach((scenario) => {
     it(`fails passively but needs only one build on Intern in "${scenario.name}"`, () => {
       const passive = runSimulation({
@@ -661,9 +688,16 @@ describe("simulation economics", () => {
         ...play,
       });
       expectNoViolations(active);
-      expect(active.meaningfulDecisionCount).toBe(10);
-      expect(new Set(active.meaningfulDecisionKeys).size).toBe(10);
-      expect(active.outcome).toBe("completed");
+      expect([
+        active.meaningfulDecisionCount,
+        active.meaningfulDecisionCategoryCount >= 4,
+        new Set(active.meaningfulDecisionKeys).size,
+        active.outcome,
+        active.meaningfulDecisionLabels,
+      ]).toEqual([10, true, 10, "completed", expect.any(Array)]);
+      expect(active.meaningfulDecisionCategories).toEqual(
+        expectedCeoCategories[scenario.id],
+      );
     });
   });
 
@@ -705,28 +739,43 @@ describe("simulation economics", () => {
         expect([
           scenario.id,
           active.meaningfulDecisionCount,
+          active.meaningfulDecisionCategoryCount >= 4,
           active.outcome,
-        ]).toEqual([scenario.id, 10, "completed"]);
+        ]).toEqual([scenario.id, 10, true, "completed"]);
       });
     },
   );
 
-  it("rejects every one-action deletion from the authored ten-decision CEO plans", () => {
-    scenarios.forEach((scenario) => {
-      const play = STANDARD_BALANCE_PLAYS[scenario.id];
-      const authoredActionCount =
-        (play.scheduledActions?.length || 0) +
-        (play.initialBuild ? 1 : 0) +
-        (play.sellFacilityId !== undefined ? 1 : 0);
-      expect(authoredActionCount).toBe(10);
+  scenarios.forEach((scenario) => {
+    const play = STANDARD_BALANCE_PLAYS[scenario.id];
+    const omissions: Array<Partial<SimOptionsType>> = (
+      play.scheduledActions || []
+    ).map((_action, omitted) => ({
+      scheduledActions: play.scheduledActions!.filter(
+        (_candidate, index) => index !== omitted,
+      ),
+    }));
+    if (play.initialBuild) omissions.push({ initialBuild: undefined });
+    if (play.sellFacilityId !== undefined)
+      omissions.push({ sellFacilityId: undefined });
 
-      // Every possible one-action deletion leaves nine accepted commitments, so the explicit
-      // decision gate rejects it independently of how comfortably the economic goals were met.
-      for (let omitted = 0; omitted < authoredActionCount; omitted++) {
-        expect(scenarioObjectiveFailure(scenario, [], "CEO", 9)).toMatch(
-          /meaningful decisions/i,
-        );
-      }
+    if (omissions.length !== 10) {
+      throw new Error(
+        `CEO ${scenario.id} play must author exactly ten choices`,
+      );
+    }
+    omissions.forEach((omission, index) => {
+      it(`rejects actual CEO ${scenario.id} plan with choice ${index + 1} removed`, () => {
+        const shortened = runSimulation({
+          scenarioId: scenario.id,
+          difficulty: "CEO",
+          ...play,
+          ...omission,
+        });
+        expectNoViolations(shortened);
+        expect(shortened.meaningfulDecisionCount).toBeLessThan(10);
+        expect(shortened.outcome).not.toBe("completed");
+      });
     });
   });
 

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -13,7 +13,7 @@ import {
 import { loadSimData } from "./SimData";
 import { LOCATIONS, TICKS_PER_MONTH } from "../Constants";
 import { getTimeFromTimeline } from "../helpers/DateTime";
-import { tickState } from "../reducers/Game";
+import { scenarioObjectiveFailure, tickState } from "../reducers/Game";
 import { parseSave, serializeSave } from "../SaveGame";
 import { serializeReplay } from "../Replay";
 import { getAirborneWindOutputFactor } from "../helpers/Energy";
@@ -390,7 +390,10 @@ describe("researched public-utility scenarios", () => {
     "VP",
     "CEO",
   ];
-  it.each(difficulties)(
+  const operatingDifficulties = difficulties.filter(
+    (difficulty) => difficulty !== "CEO",
+  );
+  it.each(operatingDifficulties)(
     "completes Data Center Boom on %s with capacity planned before the arrival",
     (difficulty) => {
       const result = runSimulation({
@@ -407,7 +410,7 @@ describe("researched public-utility scenarios", () => {
     },
   );
 
-  it.each(difficulties)(
+  it.each(operatingDifficulties)(
     "rejects passive customer attrition as a Data Center Boom win on %s",
     (difficulty) => {
       const result = runSimulation({ scenarioId: 106, difficulty });
@@ -432,7 +435,7 @@ describe("researched public-utility scenarios", () => {
     },
   );
 
-  it.each(difficulties)(
+  it.each(operatingDifficulties)(
     "keeps Texas Deep Freeze winnable with planned firm capacity on %s",
     (difficulty) => {
       const result = runSimulation({
@@ -615,9 +618,8 @@ describe("airborne wind dispatch", () => {
 });
 
 describe("simulation economics", () => {
-  SCENARIOS.filter(
-    (scenario) => !scenario.tutorialSteps && scenario.id < 106,
-  ).forEach((scenario) => {
+  const scenarios = SCENARIOS.filter((scenario) => !scenario.tutorialSteps);
+  scenarios.forEach((scenario) => {
     it(`fails passively but needs only one build on Intern in "${scenario.name}"`, () => {
       const passive = runSimulation({
         scenarioId: scenario.id,
@@ -625,6 +627,7 @@ describe("simulation economics", () => {
       });
       expectNoViolations(passive);
       expect(passive.actionCount).toBe(0);
+      expect(passive.meaningfulDecisionCount).toBe(0);
       expect(passive.outcome).not.toBe("completed");
 
       const active = runSimulation({
@@ -634,45 +637,21 @@ describe("simulation economics", () => {
       });
       expectNoViolations(active);
       expect(active.actionCount).toBe(1);
+      expect(active.meaningfulDecisionCount).toBe(1);
       expect(active.builds).toHaveLength(1);
       expect(active.outcome).toBe("completed");
     });
   });
 
-  SCENARIOS.filter((scenario) => [108, 110].includes(scenario.id)).forEach(
-    (scenario) => {
-      it(`requires player input but accepts one build on Intern in "${scenario.name}"`, () => {
-        const passive = runSimulation({
-          scenarioId: scenario.id,
-          difficulty: "Intern",
-        });
-        expectNoViolations(passive);
-        expect(passive.actionCount).toBe(0);
-        expect(passive.outcome).not.toBe("completed");
-
-        const active = runSimulation({
-          scenarioId: scenario.id,
-          difficulty: "Intern",
-          ...INTERN_ONE_BUILD_PLAYS[scenario.id],
-        });
-        expectNoViolations(active);
-        expect(active.actionCount).toBe(1);
-        expect(active.builds).toHaveLength(1);
-        expect(active.outcome).toBe("completed");
-      });
-    },
-  );
-
-  SCENARIOS.filter(
-    (scenario) => !scenario.tutorialSteps && scenario.id < 106,
-  ).forEach((scenario) => {
-    it(`rejects passive play and accepts a multi-action plan in "${scenario.name}" on CEO`, () => {
+  scenarios.forEach((scenario) => {
+    it(`requires ten validated decisions in "${scenario.name}" on CEO`, () => {
       const passive = runSimulation({
         scenarioId: scenario.id,
         difficulty: "CEO",
       });
       expectNoViolations(passive);
       expect(passive.actionCount).toBe(0);
+      expect(passive.meaningfulDecisionCount).toBe(0);
       expect(passive.outcome).not.toBe("completed");
 
       const play = STANDARD_BALANCE_PLAYS[scenario.id];
@@ -682,8 +661,72 @@ describe("simulation economics", () => {
         ...play,
       });
       expectNoViolations(active);
-      expect(active.actionCount).toBeGreaterThanOrEqual(3);
+      expect(active.meaningfulDecisionCount).toBe(10);
+      expect(new Set(active.meaningfulDecisionKeys).size).toBe(10);
       expect(active.outcome).toBe("completed");
+    });
+  });
+
+  it.each([107, 111])(
+    "keeps Intern scenario %s passive-fail / one-build-win across seeds 1-20",
+    (scenarioId) => {
+      for (let seed = 1; seed <= 20; seed++) {
+        const passive = runSimulation({
+          scenarioId,
+          difficulty: "Intern",
+          seed,
+        });
+        const active = runSimulation({
+          scenarioId,
+          difficulty: "Intern",
+          seed,
+          ...INTERN_ONE_BUILD_PLAYS[scenarioId],
+        });
+        expectNoViolations(passive);
+        expectNoViolations(active);
+        expect([seed, passive.outcome]).not.toEqual([seed, "completed"]);
+        expect([seed, active.outcome]).toEqual([seed, "completed"]);
+        expect(active.meaningfulDecisionCount).toBe(1);
+      }
+    },
+  );
+
+  it.each([1, 7, 20])(
+    "wins all CEO playbooks with ten decisions on representative seed %s",
+    (seed) => {
+      scenarios.forEach((scenario) => {
+        const active = runSimulation({
+          scenarioId: scenario.id,
+          difficulty: "CEO",
+          seed,
+          ...STANDARD_BALANCE_PLAYS[scenario.id],
+        });
+        expectNoViolations(active);
+        expect([
+          scenario.id,
+          active.meaningfulDecisionCount,
+          active.outcome,
+        ]).toEqual([scenario.id, 10, "completed"]);
+      });
+    },
+  );
+
+  it("rejects every one-action deletion from the authored ten-decision CEO plans", () => {
+    scenarios.forEach((scenario) => {
+      const play = STANDARD_BALANCE_PLAYS[scenario.id];
+      const authoredActionCount =
+        (play.scheduledActions?.length || 0) +
+        (play.initialBuild ? 1 : 0) +
+        (play.sellFacilityId !== undefined ? 1 : 0);
+      expect(authoredActionCount).toBe(10);
+
+      // Every possible one-action deletion leaves nine accepted commitments, so the explicit
+      // decision gate rejects it independently of how comfortably the economic goals were met.
+      for (let omitted = 0; omitted < authoredActionCount; omitted++) {
+        expect(scenarioObjectiveFailure(scenario, [], "CEO", 9)).toMatch(
+          /meaningful decisions/i,
+        );
+      }
     });
   });
 

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -3,7 +3,12 @@
 // the reducer directly. Importing Store creates and registers it.
 import cloneDeep from "lodash.clonedeep";
 import { schedulePolicy } from "../reducers/GameActions";
-import type { PolicyId, PolicyTier, TradingPolicyType } from "../Types";
+import type {
+  MeaningfulDecisionKindType,
+  PolicyId,
+  PolicyTier,
+  TradingPolicyType,
+} from "../Types";
 import "../Store";
 import gameReducer, {
   buildTransmissionLine,
@@ -26,6 +31,7 @@ import { SCENARIOS } from "../data/Scenarios";
 import { getStartingCustomers } from "../data/LocationProfiles";
 import { getTimeFromTimeline } from "../helpers/DateTime";
 import { getScenarioLocation } from "../helpers/Locations";
+import { meaningfulDecisionCategoryCount } from "../helpers/MeaningfulDecisions";
 import {
   ActiveWorldEventType,
   DifficultyType,
@@ -62,7 +68,7 @@ export type ScheduledSimActionType =
   | { month: number; type: "build"; build: InitialBuildType }
   | { month: number; type: "sell"; facilityId: number }
   | { month: number; type: "toggle"; facilityId: number }
-  | { month: number; type: "reprioritize"; spotInList: number; delta: number }
+  | { month: number; type: "reprioritize"; facilityId: number }
   | { month: number; type: "policy"; id: PolicyId; tier: PolicyTier }
   | { month: number; type: "trading"; policy: TradingPolicyType }
   | { month: number; type: "intertie"; corridorId: string; financed: boolean };
@@ -137,7 +143,10 @@ export interface SimResultType {
   outcome: "completed" | "bankrupt" | "fired";
   actionCount: number;
   meaningfulDecisionCount: number;
+  meaningfulDecisionCategoryCount: number;
+  meaningfulDecisionCategories: MeaningfulDecisionKindType[];
   meaningfulDecisionKeys: string[];
+  meaningfulDecisionLabels: string[];
   builds: BuildRecordType[];
   // Mean fill level of the storage fleet across the run, 0 - 1, or null with no storage built
   averageStateOfCharge: number | null;
@@ -455,15 +464,20 @@ export function runSimulation(options: SimOptionsType): SimResultType {
             );
             break;
           case "reprioritize":
-            state = cloneDeep(
-              gameReducer(
-                state,
-                reprioritizeFacility({
-                  spotInList: action.spotInList,
-                  delta: action.delta,
-                }),
-              ),
-            );
+            {
+              const spotInList = state.facilities.findIndex(
+                ({ id }) => id === action.facilityId,
+              );
+              state = cloneDeep(
+                gameReducer(
+                  state,
+                  reprioritizeFacility({
+                    spotInList,
+                    delta: spotInList === 0 ? 1 : -1,
+                  }),
+                ),
+              );
+            }
             break;
           case "policy":
             state = cloneDeep(
@@ -601,7 +615,8 @@ export function runSimulation(options: SimOptionsType): SimResultType {
       scenario,
       state.monthlyHistory,
       state.difficulty,
-      state.meaningfulDecisions.length,
+      state.meaningfulDecisions,
+      !!state.meaningfulDecisionGateWaived,
     )
   ) {
     firedAtMonth = state.date.monthsElapsed;
@@ -627,7 +642,16 @@ export function runSimulation(options: SimOptionsType): SimResultType {
           : "completed",
     actionCount: state.replayLog?.length || 0,
     meaningfulDecisionCount: state.meaningfulDecisions.length,
+    meaningfulDecisionCategoryCount: meaningfulDecisionCategoryCount(
+      state.meaningfulDecisions,
+    ),
+    meaningfulDecisionCategories: Array.from(
+      new Set(state.meaningfulDecisions.map(({ kind }) => kind)),
+    ).sort(),
     meaningfulDecisionKeys: state.meaningfulDecisions.map(({ key }) => key),
+    meaningfulDecisionLabels: state.meaningfulDecisions.map(
+      ({ label }) => label,
+    ),
     builds,
     averageStateOfCharge: stateOfChargeTicks
       ? stateOfChargeSum / stateOfChargeTicks

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -3,18 +3,22 @@
 // the reducer directly. Importing Store creates and registers it.
 import cloneDeep from "lodash.clonedeep";
 import { schedulePolicy } from "../reducers/GameActions";
-import type { PolicyId, PolicyTier } from "../Types";
+import type { PolicyId, PolicyTier, TradingPolicyType } from "../Types";
 import "../Store";
 import gameReducer, {
+  buildTransmissionLine,
   buildFacility,
   delta,
   initGame,
   hasChronicBlackouts,
   scenarioObjectiveFailure,
+  reprioritizeFacility,
+  setTradingPolicy,
   start,
   startReplay,
   sellFacility,
   tickState,
+  togglePauseFacility,
 } from "../reducers/Game";
 import { DIFFICULTIES } from "../Constants";
 import { GENERATORS, STORAGE } from "../data/Facilities";
@@ -26,6 +30,7 @@ import {
   ActiveWorldEventType,
   DifficultyType,
   FacilityOperatingType,
+  FacilityShoppingType,
   GameType,
   GeneratorShoppingType,
   LocationType,
@@ -51,6 +56,16 @@ interface InitialBuildBaseType {
 
 export type InitialBuildType = InitialBuildBaseType &
   ({ peakW: number; peakWh?: never } | { peakWh: number; peakW?: never });
+
+export type ScheduledSimActionType =
+  | { month: number; type: "rate"; dollarsPerkWh: number }
+  | { month: number; type: "build"; build: InitialBuildType }
+  | { month: number; type: "sell"; facilityId: number }
+  | { month: number; type: "toggle"; facilityId: number }
+  | { month: number; type: "reprioritize"; spotInList: number; delta: number }
+  | { month: number; type: "policy"; id: PolicyId; tier: PolicyTier }
+  | { month: number; type: "trading"; policy: TradingPolicyType }
+  | { month: number; type: "intertie"; corridorId: string; financed: boolean };
 
 /**
  * Where a scenario is played, or a hard failure. The browser can put an alert on screen and go
@@ -83,6 +98,7 @@ export interface SimOptionsType {
   sellFacilityId?: number;
   sellAtMonth?: number;
   storyEffectsEnabled?: boolean;
+  scheduledActions?: ScheduledSimActionType[];
 }
 
 export interface ResolvedSimOptionsType {
@@ -97,6 +113,7 @@ export interface ResolvedSimOptionsType {
   sellFacilityId: number | null;
   sellAtMonth: number;
   storyEffectsEnabled: boolean;
+  scheduledActions: ScheduledSimActionType[];
 }
 
 export interface BuildRecordType {
@@ -119,6 +136,8 @@ export interface SimResultType {
   firedAtMonth: number | null;
   outcome: "completed" | "bankrupt" | "fired";
   actionCount: number;
+  meaningfulDecisionCount: number;
+  meaningfulDecisionKeys: string[];
   builds: BuildRecordType[];
   // Mean fill level of the storage fleet across the run, 0 - 1, or null with no storage built
   averageStateOfCharge: number | null;
@@ -334,7 +353,28 @@ function resolveOptions(
     sellFacilityId: options.sellFacilityId ?? null,
     sellAtMonth: options.sellAtMonth || 0,
     storyEffectsEnabled: options.storyEffectsEnabled !== false,
+    scheduledActions: options.scheduledActions || [],
   };
+}
+
+function shoppingFacility(
+  state: GameType,
+  build: InitialBuildType,
+): FacilityShoppingType | undefined {
+  return build.peakWh !== undefined
+    ? STORAGE(state, build.peakWh).find(
+        (facility) => facility.available && facility.name === build.name,
+      )
+    : GENERATORS(
+        state,
+        build.peakW,
+        state.timeline.map((tick) => tick.windKph),
+        state.timeline.map((tick) => tick.solarIrradianceWM2),
+        state.timeline
+          .map((tick) => tick.windOffshoreKph)
+          .filter((wind): wind is number => wind !== undefined),
+        state.timeline.map((tick) => tick.windAirborneKph),
+      ).find((facility) => facility.available && facility.name === build.name);
 }
 
 export function runSimulation(options: SimOptionsType): SimResultType {
@@ -364,6 +404,99 @@ export function runSimulation(options: SimOptionsType): SimResultType {
         },
       ]
     : [];
+  const applyScheduledActions = (month: number) => {
+    resolved.scheduledActions
+      .filter((action) => action.month === month)
+      .forEach((action) => {
+        const previousIds = new Set(state.facilities.map(({ id }) => id));
+        switch (action.type) {
+          case "rate":
+            state = cloneDeep(
+              gameReducer(
+                state,
+                delta({ dollarsPerkWh: action.dollarsPerkWh }),
+              ),
+            );
+            break;
+          case "build": {
+            const facility = shoppingFacility(state, action.build);
+            if (!facility)
+              throw new Error(
+                `Cannot build ${action.build.name} in ${scenario.name}`,
+              );
+            state = cloneDeep(
+              gameReducer(
+                state,
+                buildFacility({
+                  facility,
+                  financed: action.build.financed,
+                }),
+              ),
+            );
+            const added = state.facilities.find(
+              ({ id }) => !previousIds.has(id),
+            );
+            if (added)
+              builds.push({
+                month,
+                name: added.name,
+                buildCost: added.buildCost,
+              });
+            break;
+          }
+          case "sell":
+            state = cloneDeep(
+              gameReducer(state, sellFacility(action.facilityId)),
+            );
+            break;
+          case "toggle":
+            state = cloneDeep(
+              gameReducer(state, togglePauseFacility(action.facilityId)),
+            );
+            break;
+          case "reprioritize":
+            state = cloneDeep(
+              gameReducer(
+                state,
+                reprioritizeFacility({
+                  spotInList: action.spotInList,
+                  delta: action.delta,
+                }),
+              ),
+            );
+            break;
+          case "policy":
+            state = cloneDeep(
+              gameReducer(
+                state,
+                schedulePolicy({
+                  id: action.id,
+                  tier: action.tier,
+                  month: month + 1,
+                }),
+              ),
+            );
+            break;
+          case "trading":
+            state = cloneDeep(
+              gameReducer(state, setTradingPolicy(action.policy)),
+            );
+            break;
+          case "intertie":
+            state = cloneDeep(
+              gameReducer(
+                state,
+                buildTransmissionLine({
+                  corridorId: action.corridorId,
+                  financed: action.financed,
+                }),
+              ),
+            );
+            break;
+        }
+      });
+  };
+  applyScheduledActions(0);
   let stateOfChargeSum = 0;
   let stateOfChargeTicks = 0;
   let ticks = 0;
@@ -453,6 +586,9 @@ export function runSimulation(options: SimOptionsType): SimResultType {
         justBuilt = true;
       }
     }
+    if (state.date.monthsElapsed < resolved.months) {
+      applyScheduledActions(state.date.monthsElapsed);
+    }
     // The timeline was just regenerated and pre-rolled, so tick continuity restarts next tick
     prevTick = null;
   }
@@ -461,7 +597,12 @@ export function runSimulation(options: SimOptionsType): SimResultType {
     firedAtMonth === null &&
     bankruptAtMonth === null &&
     state.date.monthsElapsed >= scenario.durationMonths &&
-    scenarioObjectiveFailure(scenario, state.monthlyHistory)
+    scenarioObjectiveFailure(
+      scenario,
+      state.monthlyHistory,
+      state.difficulty,
+      state.meaningfulDecisions.length,
+    )
   ) {
     firedAtMonth = state.date.monthsElapsed;
   }
@@ -485,6 +626,8 @@ export function runSimulation(options: SimOptionsType): SimResultType {
           ? "fired"
           : "completed",
     actionCount: state.replayLog?.length || 0,
+    meaningfulDecisionCount: state.meaningfulDecisions.length,
+    meaningfulDecisionKeys: state.meaningfulDecisions.map(({ key }) => key),
     builds,
     averageStateOfCharge: stateOfChargeTicks
       ? stateOfChargeSum / stateOfChargeTicks


### PR DESCRIPTION
Closes #61.

## Summary

- Adds deterministic adjacent electricity markets, temperature/solar-adjusted intertie ratings, construction, financing, dispatch, reserve-protected exports, and trade cash flow.
- Adds researched intertie profiles for all 285 planned locations, including all 113 currently downloaded cities: 254 connected locations, 31 explicit no-intertie locations, and 302 unique markets/corridors.
- Completely hides Interties and Power exchange for islanded grids such as Hawaii and Puerto Rico; unknown custom locations also default to no interties.
- Preserves real grid seams, connected islands such as Ireland/Tasmania/New Zealand, operating-vs-proposed route distinctions, and existing California save/replay IDs.
- Adds Facilities `Plants | Interties` controls and an Insights `Power exchange` layer using the standard circular `transmission.svg` icon with a 40 px boundary and two large opposing arrows with 20 px primary strokes.
- Adds Mission 7, a ten-step interties tutorial covering financing, construction, shortage imports, weather-limited capacity, and reserve-safe exports. Missions 1–6 remain transmission-free.
- Prevents auto-winning: Intern requires one visible, validated meaningful decision; CEO requires ten material, persistent decisions across at least four categories.
- Adds lifetime decision tracking with anti-churn/inverse cancellation, materiality filters, labeled progress, deterministic save/replay support, and visible legacy-run grandfathering.

## Research and coverage

- Every ID in `scripts/cities.json` maps exactly once to an enabled profile or an explicit no-intertie result.
- Market/corridor facts were researched from system operators, transmission organizations, utilities, energy ministries, and regional power-pool sources; gameplay costs/capacities are clearly treated as calibrated abstractions.
- Profile tests enforce unique IDs, valid market references, nonnegative values, stable California compatibility IDs, and representative island/connected/proposed-only cases.

## Verification

- TypeScript, ESLint, Prettier, production build, and `npm run sim -- --all` pass.
- All 11 non-tutorial scenarios reject passive Intern play and accept a meaningful one-build plan.
- Deep Freeze and Wildfire pass passive-fail / active-win checks across seeds 1–20 with all invariants clean.
- All 11 CEO scenarios complete with exactly ten validated decisions spanning 5–7 categories on seeds 1, 7, and 20.
- All 110 real one-action-deleted CEO playthroughs fail completion; no shortened plan wins.
- Location/tutorial focused QA: 192 Jest tests passed; Mission 7 and connected/island flows pass all six desktop and 320 px Playwright cases.
- Final independent design and QA reviews found no blocking, high, or medium issues.
- Post-merge regression pass: all 105 Jest suites (1,040 tests), typecheck, lint, formatting, scenarios, and simulation invariants pass.

Note: on Windows, Jest/CRA occasionally retain an open handle after reporting passing results; affected runs were stopped only after their assertions completed.

## Screenshots

![transmission-desktop](https://github.com/user-attachments/assets/04ea685d-43ca-47d9-bbe5-64e4003ac5d7)

![transmission-phone](https://github.com/user-attachments/assets/35797d20-7895-4804-9501-ef2db493eec6)
