### PR TITLE
Improve custom setup coverage, facility icons, and map zoom

### DIFF
--- a/e2e/custom-location-picker.spec.ts
+++ b/e2e/custom-location-picker.spec.ts
@@ -170,6 +170,24 @@ test("custom setup uses side-by-side settings and facilities only at desktop wid
   const settings = page.getByRole("region", { name: "Game setup" });
   const facilities = page.getByRole("region", { name: "Facilities" });
   const outlook = page.getByRole("region", { name: "Year 1 outlook" });
+  const row = facilities.locator(".build-list-item").first();
+  const contentBox = await row.locator(".MuiCardHeader-content").boundingBox();
+  const removeBox = await row
+    .getByRole("button", { name: "Remove Natural Gas" })
+    .boundingBox();
+  expect(contentBox).not.toBeNull();
+  expect(removeBox).not.toBeNull();
+  expect(removeBox!.x).toBeGreaterThanOrEqual(
+    contentBox!.x + contentBox!.width,
+  );
+  expect(
+    Math.abs(
+      removeBox!.y +
+        removeBox!.height / 2 -
+        (contentBox!.y + contentBox!.height / 2),
+    ),
+  ).toBeLessThanOrEqual(1);
+  expect(removeBox!.height).toBeGreaterThanOrEqual(44);
   const settingsBox = await settings.boundingBox();
   const facilitiesBox = await facilities.boundingBox();
   const outlookBox = await outlook.boundingBox();

--- a/e2e/custom-location-picker.spec.ts
+++ b/e2e/custom-location-picker.spec.ts
@@ -222,7 +222,25 @@ test("Year 1 outlook recalculates from the selected facilities", async ({
   await page.getByRole("button", { name: "Add facility" }).click();
   await expect(outlook).toContainText("Calculating Year 1 outlook…");
   await expect(outlook).toContainText("Demand covered", { timeout: 20000 });
-  await expect(outlook).toContainText("100%");
+  await expect
+    .poll(async () =>
+      Number(
+        (
+          await outlook
+            .locator(".customSetupOutlookMetrics strong")
+            .first()
+            .innerText()
+        ).replace("%", ""),
+      ),
+    )
+    .toBeGreaterThan(300);
+  const icon = page
+    .getByRole("region", { name: "Facilities", exact: true })
+    .locator(".MuiCardHeader-avatar img");
+  await expect(icon).toHaveAttribute("src", "/images/natural gas.svg");
+  await expect
+    .poll(() => icon.evaluate((img: HTMLImageElement) => img.naturalWidth))
+    .toBeGreaterThan(0);
   await expect(outlook).toContainText("No forecast shortfall");
 });
 
@@ -282,7 +300,14 @@ test("keyboard navigation retains one map stop and honors activation and zoom bo
   await zoomIn.click();
   await zoomIn.click();
   await zoomIn.click();
+  await expect(zoomIn).toBeEnabled();
+  await zoomIn.click();
+  await expect(map.locator(".worldMapLand > g")).toHaveAttribute(
+    "transform",
+    /scale\(16\)/,
+  );
   await expect(zoomIn).toBeDisabled();
+  await zoomOut.click();
   await zoomOut.click();
   await zoomOut.click();
   await zoomOut.click();

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -288,6 +288,7 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
   HistoryForecastShared & {
     minute: number;
     supplyW: number; // Watts
+    availableSupplyW?: number; // Supply plus unused fuel-burning generation capacity
     demandW: number; // Watts
     // Components sum to demandW. Kept on forecast ticks so Insights can explain what is driving
     // load without bloating the long-lived monthly history in saves.

--- a/src/app.scss
+++ b/src/app.scss
@@ -3918,6 +3918,28 @@ $sizemap: (
   }
 }
 
+// Setup rows have one compact removal action beside the facility name.
+.customSetupFacilities .build-list-item .MuiCardHeader-root {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  .MuiCardHeader-avatar {
+    margin: 0;
+  }
+
+  .MuiCardHeader-content {
+    min-width: 0;
+  }
+
+  .MuiCardHeader-action {
+    width: auto;
+    margin: 0 !important;
+    align-self: center;
+    flex-shrink: 0;
+  }
+}
+
 // Shared purchase rows: keep the decision and touch targets compact without clipping copy.
 .build-list-item.buildOption {
   .MuiCardHeader-root {

--- a/src/components/base/LocationPicker.test.tsx
+++ b/src/components/base/LocationPicker.test.tsx
@@ -236,7 +236,7 @@ it("drills into a cluster and lists unresolved cities at maximum zoom", async ()
     />,
   );
 
-  for (let level = 0; level < 4; level += 1) {
+  for (let level = 0; level < 5; level += 1) {
     await user.click(
       screen.getByRole("button", { name: /Zoom to 3 locations/ }),
     );

--- a/src/components/base/LocationPicker.tsx
+++ b/src/components/base/LocationPicker.tsx
@@ -35,7 +35,7 @@ interface Props {
 }
 
 const WORLD_VIEW: MapViewport = { center: { x: 0.5, y: 0.5 }, zoom: 0 };
-const MAX_ZOOM = 3;
+const MAX_ZOOM = MAP_ZOOM_SCALES.length - 1;
 
 interface MapDrag {
   pointerId: number;

--- a/src/components/views/CustomGame.test.tsx
+++ b/src/components/views/CustomGame.test.tsx
@@ -172,7 +172,7 @@ it("ignores an older forecast result after the setup changes", () => {
     worker.onmessage?.({
       data: {
         requestId: secondRequest.requestId,
-        outlook: { demandServed: 1, worstShortfallW: 0 },
+        outlook: { demandServed: 3, worstShortfallW: 0 },
       },
     } as MessageEvent);
     worker.onmessage?.({
@@ -184,6 +184,7 @@ it("ignores an older forecast result after the setup changes", () => {
   });
 
   expect(screen.getByText("Demand covered")).toBeInTheDocument();
+  expect(screen.getByText("300%")).toBeInTheDocument();
   expect(screen.queryByText("Deficit forecast")).not.toBeInTheDocument();
 });
 

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {
+  Avatar,
   Button,
   Card,
   CardHeader,
@@ -200,12 +201,12 @@ function facilitySize(facility: Partial<FacilityShoppingType>): string {
 }
 
 function demandServedLabel(outlook: YearOneOutlook): string {
-  if (outlook.worstShortfallW === 0) {
-    return "100%";
+  const percent = outlook.demandServed * 100;
+  // Preserve a near-100% annual deficit without hiding surplus generation.
+  if (percent >= 99 && percent < 100) {
+    return `${Math.min(99.9, percent).toFixed(1)}%`;
   }
-  // Never round a real deficit up to the covered state's 100%.
-  const percent = Math.min(99.9, outlook.demandServed * 100);
-  return `${percent >= 99 ? percent.toFixed(1) : Math.round(percent)}%`;
+  return `${Math.round(percent)}%`;
 }
 
 /**
@@ -829,7 +830,8 @@ export default function CustomGame(props: Props): React.JSX.Element {
                       variant="caption"
                       className="customSetupOutlookAssumption"
                     >
-                      Assumes this fleet and rate stay unchanged.
+                      Includes spare generation capacity. Assumes this fleet and
+                      rate stay unchanged.
                     </Typography>
                   </>
                 )}
@@ -844,6 +846,12 @@ export default function CustomGame(props: Props): React.JSX.Element {
                     key={`${facilityName(f)}${i}`}
                   >
                     <CardHeader
+                      avatar={
+                        <Avatar
+                          alt=""
+                          src={`/images/${facilityName(f).toLowerCase()}.svg`}
+                        />
+                      }
                       title={facilityName(f)}
                       subheader={facilitySize(f)}
                       action={

--- a/src/helpers/CustomGameForecast.test.ts
+++ b/src/helpers/CustomGameForecast.test.ts
@@ -12,9 +12,9 @@ function tick(demandW: number, supplyW: number): TickPresentFutureType {
 }
 
 describe("summarizeYearOneOutlook", () => {
-  it("reports full coverage with no shortfall", () => {
-    expect(summarizeYearOneOutlook([tick(100, 105), tick(200, 220)])).toEqual({
-      demandServed: 1,
+  it("reports surplus annual generation with no shortfall", () => {
+    expect(summarizeYearOneOutlook([tick(100, 300), tick(200, 600)])).toEqual({
+      demandServed: 3,
       worstShortfallW: 0,
     });
   });
@@ -22,7 +22,14 @@ describe("summarizeYearOneOutlook", () => {
   it("combines annual coverage with the worst instantaneous deficit", () => {
     expect(
       summarizeYearOneOutlook([tick(100, 80), tick(200, 150), tick(100, 120)]),
-    ).toEqual({ demandServed: 0.825, worstShortfallW: 50 });
+    ).toEqual({ demandServed: 0.875, worstShortfallW: 50 });
+  });
+
+  it("keeps an instantaneous shortfall even with an annual surplus", () => {
+    expect(summarizeYearOneOutlook([tick(100, 50), tick(100, 550)])).toEqual({
+      demandServed: 3,
+      worstShortfallW: 50,
+    });
   });
 
   it("handles an empty forecast without inventing a shortfall", () => {
@@ -59,7 +66,7 @@ describe("forecastCustomGameYearOne", () => {
 
     expect(empty.demandServed).toBe(0);
     expect(empty.worstShortfallW).toBeGreaterThan(0);
-    expect(supplied.demandServed).toBeGreaterThan(empty.demandServed);
+    expect(supplied.demandServed).toBeGreaterThan(3);
     expect(supplied.worstShortfallW).toBeLessThan(empty.worstShortfallW);
   });
 });

--- a/src/helpers/CustomGameForecast.ts
+++ b/src/helpers/CustomGameForecast.ts
@@ -37,15 +37,15 @@ export function summarizeYearOneOutlook(
   timeline: readonly TickPresentFutureType[],
 ): YearOneOutlook {
   let demand = 0;
-  let served = 0;
+  let supply = 0;
   let worstShortfallW = 0;
   timeline.forEach((tick) => {
     demand += Math.max(0, tick.demandW);
-    served += Math.max(0, Math.min(tick.supplyW, tick.demandW));
+    supply += Math.max(0, tick.availableSupplyW ?? tick.supplyW);
     worstShortfallW = Math.max(worstShortfallW, tick.demandW - tick.supplyW);
   });
   return {
-    demandServed: demand > 0 ? Math.min(1, served / demand) : 1,
+    demandServed: demand > 0 ? supply / demand : 1,
     // Fractions of a watt are forecast arithmetic, not a meaningful shortage.
     worstShortfallW: worstShortfallW < 1 ? 0 : worstShortfallW,
   };

--- a/src/helpers/WorldMap.test.ts
+++ b/src/helpers/WorldMap.test.ts
@@ -21,8 +21,8 @@ it("projects geographic extremes onto the map", () => {
 
 it("clamps zoom and map centers to visible bounds", () => {
   expect(clampViewport({ center: { x: -2, y: 4 }, zoom: 99 })).toEqual({
-    center: { x: 0.0625, y: 0.9375 },
-    zoom: 3,
+    center: { x: 0.03125, y: 0.96875 },
+    zoom: 4,
   });
 });
 
@@ -48,7 +48,7 @@ it("zooms around a screen point and keeps its world location stationary", () => 
 
   expect(zoomed).toEqual({ center: { x: 0.625, y: 0.375 }, zoom: 1 });
   expect(pointInViewport({ x: 0.75, y: 0.25 }, zoomed)).toEqual(anchor);
-  expect(zoomViewportAt(zoomed, 99, anchor).zoom).toBe(3);
+  expect(zoomViewportAt(zoomed, 99, anchor).zoom).toBe(4);
 });
 
 it("clusters close locations deterministically but keeps selection visible", () => {

--- a/src/helpers/WorldMap.ts
+++ b/src/helpers/WorldMap.ts
@@ -28,7 +28,7 @@ export interface MapCluster<T extends MapLocation> extends MapPoint {
 
 export type MapControl<T extends MapLocation> = MapMarker<T> | MapCluster<T>;
 
-export const MAP_ZOOM_SCALES = [1, 2, 4, 8] as const;
+export const MAP_ZOOM_SCALES = [1, 2, 4, 8, 16] as const;
 
 export function projectLocation(
   location: Pick<MapLocation, "lat" | "long">,

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1946,6 +1946,7 @@ function updateSupplyFacilitiesFinances(
 
   // Update supply and facility outputs
   let supply = 0;
+  let spareGenerationW = 0;
   const supplyByFuel = {} as FuelProductionType;
   let charge = 0;
   let storedWh = 0;
@@ -2134,6 +2135,11 @@ function updateSupplyFacilitiesFinances(
                 ? Math.min(committedTargetW, g.currentW + rampW)
                 : Math.max(committedTargetW, g.currentW - rampW),
             );
+            // Setup can show surplus capacity even when dispatch follows demand. Hydro stays
+            // at its dispatched output so stored water is not counted repeatedly as energy.
+            if (!hydro) {
+              spareGenerationW += Math.max(0, dispatchPeakW - g.currentW);
+            }
             break;
         }
         supply += g.currentW;
@@ -2190,6 +2196,7 @@ function updateSupplyFacilitiesFinances(
     }
   });
   now.supplyW = supply;
+  now.availableSupplyW = supply + spareGenerationW;
   now.supplyByFuel = supplyByFuel;
   now.storedWh = storedWh;
   now.storageLossWh = storageLossWh;


### PR DESCRIPTION
Custom setup now reports annual available supply as a percentage of demand without a 100% cap. Adding a 2 GW gas plant to the default fleet shows over 600% instead of 100%. Spare fuel-burning capacity is included even when normal dispatch follows demand; the separate shortfall warning still uses actual dispatched supply. Hydro and storage retain their resource-constrained forecast output.

Facility rows reuse the in-game icons to the left of their names and keep the trash button beside the text on mobile, including 320 px screens. The world map gains a 16x zoom level, with controls and cluster navigation sharing the same zoom limit.

Validation: Node 24, lockfile install, `npm run check` (Jest limited to two workers for this run), and `npm run build`. Custom location browser coverage passed across desktop, tablet, and 320/390 px mobile layouts, including dark mode, loaded icons, surplus demand coverage, and zoom bounds. The first run hit the old UI zoom limit and unrelated test timeouts under parallel load; the corrected zoom checks and bounded-worker suite were rerun.

Desktop, dark mobile, and maximum-zoom screenshots:

![Desktop setup with surplus capacity and facility icons](https://github.com/user-attachments/assets/3f323f19-a463-49ed-80fe-3b6bbd7ddc39)

![Dark mobile setup with inline trash buttons](https://github.com/user-attachments/assets/83b60c01-f884-4f46-8962-058d8f28e23d)

![World map at the new 16x maximum zoom](https://github.com/user-attachments/assets/84bcc653-5505-4340-90fa-ac4779593bec)

