### PR TITLE
Fix Insights regressions and remove 92 low-value tests

### DIFF
--- a/e2e/insights-policy-projection.spec.ts
+++ b/e2e/insights-policy-projection.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+test("paused insights refresh customer programs and keep chart zoom after a palette change", async ({
+  page,
+}, testInfo) => {
+  await page.emulateMedia({ colorScheme: "light" });
+  await page.addInitScript(() => {
+    localStorage.clear();
+    localStorage.setItem("insightsLayers", JSON.stringify(["supplyDemand"]));
+  });
+  await page.goto("/?scenario=106");
+  await page.getByRole("button", { name: "Start game", exact: true }).click();
+  const insights = page.locator(".insights:visible");
+  if (!(await insights.isVisible()))
+    await page.getByRole("button", { name: "Insights", exact: true }).click();
+  const chart = insights.locator(".accessibleChart [role=img]").first();
+  const before = await chart.getAttribute("aria-label");
+  await insights
+    .getByRole("button", { name: "Customer programs", exact: true })
+    .click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByRole("button", { name: /Efficiency.*Off/i }).click();
+  await dialog.getByRole("radio", { name: /^Large/ }).check();
+  await dialog.getByRole("button", { name: "Start next month" }).click();
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+  await expect(chart).not.toHaveAttribute("aria-label", before!);
+  const span = async () =>
+    Number(await chart.getAttribute("data-viewport-max")) -
+    Number(await chart.getAttribute("data-viewport-min"));
+  const zoom = async () => {
+    const initialSpan = await span();
+    await chart.locator(".u-over").hover();
+    await page.keyboard.down("Control");
+    await page.mouse.wheel(0, -120);
+    await page.keyboard.up("Control");
+    await expect.poll(span).toBeLessThan(initialSpan);
+  };
+  await zoom();
+  const zoomedSpan = await span();
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  expect(await span()).toBe(zoomedSpan);
+  await zoom();
+  await page.mouse.move(0, 0);
+  await page.screenshot({
+    path: testInfo.outputPath("insights-program-zoom-dark.png"),
+  });
+});

--- a/src/SaveFile.test.tsx
+++ b/src/SaveFile.test.tsx
@@ -73,12 +73,6 @@ describe("SaveFile", () => {
   });
 
   describe("saveFilename", () => {
-    it("slugs the scenario name", () => {
-      expect(saveFilename("Rise of Renewables", 2035)).toBe(
-        "electrify-rise-of-renewables-2035.json",
-      );
-    });
-
     // A custom game's name is typed by the player, so it reaches here as anything at all
     it("folds away everything a filename shouldn't carry", () => {
       expect(saveFilename("../../etc/passwd", 2020)).toBe(
@@ -128,13 +122,6 @@ describe("SaveFile", () => {
   });
 
   describe("readSaveFile", () => {
-    it("accepts a save this build can play", async () => {
-      const game = fakeGame();
-      const { save, error } = await readSaveFile(saveFile(serializeSave(game)));
-      expect(error).toBeUndefined();
-      expect(save?.game.seed).toBe(game.seed);
-    });
-
     it("round trips an exported save", async () => {
       writeSave(fakeGame());
       const exported = resumableSave()!.save;

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -90,10 +90,6 @@ describe("SaveGame", () => {
     });
   });
 
-  it("reports no save when nothing has been written", () => {
-    expect(readSave()).toBeNull();
-  });
-
   it("forgets the save it just cleared", () => {
     writeSave(game);
     expect(readSave()).not.toBeNull();
@@ -322,16 +318,6 @@ describe("SaveGame", () => {
 
     // What quit leaves behind
     const quit = { ...game, inGame: false };
-
-    it("writes as soon as a game starts", () => {
-      const store = fakeStore(quit);
-      const stop = startAutosave(store as never, () => true);
-
-      store.set(playing(game, 2020, 0));
-      expect(readSave()!.game.date.year).toBe(2020);
-
-      stop();
-    });
 
     it("writes once a year, at the turn of the year", () => {
       const store = fakeStore(quit);

--- a/src/components/CompositorContainer.test.tsx
+++ b/src/components/CompositorContainer.test.tsx
@@ -71,28 +71,6 @@ function navigatedTo(dispatched: UnknownAction[]): CardNameType | undefined {
 describe("onTutorialStep", () => {
   const generators = walkthrough("Mission 2: Generators");
 
-  it("moves the walkthrough to the new step", () => {
-    const dispatched = step({
-      steps: generators,
-      fromStep: 0,
-      toStep: 1,
-      currentCard: STARTING_CARD,
-    });
-    expect(dispatched).toContainEqual(
-      expect.objectContaining({ payload: { tutorialStep: 1 } }),
-    );
-  });
-
-  it("navigates forwards onto the card holding the next step's target", () => {
-    const dispatched = step({
-      steps: generators,
-      fromStep: 0,
-      toStep: 1,
-      currentCard: STARTING_CARD,
-    });
-    expect(navigatedTo(dispatched)).toBe("BUILD_GENERATORS");
-  });
-
   /**
    * Regression test. Back used to dispatch the previous step's onNext, which only ever modelled
    * moving forwards, so nothing undid the navigation the forward step performed: the player was
@@ -253,10 +231,6 @@ describe("walkthrough steps", () => {
     togglePauseFacility.type,
   ]);
 
-  it("covers every walkthrough", () => {
-    expect(tutorials.length).toBeGreaterThan(0);
-  });
-
   it("uses real game actions for every action gate", () => {
     const declared = tutorials.flatMap(
       (scenario) =>
@@ -267,22 +241,6 @@ describe("walkthrough steps", () => {
         ) || [],
     );
     expect(declared.filter((type) => !actionGateTypes.has(type))).toEqual([]);
-  });
-
-  it("uses the same symbols as the generator and storage buttons it highlights", () => {
-    const conceptsOf = (step: TutorialStepType) =>
-      React.isValidElement<{ concepts?: string[] }>(step.content)
-        ? step.content.props.concepts
-        : undefined;
-    const generatorStep = walkthrough("Mission 2: Generators").find(
-      (step) => step.target === ".button-buildGenerator",
-    )!;
-    const storageStep = walkthrough("Mission 3: Storage").find(
-      (step) => step.target === ".button-buildStorage",
-    )!;
-
-    expect(conceptsOf(generatorStep)).toEqual(["build", "generator"]);
-    expect(conceptsOf(storageStep)).toEqual(["build", "storage"]);
   });
 
   it("declares the card every tutorial target lives on", () => {

--- a/src/components/base/GameAppBar.test.tsx
+++ b/src/components/base/GameAppBar.test.tsx
@@ -159,21 +159,6 @@ describe("GameAppBar", () => {
     ).toBe(500000);
   });
 
-  it("omits the redundant money and time icons on desktop", () => {
-    renderAppBar();
-    expect(screen.queryByLabelText("Money")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Time")).not.toBeInTheDocument();
-  });
-
-  it("omits events and sound controls from the menu", () => {
-    renderAppBar();
-    fireEvent.click(screen.getByRole("button", { name: "menu" }));
-
-    expect(screen.queryByRole("menuitem", { name: /events/i })).toBeNull();
-    expect(screen.queryByRole("menuitem", { name: /turn sound/i })).toBeNull();
-    expect(screen.getByRole("menuitem", { name: "Options" })).toBeVisible();
-  });
-
   it("gives the scenario dialog only the scenario name", () => {
     renderAppBar();
     fireEvent.click(screen.getByRole("button", { name: "menu" }));

--- a/src/components/base/TutorialHud.test.tsx
+++ b/src/components/base/TutorialHud.test.tsx
@@ -55,14 +55,6 @@ describe("TutorialHud", () => {
     expect(hudProps.onExit).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the compact objective visible without collapse controls", () => {
-    render(<TutorialHud {...props()} />);
-
-    expect(screen.getByText("Keep supply above demand.")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Collapse objective")).toBeNull();
-    expect(screen.queryByLabelText("Expand objective")).toBeNull();
-  });
-
   it("reveals help only when requested and has no redundant Next for gates", async () => {
     const user = userEvent.setup();
     render(

--- a/src/components/base/TutorialPrompt.test.tsx
+++ b/src/components/base/TutorialPrompt.test.tsx
@@ -3,19 +3,6 @@ import { render, screen } from "@testing-library/react";
 import TutorialPrompt from "./TutorialPrompt";
 
 describe("TutorialPrompt", () => {
-  it("keeps the instruction to one concise line", () => {
-    render(
-      <TutorialPrompt
-        concepts={["build", "generator"]}
-        text="Open the generator shop."
-      />,
-    );
-
-    expect(screen.getByText("Open the generator shop.")).toBeInTheDocument();
-    expect(screen.queryByText("Do this to continue:")).toBeNull();
-    expect(screen.queryByRole("status")).toBeNull();
-  });
-
   it("gives the concept sequence an accessible summary", () => {
     render(<TutorialPrompt concepts={["supply", "demand"]} />);
 

--- a/src/components/base/UPlotChart.test.tsx
+++ b/src/components/base/UPlotChart.test.tsx
@@ -2,10 +2,10 @@ import { act, render } from "@testing-library/react";
 import uPlot from "uplot";
 import UPlotChart from "./UPlotChart";
 import { ChartViewportContext } from "./ChartViewportContext";
+import { setThemeMode } from "../../Theme";
 
 jest.mock("uplot", () => {
   const MockUPlot = jest.fn();
-  MockUPlot.prototype.over = global.document.createElement("div");
   MockUPlot.prototype.cursor = {};
   MockUPlot.prototype.setData = jest.fn();
   MockUPlot.prototype.setSize = jest.fn();
@@ -33,11 +33,19 @@ describe("UPlotChart resizing", () => {
   ).prototype;
   let width = 400;
   let resize: ResizeObserverCallback;
+  const currentPlot = () =>
+    (uPlot as unknown as jest.Mock).mock.results.at(-1)?.value;
 
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
+    (uPlot as unknown as jest.Mock).mockImplementation(() =>
+      Object.assign(Object.create(uPlotPrototype), {
+        over: document.createElement("div"),
+      }),
+    );
     width = 400;
+    setThemeMode("light");
     jest.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
       () =>
         ({
@@ -147,7 +155,7 @@ describe("UPlotChart resizing", () => {
       cancelable: true,
       deltaY: 100,
     });
-    uPlotPrototype.over.dispatchEvent(ordinaryWheel);
+    currentPlot().over.dispatchEvent(ordinaryWheel);
     expect(ordinaryWheel.defaultPrevented).toBe(false);
 
     const zoomWheel = new WheelEvent("wheel", {
@@ -158,7 +166,7 @@ describe("UPlotChart resizing", () => {
       deltaY: -120,
     });
     act(() => {
-      uPlotPrototype.over.dispatchEvent(zoomWheel);
+      currentPlot().over.dispatchEvent(zoomWheel);
       jest.advanceTimersByTime(200);
     });
     expect(zoomWheel.defaultPrevented).toBe(true);
@@ -172,7 +180,7 @@ describe("UPlotChart resizing", () => {
     const pointer = (type: string, values: Record<string, string | number>) => {
       const event = new Event(type, { bubbles: true, cancelable: true });
       Object.assign(event, values);
-      uPlotPrototype.over.dispatchEvent(event);
+      currentPlot().over.dispatchEvent(event);
     };
     render(
       <ChartViewportContext.Provider
@@ -248,4 +256,86 @@ describe("UPlotChart resizing", () => {
     const pinched = onRangeChange.mock.calls.at(-1)?.[0];
     expect(pinched[1] - pinched[0]).toBeLessThan(50);
   });
+
+  it.each(["theme", "structure", "height"])(
+    "restores the viewport and gestures after a %s rebuild",
+    (change) => {
+      const onRangeChange = jest.fn();
+      const onReset = jest.fn();
+      const viewport = {
+        bounds: [0, 100] as [number, number],
+        range: [25, 75] as [number, number],
+        minSpan: 10,
+        onRangeChange,
+        onReset,
+      };
+      const ui = (changed = false) => (
+        <ChartViewportContext.Provider value={viewport}>
+          <UPlotChart
+            ariaLabel="Rebuilt chart"
+            state={{}}
+            data={[
+              [0, 100],
+              [2, 3],
+            ]}
+            height={changed && change === "height" ? 400 : 300}
+            structureKey={
+              changed && change === "structure" ? "changed" : "initial"
+            }
+            buildOptions={() => ({ width: 0, height: 0, series: [{}, {}] })}
+          />
+        </ChartViewportContext.Provider>
+      );
+      const view = render(ui());
+      const oldOver = currentPlot().over;
+      uPlotPrototype.setScale.mockClear();
+      if (change === "theme") act(() => setThemeMode("dark"));
+      else view.rerender(ui(true));
+      const over = currentPlot().over;
+      expect(over).not.toBe(oldOver);
+      expect(uPlotPrototype.setScale).toHaveBeenCalledWith("x", {
+        min: 25,
+        max: 75,
+      });
+      const wheel = () =>
+        new WheelEvent("wheel", {
+          ctrlKey: true,
+          deltaY: -120,
+          clientX: 200,
+          cancelable: true,
+        });
+      act(() => {
+        oldOver.dispatchEvent(wheel());
+        jest.advanceTimersByTime(200);
+      });
+      expect(onRangeChange).not.toHaveBeenCalled();
+      act(() => {
+        over.dispatchEvent(wheel());
+        jest.advanceTimersByTime(200);
+      });
+      const zoomed = onRangeChange.mock.calls.at(-1)?.[0];
+      expect(zoomed[1] - zoomed[0]).toBeLessThan(50);
+      onRangeChange.mockClear();
+      act(() => {
+        for (const [type, clientX] of [
+          ["pointerdown", 100],
+          ["pointermove", 80],
+          ["pointerup", 80],
+        ] as const) {
+          const event = new Event(type, { cancelable: true });
+          Object.assign(event, {
+            pointerId: 1,
+            pointerType: "mouse",
+            button: 0,
+            clientX,
+            clientY: 10,
+          });
+          over.dispatchEvent(event);
+        }
+      });
+      expect(onRangeChange).toHaveBeenLastCalledWith([50, 100], true);
+      over.dispatchEvent(new MouseEvent("dblclick", { cancelable: true }));
+      expect(onReset).toHaveBeenCalledWith(true);
+    },
+  );
 });

--- a/src/components/base/UPlotChart.tsx
+++ b/src/components/base/UPlotChart.tsx
@@ -330,7 +330,7 @@ export default function UPlotChart<S>(
         max: viewport.range[1],
       });
     }
-  }, [viewport, width]);
+  }, [viewport, width, height, structureKey, themeVersion]);
 
   React.useLayoutEffect(() => {
     const plot = plotRef.current;
@@ -521,7 +521,7 @@ export default function UPlotChart<S>(
       if (frame !== undefined) cancelAnimationFrame(frame);
       if (wheelTimer) clearTimeout(wheelTimer);
     };
-  }, [width, viewportEnabled]);
+  }, [width, height, structureKey, themeVersion, viewportEnabled]);
 
   React.useLayoutEffect(() => {
     plotRef.current?.redraw();

--- a/src/components/views/BuildStorage.test.tsx
+++ b/src/components/views/BuildStorage.test.tsx
@@ -64,21 +64,6 @@ it("keeps toolbar actions inside compact viewport gutters", () => {
   ).not.toHaveClass("MuiIconButton-edgeEnd");
 });
 
-it("shows decision context without live-time controls", () => {
-  render(
-    <BuildStorage
-      game={game()}
-      onBuildStorage={jest.fn()}
-      onBack={jest.fn()}
-    />,
-  );
-
-  expect(screen.getByText("Build Storage")).toBeInTheDocument();
-  expect(screen.getByLabelText(/Available cash/)).toHaveTextContent("cash");
-  expect(screen.getByText("Capacity")).toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "pause" })).toBeNull();
-});
-
 it("shows the current sort text when the controls have enough width", () => {
   const originalMatchMedia = window.matchMedia;
   window.matchMedia = (query: string) =>

--- a/src/components/views/EventLog.test.tsx
+++ b/src/components/views/EventLog.test.tsx
@@ -102,42 +102,6 @@ describe("EventLog", () => {
     expect(screen.getByText("Event history")).toBeVisible();
   });
 
-  it("keeps upcoming and past events in labeled sections", () => {
-    render(
-      <EventLog
-        events={[
-          {
-            id: 1,
-            kind: "BUILD",
-            label: "Jan 2024",
-            message: "Solar project started.",
-          },
-          {
-            id: 2,
-            kind: "CONSTRUCTION",
-            label: "Feb 2024",
-            message: "Solar project finished.",
-          },
-        ]}
-        upcoming={[
-          {
-            key: "next",
-            label: "Mar 2024",
-            message: "Demand will rise.",
-          },
-        ]}
-        onOpen={jest.fn()}
-        onSelect={jest.fn()}
-      />,
-    );
-
-    expect(screen.getByText("Upcoming events")).toBeVisible();
-    expect(screen.getByText("Event history")).toBeVisible();
-    expect(
-      screen.queryByText(/recorded after they happen/i),
-    ).not.toBeInTheDocument();
-  });
-
   it("filters event history into useful event groups", async () => {
     const user = userEvent.setup();
     render(

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -192,19 +192,6 @@ describe("the fleet list", () => {
     );
   });
 
-  it("renders the reasonable worst-case fleet size", () => {
-    const tenFacilities = createGame({ scenarioId: 103 });
-    const template = tenFacilities.facilities[0];
-    tenFacilities.facilities = Array.from({ length: 10 }, (_, index) => ({
-      ...template,
-      id: index + 1,
-    }));
-
-    renderFacilities(tenFacilities, null);
-
-    expect(rows()).toHaveLength(10);
-  });
-
   it("uses compact watt units in the accessible chart summary", () => {
     renderFacilities(game, null);
 

--- a/src/components/views/Finances.test.tsx
+++ b/src/components/views/Finances.test.tsx
@@ -10,7 +10,7 @@ import Finances, {
 } from "./Finances";
 import { createGame } from "../../testing/Simulator";
 import { tickState } from "../../reducers/Game";
-import { MINUTES_PER_MONTH, summarizeTimeline } from "../../helpers/DateTime";
+import { summarizeTimeline } from "../../helpers/DateTime";
 import { GameType, MonthlyHistoryType, SpeedType } from "../../Types";
 
 // Every test in here plays a couple of game years and then renders the real pane, chart and all.
@@ -157,20 +157,6 @@ describe("the Finances chart selectors", () => {
     }
   });
 
-  it("keeps the dropdown in sync on paused and throttled paths", async () => {
-    for (const speed of ["PAUSED", "FAST"] as SpeedType[]) {
-      localStorage.clear();
-      renderFinances(game, speed);
-
-      await choose(metricSelect(), "Revenue");
-      await choose(metricSelect(), "Expenses");
-
-      expect(metricSelect()).toHaveTextContent("Expenses");
-      expect(plottedMetric()).toContain("Expenses");
-      cleanup();
-    }
-  });
-
   it("replots period changes on paused and throttled paths", async () => {
     for (const speed of ["PAUSED", "FAST"] as SpeedType[]) {
       localStorage.clear();
@@ -249,10 +235,6 @@ describe("the Finances chart selectors", () => {
 });
 
 describe("parseRange", () => {
-  it("should follow the clock rather than pinning the year it was chosen in", () => {
-    expect(parseRange("current", 2050)).toEqual({ mode: "year", year: 2050 });
-  });
-
   it("should read a year the game has been to as that year", () => {
     expect(parseRange("2032", 2050)).toEqual({ mode: "year", year: 2032 });
   });
@@ -260,10 +242,6 @@ describe("parseRange", () => {
   it("should read the forward ranges as horizons", () => {
     expect(parseRange("next1", 2050)).toEqual({ mode: "future", years: 1 });
     expect(parseRange("next20", 2050)).toEqual({ mode: "future", years: 20 });
-  });
-
-  it("should treat all time as its own mode", () => {
-    expect(parseRange("all", 2050)).toEqual({ mode: "all" });
   });
 
   /**
@@ -335,15 +313,6 @@ describe("projectMonths", () => {
     const cash = months.map((m: MonthlyHistoryType) => m.cash);
     expect(new Set(cash).size).toBeGreaterThan(1);
   });
-
-  it("should start where the live timeline's own month does", () => {
-    const game = createGame({ scenarioId: 103 });
-    const months = monthsAhead(game, 12);
-    expect(Math.floor(game.date.minute / MINUTES_PER_MONTH)).toEqual(
-      Math.floor(game.timeline[0].minute / MINUTES_PER_MONTH),
-    );
-    expect(months[0].month).toEqual(game.date.monthNumber);
-  });
 });
 
 /**
@@ -405,15 +374,6 @@ describe("the month over month column", () => {
         monthlyHistory: [game.monthlyHistory[0]],
       }),
     ).toBeUndefined();
-  });
-
-  it("puts the change beside each total once there are two months on the record", () => {
-    renderFinances(game, "PAUSED");
-    const comparison = getComparison(game);
-    expect(screen.getByText(comparison?.label || "")).toBeInTheDocument();
-    // Every metric gets one, even if it is the em dash that means it hasn't moved
-    expect(changeCell("Profit").textContent).not.toEqual("");
-    expect(changeCell("Revenue").textContent).not.toEqual("");
   });
 
   // Both point up, so the arrow alone can't tell these apart -- and colouring a rise in

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -3,7 +3,9 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EMPTY_HISTORY, MINUTES_PER_MONTH } from "../../helpers/DateTime";
 import { createGame } from "../../testing/Simulator";
-import { GameType } from "../../Types";
+import { GameType, TickPresentFutureType } from "../../Types";
+import gameReducer from "../../reducers/Game";
+import { schedulePolicy, cancelPolicy } from "../../reducers/GameActions";
 import Insights, {
   INSIGHT_LAYERS,
   INSIGHT_PRESETS,
@@ -31,6 +33,68 @@ const domainValue = (domain?: ChartMockProps["domain"]) =>
   JSON.stringify(Array.isArray(domain) ? domain : domain?.x);
 
 let mockSupplyDemandPaints = 0;
+
+it("refreshes paused projections when a customer program is scheduled, replaced, or cancelled", () => {
+  const game = createGame({ scenarioId: 106, seed: 4 });
+  const props = {
+    game,
+    onDelta: jest.fn(),
+    selectedFacilityId: null,
+    facilityDragActive: false,
+  };
+  const insights = new Insights(props);
+  const internals = insights as unknown as {
+    props: typeof props;
+    getProjection: (now: TickPresentFutureType) => {
+      timeline: TickPresentFutureType[];
+    };
+  };
+  const before = internals.getProjection(game.timeline[0]);
+  const change = {
+    id: "efficiency" as const,
+    tier: "Large" as const,
+    month: 1,
+  };
+  const project = (nextGame: GameType) => {
+    const nextProps = { ...props, game: nextGame };
+    expect(insights.shouldComponentUpdate(nextProps, insights.state)).toBe(
+      true,
+    );
+    internals.props = nextProps;
+    return internals.getProjection(nextGame.timeline[0]);
+  };
+  const scheduledGame = gameReducer(game, schedulePolicy(change));
+  const scheduled = project(scheduledGame);
+  const replacedGame = gameReducer(
+    scheduledGame,
+    schedulePolicy({ ...change, tier: "Small" }),
+  );
+  const replaced = project(replacedGame);
+  const cancelled = project(
+    gameReducer(replacedGame, cancelPolicy({ ...change, tier: "Small" })),
+  );
+  const future = (projection: typeof before) =>
+    projection.timeline.find((tick) => tick.minute >= 3 * MINUTES_PER_MONTH)!;
+  expect(future(scheduled).demandW).toBeLessThan(future(replaced).demandW);
+  expect(future(replaced).demandW).toBeLessThan(future(before).demandW);
+  expect(future(scheduled).expensesPolicy).toBeGreaterThan(
+    future(replaced).expensesPolicy!,
+  );
+  expect(future(replaced).expensesPolicy).toBeGreaterThan(0);
+  expect(cancelled.timeline).toEqual(before.timeline);
+  expect(
+    insights.shouldComponentUpdate(
+      {
+        ...internals.props,
+        game: {
+          ...internals.props.game,
+          policies: JSON.parse(JSON.stringify(internals.props.game.policies)),
+        },
+      },
+      insights.state,
+    ),
+  ).toBe(false);
+});
 
 jest.mock("../base/ChartFinances", () => ({
   __esModule: true,

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -7,10 +7,8 @@ import { GameType, TickPresentFutureType } from "../../Types";
 import gameReducer from "../../reducers/Game";
 import { schedulePolicy, cancelPolicy } from "../../reducers/GameActions";
 import Insights, {
-  INSIGHT_LAYERS,
   INSIGHT_PRESETS,
   MAX_CUSTOM_INSIGHT_PRESETS,
-  presetForLayers,
   withRequiredLayers,
 } from "./Insights";
 import { UpcomingStoryEventType } from "./StoryEventSelectors";
@@ -279,58 +277,6 @@ function storeCustomPreset(name: string) {
 describe("Insights layers", () => {
   beforeEach(() => localStorage.clear());
 
-  it("defines five distinct, purpose-ordered presets", () => {
-    expect(new Set(INSIGHT_LAYERS.map((layer) => layer.id)).size).toBe(
-      INSIGHT_LAYERS.length,
-    );
-    expect(Object.keys(INSIGHT_PRESETS)).toHaveLength(5);
-    expect(INSIGHT_PRESETS.overview.layers).toEqual([
-      "supplyDemand",
-      "cash",
-      "profit",
-      "customers",
-      "emissions",
-    ]);
-    expect(INSIGHT_PRESETS.reliability.layers).toEqual([
-      "supplyDemand",
-      "supplyByFuel",
-      "storage",
-      "weather",
-      "water",
-    ]);
-    expect(INSIGHT_PRESETS.profitability.layers).toEqual([
-      "profit",
-      "cash",
-      "revenue",
-      "expenses",
-      "fuelPrices",
-    ]);
-    expect(INSIGHT_PRESETS.growth.layers).toEqual([
-      "customers",
-      "demandByType",
-      "supplyDemand",
-      "revenue",
-      "profit",
-    ]);
-    expect(INSIGHT_PRESETS.decarbonization.layers).toEqual([
-      "emissions",
-      "supplyByFuel",
-      "supplyDemand",
-      "fuelPrices",
-      "profit",
-    ]);
-    expect(presetForLayers(INSIGHT_PRESETS.growth.layers)).toBe("growth");
-  });
-
-  it("groups demand with customers and places rates last in economics", () => {
-    expect(
-      INSIGHT_LAYERS.find((layer) => layer.id === "demandByType")?.group,
-    ).toBe("Customers");
-    expect(
-      INSIGHT_LAYERS.filter((layer) => layer.group === "Economics").at(-1)?.id,
-    ).toBe("inflationInterest");
-  });
-
   it("shows expanded finance rows and both rate graphs", () => {
     localStorage.setItem(
       "insightsLayers",
@@ -506,16 +452,6 @@ describe("Insights layers", () => {
     expect(
       screen.queryByRole("region", { name: "Upcoming scenario events" }),
     ).toBeNull();
-  });
-
-  it("replaces preset horizons with a displayed 12-month date range", () => {
-    localStorage.setItem("insightsRange", "current");
-    renderInsights();
-
-    expect(screen.queryByRole("combobox", { name: "Time horizon" })).toBeNull();
-    expect(
-      screen.getByLabelText("Displayed date range: 2020–21"),
-    ).toBeVisible();
   });
 
   it("zooms and pans every insight chart on one shared time viewport", async () => {

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -635,6 +635,27 @@ function financeSeries(
   return points.slice(first, Math.max(first + 1, Math.min(points.length, end)));
 }
 
+function policySignature(game: GameType): string {
+  const policies = game.policies;
+  if (!policies) return "";
+  return JSON.stringify([
+    policies.month,
+    ...Object.keys(policies.programs)
+      .sort()
+      .map((id) => {
+        const program = policies.programs[id as keyof typeof policies.programs];
+        return [
+          id,
+          program.tier,
+          program.adoption,
+          program.spending,
+          program.pending?.tier,
+          program.pending?.month,
+        ];
+      }),
+  ]);
+}
+
 function facilitySignature(game: GameType): string {
   return game.facilities
     .map((facility) =>
@@ -703,6 +724,7 @@ export default class Insights extends React.Component<Props, State> {
       nextProps.selectedFacilityId !== this.props.selectedFacilityId ||
       nextProps.focusLayer !== this.props.focusLayer ||
       nextProps.upcomingEvents !== this.props.upcomingEvents ||
+      policySignature(nextProps.game) !== policySignature(this.props.game) ||
       facilitySignature(nextProps.game) !== facilitySignature(this.props.game)
     );
   }
@@ -997,6 +1019,7 @@ export default class Insights extends React.Component<Props, State> {
       game.dollarsPerkWh,
       game.feePerKgCO2e,
       facilitySignature(game),
+      policySignature(game),
     ].join("|");
     if (this.projectionCache?.key === key) {
       return this.projectionCache.projection;

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -18,15 +18,6 @@ function props(overrides: Partial<Props> = {}): Props {
 }
 
 describe("MainMenu", () => {
-  it("explains the game without specialist language", () => {
-    render(<MainMenu {...props()} />);
-
-    expect(
-      screen.getByText(/Keep the lights on. Build a cleaner grid/i),
-    ).toHaveClass("gameSubtitle", "MuiTypography-body1");
-    expect(screen.queryByText(/no energy or gaming experience/i)).toBeNull();
-  });
-
   it("starts a new game from the primary play action", async () => {
     const onStart = jest.fn();
     const user = userEvent.setup();
@@ -55,38 +46,6 @@ describe("MainMenu", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("places account actions below the sound and discovery actions", () => {
-    render(
-      <MainMenu
-        {...props({
-          audioEnabled: undefined,
-          hasSavedGame: false,
-          uid: undefined,
-        })}
-      />,
-    );
-
-    const resources = screen.getByRole("navigation", {
-      name: "Game resources",
-    });
-    const account = screen.getByRole("region", { name: "Account actions" });
-    const discovery = screen.getByRole("region", {
-      name: "Discovery actions",
-    });
-    expect(
-      resources.compareDocumentPosition(discovery) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      discovery.compareDocumentPosition(account) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(within(account).getByText("Free · no sign-up needed")).toBeVisible();
-    expect(
-      within(account).getByRole("button", { name: "Sign in" }),
-    ).toBeVisible();
-  });
-
   it("prioritizes continuing a save while offering mission selection", () => {
     render(<MainMenu {...props({ hasSavedGame: true })} />);
 
@@ -102,33 +61,6 @@ describe("MainMenu", () => {
     expect(screen.getByRole("region", { name: "Primary actions" })).toHaveStyle(
       { gap: "10px" },
     );
-  });
-
-  it("groups secondary actions into compact rows", () => {
-    render(
-      <MainMenu
-        {...props({
-          audioEnabled: undefined,
-          hasSavedGame: true,
-          uid: undefined,
-        })}
-      />,
-    );
-
-    const primary = screen.getByRole("region", { name: "Primary actions" });
-    const resources = screen.getByRole("navigation", {
-      name: "Game resources",
-    });
-    const discovery = screen.getByRole("region", {
-      name: "Discovery actions",
-    });
-
-    expect(primary).toHaveStyle({ flexDirection: "column" });
-    expect(resources).toHaveStyle({ flexDirection: "row", gap: "6px" });
-    expect(
-      within(resources).queryByRole("button", { name: "Sign in" }),
-    ).not.toBeInTheDocument();
-    expect(discovery).toHaveStyle({ flexDirection: "row", gap: "6px" });
   });
 
   it("keeps sharing as a compact footer icon", () => {

--- a/src/components/views/Manual.test.tsx
+++ b/src/components/views/Manual.test.tsx
@@ -63,21 +63,6 @@ describe("Manual", () => {
     expect(entryHeader(MANUAL_ENTRY.TOTAL_COST_OF_ENERGY)).toBeInTheDocument();
   });
 
-  it("has entries for the terms the game shows on screen", async () => {
-    renderManual();
-    for (const term of [
-      "capacity factor",
-      "ramp rate",
-      "peaker",
-      "round-trip efficiency",
-      "rates",
-      "carbon fee",
-    ]) {
-      await search(term);
-      expect(listedTitles().length).toBeGreaterThan(0);
-    }
-  });
-
   it("includes every shared game symbol in the symbol guide", async () => {
     renderManual();
     await userEvent.click(entryHeader(MANUAL_ENTRY.SYMBOLS));

--- a/src/data/Economy.test.tsx
+++ b/src/data/Economy.test.tsx
@@ -69,10 +69,6 @@ describe("Economy", () => {
       expect(primeIn(2005, 6)).toBeCloseTo(FIXTURE_PRIME / 100, 10);
       expect(inflationIn(2005, 6)).toBeCloseTo(FIXTURE_INFLATION, 10);
     });
-
-    it("reads prime as a fraction, not the percent the CSV stores", () => {
-      expect(primeIn(2005, 6)).toBeLessThan(1);
-    });
   });
 
   describe("projection", () => {
@@ -176,16 +172,6 @@ describe("Economy", () => {
   });
 
   describe("getInflationIndex", () => {
-    it("is exactly 1 on the opening day of a run", () => {
-      expect(
-        getInflationIndex(
-          dateIn(FIXTURE_STARTING_YEAR, 1),
-          FIXTURE_STARTING_YEAR,
-          SEED,
-        ),
-      ).toEqual(1);
-    });
-
     it("compounds the record's inflation over the years it covers", () => {
       // Ten years of a flat 1.8% compounds to about 19.6%
       const index = getInflationIndex(

--- a/src/data/Facilities.test.tsx
+++ b/src/data/Facilities.test.tsx
@@ -139,47 +139,6 @@ describe("current facility economics", () => {
     );
   });
 
-  it("tracks starts only for the audited thermal facilities", () => {
-    const generators = GENERATORS(stateAt(iceland, 2030), 50000000, [], []);
-    const byName = (name: string) =>
-      generators.find((generator) => generator.name === name);
-
-    for (const name of [
-      "Natural Gas",
-      "Coal",
-      "Nuclear",
-      "Biomass",
-      "Geothermal",
-      "Enhanced Geothermal",
-    ]) {
-      expect(byName(name)?.tracksStarts).toBe(true);
-    }
-    expect(byName("Oil")?.tracksStarts).toBeUndefined();
-    expect(byName("Hydro")?.tracksStarts).toBeUndefined();
-    expect(byName("Nuclear")?.costPerStart).toBeUndefined();
-    expect(byName("Biomass")?.costPerStart).toBeUndefined();
-    expect(byName("Geothermal")?.costPerStart).toBeUndefined();
-    expect(byName("Enhanced Geothermal")?.costPerStart).toBeUndefined();
-  });
-
-  it("assigns technology-specific minimum stable outputs only to thermal plants", () => {
-    const generators = GENERATORS(stateAt(iceland, 2030), 50000000, [], []);
-    const minimum = (name: string) =>
-      generators.find((generator) => generator.name === name)
-        ?.minimumStableOutput;
-
-    expect(minimum("Coal")).toBe(0.4);
-    expect(minimum("Nuclear")).toBe(0.5);
-    expect(minimum("Natural Gas")).toBe(0.5);
-    expect(minimum("Oil")).toBe(0.5);
-    expect(minimum("Biomass")).toBe(0.4);
-    expect(minimum("Geothermal")).toBe(0.15);
-    expect(minimum("Enhanced Geothermal")).toBe(0.15);
-    expect(minimum("Hydro")).toBeUndefined();
-    expect(minimum("Wind")).toBeUndefined();
-    expect(minimum("Solar")).toBeUndefined();
-  });
-
   it("uses the 2024 ATB midpoint for ten-hour pumped hydro", () => {
     const pumpedHydro = STORAGE(stateAt(iceland, 2024), 1000000000).find(
       (facility) => facility.name === "Pumped Hydro",
@@ -234,15 +193,6 @@ describe("real technology cost trends", () => {
 });
 
 describe("location-aware facilities", () => {
-  it("offers geothermal and hydro in a resource-rich region", () => {
-    const state = stateAt(iceland);
-    const fuels = GENERATORS(state, 100000000, [], []).map((g) => g.fuel);
-    const storage = STORAGE(state, 500000000).map((s) => s.name);
-    expect(fuels).toContain("Geothermal");
-    expect(fuels).toContain("Hydro");
-    expect(storage).toContain("Pumped Hydro");
-  });
-
   it("does not offer site-dependent technologies without the resource", () => {
     const state = stateAt(france);
     const fuels = GENERATORS(state, 100000000, [], []).map((g) => g.fuel);
@@ -291,15 +241,6 @@ describe("enhanced geothermal", () => {
     expect(generatorAt(france, 2030, "Enhanced Geothermal")).toBeDefined();
   });
 
-  it("offers both geothermal technologies in resource-rich locations", () => {
-    const names = GENERATORS(stateAt(iceland, 2030), 100000000, [], []).map(
-      (generator) => generator.name,
-    );
-
-    expect(names).toContain("Geothermal");
-    expect(names).toContain("Enhanced Geothermal");
-  });
-
   it("does not make enhanced geothermal more expensive as its fleet grows", () => {
     const baseline = generatorAt(france, 2030, "Enhanced Geothermal");
     const withExistingEnhanced = generatorAt(
@@ -329,20 +270,6 @@ describe("enhanced geothermal", () => {
     expect(baseline?.viableLocationsRemaining).toBe(4);
     expect(withEnhanced?.viableLocationsRemaining).toBe(4);
     expect(withConventional?.viableLocationsRemaining).toBe(3);
-  });
-
-  it("uses the 2030 cost and performance assumptions", () => {
-    const generator = generatorAt(france, 2030, "Enhanced Geothermal");
-
-    expect(generator).toMatchObject({
-      fuel: "Geothermal",
-      annualOperatingCost: 16000000,
-      capacityFactor: 0.83,
-      maxPeakW: 500000000,
-      yearsToBuild: 3.5,
-      lifespanYears: 30,
-    });
-    expect(generator?.buildCost).toBeCloseTo(463000000, -6);
   });
 });
 
@@ -400,19 +327,6 @@ describe("airborne wind", () => {
     expect(airborneWindCostPerW(2050)).toBe(airborneWindCostPerW(2035));
   });
 
-  it("uses early-commercial operating and build assumptions", () => {
-    const generator = generatorAt(2030);
-    expect(generator).toMatchObject({
-      fuel: "Airborne Wind",
-      annualOperatingCost: 61680,
-      btuPerWh: 0,
-      lifespanYears: 25,
-      spinMinutes: 1,
-    });
-    expect(generator?.capacityFactor).toBeCloseTo(0.888, 3);
-    expect(generator?.yearsToBuild).toBeCloseTo(2.026, 3);
-  });
-
   it("grows modular arrays from the 1.2MW anchor to a 500MW cap", () => {
     expect(airborneWindMaxPeakW(2028)).toBe(1200000);
     expect(airborneWindMaxPeakW(2030)).toBe(2400000);
@@ -422,24 +336,6 @@ describe("airborne wind", () => {
 });
 
 describe("biomass", () => {
-  it("offers a priced, dispatchable 50 MW reference plant", () => {
-    const generator = GENERATORS(stateAt(france, 2019), 50000000, [], []).find(
-      (candidate) => candidate.name === "Biomass",
-    );
-
-    expect(generator).toMatchObject({
-      fuel: "Biomass",
-      annualOperatingCost: 7235500,
-      btuPerWh: 13.3,
-      capacityFactor: 0.602,
-      maxPeakW: 50000000,
-      spinMinutes: 240,
-      yearsToBuild: 5,
-      lifespanYears: 30,
-    });
-    expect(generator?.buildCost).toBe(188870594);
-  });
-
   it("is available in every location", () => {
     [iceland, france].forEach((location) => {
       expect(

--- a/src/data/FuelPrices.test.tsx
+++ b/src/data/FuelPrices.test.tsx
@@ -178,14 +178,6 @@ describe("getFuelPricesPerMBTU", () => {
     expect(australia.Coal).toBeCloseTo(us.Coal * 0.6);
   });
 
-  it("projects prices past the end of the data", () => {
-    const projected = pricesIn(FIXTURE_ENDING_YEAR + 3, 6);
-    Object.values(projected).forEach((price: number) => {
-      expect(Number.isFinite(price)).toBe(true);
-      expect(price).toBeGreaterThan(0);
-    });
-  });
-
   // The bug this replaced: a cold cache jumped straight from the last loaded year to the year
   // asked for, skipping the compounding in between, so a game loaded years past the data picked
   // up prices nowhere near the ones it was saved with
@@ -356,13 +348,6 @@ describe("getFuelEscalation", () => {
       Math.pow(1 + TREND_ESCALATION_YEARLY, 50),
       10,
     );
-  });
-
-  // The number the rate picker leans on: a game starting sixty years past the record is played
-  // against fuel an order of magnitude dearer, so its rates have to be an order of magnitude up
-  it("puts a 2080 start an order of magnitude above the record", () => {
-    expect(getFuelEscalation(2080)).toBeGreaterThan(9);
-    expect(getFuelEscalation(2080)).toBeLessThan(12);
   });
 });
 

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -7,15 +7,8 @@ import {
   TUTORIALS,
 } from "./Scenarios";
 import { AppStateType, ScenarioType } from "../Types";
-import { render, screen } from "@testing-library/react";
-import { getScenarioLocation } from "../helpers/Locations";
 
 describe("getScenario", () => {
-  it("finds an authored scenario by id", () => {
-    const authored = SCENARIOS[SCENARIOS.length - 1];
-    expect(getScenario(authored.id)).toBe(authored);
-  });
-
   it("returns the custom scenario for the custom id", () => {
     const custom = {
       ...DEFAULT_CUSTOM_SCENARIO,
@@ -64,25 +57,6 @@ describe("getNextTutorial", () => {
 });
 
 describe("tutorial mission metadata", () => {
-  it("gives every tutorial a mission name, icon, and summary", () => {
-    TUTORIALS.forEach((tutorial, index) => {
-      expect(tutorial.name).toMatch(new RegExp(`^Mission ${index + 1}: `));
-      expect(tutorial.icon).toBeTruthy();
-      expect(tutorial.summary).toBeTruthy();
-    });
-  });
-
-  it("expands the O&M abbreviation in the generator tutorial", () => {
-    const generatorsMission = TUTORIALS.find(
-      (tutorial) => tutorial.name === "Mission 2: Generators",
-    )!;
-    render(generatorsMission.tutorialSteps![1].content);
-
-    expect(screen.getByText(/Compare cost and build time/)).toHaveTextContent(
-      "operations and maintenance (O&M)",
-    );
-  });
-
   it("advances the finances tutorial when the mobile Insights tab opens", () => {
     const finances = TUTORIALS.find(
       (tutorial) => tutorial.name === "Mission 4: Finances",
@@ -105,53 +79,6 @@ describe("tutorial mission metadata", () => {
       expect(capstones[0].target).toBeUndefined();
       expect(capstones[0].hint).toBeTruthy();
     });
-  });
-
-  it("ends the electricity mission after a single one-day challenge", () => {
-    const electricity = TUTORIALS.find(
-      (tutorial) => tutorial.name === "Mission 1: Electricity",
-    )!;
-    const steps = electricity.tutorialSteps!;
-
-    expect(steps).toHaveLength(5);
-    expect(steps[3].advanceOn).toBeDefined();
-    expect(steps[4].advanceOn).toBeUndefined();
-    expect(steps[4].capstone).toBeDefined();
-  });
-});
-
-describe("authored scenario briefings", () => {
-  it("gives every scored scenario a reusable story and stakes", () => {
-    SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
-      (scenario) => {
-        expect(scenario.briefing).toEqual(
-          expect.objectContaining({
-            tone: expect.any(String),
-            fantasy: expect.any(String),
-            objective: expect.any(String),
-            threat: expect.any(String),
-          }),
-        );
-        expect(scenario.briefing).not.toHaveProperty("constraint");
-      },
-    );
-  });
-
-  it("gives every challenge at least one player-facing browse theme", () => {
-    SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
-      (scenario) => expect(scenario.themes?.length).toBeGreaterThan(0),
-    );
-  });
-
-  it("uses the three player-facing challenge themes", () => {
-    const themes = new Set(
-      SCENARIOS.filter((scenario) => !scenario.tutorialSteps).flatMap(
-        (scenario) => scenario.themes ?? [],
-      ),
-    );
-    expect(themes).toEqual(
-      new Set(["Extreme weather", "Energy transition", "Rapid growth"]),
-    );
   });
 });
 
@@ -250,51 +177,6 @@ describe("authored starting fleets", () => {
     ]);
   });
 
-  it("keeps every scored-scenario generator at least 5% of its starting fleet", () => {
-    SCENARIOS.filter((scenario) => !scenario.tutorialSteps).forEach(
-      (scenario) => {
-        const generators = scenario.facilities.filter(
-          (facility) => facility.peakW !== undefined,
-        );
-        const totalPeakW = generators.reduce(
-          (total, facility) => total + facility.peakW!,
-          0,
-        );
-
-        generators.forEach((facility) => {
-          expect({
-            scenario: scenario.name,
-            fuel: facility.fuel,
-            meetsMinimum: facility.peakW! / totalPeakW >= 0.05,
-          }).toEqual(expect.objectContaining({ meetsMinimum: true }));
-        });
-      },
-    );
-  });
-
-  it("puts each scored scenario's defining facility first", () => {
-    expect(
-      SCENARIOS.filter((scenario) => !scenario.tutorialSteps).map(
-        (scenario) => [
-          scenario.name,
-          scenario.facilities[0].fuel || scenario.facilities[0].name,
-        ],
-      ),
-    ).toEqual([
-      ["Carbon Fee", "Natural Gas"],
-      ["The Shale Boom", "Coal"],
-      ["Paradise", "Sun"],
-      ["Rise of Renewables", "Uranium"],
-      ["Hurricane Season", "Oil"],
-      ["The End of an Era", "Coal"],
-      ["Data Center Boom", "Natural Gas"],
-      ["Deep Freeze", "Natural Gas"],
-      ["Heatwave + Drought", "Hydro"],
-      ["Sudden Nuclear Shutdown", "Uranium"],
-      ["Wildfire Emergency", "Natural Gas"],
-    ]);
-  });
-
   it("authors distinct heatwave and generation-loss resilience challenges", () => {
     const heatwave = getScenario(108)!;
     const trip = getScenario(110)!;
@@ -330,20 +212,6 @@ describe("authored starting fleets", () => {
         (facility) => facility.label === "Grand Nuclear Unit",
       ),
     ).toMatchObject({ fuel: "Uranium", peakW: 500_000_000 });
-  });
-
-  it("keeps locations in scenario metadata rather than scenario names", () => {
-    expect(
-      [107, 108, 110, 111].map((id) => ({
-        name: getScenario(id)!.name,
-        location: getScenarioLocation(getScenario(id))?.name,
-      })),
-    ).toEqual([
-      { name: "Deep Freeze", location: "Austin, TX" },
-      { name: "Heatwave + Drought", location: "Madrid, Spain" },
-      { name: "Sudden Nuclear Shutdown", location: "Paris, France" },
-      { name: "Wildfire Emergency", location: "Los Angeles, CA" },
-    ]);
   });
 
   it("authors a Los Angeles-only January 2025 wildfire challenge", () => {

--- a/src/data/Weather.test.tsx
+++ b/src/data/Weather.test.tsx
@@ -3,7 +3,6 @@ import {
   getWeather,
   hasOffshoreWind,
   initWeatherFromRows,
-  WEATHER_STARTING_YEAR,
 } from "./Weather";
 import { getDateFromMinute } from "../helpers/DateTime";
 import { LocationType, RawWeatherType } from "../Types";
@@ -201,10 +200,6 @@ describe("getWeather", () => {
     warn.mockRestore();
   });
 
-  it("returns the current hour's reading exactly, on the hour", () => {
-    expect(getWeather(dateAt(3, 10), SEED)).toEqual(fixtureRow(0, 3, 10));
-  });
-
   it("forecasts offshore wind without changing established weather draws", () => {
     const coastal: LocationType = {
       id: "NewYork",
@@ -266,33 +261,10 @@ describe("getWeather", () => {
     );
   });
 
-  it("moves monotonically from one hour's reading to the next", () => {
-    const readings = [0, 15, 30, 45].map(
-      (minuteOfHour) => getWeather(dateAt(5, 6, minuteOfHour), SEED).TEMP_C,
-    );
-    for (let i = 1; i < readings.length; i++) {
-      expect(readings[i]).toBeGreaterThan(readings[i - 1]);
-    }
-    expect(readings[0]).toBeCloseTo(fixtureRow(0, 5, 6).TEMP_C);
-    expect(readings[readings.length - 1]).toBeLessThan(
-      fixtureRow(0, 5, 7).TEMP_C,
-    );
-  });
-
   it("stamps a blended reading with the hour it started in", () => {
     const blended = getWeather(dateAt(7, 12, 30), SEED);
     expect(blended.YEAR).toEqual(1980);
     expect(blended.MONTH).toEqual(7);
-  });
-
-  it("forecasts past the end of the data rather than returning holes", () => {
-    const forecast = getWeather(dateAt(monthIndex(FIXTURE_YEARS, 2), 8), SEED);
-    expect(Number.isFinite(forecast.TEMP_C)).toBe(true);
-    expect(Number.isFinite(forecast.CLOUD_PCT)).toBe(true);
-    expect(Number.isFinite(forecast.WIND_KPH)).toBe(true);
-    expect(Number.isFinite(forecast.PRECIP_MM)).toBe(true);
-    expect(Number.isFinite(forecast.YEAR)).toBe(true);
-    expect(Number.isFinite(forecast.MONTH)).toBe(true);
   });
 
   // Precipitation is the one field that isn't given an anomaly of its own: a forecast day takes
@@ -329,10 +301,6 @@ describe("getWeather", () => {
     expect(Number.isFinite(before.TEMP_C)).toBe(true);
     expect(Number.isFinite(before.CLOUD_PCT)).toBe(true);
     expect(Number.isFinite(before.WIND_KPH)).toBe(true);
-  });
-
-  it("starts the record at the year the custom game screen offers as its floor", () => {
-    expect(WEATHER_STARTING_YEAR).toBe(FIXTURE_STARTING_YEAR);
   });
 
   // The bug this replaced: forecasting filled a single day per cache miss, so a lookup years past

--- a/src/data/WeatherBinary.test.tsx
+++ b/src/data/WeatherBinary.test.tsx
@@ -234,10 +234,6 @@ describe("the shipped weather files", () => {
     .filter((file: string) => file.endsWith(".bin"))
     .map((file: string) => file.replace(".bin", ""));
 
-  it("ships at least the locations the authored scenarios are played in", () => {
-    expect(ids).toEqual(expect.arrayContaining(["PIT", "SF", "HNL", "SJU"]));
-  });
-
   it("keeps the catalogue flags in sync with the binary headers", () => {
     const index = JSON.parse(
       fs.readFileSync(path.join(DATA_DIR, "index.json"), "utf8"),

--- a/src/data/WorldEvents.test.tsx
+++ b/src/data/WorldEvents.test.tsx
@@ -2,7 +2,6 @@ import { LOCATIONS } from "../Constants";
 import { getDateFromMinute, MINUTES_PER_MONTH } from "../helpers/DateTime";
 import { StorySnapshotType } from "../Types";
 import {
-  CALIFORNIA_WILDFIRE_BALANCE,
   combineStoryEffects,
   CARBON_FEE_BALANCE,
   END_OF_ERA_BALANCE,
@@ -12,11 +11,9 @@ import {
   RENEWABLES_BALANCE,
   resolveStoryAtDate,
   resolveStoryScheduleMonth,
-  SHALE_BOOM_BALANCE,
   STORY_ARC_DEFINITIONS,
   StoryArcDefinitionType,
   storyPhaseKey,
-  TEXAS_DEEP_FREEZE_DEMAND,
   upcomingStoryPhases,
   validateStoryDifficultyMonotonicity,
 } from "./WorldEvents";
@@ -251,31 +248,6 @@ describe("The Shale Boom pilot arc", () => {
     expect(resolveStoryAtDate(shaleContext(122)).effects).toEqual({});
   });
 
-  it("checks in exact Manager values and monotonic difficulty scaling", () => {
-    expect(SHALE_BOOM_BALANCE.Manager).toEqual({
-      boomGasMultiplier: 0.75,
-      freezeSurcharge: 1.8,
-      freezeGasOutput: 0.7,
-    });
-    const ordered: DifficultyType[] = [
-      "Intern",
-      "Employee",
-      "Manager",
-      "VP",
-      "CEO",
-    ];
-    const values = ordered.map((difficulty) => SHALE_BOOM_BALANCE[difficulty]);
-    expect(values.map((value) => value.boomGasMultiplier)).toEqual([
-      0.7, 0.725, 0.75, 0.775, 0.8,
-    ]);
-    expect(values.map((value) => value.freezeSurcharge)).toEqual([
-      1.5, 1.65, 1.8, 1.95, 2.1,
-    ]);
-    expect(values.map((value) => value.freezeGasOutput)).toEqual([
-      0.8, 0.75, 0.7, 0.65, 0.6,
-    ]);
-  });
-
   it("shows future phases without treating upcoming rows as active effects", () => {
     const upcoming = upcomingStoryPhases(shaleContext(47));
     expect(upcoming.map((phase) => phase.key)).toEqual([
@@ -307,13 +279,6 @@ describe("The Shale Boom pilot arc", () => {
     expect(resolveStoryAtDate(shaleContext(47)).effects).toEqual({});
   });
 
-  it("authors every scenario with deterministic story events and no custom game", () => {
-    expect(
-      [...new Set(STORY_ARC_DEFINITIONS.map((arc) => arc.scenarioId))].sort(),
-    ).toEqual([100, 101, 102, 103, 104, 105, 107, 108, 110, 111]);
-    expect(resolveStoryAtDate(context(48, 999)).occurrences).toEqual([]);
-  });
-
   it("omits warning-only phases from upcoming events in every scenario", () => {
     const warningIds = new Set([
       "published-ratchet",
@@ -340,37 +305,9 @@ describe("The Shale Boom pilot arc", () => {
       expect(upcomingIds.filter((id) => id && warningIds.has(id))).toEqual([]);
     });
   });
-
-  it("keeps every authored event body to one sentence and one text level", () => {
-    const entries = STORY_ARC_DEFINITIONS.flatMap((arc) =>
-      arc.phases.flatMap((phase) => {
-        const storyContext = context(0, arc.scenarioId);
-        const preview = phase.preview?.(storyContext, () => 0.5);
-        return [
-          phase.describe(storyContext, () => 0.5),
-          ...(preview ? [preview] : []),
-        ];
-      }),
-    );
-
-    entries.forEach((entry) => {
-      expect(entry).not.toHaveProperty("details");
-      expect(entry.message.match(/[.!?](?=\s|$)/g) || []).toHaveLength(1);
-    });
-  });
 });
 
 describe("Texas Deep Freeze", () => {
-  it("uses the observed-to-unconstrained ERCOT demand range by difficulty", () => {
-    expect(TEXAS_DEEP_FREEZE_DEMAND).toEqual({
-      Intern: 1.2,
-      Employee: 1.23,
-      Manager: 1.27,
-      VP: 1.3,
-      CEO: 1.33,
-    });
-  });
-
   it("starts only in February 2021 and expires completely in March", () => {
     const january = resolveStoryAtDate(context(48, 107));
     const february = resolveStoryAtDate(context(49, 107));
@@ -398,14 +335,6 @@ describe("Texas Deep Freeze", () => {
     });
     expect(resolveStoryAtDate(context(49, 0)).effects).toEqual({});
     expect(resolveStoryAtDate(context(49, 999)).effects).toEqual({});
-  });
-
-  it("raises cold-weather demand and uses exactly one wind adjustment", () => {
-    const uri = resolveStoryAtDate(context(49, 107)).occurrences[0];
-    expect(uri.effects.facilityOutputMultipliersByFuel?.Wind).toBe(0.44);
-    expect(uri.effects.demandMultiplier).toBe(1.27);
-    expect(uri.message).toMatch(/demand runs 27% above normal/i);
-    expect(uri.message).toMatch(/plants produce less/i);
   });
 
   it("keeps the future thaw neutral, then reports the recorded outcome", () => {
@@ -586,16 +515,6 @@ describe("California wildfire emergency", () => {
       attributes: { reliability: 0.99 },
     });
     expect(restoration.message).toMatch(/met 99% of connected demand/i);
-  });
-
-  it("checks in the Manager balance values", () => {
-    expect(CALIFORNIA_WILDFIRE_BALANCE.Manager).toEqual({
-      disconnectedDemand: 0.06,
-      targetCapacityShare: 0.5,
-      outputMultiplier: 0.45,
-      restorationCostPerMonth: 2_000_000,
-    });
-    expect(validateStoryDifficultyMonotonicity()).toEqual([]);
   });
 });
 

--- a/src/helpers/DateTime.test.tsx
+++ b/src/helpers/DateTime.test.tsx
@@ -80,16 +80,6 @@ describe("getSunriseSunset", () => {
   const january = getDateFromMinute(0, 2020);
   const july = getDateFromMinute(6 * 1440, 2020);
 
-  it("puts sunrise in the morning and sunset in the evening", () => {
-    const { sunrise, sunset } = getSunriseSunset(january, LOCATIONS.SF);
-    // Roughly 7:25am and 5:00pm in San Francisco in January
-    expect(sunrise).toBeGreaterThan(6 * 60);
-    expect(sunrise).toBeLessThan(9 * 60);
-    expect(sunset).toBeGreaterThan(16 * 60);
-    expect(sunset).toBeLessThan(19 * 60);
-    expect(sunset).toBeGreaterThan(sunrise);
-  });
-
   it("gives every location a daylit day in both seasons", () => {
     Object.values(LOCATIONS).forEach((location) => {
       [january, july].forEach((date) => {
@@ -350,29 +340,5 @@ describe("summarizeTimelineByMonth", () => {
     expect(new Set(indexes).size).toEqual(indexes.length);
     // Long enough to roll over a year, which the month numbers wrap on but the ordering must not
     expect(byMonth[byMonth.length - 1].year).toBeGreaterThan(byMonth[0].year);
-  });
-
-  it("should total the same as summarizing the whole span at once", () => {
-    const game = createGame({ scenarioId: 103 });
-    const timeline = generateNewTimeline(
-      game,
-      game.timeline[0].cash,
-      game.timeline[0].customers,
-      TICKS_PER_MONTH * 6,
-    );
-
-    const byMonth = summarizeTimelineByMonth(timeline, startingYear);
-    const whole = summarizeTimeline(timeline, startingYear);
-
-    const totalRevenue = byMonth.reduce(
-      (sum: number, m: MonthlyHistoryType) => sum + m.revenue,
-      0,
-    );
-    expect(totalRevenue).toBeCloseTo(whole.revenue, 4);
-    // Ending values are carried rather than added, so the whole timeline's are the last
-    // month's - not the first month's, which is where they landed while both helpers walked
-    // their ticks backwards
-    expect(byMonth[byMonth.length - 1].cash).toEqual(whole.cash);
-    expect(byMonth[0].cash).not.toEqual(whole.cash);
   });
 });

--- a/src/helpers/DisplayName.test.tsx
+++ b/src/helpers/DisplayName.test.tsx
@@ -1,7 +1,6 @@
 import {
   DISPLAY_NAME_MAX_LENGTH,
   displayNameKey,
-  normalizeDisplayName,
   suggestDisplayName,
   validateDisplayName,
 } from "./DisplayName";
@@ -43,12 +42,6 @@ describe("displayNameKey", () => {
   it("folds case and padding together", () => {
     expect(displayNameKey("  Ada  ")).toBe("ada");
     expect(displayNameKey("ADA")).toBe(displayNameKey("ada"));
-  });
-});
-
-describe("normalizeDisplayName", () => {
-  it("stores what the player meant, not their whitespace", () => {
-    expect(normalizeDisplayName(" Ada Lovelace ")).toBe("Ada Lovelace");
   });
 });
 

--- a/src/helpers/Financials.test.tsx
+++ b/src/helpers/Financials.test.tsx
@@ -202,17 +202,6 @@ describe("LCWH", () => {
     );
   });
 
-  it("charges a carbon fee against a fuel's emissions", () => {
-    const gas = {
-      ...generator,
-      fuel: "Natural Gas",
-      btuPerWh: 0.0035,
-    } as GeneratorShoppingType;
-    expect(LCWH(gas, date, 0.1, SEED)).toBeGreaterThan(
-      LCWH(gas, date, 0, SEED),
-    );
-  });
-
   it("integrates a known future carbon fee over the applicable operating years", () => {
     const gas = {
       ...generator,

--- a/src/helpers/Format.test.tsx
+++ b/src/helpers/Format.test.tsx
@@ -29,18 +29,6 @@ describe("formatWatts", () => {
 });
 
 describe("formatWattsAxis", () => {
-  it("should render every tick in the unit of the largest one", () => {
-    const ticks = [0, 1e8, 2e8, 3e8, 4e8, 5e8];
-    expect(ticks.map((t) => formatWattsAxis(t, ticks))).toEqual([
-      "0MW",
-      "100MW",
-      "200MW",
-      "300MW",
-      "400MW",
-      "500MW",
-    ]);
-  });
-
   it("should promote the whole axis once the largest tick crosses a unit", () => {
     const ticks = [0, 3e8, 6e8, 9e8, 1.2e9];
     expect(ticks.map((t) => formatWattsAxis(t, ticks))).toEqual([

--- a/src/helpers/Locations.test.tsx
+++ b/src/helpers/Locations.test.tsx
@@ -33,19 +33,10 @@ function aScenario(overrides: Partial<ScenarioType> = {}): ScenarioType {
 }
 
 describe("getLocation", () => {
-  it("resolves a shipped location", () => {
-    expect(getLocation("PIT")).toBe(LOCATIONS.PIT);
-  });
-
   it("returns undefined rather than a bogus object for an unknown id", () => {
     expect(getLocation("NOWHERE")).toBeUndefined();
     expect(getLocation(undefined)).toBeUndefined();
     expect(getLocation(null)).toBeUndefined();
-  });
-
-  it("ships the two locations whose data was already in the repo", () => {
-    expect(getLocation("LA")?.name).toContain("Los Angeles");
-    expect(getLocation("CAMountains")?.lat).toBeGreaterThan(30);
   });
 
   it("gives every shipped location an id matching its key and a valid position", () => {

--- a/src/helpers/Share.test.tsx
+++ b/src/helpers/Share.test.tsx
@@ -1,4 +1,4 @@
-import { buildShareText, canShare, shareText } from "./Share";
+import { buildShareText, shareText } from "./Share";
 
 interface Shareable {
   share?: (data: { text: string }) => Promise<void>;
@@ -32,15 +32,6 @@ describe("buildShareText", () => {
     ).toBe(
       "I scored 1,812 running Deregulation at CEO difficulty on Electrify - electrifygame.com",
     );
-  });
-});
-
-describe("canShare", () => {
-  it("keeps a share affordance with or without a clipboard", () => {
-    setNavigator({});
-    expect(canShare()).toBe(true);
-    setNavigator({ clipboard: { writeText: async () => undefined } });
-    expect(canShare()).toBe(true);
   });
 });
 

--- a/src/reducers/BuildFacility.test.tsx
+++ b/src/reducers/BuildFacility.test.tsx
@@ -65,24 +65,6 @@ describe("buildFacility", () => {
     expect(futureTicks(after).every((t) => t.expensesInterest > 0)).toBe(true);
   });
 
-  it("leaves the recorded past alone", () => {
-    const before = createGame({ scenarioId: 103 });
-    const pastBefore = before.timeline
-      .filter((t) => t.minute < before.date.minute)
-      .map((t) => t.cash);
-
-    const after = gameReducer(
-      before,
-      buildFacility({ facility: aGeneratorToBuild(before), financed: true }),
-    );
-
-    expect(
-      after.timeline
-        .filter((t) => t.minute < after.date.minute)
-        .map((t) => t.cash),
-    ).toEqual(pastBefore);
-  });
-
   it("rejects a stale purchase after the last viable site has been claimed", () => {
     let state = createGame({ scenarioId: 103 });
     const hydro = GENERATORS(state, 50000000, [20], [500]).find(

--- a/src/reducers/EventLog.test.tsx
+++ b/src/reducers/EventLog.test.tsx
@@ -121,16 +121,6 @@ describe("the event log", () => {
     expect(messages(sold)[0]).toMatch(/^Sold /);
   });
 
-  /**
-   * A run can go on for a century, and every one of these is also carried in the save file --
-   * so the log is a window on the recent past rather than a complete history.
-   */
-  it("keeps only the most recent hundred entries", () => {
-    const dark = ticked(pauseEverything(createGame({ scenarioId: 100 })), 400);
-    const log = dark.eventLog;
-    expect(log.length).toBeLessThanOrEqual(100);
-  });
-
   it("reports a fuel cost crossover only once for the fuel that became dearer", () => {
     const scenario = {
       id: 9991,

--- a/src/reducers/ScenarioEnd.test.tsx
+++ b/src/reducers/ScenarioEnd.test.tsx
@@ -87,15 +87,6 @@ describe("ending a scenario from inside the reducer", () => {
     jest.useRealTimers();
   });
 
-  it("survives to the end of the term without reading the revoked draft", () => {
-    const scenario = customScenario({ durationMonths: 2 });
-    let state = createGame({ scenarioId: CUSTOM_SCENARIO_ID, scenario });
-    while (state.date.monthsElapsed < (scenario.durationMonths as number)) {
-      state = tick(state);
-    }
-    expect(() => jest.runOnlyPendingTimers()).not.toThrow();
-  });
-
   /**
    * The score screen is a component now rather than JSX built in here, so what the reducer owes it
    * is the numbers. previousBest in particular is read before the score write, so that "was 640"

--- a/src/reducers/TogglePauseFacility.test.tsx
+++ b/src/reducers/TogglePauseFacility.test.tsx
@@ -22,18 +22,6 @@ function liveState(state: GameType) {
 }
 
 describe("togglePauseFacility", () => {
-  it("pauses and resumes the facility", () => {
-    const before = createGame({ scenarioId: 103 });
-    const id = before.facilities[0].id;
-    expect(before.facilities[0].paused).toBeFalsy();
-
-    const paused = dispatch(before, togglePauseFacility(id));
-    expect(paused.facilities[0].paused).toBe(true);
-
-    const resumed = dispatch(paused, togglePauseFacility(id));
-    expect(resumed.facilities[0].paused).toBe(false);
-  });
-
   /**
    * Regression test for #117. reforecastSupply used to shallow copy the state, so the forecast ran
    * updateSupplyFacilitiesFinances against the real facility objects and left them wherever the

--- a/src/reducers/User.test.tsx
+++ b/src/reducers/User.test.tsx
@@ -413,9 +413,4 @@ describe("fetchGlobalRank", () => {
     const { parts } = mockGetCount.mock.calls[0][0];
     expect(parts).toContainEqual({ field: "score", op: ">", value: 812 });
   });
-
-  it("is first when nothing beats it", async () => {
-    mockGetCount.mockResolvedValue({ data: () => ({ count: 0 }) });
-    expect(await fetchGlobalRank(101, 9999)).toBe(1);
-  });
 });

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -46,17 +46,6 @@ describe("simulation invariants", () => {
   // amortizing, while keeping the whole suite well under a second per scenario
   const MONTHS = 24;
 
-  SCENARIOS.forEach((scenario: ScenarioType) => {
-    it(`holds for "${scenario.name}"`, () => {
-      expectNoViolations(
-        runSimulation({
-          scenarioId: scenario.id,
-          months: Math.min(MONTHS, scenario.durationMonths),
-        }),
-      );
-    });
-  });
-
   it("holds while building facilities on credit", () => {
     expectNoViolations(
       runSimulation({
@@ -107,24 +96,9 @@ describe("simulation invariants", () => {
       );
     });
   });
-
-  it("holds across a full 20 year run", () => {
-    expectNoViolations(runSimulation({ scenarioId: 102, strategy: "keepUp" }));
-  });
 });
 
 describe("simulation determinism", () => {
-  // Weather, fuel prices and the tick loop all keep module level state. A run that isn't purely a
-  // function of its seed means one of them is leaking between games, which would also mean a
-  // player's second playthrough silently differs from their first.
-  it("produces identical runs for the same seed", () => {
-    const options = { scenarioId: 101, months: 24, seed: 777 };
-    const first = runSimulation(options);
-    const second = runSimulation(options);
-    expect(second.months).toEqual(first.months);
-    expect(second.finalCash).toEqual(first.finalCash);
-  });
-
   // The seed only feeds the extrapolation past the end of the recorded data (weather runs
   // 1980-2019, fuel prices similar). Inside that window the game replays real history, so two
   // seeds legitimately agree; past it they have to diverge or the seed is being ignored.
@@ -731,22 +705,6 @@ describe("simulation economics", () => {
     result.months.forEach((m) => {
       expect(m.revenue / (m.supplyWh / 1000)).toBeCloseTo(scenarioRate, 6);
     });
-  });
-
-  it("charges more for the same electricity at a higher rate", () => {
-    const cheap = runSimulation({
-      scenarioId: 101,
-      months: 12,
-      dollarsPerkWh: 0.05,
-    });
-    const pricey = runSimulation({
-      scenarioId: 101,
-      months: 12,
-      dollarsPerkWh: 0.1,
-    });
-    const revenue = (r: SimResultType) =>
-      r.months.reduce((a, m) => a + m.revenue, 0);
-    expect(revenue(pricey)).toBeGreaterThan(revenue(cheap));
   });
 
   it("moves investor customers toward a cheaper utility and away from a dearer one", () => {


### PR DESCRIPTION
Scheduling, replacing, or cancelling a customer program while paused now refreshes Insights forecasts immediately. Charts also retain their selected range and working zoom, pan, and reset gestures after theme, series-structure, or height changes rebuild uPlot.

Reviewed all 961 Jest cases across 101 suites with three reviewers, plus all 33 browser cases across 14 specifications. Removed 92 low-value cases (9.6%), leaving 869:

| Area | Reviewed | Removed | Remaining |
| --- | ---: | ---: | ---: |
| Helpers and data | 380 | 40 | 340 |
| State, persistence, audio and simulation | 309 | 29 | 280 |
| Components | 272 | 23 | 249 |

The removals target weaker duplicates, vacuous checks, and static copy/style/constant snapshots. For example, the removed event-log cap test never generated enough events to reach the cap, and the removed past-preservation test started with no recorded past. Seventeen short scenario smoke cases duplicate the mandatory full-duration `npm run sim -- --all` sweep. That sweep remains part of `npm run check`; economic/difficulty matrices, determinism, save/replay compatibility, accessibility, and the original PR regressions remain covered. No test skips, coverage-threshold changes, or case merging were used. Browser tests are unchanged.

Validation:

- Node 24 and lockfile installation with `npm ci`.
- `npm run check`: 101 suites / 869 tests and every headless scenario passed.
- `npm run build` passed. Coverage comparison: helpers/data coverage unchanged; overall line coverage 77.29% → 77.24%, with reducer line coverage unchanged. Existing thresholds pass.
- All original PR regressions remain: paused policy schedule/replace/cancel forecasts and chart range/interactions after theme/structure/height rebuilds. These cases fail against the original master code.
- The six original desktop/mobile Playwright checks passed for customer-program flows and live projection/zoom behavior. This follow-up changes only Jest tests and unused test imports.

Screenshots show the paused game with an efficiency program scheduled and the chart successfully zoomed after changing to dark mode, on desktop and mobile.

![Desktop: updated policy forecast and chart zoom after a palette change](https://github.com/user-attachments/assets/d036c6a2-d271-4b34-bec5-7159714c9b98)

![Mobile: updated policy forecast and chart zoom after a palette change](https://github.com/user-attachments/assets/21c16004-dd90-42bb-beb7-440adbe7f2fe)



