### PR TITLE
Make home page spacing consistent on mobile and desktop

### DIFF
--- a/e2e/main-menu-spacing.spec.ts
+++ b/e2e/main-menu-spacing.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test, Locator } from "@playwright/test";
+
+async function expectGap(above: Locator, below: Locator, gap: number) {
+  const first = await above.boundingBox();
+  const second = await below.boundingBox();
+  expect(first).not.toBeNull();
+  expect(second).not.toBeNull();
+  expect(second!.y - first!.y - first!.height).toBeCloseTo(gap, 0);
+}
+
+for (const theme of ["light", "dark"]) {
+  test(`home action spacing follows the same rhythm in ${theme} mode`, async ({
+    page,
+  }) => {
+    await page.addInitScript(
+      (value) => localStorage.setItem("theme", value),
+      theme,
+    );
+    await page.goto("/");
+    const primary = page.getByRole("region", { name: "Primary actions" });
+    const resources = page.getByRole("navigation", { name: "Game resources" });
+    const discovery = page.locator(".discoveryActions");
+    const account = page.getByRole("region", { name: "Account actions" });
+    await expect(primary).toBeVisible();
+    await expectGap(page.locator(".gameSubtitle"), primary, 16);
+    await expectGap(primary, resources, 8);
+    await expectGap(resources, discovery, 16);
+    await expectGap(discovery, account, 8);
+    await expectGap(
+      account.getByRole("button"),
+      account.locator(".MuiTypography-caption"),
+      4,
+    );
+    const button = await primary.getByRole("button").boundingBox();
+    expect(button!.width).toBeLessThanOrEqual(260);
+    expect(button!.x).toBeGreaterThanOrEqual(24);
+
+    await page.getByRole("button", { name: "Turn on sound" }).click();
+    await expect(discovery).toBeHidden();
+    await expectGap(resources, account, 16);
+    const overflow = await page
+      .locator("#menuCard")
+      .evaluate((element) => element.scrollWidth - element.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+}
+
+test("a saved game remains separated from the logo and footer on short screens", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "mobile-320px");
+  await page.goto("/?scenario=103");
+  await page.getByRole("button", { name: "Start game", exact: true }).click();
+  await expect
+    .poll(() => page.evaluate(() => Boolean(localStorage.getItem("savedGame"))))
+    .toBe(true);
+  await page.setViewportSize({ width: 360, height: 320 });
+  await page.goto("/");
+  const primary = page.getByRole("region", { name: "Primary actions" });
+  await expect(
+    primary.getByRole("button", { name: "Continue", exact: true }),
+  ).toBeVisible();
+  await expectGap(
+    primary.getByRole("button").nth(0),
+    primary.getByRole("button").nth(1),
+    12,
+  );
+  const logo = await page.locator("#logo").boundingBox();
+  const menu = await page.locator("#centeredMenu").boundingBox();
+  const footer = await page.locator(".mainMenuFooter").boundingBox();
+  expect(menu!.y).toBeGreaterThanOrEqual(logo!.y + logo!.height);
+  expect(footer!.y).toBeGreaterThanOrEqual(menu!.y + menu!.height);
+  await page.getByRole("link", { name: "Privacy" }).scrollIntoViewIfNeeded();
+  await expect(page.getByRole("link", { name: "Privacy" })).toBeInViewport();
+});

--- a/e2e/main-menu-spacing.spec.ts
+++ b/e2e/main-menu-spacing.spec.ts
@@ -24,8 +24,8 @@ for (const theme of ["light", "dark"]) {
     await expect(primary).toBeVisible();
     await expectGap(page.locator(".gameSubtitle"), primary, 16);
     await expectGap(primary, resources, 8);
-    await expectGap(resources, discovery, 16);
-    await expectGap(discovery, account, 8);
+    await expectGap(resources, discovery, 0);
+    await expectGap(discovery, account, 0);
     await expectGap(
       account.getByRole("button"),
       account.locator(".MuiTypography-caption"),
@@ -37,7 +37,7 @@ for (const theme of ["light", "dark"]) {
 
     await page.getByRole("button", { name: "Turn on sound" }).click();
     await expect(discovery).toBeHidden();
-    await expectGap(resources, account, 16);
+    await expectGap(resources, account, 0);
     const overflow = await page
       .locator("#menuCard")
       .evaluate((element) => element.scrollWidth - element.clientWidth);

--- a/src/app.scss
+++ b/src/app.scss
@@ -2253,14 +2253,27 @@ html[data-theme="dark"] .uplot {
     position: relative;
     background-color: $bg_primary;
     text-align: center;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+
+    #logo {
+      position: static;
+      flex: 0 0 auto;
+      padding: $space-4 24px 0;
+    }
 
     #centeredMenu {
-      position: absolute;
-      top: 27%;
-      left: 0;
-      right: 0;
+      flex: 1 0 auto;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      box-sizing: border-box;
+      width: 100%;
       max-width: 680px;
-      margin: auto;
+      margin: 0 auto;
+      padding-top: 24px;
+      padding-bottom: 24px;
 
       .gameSubtitle {
         max-width: 380px;
@@ -2284,9 +2297,20 @@ html[data-theme="dark"] .uplot {
         margin: 0 auto;
       }
 
+      .utilityActions {
+        margin-top: $space-4;
+        display: flex;
+        flex-direction: column;
+        gap: $space-2;
+
+        // InstallAppButton can render nothing, leaving an empty discovery row.
+        &:has(> .discoveryActions:empty):not(:has(> .accountActions)) {
+          display: none;
+        }
+      }
+
       .accountActions {
         align-items: center;
-        margin-top: $space-2;
 
         .MuiTypography-caption {
           font-size: 0.8125rem;
@@ -2295,67 +2319,52 @@ html[data-theme="dark"] .uplot {
       }
 
       .discoveryActions {
-        margin-top: $space-4;
+        &:empty {
+          display: none;
+        }
       }
 
       button {
         margin: 0;
       }
     }
+
+    .MuiButton-root,
+    .MuiIconButton-root {
+      min-height: 40px;
+    }
+
+    @media (pointer: coarse) {
+      .MuiButton-root,
+      .MuiIconButton-root {
+        min-height: 44px;
+      }
+    }
   }
 
   .mainMenuFooter {
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    flex: 0 0 auto;
     box-sizing: border-box;
     padding-bottom: env(safe-area-inset-bottom);
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
   }
 
-  @media screen and (max-height: 700px) {
-    #logo {
-      top: 12px;
-    }
-
+  @media screen and (max-width: 600px) {
     #menuCard #centeredMenu {
-      top: 23%;
-    }
-
-    #menuCard .gameSubtitle {
-      margin-bottom: 8px;
+      padding-top: $space-4;
+      padding-bottom: $space-4;
     }
   }
 
   @media screen and (max-height: 450px) {
-    #menuCard {
-      display: flex;
-      flex-direction: column;
-      overflow-y: auto;
-    }
-
-    #logo {
-      position: static;
-      flex: 0 0 auto;
+    #menuCard #logo {
       padding: 8px 24px 0;
 
       img {
         max-height: 72px;
+        object-fit: contain;
       }
-    }
-
-    #menuCard #centeredMenu {
-      position: static;
-      flex: 0 0 auto;
-      margin: 0 auto;
-    }
-
-    .mainMenuFooter {
-      position: static;
-      flex: 0 0 auto;
-      margin-top: auto;
     }
   }
 

--- a/src/app.scss
+++ b/src/app.scss
@@ -2298,10 +2298,8 @@ html[data-theme="dark"] .uplot {
       }
 
       .utilityActions {
-        margin-top: $space-4;
         display: flex;
         flex-direction: column;
-        gap: $space-2;
 
         // InstallAppButton can render nothing, leaving an empty discovery row.
         &:has(> .discoveryActions:empty):not(:has(> .accountActions)) {

--- a/src/components/views/MainMenu.test.tsx
+++ b/src/components/views/MainMenu.test.tsx
@@ -100,7 +100,7 @@ describe("MainMenu", () => {
       screen.getByRole("navigation", { name: "Game resources" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Primary actions" })).toHaveStyle(
-      { gap: "10px" },
+      { gap: "12px" },
     );
   });
 
@@ -124,11 +124,11 @@ describe("MainMenu", () => {
     });
 
     expect(primary).toHaveStyle({ flexDirection: "column" });
-    expect(resources).toHaveStyle({ flexDirection: "row", gap: "6px" });
+    expect(resources).toHaveStyle({ flexDirection: "row", gap: "8px" });
     expect(
       within(resources).queryByRole("button", { name: "Sign in" }),
     ).not.toBeInTheDocument();
-    expect(discovery).toHaveStyle({ flexDirection: "row", gap: "6px" });
+    expect(discovery).toHaveStyle({ flexDirection: "row", gap: "8px" });
   });
 
   it("keeps sharing as a compact footer icon", () => {

--- a/src/components/views/MainMenu.tsx
+++ b/src/components/views/MainMenu.tsx
@@ -61,7 +61,7 @@ const MainMenu = (props: Props): React.JSX.Element => {
           component="section"
           aria-label="Primary actions"
           className="mainActions"
-          spacing={1.25}
+          spacing={1.5}
           useFlexGap
         >
           {props.hasSavedGame && (
@@ -90,7 +90,7 @@ const MainMenu = (props: Props): React.JSX.Element => {
           aria-label="Game resources"
           className="resourceActions"
           direction="row"
-          spacing={0.75}
+          spacing={1}
           useFlexGap
           sx={{
             alignItems: "center",
@@ -110,47 +110,49 @@ const MainMenu = (props: Props): React.JSX.Element => {
             Settings
           </Button>
         </Stack>
-        <Stack
-          component="section"
-          aria-label="Discovery actions"
-          className="discoveryActions"
-          direction="row"
-          spacing={0.75}
-          useFlexGap
-          sx={{
-            alignItems: "center",
-            justifyContent: "center",
-            flexWrap: "wrap",
-          }}
-        >
-          <InstallAppButton />
-          {props.audioEnabled === undefined && (
-            <Button
-              color="primary"
-              startIcon={<VolumeUpIcon />}
-              onClick={() => props.onAudioChange(true)}
-            >
-              Turn on sound
-            </Button>
-          )}
-        </Stack>
-        {!props.uid && (
+        <Box className="utilityActions">
           <Stack
             component="section"
-            aria-label="Account actions"
-            className="accountActions"
-            spacing={0}
+            aria-label="Discovery actions"
+            className="discoveryActions"
+            direction="row"
+            spacing={1}
+            useFlexGap
+            sx={{
+              alignItems: "center",
+              justifyContent: "center",
+              flexWrap: "wrap",
+            }}
           >
-            <Button variant="text" color="primary" onClick={login}>
-              Sign in
-            </Button>
-            {!props.hasSavedGame && (
-              <Typography variant="caption" color="text.secondary">
-                Free · no sign-up needed
-              </Typography>
+            <InstallAppButton />
+            {props.audioEnabled === undefined && (
+              <Button
+                color="primary"
+                startIcon={<VolumeUpIcon />}
+                onClick={() => props.onAudioChange(true)}
+              >
+                Turn on sound
+              </Button>
             )}
           </Stack>
-        )}
+          {!props.uid && (
+            <Stack
+              component="section"
+              aria-label="Account actions"
+              className="accountActions"
+              spacing={0.5}
+            >
+              <Button variant="text" color="primary" onClick={login}>
+                Sign in
+              </Button>
+              {!props.hasSavedGame && (
+                <Typography variant="caption" color="text.secondary">
+                  Free · no sign-up needed
+                </Typography>
+              )}
+            </Stack>
+          )}
+        </Box>
         <Typography className="srOnly" role="status" aria-live="polite">
           {shareStatus}
         </Typography>


### PR DESCRIPTION
The home menu mixed independent margins and irregular gaps, and hidden sound/install controls could leave empty space. Keep the primary action distinct, and make the secondary controls compact: resources, sound/install, and sign-in use adjacent button rows with no added vertical gaps. Their existing button padding provides separation while preserving 44px touch targets. The speaker icon follows the Turn on sound label.

The logo, menu, and footer now follow normal document flow, centering the menu when space allows and scrolling on short screens. Preserve the action order, theme colors, and button width.

Validation: `npm run check`, `npm run build`, and responsive Playwright checks (13 passed; 12 intentionally skipped by viewport). Browser checks cover light/dark, 320/390/768/1280/1440px widths, disappearing sound controls, and saved-game footer access on a short screen.

![Desktop dark theme](https://github.com/user-attachments/assets/db77d045-6134-4525-8804-851b8a8705a4)

![Mobile dark theme](https://github.com/user-attachments/assets/d5c3b087-e6f4-4350-a7ff-53c92287784e)

![Narrow mobile light theme](https://github.com/user-attachments/assets/cd9dadc9-ffb0-4540-aad8-9c2fd9070a20)