### PR TITLE
Add blocking scenario choices with wildfire preparedness outcomes

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
+const port = process.env.E2E_PORT || "3000";
+const baseURL = `http://127.0.0.1:${port}`;
+
 export default defineConfig({
   testDir: ".",
   timeout: 45000,
@@ -9,7 +12,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? "github" : "list",
   use: {
-    baseURL: "http://127.0.0.1:3000",
+    baseURL,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
   },
@@ -51,13 +54,13 @@ export default defineConfig({
   ],
   webServer: {
     command: "npm start",
-    url: "http://127.0.0.1:3000",
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
     env: {
       BROWSER: "none",
       HOST: "127.0.0.1",
-      PORT: "3000",
+      PORT: port,
     },
   },
 });

--- a/e2e/wildfire-decision.spec.ts
+++ b/e2e/wildfire-decision.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+for (const theme of ["light", "dark"]) {
+  test(`wildfire response is actionable and persistent in ${theme}`, async ({
+    page,
+  }, testInfo) => {
+    await page.addInitScript((mode) => {
+      localStorage.clear();
+      localStorage.setItem("theme", mode);
+    }, theme);
+    await page.goto("/?scenario=111");
+    await page.getByRole("button", { name: "Start game", exact: true }).click();
+    if (!(await page.locator(".eventLog:visible").isVisible()))
+      await page.getByRole("button", { name: "Events", exact: true }).click();
+    const fast = page
+      .locator("#appbar:visible")
+      .getByRole("button", { name: "fast speed" })
+      .first();
+    await fast.click();
+    const region = page.getByRole("region", { name: "Wildfire preparedness" });
+    await expect(region).toBeVisible({ timeout: 30000 });
+    const fund = region.getByRole("button", { name: "Fund preparedness" });
+    await expect(fund).toBeEnabled();
+    await expect(region).toContainText("before January");
+    await expect(region).toContainText("Normal restoration costs still apply");
+    expect(
+      await region.evaluate((el) => el.scrollWidth - el.clientWidth),
+    ).toBeLessThanOrEqual(1);
+    for (const button of await region.getByRole("button").all()) {
+      const box = await button.boundingBox();
+      expect(box!.height).toBeGreaterThanOrEqual(44);
+      expect(box!.x).toBeGreaterThanOrEqual(0);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(
+        page.viewportSize()!.width,
+      );
+    }
+    await fund.scrollIntoViewIfNeeded();
+    await page.screenshot({
+      path: testInfo.outputPath(`wildfire-choice-${theme}.png`),
+    });
+    await (
+      theme === "light"
+        ? fund
+        : region.getByRole("button", { name: "Keep cash (standard response)" })
+    ).focus();
+    await page.keyboard.press("Enter");
+    await expect(region.getByRole("status")).toContainText(
+      theme === "light" ? "Preparedness funded" : "Standard response",
+    );
+    await expect(region.getByRole("button")).toHaveCount(0);
+    await fast.click();
+    await expect(page.getByText("Through Feb 2025")).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(
+      page.getByText(
+        theme === "light"
+          ? /Prepared crews are in place/
+          : /Standard response is in place/,
+      ),
+    ).toBeVisible();
+    await page.screenshot({
+      path: testInfo.outputPath(`wildfire-outcome-${theme}.png`),
+    });
+  });
+}

--- a/e2e/wildfire-decision.spec.ts
+++ b/e2e/wildfire-decision.spec.ts
@@ -9,18 +9,16 @@ for (const theme of ["light", "dark"]) {
     }, theme);
     await page.goto("/?scenario=111");
     await page.getByRole("button", { name: "Start game", exact: true }).click();
-    if (!(await page.locator(".eventLog:visible").isVisible()))
-      await page.getByRole("button", { name: "Events", exact: true }).click();
     const fast = page
       .locator("#appbar:visible")
       .getByRole("button", { name: "fast speed" })
       .first();
     await fast.click();
-    const region = page.getByRole("region", { name: "Wildfire preparedness" });
+    const region = page.getByRole("dialog", { name: "Wildfire preparedness" });
     await expect(region).toBeVisible({ timeout: 30000 });
     const fund = region.getByRole("button", { name: "Fund preparedness" });
     await expect(fund).toBeEnabled();
-    await expect(region).toContainText("before January");
+    await expect(region).toContainText("Game paused");
     await expect(region).toContainText("Normal restoration costs still apply");
     expect(
       await region.evaluate((el) => el.scrollWidth - el.clientWidth),
@@ -33,6 +31,22 @@ for (const theme of ["light", "dark"]) {
         page.viewportSize()!.width,
       );
     }
+    const pausedStatus = await page
+      .locator("#appbar:visible")
+      .first()
+      .innerText();
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("3");
+    await page.mouse.click(1, 1);
+    await expect(region).toBeVisible();
+    await page.waitForTimeout(400);
+    expect(await page.locator("#appbar:visible").first().innerText()).toBe(
+      pausedStatus,
+    );
+    await page.keyboard.press("Tab");
+    expect(
+      await region.evaluate((el) => el.contains(document.activeElement)),
+    ).toBe(true);
     await fund.scrollIntoViewIfNeeded();
     await page.screenshot({
       path: testInfo.outputPath(`wildfire-choice-${theme}.png`),
@@ -40,13 +54,12 @@ for (const theme of ["light", "dark"]) {
     await (
       theme === "light"
         ? fund
-        : region.getByRole("button", { name: "Keep cash (standard response)" })
+        : region.getByRole("button", { name: "Keep cash" })
     ).focus();
     await page.keyboard.press("Enter");
-    await expect(region.getByRole("status")).toContainText(
-      theme === "light" ? "Preparedness funded" : "Standard response",
-    );
-    await expect(region.getByRole("button")).toHaveCount(0);
+    await expect(region).not.toBeVisible();
+    if (!(await page.locator(".eventLog:visible").isVisible()))
+      await page.getByRole("button", { name: "Events", exact: true }).click();
     await fast.click();
     await expect(page.getByText("Through Feb 2025")).toBeVisible({
       timeout: 15000,

--- a/e2e/wildfire-decision.spec.ts
+++ b/e2e/wildfire-decision.spec.ts
@@ -20,9 +20,40 @@ for (const theme of ["light", "dark"]) {
     await expect(fund).toBeEnabled();
     await expect(region).toContainText("Game paused");
     await expect(region).toContainText("Normal restoration costs still apply");
+    const titleInset = await region
+      .locator("#scenarioChoiceTitle")
+      .evaluate(
+        (el) =>
+          el.getBoundingClientRect().left +
+          parseFloat(getComputedStyle(el).paddingLeft),
+      );
+    const descriptionBox = (await region
+      .locator("#scenarioChoiceDescription")
+      .boundingBox())!;
+    expect(titleInset).toBe(descriptionBox.x);
     expect(
       await region.evaluate((el) => el.scrollWidth - el.clientWidth),
     ).toBeLessThanOrEqual(1);
+    if (page.viewportSize()!.width < 600) {
+      const dialogBox = (await region.boundingBox())!;
+      expect(dialogBox.width).toBeGreaterThanOrEqual(
+        page.viewportSize()!.width - 32,
+      );
+      const fundBox = (await fund.boundingBox())!;
+      const costBox = (await region
+        .getByText("One-time cost:", { exact: false })
+        .boundingBox())!;
+      const keepCashBox = (await region
+        .getByRole("button", { name: "Keep cash" })
+        .boundingBox())!;
+      // Keep the cost attached to its own action and separate from the next choice.
+      expect(costBox.y - (fundBox.y + fundBox.height)).toBeLessThanOrEqual(8);
+      expect(
+        keepCashBox.y - (costBox.y + costBox.height),
+      ).toBeGreaterThanOrEqual(16);
+      expect(keepCashBox.x).toBe(fundBox.x);
+      expect(keepCashBox.width).toBe(fundBox.width);
+    }
     for (const button of await region.getByRole("button").all()) {
       const box = await button.boundingBox();
       expect(box!.height).toBeGreaterThanOrEqual(44);

--- a/e2e/wildfire-scenario.spec.ts
+++ b/e2e/wildfire-scenario.spec.ts
@@ -34,9 +34,7 @@ test("wildfire briefing and ongoing emergency stay usable", async ({
     .first()
     .click();
 
-  await page
-    .getByRole("button", { name: "Keep cash (standard response)" })
-    .click();
+  await page.getByRole("button", { name: "Keep cash" }).click();
   await page
     .locator("#appbar:visible")
     .getByRole("button", { name: "fast speed" })

--- a/e2e/wildfire-scenario.spec.ts
+++ b/e2e/wildfire-scenario.spec.ts
@@ -34,6 +34,15 @@ test("wildfire briefing and ongoing emergency stay usable", async ({
     .first()
     .click();
 
+  await page
+    .getByRole("button", { name: "Keep cash (standard response)" })
+    .click();
+  await page
+    .locator("#appbar:visible")
+    .getByRole("button", { name: "fast speed" })
+    .first()
+    .click();
+
   await expect(
     page.getByRole("heading", { name: "Ongoing events" }),
   ).toBeVisible({ timeout: 25000 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import ScenarioChoiceDialog from "./components/base/ScenarioChoiceDialog";
 import { ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { User } from "firebase/auth";
@@ -258,6 +259,7 @@ export default function App() {
           <OfflineNotice />
           <UnitsProvider>
             <CompositorContainer store={store} />
+            <ScenarioChoiceDialog />
           </UnitsProvider>
         </InstallPromptProvider>
       </ThemedApp>

--- a/src/Replay.test.tsx
+++ b/src/Replay.test.tsx
@@ -192,7 +192,7 @@ describe("decodeReplay", () => {
     expect(decodeReplay(current)?.meaningfulDecisionGateWaived).toBeUndefined();
   });
 
-  it.each([1, 2, 3, 4, 5, 6, 7])(
+  it.each([1, 2, 3, 4, 5, 6, 7, 8, 9])(
     "rejects version %i recorded with older simulation rules",
     (version) => {
       expect(decodeReplay({ ...encodeReplay(aReplay()), version })).toBeNull();

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -1,3 +1,4 @@
+import { validScenarioResponse } from "./helpers/ScenarioChoices";
 import { validPolicyChange } from "./helpers/Policies";
 import cloneDeep from "lodash.clonedeep";
 import packageJson from "../package.json";
@@ -35,8 +36,8 @@ import {
 // Version 7 corrects storage, solar, emissions and weather physics. Earlier action streams cannot
 // reproduce their recorded outcomes and must not be relabeled as current replays.
 // Version 8 changes dispatch, neighboring emissions and resource/demand calibration.
-// Version 9 adds irreversible wildfire response actions.
-export const REPLAY_VERSION = 9;
+// Version 10 replaces wildfire actions with mandatory generic scenario choices.
+export const REPLAY_VERSION = 10;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few
@@ -64,7 +65,7 @@ export type RecordedDeltaType = Partial<
 >;
 
 const REPLAY_ACTION_NAMES: ReplayActionNameType[] = [
-  "chooseWildfireResponse",
+  "chooseScenarioResponse",
   "schedulePolicy",
   "cancelPolicy",
   "buildFacility",
@@ -212,9 +213,8 @@ function parseActions(raw: unknown): ReplayActionType[] | null {
     )
       return null;
     if (
-      action.type === "chooseWildfireResponse" &&
-      action.payload !== "prepare" &&
-      action.payload !== "standard"
+      action.type === "chooseScenarioResponse" &&
+      !validScenarioResponse(action.payload)
     )
       return null;
     actions.push({

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -35,7 +35,8 @@ import {
 // Version 7 corrects storage, solar, emissions and weather physics. Earlier action streams cannot
 // reproduce their recorded outcomes and must not be relabeled as current replays.
 // Version 8 changes dispatch, neighboring emissions and resource/demand calibration.
-export const REPLAY_VERSION = 8;
+// Version 9 adds irreversible wildfire response actions.
+export const REPLAY_VERSION = 9;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few
@@ -63,6 +64,7 @@ export type RecordedDeltaType = Partial<
 >;
 
 const REPLAY_ACTION_NAMES: ReplayActionNameType[] = [
+  "chooseWildfireResponse",
   "schedulePolicy",
   "cancelPolicy",
   "buildFacility",
@@ -207,6 +209,12 @@ function parseActions(raw: unknown): ReplayActionType[] | null {
       !["BALANCED", "RELIABILITY_FIRST", "SURPLUS_ONLY", "CLOSED"].includes(
         action.payload as string,
       )
+    )
+      return null;
+    if (
+      action.type === "chooseWildfireResponse" &&
+      action.payload !== "prepare" &&
+      action.payload !== "standard"
     )
       return null;
     actions.push({

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -75,7 +75,7 @@ describe("SaveGame", () => {
     expect(parseSave(raw)).toBeNull();
   });
 
-  it.each([1, 2, 3, 4, 5])(
+  it.each([1, 2, 3, 4, 5, 6])(
     "rejects version %i calculated with older physics without modifying it",
     (version) => {
       const legacy = { ...serializeSave(game), version };

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -38,7 +38,8 @@ export const SAVE_KEY = "savedGame";
 // Older snapshots contain forecasts and financial results calculated with different physics;
 // do not silently mix those results with the new simulation. Original files remain untouched.
 // Version 6 separates reachable reserve and local/purchased emissions and recalibrates resources.
-export const SAVE_VERSION = 6;
+// Version 7 requires explicit scenario choices; older runs could advance past unanswered prompts.
+export const SAVE_VERSION = 7;
 
 export interface SaveGameType {
   version: number;

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -259,6 +259,7 @@ export interface ScoreType {
 // The player actions a replay has to reproduce. Everything else about a run -- weather, fuel
 // prices, demand -- falls out of the seed, so this is the whole of what the player contributed.
 export type ReplayActionNameType =
+  | "chooseWildfireResponse"
   | "schedulePolicy"
   | "cancelPolicy"
   | "buildFacility"

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -259,7 +259,7 @@ export interface ScoreType {
 // The player actions a replay has to reproduce. Everything else about a run -- weather, fuel
 // prices, demand -- falls out of the seed, so this is the whole of what the player contributed.
 export type ReplayActionNameType =
-  | "chooseWildfireResponse"
+  | "chooseScenarioResponse"
   | "schedulePolicy"
   | "cancelPolicy"
   | "buildFacility"
@@ -1088,4 +1088,21 @@ export interface AppStateType {
   settings: SettingsType;
   ui: UIType;
   user: UserType;
+}
+
+/** Authored time-triggered choices; IDs are persisted in story occurrences. */
+export interface ScenarioChoiceType {
+  id: string;
+  scenarioId: number;
+  atMonth: number;
+  title: string;
+  message: string;
+  options: {
+    id: string;
+    label: string;
+    message: string;
+    cost: (difficulty: DifficultyType) => number;
+    /** False for a response that preserves the baseline without changing the operating plan. */
+    meaningful?: boolean;
+  }[];
 }

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -91,6 +91,7 @@ const NON_TEXT_INPUT_TYPES = new Set([
 ]);
 configure({
   ignoreEventsCondition: (event: KeyboardEvent) => {
+    if (document.querySelector('[data-scenario-choice="true"]')) return true;
     if (document.querySelector('[data-manual-help="true"]')) return true;
     if (document.querySelector('[data-customer-programs="true"]')) return true;
     if (event.key === "Escape") {

--- a/src/components/base/ScenarioChoiceDialog.tsx
+++ b/src/components/base/ScenarioChoiceDialog.tsx
@@ -28,10 +28,27 @@ export default function ScenarioChoiceDialog() {
       aria-labelledby="scenarioChoiceTitle"
       aria-describedby="scenarioChoiceDescription"
       data-scenario-choice="true"
+      slotProps={{
+        paper: {
+          sx: {
+            m: { xs: 1.5, sm: 4 },
+            width: { xs: "calc(100% - 24px)", sm: "calc(100% - 64px)" },
+            maxHeight: {
+              xs: "calc(100dvh - 24px)",
+              sm: "calc(100dvh - 64px)",
+            },
+          },
+        },
+      }}
     >
-      <DialogTitle id="scenarioChoiceTitle">{decision.title}</DialogTitle>
-      <DialogContent>
-        <Typography variant="body2" sx={{ mb: 2 }}>
+      <DialogTitle
+        id="scenarioChoiceTitle"
+        sx={{ "&&": { px: { xs: 2, sm: 3 }, pt: 2, pb: 1 } }}
+      >
+        {decision.title}
+      </DialogTitle>
+      <DialogContent sx={{ px: { xs: 2, sm: 3 }, pb: 3 }}>
+        <Typography variant="body2" sx={{ color: "text.secondary", mb: 1.5 }}>
           Game paused — choose a response to continue.
         </Typography>
         <Typography id="scenarioChoiceDescription">
@@ -40,12 +57,18 @@ export default function ScenarioChoiceDialog() {
         <Typography sx={{ my: 2 }}>
           Cash available: ${(cash / 1000000).toFixed(1)}M
         </Typography>
-        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", sm: "repeat(2, minmax(0, 1fr))" },
+            gap: 2,
+          }}
+        >
           {decision.options.map((option, index) => {
             const cost = option.cost(game.difficulty);
             const affordable = cost === 0 || cash >= cost;
             return (
-              <Box key={option.id} sx={{ flex: "1 1 180px" }}>
+              <Box key={option.id}>
                 <Button
                   fullWidth
                   autoFocus={index === 0 && affordable}
@@ -63,7 +86,10 @@ export default function ScenarioChoiceDialog() {
                 >
                   {option.label}
                 </Button>
-                <Typography variant="body2" sx={{ mt: 1 }}>
+                <Typography
+                  variant="body2"
+                  sx={{ color: "text.secondary", mt: 0.5 }}
+                >
                   {cost > 0
                     ? `One-time cost: $${(cost / 1000000).toFixed(1)}M`
                     : "No upfront cost"}

--- a/src/components/base/ScenarioChoiceDialog.tsx
+++ b/src/components/base/ScenarioChoiceDialog.tsx
@@ -1,0 +1,79 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@mui/material";
+import { useAppDispatch, useAppSelector } from "../../Store";
+import { pendingScenarioChoice } from "../../helpers/ScenarioChoices";
+import { getTimeFromTimeline } from "../../helpers/DateTime";
+import { chooseScenarioResponse } from "../../reducers/GameActions";
+
+export default function ScenarioChoiceDialog() {
+  const game = useAppSelector((state) => state.game);
+  const dispatch = useAppDispatch();
+  const decision =
+    game.inGame && !game.replayPlayback
+      ? pendingScenarioChoice(game)
+      : undefined;
+  if (!decision) return null;
+  const cash = getTimeFromTimeline(game.date.minute, game.timeline)?.cash ?? 0;
+  return (
+    <Dialog
+      open
+      fullWidth
+      maxWidth="sm"
+      aria-labelledby="scenarioChoiceTitle"
+      aria-describedby="scenarioChoiceDescription"
+      data-scenario-choice="true"
+    >
+      <DialogTitle id="scenarioChoiceTitle">{decision.title}</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" sx={{ mb: 2 }}>
+          Game paused — choose a response to continue.
+        </Typography>
+        <Typography id="scenarioChoiceDescription">
+          {decision.message}
+        </Typography>
+        <Typography sx={{ my: 2 }}>
+          Cash available: ${(cash / 1000000).toFixed(1)}M
+        </Typography>
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+          {decision.options.map((option, index) => {
+            const cost = option.cost(game.difficulty);
+            const affordable = cost === 0 || cash >= cost;
+            return (
+              <Box key={option.id} sx={{ flex: "1 1 180px" }}>
+                <Button
+                  fullWidth
+                  autoFocus={index === 0 && affordable}
+                  variant={index === 0 ? "contained" : "outlined"}
+                  disabled={!affordable}
+                  sx={{ minHeight: 44, whiteSpace: "normal" }}
+                  onClick={() =>
+                    dispatch(
+                      chooseScenarioResponse({
+                        decisionId: decision.id,
+                        optionId: option.id,
+                      }),
+                    )
+                  }
+                >
+                  {option.label}
+                </Button>
+                <Typography variant="body2" sx={{ mt: 1 }}>
+                  {cost > 0
+                    ? `One-time cost: $${(cost / 1000000).toFixed(1)}M`
+                    : "No upfront cost"}
+                  {!affordable && " · Insufficient cash"}
+                </Typography>
+              </Box>
+            );
+          })}
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
 import {
-  Box,
-  Button,
   IconButton,
   ListItemIcon,
   ListItemText,
@@ -80,19 +78,12 @@ const EVENT_HISTORY_FILTERS: {
 ];
 
 export interface StateProps {
-  wildfireDecision?: {
-    cost: number;
-    cash: number;
-    choice?: string;
-    available: boolean;
-  };
   events: GameEventType[];
   upcoming?: UpcomingStoryEventType[];
   ongoing?: UpcomingStoryEventType[];
 }
 
 export interface DispatchProps {
-  onChooseWildfire?: (choice: "prepare" | "standard") => void;
   onOpen: () => void;
   onSelect: (target?: StoryActionTargetType) => void;
 }
@@ -121,73 +112,6 @@ export default function EventLog(props: Props): React.JSX.Element {
   return (
     <GameCard className="eventLog" title="Events" id="eventsPane">
       <div className="scrollable">
-        {props.wildfireDecision && (
-          <Box
-            component="section"
-            aria-labelledby="wildfireDecisionTitle"
-            sx={{ p: 2, borderBottom: 1, borderColor: "divider" }}
-          >
-            <Typography id="wildfireDecisionTitle" variant="subtitle2">
-              Wildfire preparedness
-            </Typography>
-            {props.wildfireDecision.available ? (
-              <>
-                <Typography variant="body2" sx={{ my: 1 }}>
-                  Decide before January. Prepared crews halve physical customer
-                  disconnections and generator output losses during January and
-                  February. Normal restoration costs still apply. Keeping cash
-                  means accepting the full outage impact.
-                </Typography>
-                <Typography variant="body2" sx={{ mb: 1 }}>
-                  One-time cost: $
-                  {(props.wildfireDecision.cost / 1000000).toFixed(1)}M. Cash
-                  available: $
-                  {(props.wildfireDecision.cash / 1000000).toFixed(1)}M. No
-                  response by January selects standard response.
-                </Typography>
-                <Box
-                  sx={{
-                    display: "flex",
-                    flexWrap: "wrap",
-                    gap: 1,
-                    "& button": {
-                      minHeight: 44,
-                      flex: "1 1 180px",
-                      whiteSpace: "normal",
-                    },
-                  }}
-                >
-                  <Button
-                    variant="contained"
-                    disabled={
-                      props.wildfireDecision.cash < props.wildfireDecision.cost
-                    }
-                    onClick={() => props.onChooseWildfire?.("prepare")}
-                  >
-                    Fund preparedness
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    onClick={() => props.onChooseWildfire?.("standard")}
-                  >
-                    Keep cash (standard response)
-                  </Button>
-                </Box>
-                {props.wildfireDecision.cash < props.wildfireDecision.cost && (
-                  <Typography variant="body2" sx={{ mt: 1 }}>
-                    Insufficient cash to fund preparedness.
-                  </Typography>
-                )}
-              </>
-            ) : (
-              <Typography role="status" variant="body2" sx={{ mt: 1 }}>
-                {props.wildfireDecision.choice === "prepare"
-                  ? "Preparedness funded. Crews halve disconnections and generation losses during January and February."
-                  : "Standard response: preparedness cash preserved; full outage impact applies."}
-              </Typography>
-            )}
-          </Box>
-        )}
         {ongoing.length > 0 && (
           <section
             className="eventLogSection ongoingEvents"

--- a/src/components/views/EventLog.tsx
+++ b/src/components/views/EventLog.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import {
+  Box,
+  Button,
   IconButton,
   ListItemIcon,
   ListItemText,
@@ -78,12 +80,19 @@ const EVENT_HISTORY_FILTERS: {
 ];
 
 export interface StateProps {
+  wildfireDecision?: {
+    cost: number;
+    cash: number;
+    choice?: string;
+    available: boolean;
+  };
   events: GameEventType[];
   upcoming?: UpcomingStoryEventType[];
   ongoing?: UpcomingStoryEventType[];
 }
 
 export interface DispatchProps {
+  onChooseWildfire?: (choice: "prepare" | "standard") => void;
   onOpen: () => void;
   onSelect: (target?: StoryActionTargetType) => void;
 }
@@ -112,6 +121,73 @@ export default function EventLog(props: Props): React.JSX.Element {
   return (
     <GameCard className="eventLog" title="Events" id="eventsPane">
       <div className="scrollable">
+        {props.wildfireDecision && (
+          <Box
+            component="section"
+            aria-labelledby="wildfireDecisionTitle"
+            sx={{ p: 2, borderBottom: 1, borderColor: "divider" }}
+          >
+            <Typography id="wildfireDecisionTitle" variant="subtitle2">
+              Wildfire preparedness
+            </Typography>
+            {props.wildfireDecision.available ? (
+              <>
+                <Typography variant="body2" sx={{ my: 1 }}>
+                  Decide before January. Prepared crews halve physical customer
+                  disconnections and generator output losses during January and
+                  February. Normal restoration costs still apply. Keeping cash
+                  means accepting the full outage impact.
+                </Typography>
+                <Typography variant="body2" sx={{ mb: 1 }}>
+                  One-time cost: $
+                  {(props.wildfireDecision.cost / 1000000).toFixed(1)}M. Cash
+                  available: $
+                  {(props.wildfireDecision.cash / 1000000).toFixed(1)}M. No
+                  response by January selects standard response.
+                </Typography>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    gap: 1,
+                    "& button": {
+                      minHeight: 44,
+                      flex: "1 1 180px",
+                      whiteSpace: "normal",
+                    },
+                  }}
+                >
+                  <Button
+                    variant="contained"
+                    disabled={
+                      props.wildfireDecision.cash < props.wildfireDecision.cost
+                    }
+                    onClick={() => props.onChooseWildfire?.("prepare")}
+                  >
+                    Fund preparedness
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    onClick={() => props.onChooseWildfire?.("standard")}
+                  >
+                    Keep cash (standard response)
+                  </Button>
+                </Box>
+                {props.wildfireDecision.cash < props.wildfireDecision.cost && (
+                  <Typography variant="body2" sx={{ mt: 1 }}>
+                    Insufficient cash to fund preparedness.
+                  </Typography>
+                )}
+              </>
+            ) : (
+              <Typography role="status" variant="body2" sx={{ mt: 1 }}>
+                {props.wildfireDecision.choice === "prepare"
+                  ? "Preparedness funded. Crews halve disconnections and generation losses during January and February."
+                  : "Standard response: preparedness cash preserved; full outage impact applies."}
+              </Typography>
+            )}
+          </Box>
+        )}
         {ongoing.length > 0 && (
           <section
             className="eventLogSection ongoingEvents"

--- a/src/components/views/EventLogContainer.tsx
+++ b/src/components/views/EventLogContainer.tsx
@@ -1,3 +1,9 @@
+import { chooseWildfireResponse } from "../../reducers/GameActions";
+import {
+  WILDFIRE_DECISION_KEY,
+  wildfirePreparationCost,
+} from "../../data/WorldEvents";
+import { getTimeFromTimeline } from "../../helpers/DateTime";
 import { connect } from "react-redux";
 import {
   AppStateType,
@@ -64,12 +70,33 @@ const mapStateToProps = (state: AppStateType): StateProps => {
     events: state.game.eventLog.filter(
       (event) => !event.storyPhaseKey || !ongoingKeys.has(event.storyPhaseKey),
     ),
+    wildfireDecision:
+      state.game.scenarioId === 111 &&
+      !state.game.storyEffectsDisabled &&
+      state.game.date.monthsElapsed >= 11
+        ? {
+            cost: wildfirePreparationCost(state.game.difficulty),
+            cash:
+              getTimeFromTimeline(state.game.date.minute, state.game.timeline)
+                ?.cash ?? 0,
+            choice: state.game.worldEvents.occurrences.find(
+              (event) => event.key === WILDFIRE_DECISION_KEY,
+            )?.attributes.choice as string | undefined,
+            available:
+              !state.game.replayPlayback &&
+              state.game.date.monthsElapsed === 11 &&
+              !state.game.worldEvents.occurrences.some(
+                (event) => event.key === WILDFIRE_DECISION_KEY,
+              ),
+          }
+        : undefined,
     ongoing,
     upcoming: selectUpcomingStoryEvents(state),
   };
 };
 
 const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => ({
+  onChooseWildfire: (choice) => dispatch(chooseWildfireResponse(choice)),
   onOpen: () => dispatch(markEventsRead()),
   onSelect: (target?: StoryActionTargetType) => {
     if (target) {

--- a/src/components/views/EventLogContainer.tsx
+++ b/src/components/views/EventLogContainer.tsx
@@ -1,9 +1,3 @@
-import { chooseWildfireResponse } from "../../reducers/GameActions";
-import {
-  WILDFIRE_DECISION_KEY,
-  wildfirePreparationCost,
-} from "../../data/WorldEvents";
-import { getTimeFromTimeline } from "../../helpers/DateTime";
 import { connect } from "react-redux";
 import {
   AppStateType,
@@ -70,33 +64,12 @@ const mapStateToProps = (state: AppStateType): StateProps => {
     events: state.game.eventLog.filter(
       (event) => !event.storyPhaseKey || !ongoingKeys.has(event.storyPhaseKey),
     ),
-    wildfireDecision:
-      state.game.scenarioId === 111 &&
-      !state.game.storyEffectsDisabled &&
-      state.game.date.monthsElapsed >= 11
-        ? {
-            cost: wildfirePreparationCost(state.game.difficulty),
-            cash:
-              getTimeFromTimeline(state.game.date.minute, state.game.timeline)
-                ?.cash ?? 0,
-            choice: state.game.worldEvents.occurrences.find(
-              (event) => event.key === WILDFIRE_DECISION_KEY,
-            )?.attributes.choice as string | undefined,
-            available:
-              !state.game.replayPlayback &&
-              state.game.date.monthsElapsed === 11 &&
-              !state.game.worldEvents.occurrences.some(
-                (event) => event.key === WILDFIRE_DECISION_KEY,
-              ),
-          }
-        : undefined,
     ongoing,
     upcoming: selectUpcomingStoryEvents(state),
   };
 };
 
 const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => ({
-  onChooseWildfire: (choice) => dispatch(chooseWildfireResponse(choice)),
   onOpen: () => dispatch(markEventsRead()),
   onSelect: (target?: StoryActionTargetType) => {
     if (target) {

--- a/src/components/views/StoryEventSelectors.ts
+++ b/src/components/views/StoryEventSelectors.ts
@@ -5,6 +5,7 @@ import {
   StoryActionTargetType,
 } from "../../Types";
 import {
+  WILDFIRE_DECISION_KEY,
   STORY_ARC_DEFINITIONS,
   upcomingStoryPhases,
 } from "../../data/WorldEvents";
@@ -78,6 +79,9 @@ export function selectUpcomingStoryEvents(
     game.date.monthsElapsed,
     game.startingYear,
     game.location.id,
+    game.worldEvents.occurrences.find(
+      (event) => event.key === WILDFIRE_DECISION_KEY,
+    )?.attributes.choice || "standard",
     historyKey,
     fleetKey,
   ].join("|");
@@ -90,6 +94,7 @@ export function selectUpcomingStoryEvents(
     difficulty: game.difficulty,
     date: game.date,
     location: game.location,
+    occurrences: game.worldEvents.occurrences,
     snapshot: buildStorySnapshot(
       game.monthlyHistory,
       game.facilities,

--- a/src/data/ScenarioChoices.ts
+++ b/src/data/ScenarioChoices.ts
@@ -1,0 +1,29 @@
+import { ScenarioChoiceType } from "../Types";
+import { WILDFIRE_DECISION_KEY, wildfirePreparationCost } from "./WorldEvents";
+export const SCENARIO_CHOICES: ScenarioChoiceType[] = [
+  {
+    id: WILDFIRE_DECISION_KEY,
+    scenarioId: 111,
+    atMonth: 11,
+    title: "Wildfire preparedness",
+    message:
+      "Extreme Santa Ana winds are forecast for January. Prepared crews halve physical customer disconnections and generator output losses during January and February. Normal restoration costs still apply. Keeping cash means accepting the full outage impact.",
+    options: [
+      {
+        id: "prepare",
+        label: "Fund preparedness",
+        cost: wildfirePreparationCost,
+        message:
+          "Preparedness funded. Crews halve physical disconnections and generator output losses in January and February; normal restoration costs still apply.",
+      },
+      {
+        id: "standard",
+        meaningful: false,
+        label: "Keep cash",
+        cost: () => 0,
+        message:
+          "Cash preserved. The full January and February outage impact and restoration costs apply.",
+      },
+    ],
+  },
+];

--- a/src/data/ScenarioChoices.ts
+++ b/src/data/ScenarioChoices.ts
@@ -7,7 +7,7 @@ export const SCENARIO_CHOICES: ScenarioChoiceType[] = [
     atMonth: 11,
     title: "Wildfire preparedness",
     message:
-      "Extreme Santa Ana winds are forecast for January. Prepared crews halve physical customer disconnections and generator output losses during January and February. Normal restoration costs still apply. Keeping cash means accepting the full outage impact.",
+      "Extreme Santa Ana winds are forecast for January. Prepared crews halve physical customer disconnections and generator output losses during January and February. Normal restoration costs still apply.",
     options: [
       {
         id: "prepare",

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -1337,7 +1337,7 @@ const CALIFORNIA_WILDFIRE_ARC: StoryArcDefinitionType = {
       describe: () => ({
         title: "Red-flag warning",
         message:
-          "After an exceptionally dry fall, extreme Santa Ana winds are forecast for January, so choose a preparedness response in Events before January. Fund crews to halve physical outages, or preserve cash and use the standard response. Ignoring this decision keeps the standard response.",
+          "After an exceptionally dry fall, extreme Santa Ana winds are forecast for January, so choose whether to fund preparedness crews or preserve cash. The game is paused until you select.",
         concept: "forecast",
         kind: "WORLD_EVENT",
         importance: "CRITICAL",

--- a/src/data/WorldEvents.tsx
+++ b/src/data/WorldEvents.tsx
@@ -1309,6 +1309,23 @@ export const CALIFORNIA_WILDFIRE_BALANCE: Record<
   },
 };
 
+export const WILDFIRE_DECISION_KEY =
+  "story:111:california-wildfire-2025:preparedness";
+export function wildfirePrepared(
+  occurrences?: ActiveWorldEventType[],
+): boolean {
+  return (
+    occurrences?.some(
+      (event) =>
+        event.key === WILDFIRE_DECISION_KEY &&
+        event.attributes.choice === "prepare",
+    ) ?? false
+  );
+}
+export function wildfirePreparationCost(difficulty: DifficultyType): number {
+  return CALIFORNIA_WILDFIRE_BALANCE[difficulty].restorationCostPerMonth * 2;
+}
+
 const CALIFORNIA_WILDFIRE_ARC: StoryArcDefinitionType = {
   id: "california-wildfire-2025",
   scenarioId: 111,
@@ -1320,24 +1337,34 @@ const CALIFORNIA_WILDFIRE_ARC: StoryArcDefinitionType = {
       describe: () => ({
         title: "Red-flag warning",
         message:
-          "After an exceptionally dry fall, extreme Santa Ana winds are forecast for January, so prepare backup power for possible safety shutoffs.",
+          "After an exceptionally dry fall, extreme Santa Ana winds are forecast for January, so choose a preparedness response in Events before January. Fund crews to halve physical outages, or preserve cash and use the standard response. Ignoring this decision keeps the standard response.",
         concept: "forecast",
         kind: "WORLD_EVENT",
-        importance: "NOTABLE",
-        actionTarget: FLEET_TARGET,
+        importance: "CRITICAL",
+        actionTarget: { card: "EVENTS" },
       }),
     },
     {
       id: "firestorm",
       schedule: { atMonth: 12 },
       durationMonths: 2,
-      preview: () => ({
+      preview: (context) => ({
         title: "January wildfire emergency",
-        message:
-          "Extreme fire weather may force two months of safety shutoffs, lost sales, constrained generation, and restoration work.",
+        message: wildfirePrepared(context.occurrences)
+          ? "Prepared crews halve disconnected load and generation output losses during January and February. Normal restoration costs still apply."
+          : "Extreme fire weather may force two months of safety shutoffs, lost sales, constrained generation, and restoration work.",
       }),
       describe: (context, random) => {
-        const balance = CALIFORNIA_WILDFIRE_BALANCE[context.difficulty];
+        const original = CALIFORNIA_WILDFIRE_BALANCE[context.difficulty];
+        const prepared = wildfirePrepared(context.occurrences);
+        const balance = {
+          ...original,
+          disconnectedDemand:
+            original.disconnectedDemand * (prepared ? 0.5 : 1),
+          outputMultiplier: prepared
+            ? (1 + original.outputMultiplier) / 2
+            : original.outputMultiplier,
+        };
         const candidates = context.snapshot.facilities
           .filter((facility) => facility.operational && !!facility.fuel)
           .map((facility) => ({
@@ -1371,12 +1398,13 @@ const CALIFORNIA_WILDFIRE_ARC: StoryArcDefinitionType = {
           : "No operating generators";
         return {
           title: "Wildfire emergency",
-          message: `${Math.round(balance.disconnectedDemand * 100)}% of customer load is disconnected by safety shutoffs while ${affectedFacilities} ${selectedNames.length === 1 ? "is" : "are"} limited to ${percent(balance.outputMultiplier)} output and restoration costs $${(balance.restorationCostPerMonth / 1000000).toFixed(1)}M per month through February.`,
+          message: `${prepared ? "Prepared crews are in place. " : "Standard response is in place. "}${Math.round(balance.disconnectedDemand * 100)}% of customer load is disconnected by safety shutoffs while ${affectedFacilities} ${selectedNames.length === 1 ? "is" : "are"} limited to ${percent(balance.outputMultiplier)} output and restoration costs $${(balance.restorationCostPerMonth / 1000000).toFixed(1)}M per month through February.`,
           concept: "danger",
           kind: "WORLD_EVENT",
           importance: "CRITICAL",
           actionTarget: FLEET_TARGET,
           attributes: {
+            prepared,
             disconnectedDemand: balance.disconnectedDemand,
             targetCapacityShare: balance.targetCapacityShare,
             selectedCapacityShare: share(selectedPeakW, totalPeakW),
@@ -1411,7 +1439,7 @@ const CALIFORNIA_WILDFIRE_ARC: StoryArcDefinitionType = {
           []) as string[];
         return {
           title: "Wildfire restoration complete",
-          message: `Safety shutoffs are lifted, ${selectedNames.length ? selectedNames.join(", ") : "affected generators"} return to normal, and the grid met ${percent(reliability)} of connected demand during the emergency.`,
+          message: `${wildfirePrepared(context.occurrences) ? "Your funded preparedness halved physical disconnections and generator output losses during the emergency. " : "The standard response preserved your preparedness budget. "}Safety shutoffs are lifted, ${selectedNames.length ? selectedNames.join(", ") : "affected generators"} return to normal, and the grid met ${percent(reliability)} of connected demand during the emergency.`,
           concept: "supply",
           kind: "WORLD_EVENT",
           importance: unservedWh > demandWh * 0.001 ? "NOTABLE" : "ROUTINE",

--- a/src/helpers/ScenarioChoices.test.ts
+++ b/src/helpers/ScenarioChoices.test.ts
@@ -1,0 +1,83 @@
+import { SCENARIO_CHOICES } from "../data/ScenarioChoices";
+import reducer from "../reducers/Game";
+import { chooseScenarioResponse } from "../reducers/GameActions";
+import {
+  pendingScenarioChoice,
+  validScenarioResponse,
+} from "./ScenarioChoices";
+import { createGame } from "../testing/Simulator";
+import { ScenarioChoiceType } from "../Types";
+import { MINUTES_PER_MONTH } from "./DateTime";
+
+test("other scenarios can queue timed choices using only authored definitions", () => {
+  const game = createGame({ scenarioId: 101 });
+  const first: ScenarioChoiceType = {
+    id: "new-policy",
+    scenarioId: 101,
+    atMonth: 2,
+    title: "Policy",
+    message: "Choose",
+    options: [{ id: "yes", label: "Yes", message: "Accepted", cost: () => 0 }],
+  };
+  const second = { ...first, id: "follow-up" };
+  expect(pendingScenarioChoice(game, [first, second])).toBeUndefined();
+  game.date.minute = 2 * MINUTES_PER_MONTH;
+  expect(pendingScenarioChoice(game, [first, second])).toBe(first);
+  game.worldEvents.occurrences.push({
+    key: first.id,
+    definitionId: first.id,
+    startsMinute: game.date.minute,
+    endsMinute: game.date.minute,
+    attributes: { choice: "yes" },
+    effects: {},
+  });
+  expect(pendingScenarioChoice(game, [first, second])).toBe(second);
+  game.storyEffectsDisabled = true;
+  expect(pendingScenarioChoice(game, [first])).toBeUndefined();
+});
+
+test.each([null, "prepare", {}, { decisionId: 1, optionId: "yes" }])(
+  "rejects malformed response %p",
+  (value) => {
+    expect(validScenarioResponse(value)).toBe(false);
+  },
+);
+
+test("generic reducer accepts another scenario's authored option without wildfire wiring", () => {
+  const game = createGame({ scenarioId: 101 });
+  const definition: ScenarioChoiceType = {
+    id: "test-other-scenario",
+    scenarioId: 101,
+    atMonth: 0,
+    title: "New policy",
+    message: "Choose a policy",
+    options: [
+      { id: "adopt", label: "Adopt", message: "Policy adopted", cost: () => 0 },
+    ],
+  };
+  SCENARIO_CHOICES.push(definition);
+  try {
+    expect(
+      reducer(
+        game,
+        chooseScenarioResponse({
+          decisionId: definition.id,
+          optionId: "unknown",
+        }),
+      ),
+    ).toBe(game);
+    const chosen = reducer(
+      game,
+      chooseScenarioResponse({ decisionId: definition.id, optionId: "adopt" }),
+    );
+    expect(
+      chosen.worldEvents.occurrences.find(
+        (event) => event.key === definition.id,
+      )?.attributes.choice,
+    ).toBe("adopt");
+    expect(pendingScenarioChoice(chosen)).toBeUndefined();
+    expect(chosen.replayLog?.at(-1)?.type).toBe("chooseScenarioResponse");
+  } finally {
+    SCENARIO_CHOICES.pop();
+  }
+});

--- a/src/helpers/ScenarioChoices.ts
+++ b/src/helpers/ScenarioChoices.ts
@@ -1,0 +1,27 @@
+import { GameType, ScenarioChoiceType } from "../Types";
+import { SCENARIO_CHOICES } from "../data/ScenarioChoices";
+import { MINUTES_PER_MONTH } from "./DateTime";
+/** Due choices remain pending until explicitly answered, including after loading a save.
+ * Array order breaks ties so simultaneous choices appear sequentially. */
+export function pendingScenarioChoice(
+  game: GameType,
+  definitions: ScenarioChoiceType[] = SCENARIO_CHOICES,
+) {
+  if (game.storyEffectsDisabled) return undefined;
+  return definitions.find(
+    (choice) =>
+      choice.scenarioId === game.scenarioId &&
+      game.date.minute >= choice.atMonth * MINUTES_PER_MONTH &&
+      !game.worldEvents.occurrences.some((event) => event.key === choice.id),
+  );
+}
+export function validScenarioResponse(
+  value: unknown,
+): value is { decisionId: string; optionId: string } {
+  if (!value || typeof value !== "object") return false;
+  const response = value as Record<string, unknown>;
+  return (
+    typeof response.decisionId === "string" &&
+    typeof response.optionId === "string"
+  );
+}

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1,3 +1,8 @@
+import { chooseWildfireResponse } from "./GameActions";
+import {
+  WILDFIRE_DECISION_KEY,
+  wildfirePreparationCost,
+} from "../data/WorldEvents";
 import { getViableLocationCount } from "../data/FacilitySites";
 import {
   advancePolicies,
@@ -577,6 +582,9 @@ function scheduledStoryCacheKey(date: DateType, state: GameType): string {
     state.seed,
     date.monthsElapsed,
     fleetKey,
+    state.worldEvents.occurrences.find(
+      (event) => event.key === WILDFIRE_DECISION_KEY,
+    )?.attributes.choice || "standard",
   ].join("|");
 }
 
@@ -1115,6 +1123,10 @@ export const gameSlice = createSlice({
       state.speed = speedBeforeDialog;
       ensureTicking(state);
     });
+    builder.addCase(chooseWildfireResponse, (state, action) => {
+      if (!state.replayPlayback && applyWildfireResponse(state, action.payload))
+        recordReplayAction(state, "chooseWildfireResponse", action.payload);
+    });
     builder.addCase(schedulePolicy, (state, action) => {
       if (
         !state.replayPlayback &&
@@ -1423,6 +1435,57 @@ function applyBuildTransmissionLine(
  * skipped rather than allowed to crash the sim mid-tick -- a replay that plays back slightly
  * wrong is a disappointment, one that throws takes the whole game down with it.
  */
+function applyWildfireResponse(state: GameType, choice: unknown): boolean {
+  const now = getTimeFromTimeline(state.date.minute, state.timeline);
+  if (
+    (choice !== "prepare" && choice !== "standard") ||
+    state.scenarioId !== 111 ||
+    state.storyEffectsDisabled ||
+    state.date.monthsElapsed !== 11 ||
+    Math.floor(state.date.minute / MINUTES_PER_MONTH) !== 11 ||
+    !now ||
+    state.worldEvents.occurrences.some(
+      (event) => event.key === WILDFIRE_DECISION_KEY,
+    )
+  )
+    return false;
+  const cost =
+    choice === "prepare" ? wildfirePreparationCost(state.difficulty) : 0;
+  if (cost > 0 && now.cash < cost) return false;
+  now.cash -= cost;
+  now.netWorth -= cost;
+  now.expensesOM += cost;
+  const message =
+    choice === "prepare"
+      ? `Committed $${(cost / 1000000).toFixed(1)}M to preparedness. Crews halve physical disconnections and generator output losses in January and February; normal restoration costs still apply.`
+      : "Standard wildfire response selected: preserve cash now and accept the full January and February outage impact and restoration costs.";
+  state.worldEvents.occurrences.push({
+    key: WILDFIRE_DECISION_KEY,
+    definitionId: WILDFIRE_DECISION_KEY,
+    startsMinute: state.date.minute,
+    endsMinute: state.date.minute,
+    attributes: { choice, cost },
+    effects: {},
+    title: "Wildfire response chosen",
+    message,
+  });
+  logGameEvent(state, "WORLD_EVENT", message, {
+    title: "Wildfire response chosen",
+    importance: "NOTABLE",
+    storyPhaseKey: WILDFIRE_DECISION_KEY,
+    turningPointPriority: 115,
+  });
+  recordMeaningfulDecision(state, {
+    lever: "wildfire-response",
+    label: "Choose wildfire response",
+    kind: "policy",
+    before: "undecided",
+    after: choice,
+  });
+  state.timeline = reforecastSupply(state, true);
+  return true;
+}
+
 function applyPolicyEdit(
   state: GameType,
   payload: unknown,
@@ -1481,6 +1544,9 @@ function applyPolicyEdit(
 function applyReplayAction(state: GameType, entry: ReplayActionType) {
   const payload = entry.payload;
   switch (entry.type) {
+    case "chooseWildfireResponse":
+      applyWildfireResponse(state, payload);
+      break;
     case "schedulePolicy":
     case "cancelPolicy":
       applyPolicyEdit(state, payload, entry.type === "cancelPolicy");
@@ -2711,6 +2777,13 @@ function updateSupplyFacilitiesFinances(
   // plant, such as field crews and rebuilding damaged distribution equipment.
   let expensesOM =
     (tickStoryEffects.operatingExpensePerMonth || 0) / ticksPerMonth;
+  expensesOM += state.worldEvents.occurrences
+    .filter(
+      (event) =>
+        event.key === WILDFIRE_DECISION_KEY &&
+        event.startsMinute === now.minute,
+    )
+    .reduce((total, event) => total + Number(event.attributes.cost || 0), 0);
   let expensesFuel = 0;
   let expensesInterest = 0;
   let principalRepayment = 0;

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1,8 +1,8 @@
-import { chooseWildfireResponse } from "./GameActions";
+import { chooseScenarioResponse } from "./GameActions";
 import {
-  WILDFIRE_DECISION_KEY,
-  wildfirePreparationCost,
-} from "../data/WorldEvents";
+  pendingScenarioChoice,
+  validScenarioResponse,
+} from "../helpers/ScenarioChoices";
 import { getViableLocationCount } from "../data/FacilitySites";
 import {
   advancePolicies,
@@ -582,9 +582,12 @@ function scheduledStoryCacheKey(date: DateType, state: GameType): string {
     state.seed,
     date.monthsElapsed,
     fleetKey,
-    state.worldEvents.occurrences.find(
-      (event) => event.key === WILDFIRE_DECISION_KEY,
-    )?.attributes.choice || "standard",
+    JSON.stringify(
+      state.worldEvents.occurrences.map((event) => [
+        event.key,
+        event.attributes,
+      ]),
+    ),
   ].join("|");
 }
 
@@ -988,6 +991,7 @@ export const gameSlice = createSlice({
       }
     },
     setSpeed: (state, action: PayloadAction<SpeedType>) => {
+      if (pendingScenarioChoice(state) && action.payload !== "PAUSED") return;
       delete state.policyPause;
       // Global keyboard shortcuts still fire over full-screen cards. Keep their quotes and
       // instructions frozen until the player actually closes the card.
@@ -1123,9 +1127,9 @@ export const gameSlice = createSlice({
       state.speed = speedBeforeDialog;
       ensureTicking(state);
     });
-    builder.addCase(chooseWildfireResponse, (state, action) => {
-      if (!state.replayPlayback && applyWildfireResponse(state, action.payload))
-        recordReplayAction(state, "chooseWildfireResponse", action.payload);
+    builder.addCase(chooseScenarioResponse, (state, action) => {
+      if (!state.replayPlayback && applyScenarioResponse(state, action.payload))
+        recordReplayAction(state, "chooseScenarioResponse", action.payload);
     });
     builder.addCase(schedulePolicy, (state, action) => {
       if (
@@ -1430,58 +1434,46 @@ function applyBuildTransmissionLine(
   return true;
 }
 
-/**
- * Replays one recorded action. The payload came off the network, so anything shaped wrong is
- * skipped rather than allowed to crash the sim mid-tick -- a replay that plays back slightly
- * wrong is a disappointment, one that throws takes the whole game down with it.
- */
-function applyWildfireResponse(state: GameType, choice: unknown): boolean {
+/** Accepts one authored choice for live play, replay and headless simulation. */
+function applyScenarioResponse(state: GameType, payload: unknown): boolean {
+  if (!validScenarioResponse(payload)) return false;
+  const decision = pendingScenarioChoice(state);
+  if (!decision || decision.id !== payload.decisionId) return false;
+  const option = decision.options.find(
+    (option) => option.id === payload.optionId,
+  );
   const now = getTimeFromTimeline(state.date.minute, state.timeline);
-  if (
-    (choice !== "prepare" && choice !== "standard") ||
-    state.scenarioId !== 111 ||
-    state.storyEffectsDisabled ||
-    state.date.monthsElapsed !== 11 ||
-    Math.floor(state.date.minute / MINUTES_PER_MONTH) !== 11 ||
-    !now ||
-    state.worldEvents.occurrences.some(
-      (event) => event.key === WILDFIRE_DECISION_KEY,
-    )
-  )
+  if (!option || !now) return false;
+  const cost = option.cost(state.difficulty);
+  if (!Number.isFinite(cost) || cost < 0 || (cost > 0 && now.cash < cost))
     return false;
-  const cost =
-    choice === "prepare" ? wildfirePreparationCost(state.difficulty) : 0;
-  if (cost > 0 && now.cash < cost) return false;
   now.cash -= cost;
   now.netWorth -= cost;
   now.expensesOM += cost;
-  const message =
-    choice === "prepare"
-      ? `Committed $${(cost / 1000000).toFixed(1)}M to preparedness. Crews halve physical disconnections and generator output losses in January and February; normal restoration costs still apply.`
-      : "Standard wildfire response selected: preserve cash now and accept the full January and February outage impact and restoration costs.";
   state.worldEvents.occurrences.push({
-    key: WILDFIRE_DECISION_KEY,
-    definitionId: WILDFIRE_DECISION_KEY,
+    key: decision.id,
+    definitionId: decision.id,
     startsMinute: state.date.minute,
     endsMinute: state.date.minute,
-    attributes: { choice, cost },
+    attributes: { choice: option.id, cost, scenarioChoice: true },
     effects: {},
-    title: "Wildfire response chosen",
-    message,
+    title: decision.title,
+    message: option.message,
   });
-  logGameEvent(state, "WORLD_EVENT", message, {
-    title: "Wildfire response chosen",
+  logGameEvent(state, "WORLD_EVENT", option.message, {
+    title: decision.title,
     importance: "NOTABLE",
-    storyPhaseKey: WILDFIRE_DECISION_KEY,
+    storyPhaseKey: decision.id,
     turningPointPriority: 115,
   });
-  recordMeaningfulDecision(state, {
-    lever: "wildfire-response",
-    label: "Choose wildfire response",
-    kind: "policy",
-    before: "undecided",
-    after: choice,
-  });
+  if (option.meaningful !== false)
+    recordMeaningfulDecision(state, {
+      lever: decision.id,
+      label: decision.title,
+      kind: "policy",
+      before: "undecided",
+      after: option.id,
+    });
   state.timeline = reforecastSupply(state, true);
   return true;
 }
@@ -1544,8 +1536,8 @@ function applyPolicyEdit(
 function applyReplayAction(state: GameType, entry: ReplayActionType) {
   const payload = entry.payload;
   switch (entry.type) {
-    case "chooseWildfireResponse":
-      applyWildfireResponse(state, payload);
+    case "chooseScenarioResponse":
+      applyScenarioResponse(state, payload);
       break;
     case "schedulePolicy":
     case "cancelPolicy":
@@ -1695,6 +1687,11 @@ export function tutorialCompleteDialog({
 // Exported so the headless simulator (src/testing/Simulator.tsx) can drive the sim
 // without the wall-clock timers that the `tick` action uses.
 export function tickState(state: GameType) {
+  applyPendingReplayActions(state);
+  if (pendingScenarioChoice(state)) {
+    state.speed = "PAUSED";
+    return;
+  }
   state.date = getDateFromMinute(
     state.date.minute + TICK_MINUTES,
     state.startingYear,
@@ -2044,6 +2041,7 @@ export function tickState(state: GameType) {
 
   // After the tick, the way a player's click lands after the tick that brought the clock to it
   applyPendingReplayActions(state);
+  if (pendingScenarioChoice(state)) state.speed = "PAUSED";
 }
 
 /** The same three completed-month firing rule used by the game and headless playtests. */
@@ -2780,7 +2778,7 @@ function updateSupplyFacilitiesFinances(
   expensesOM += state.worldEvents.occurrences
     .filter(
       (event) =>
-        event.key === WILDFIRE_DECISION_KEY &&
+        event.attributes.scenarioChoice === true &&
         event.startsMinute === now.minute,
     )
     .reduce((total, event) => total + Number(event.attributes.cost || 0), 0);

--- a/src/reducers/GameActions.tsx
+++ b/src/reducers/GameActions.tsx
@@ -46,3 +46,7 @@ export const resume = createAction<GameType>("game/resume");
  * that rebuilds the run the actions will be applied to.
  */
 export const startReplay = createAction<ReplayType>("game/startReplay");
+
+export const chooseWildfireResponse = createAction<"prepare" | "standard">(
+  "game/chooseWildfireResponse",
+);

--- a/src/reducers/GameActions.tsx
+++ b/src/reducers/GameActions.tsx
@@ -47,6 +47,7 @@ export const resume = createAction<GameType>("game/resume");
  */
 export const startReplay = createAction<ReplayType>("game/startReplay");
 
-export const chooseWildfireResponse = createAction<"prepare" | "standard">(
-  "game/chooseWildfireResponse",
-);
+export const chooseScenarioResponse = createAction<{
+  decisionId: string;
+  optionId: string;
+}>("game/chooseScenarioResponse");

--- a/src/reducers/WildfireDecision.test.tsx
+++ b/src/reducers/WildfireDecision.test.tsx
@@ -1,0 +1,186 @@
+import cloneDeep from "lodash.clonedeep";
+import { createGame, createGameFromReplay } from "../testing/Simulator";
+import reducer, { generateNewTimeline, tickState, delta } from "./Game";
+import { chooseWildfireResponse } from "./GameActions";
+import {
+  getDateFromMinute,
+  getTimeFromTimeline,
+  MINUTES_PER_MONTH,
+} from "../helpers/DateTime";
+import { parseSave, serializeSave } from "../SaveGame";
+import { decodeReplay, encodeReplay, serializeReplay } from "../Replay";
+import {
+  resolveStoryAtDate,
+  WILDFIRE_DECISION_KEY,
+  wildfirePreparationCost,
+} from "../data/WorldEvents";
+import { buildStorySnapshot } from "../helpers/Story";
+
+function ready(month = 11, cash = 100000000) {
+  const game = createGame({
+    scenarioId: 111,
+    difficulty: "Employee",
+    seed: 2468,
+  });
+  game.date = getDateFromMinute(month * MINUTES_PER_MONTH, game.startingYear);
+  game.timeline = generateNewTimeline(game, cash, 1000000);
+  game.replayLog = [];
+  return game;
+}
+const now = (game: ReturnType<typeof ready>) =>
+  getTimeFromTimeline(game.date.minute, game.timeline)!;
+function emergency(game: ReturnType<typeof ready>, month = 12) {
+  return resolveStoryAtDate({
+    seed: game.seed,
+    scenarioId: game.scenarioId,
+    difficulty: game.difficulty,
+    date: getDateFromMinute(month * MINUTES_PER_MONTH, game.startingYear),
+    location: game.location,
+    snapshot: buildStorySnapshot(
+      game.monthlyHistory,
+      game.facilities,
+      game.date.minute,
+    ),
+    occurrences: game.worldEvents.occurrences,
+  });
+}
+
+test("preparedness costs cash once, records operating expense and survives save/replay", () => {
+  const before = ready();
+  const after = reducer(before, chooseWildfireResponse("prepare"));
+  const cost = wildfirePreparationCost(before.difficulty);
+  expect(now(after).cash).toBe(now(before).cash - cost);
+  expect(now(after).expensesOM - now(before).expensesOM).toBeCloseTo(cost, 2);
+  expect(
+    after.worldEvents.occurrences.filter(
+      (event) => event.key === WILDFIRE_DECISION_KEY,
+    ),
+  ).toHaveLength(1);
+  expect(reducer(after, chooseWildfireResponse("prepare"))).toBe(after);
+  expect(reducer(after, chooseWildfireResponse("standard"))).toBe(after);
+  const loaded = parseSave(
+    JSON.parse(JSON.stringify(serializeSave(after))),
+  )!.game;
+  expect(loaded.worldEvents.occurrences).toEqual(after.worldEvents.occurrences);
+  expect(reducer(loaded, chooseWildfireResponse("prepare"))).toBe(loaded);
+  const replay = decodeReplay(encodeReplay(serializeReplay(after)!))!;
+  expect(replay.actions).toEqual([
+    {
+      minute: before.date.minute,
+      type: "chooseWildfireResponse",
+      payload: "prepare",
+    },
+  ]);
+  expect(
+    reducer(
+      before,
+      chooseWildfireResponse(replay.actions[0].payload as "prepare"),
+    ),
+  ).toEqual(after);
+});
+
+test("prepared crews halve physical losses, keep restoration cost, and recovery explains the choice", () => {
+  const before = ready();
+  const after = reducer(before, chooseWildfireResponse("prepare"));
+  const standard = emergency(before).effects;
+  const prepared = emergency(after).effects;
+  expect(1 - prepared.demandMultiplier!).toBeCloseTo(
+    (1 - standard.demandMultiplier!) / 2,
+  );
+  for (const [id, output] of Object.entries(
+    standard.facilityOutputMultipliersById!,
+  ))
+    expect(prepared.facilityOutputMultipliersById![id]).toBe((1 + output) / 2);
+  expect(prepared.operatingExpensePerMonth).toBe(
+    standard.operatingExpensePerMonth,
+  );
+  expect(emergency(after, 14).occurrences[0].message).toContain(
+    "funded preparedness",
+  );
+  expect(emergency(after, 14).effects).toEqual({});
+});
+
+test("standard response and ignored decision retain baseline effects", () => {
+  const before = ready();
+  const after = reducer(before, chooseWildfireResponse("standard"));
+  expect(now(after).cash).toBe(now(before).cash);
+  expect(emergency(after).effects).toEqual(emergency(before).effects);
+});
+
+test("rejects insufficient funds, wrong scenario, disabled stories, replay UI and deadline boundaries", () => {
+  for (const month of [10, 12, 14]) {
+    const game = ready(month);
+    expect(reducer(game, chooseWildfireResponse("prepare"))).toBe(game);
+  }
+  for (const change of [{ scenarioId: 110 }, { storyEffectsDisabled: true }]) {
+    const game = { ...ready(), ...change };
+    expect(reducer(game, chooseWildfireResponse("prepare"))).toBe(game);
+  }
+  const playback = ready();
+  playback.replayPlayback = { actions: [], index: 0 };
+  expect(reducer(playback, chooseWildfireResponse("prepare"))).toBe(playback);
+  const poor = cloneDeep(ready());
+  now(poor).cash = wildfirePreparationCost(poor.difficulty) - 1;
+  expect(reducer(poor, chooseWildfireResponse("prepare"))).toBe(poor);
+  expect(reducer(poor, chooseWildfireResponse("standard"))).not.toBe(poor);
+});
+
+test.each(["prepare", "standard", undefined] as const)(
+  "live/save/replay agree after recovery with %s",
+  (choice) => {
+    let live = createGame({
+      scenarioId: 111,
+      difficulty: "Employee",
+      seed: 2468,
+    });
+    const advance = (game: typeof live, month: number) => {
+      while (game.date.monthsElapsed < month) tickState(game);
+    };
+    advance(live, 11);
+    if (choice) live = cloneDeep(reducer(live, chooseWildfireResponse(choice)));
+    const saved = cloneDeep(
+      parseSave(JSON.parse(JSON.stringify(serializeSave(live))))!.game,
+    );
+    const replay = createGameFromReplay(
+      decodeReplay(encodeReplay(serializeReplay(live)!))!,
+    );
+    advance(live, 36);
+    advance(saved, 36);
+    advance(replay, 36);
+    expect(replay.worldEvents.occurrences).toEqual(
+      live.worldEvents.occurrences,
+    );
+    expect(saved.worldEvents.occurrences).toEqual(live.worldEvents.occurrences);
+    expect(now(replay).cash).toEqual(now(live).cash);
+    expect(now(saved).cash).toEqual(now(live).cash);
+    expect(replay.monthlyHistory).toEqual(live.monthlyHistory);
+  },
+  120000,
+);
+
+test("another reforecast preserves the upfront charge in O&M", () => {
+  const funded = reducer(ready(), chooseWildfireResponse("prepare"));
+  const forecast = reducer(
+    funded,
+    delta({ dollarsPerkWh: funded.dollarsPerkWh }),
+  );
+  expect(now(forecast).expensesOM).toBe(now(funded).expensesOM);
+  expect(now(forecast).cash).toBe(now(funded).cash);
+});
+
+test("forecast refresh includes funded disconnections without changing customer counts", () => {
+  const before = ready();
+  const after = cloneDeep(reducer(before, chooseWildfireResponse("prepare")));
+  const standard = cloneDeep(before);
+  standard.date = getDateFromMinute(
+    12 * MINUTES_PER_MONTH,
+    before.startingYear,
+  );
+  after.date = standard.date;
+  const baseline = generateNewTimeline(standard, 100000000, 1000000);
+  const prepared = generateNewTimeline(after, 100000000, 1000000);
+  expect(prepared[0].customers).toBe(baseline[0].customers);
+  expect(prepared[0].demandW / baseline[0].demandW).toBeCloseTo(0.98 / 0.96, 8);
+  const repeatedBaseline = generateNewTimeline(standard, 100000000, 1000000);
+  expect(repeatedBaseline[0].demandW).toBe(baseline[0].demandW);
+});

--- a/src/reducers/WildfireDecision.test.tsx
+++ b/src/reducers/WildfireDecision.test.tsx
@@ -1,7 +1,12 @@
 import cloneDeep from "lodash.clonedeep";
 import { createGame, createGameFromReplay } from "../testing/Simulator";
-import reducer, { generateNewTimeline, tickState, delta } from "./Game";
-import { chooseWildfireResponse } from "./GameActions";
+import reducer, {
+  generateNewTimeline,
+  tickState,
+  delta,
+  setSpeed,
+} from "./Game";
+import { chooseScenarioResponse } from "./GameActions";
 import {
   getDateFromMinute,
   getTimeFromTimeline,
@@ -15,6 +20,9 @@ import {
   wildfirePreparationCost,
 } from "../data/WorldEvents";
 import { buildStorySnapshot } from "../helpers/Story";
+
+const chooseWildfireResponse = (optionId: "prepare" | "standard") =>
+  chooseScenarioResponse({ decisionId: WILDFIRE_DECISION_KEY, optionId });
 
 function ready(month = 11, cash = 100000000) {
   const game = createGame({
@@ -67,14 +75,16 @@ test("preparedness costs cash once, records operating expense and survives save/
   expect(replay.actions).toEqual([
     {
       minute: before.date.minute,
-      type: "chooseWildfireResponse",
-      payload: "prepare",
+      type: "chooseScenarioResponse",
+      payload: { decisionId: WILDFIRE_DECISION_KEY, optionId: "prepare" },
     },
   ]);
   expect(
     reducer(
       before,
-      chooseWildfireResponse(replay.actions[0].payload as "prepare"),
+      chooseScenarioResponse(
+        replay.actions[0].payload as { decisionId: string; optionId: string },
+      ),
     ),
   ).toEqual(after);
 });
@@ -100,15 +110,16 @@ test("prepared crews halve physical losses, keep restoration cost, and recovery 
   expect(emergency(after, 14).effects).toEqual({});
 });
 
-test("standard response and ignored decision retain baseline effects", () => {
+test("keeping cash retains baseline effects", () => {
   const before = ready();
   const after = reducer(before, chooseWildfireResponse("standard"));
   expect(now(after).cash).toBe(now(before).cash);
+  expect(after.meaningfulDecisions).toEqual(before.meaningfulDecisions);
   expect(emergency(after).effects).toEqual(emergency(before).effects);
 });
 
 test("rejects insufficient funds, wrong scenario, disabled stories, replay UI and deadline boundaries", () => {
-  for (const month of [10, 12, 14]) {
+  for (const month of [10]) {
     const game = ready(month);
     expect(reducer(game, chooseWildfireResponse("prepare"))).toBe(game);
   }
@@ -125,7 +136,7 @@ test("rejects insufficient funds, wrong scenario, disabled stories, replay UI an
   expect(reducer(poor, chooseWildfireResponse("standard"))).not.toBe(poor);
 });
 
-test.each(["prepare", "standard", undefined] as const)(
+test.each(["prepare", "standard"] as const)(
   "live/save/replay agree after recovery with %s",
   (choice) => {
     let live = createGame({
@@ -183,4 +194,26 @@ test("forecast refresh includes funded disconnections without changing customer 
   expect(prepared[0].demandW / baseline[0].demandW).toBeCloseTo(0.98 / 0.96, 8);
   const repeatedBaseline = generateNewTimeline(standard, 100000000, 1000000);
   expect(repeatedBaseline[0].demandW).toBe(baseline[0].demandW);
+});
+
+test("an unanswered choice blocks ticks and speed changes and survives save/load", () => {
+  const game = ready();
+  const minute = game.date.minute;
+  const cash = now(game).cash;
+  tickState(game);
+  tickState(game);
+  expect(game.date.minute).toBe(minute);
+  expect(now(game).cash).toBe(cash);
+  expect(game.speed).toBe("PAUSED");
+  expect(reducer(game, setSpeed("FAST")).speed).toBe("PAUSED");
+  const saved = cloneDeep(
+    parseSave(JSON.parse(JSON.stringify(serializeSave(game))))!.game,
+  );
+  tickState(saved);
+  expect(saved.date.minute).toBe(minute);
+  const selected = cloneDeep(
+    reducer(saved, chooseWildfireResponse("standard")),
+  );
+  tickState(selected);
+  expect(selected.date.minute).toBeGreaterThan(minute);
 });

--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -136,3 +136,23 @@ out to jest pointed at `SimCli.tsx`, which is named so CRA's default `testMatch`
   rollovers, which is why the cash and energy checks only run within a month.
 - **`getFuelPricesPerMBTU` loops forever if no prices are loaded**, and `getWeather` throws. Any
   non-browser entry point has to call `loadSimData` first.
+
+## Time-triggered scenario choices
+
+Add a definition to `src/data/ScenarioChoices.ts`: a unique persisted `id`, scenario ID,
+zero-based trigger month, prompt, and options with stable IDs, outcome copy and difficulty-based
+upfront costs. Include a free option so a player with no cash can still choose. Definitions are
+presented in array order when several are due. No UI or reducer wiring is needed.
+
+The shared modal blocks navigation and dismissal; the reducer blocks the clock until an explicit
+response is accepted. Selecting closes the prompt and leaves play paused so the player can inspect
+the result before resuming. Saves retain unanswered prompts and replay actions retain answers.
+
+Accepted choices are story occurrences with the definition ID as their key and
+`attributes.choice` as the option ID. Future `WorldEvents` phase descriptions and previews can
+read these through `context.occurrences` (see `wildfirePrepared`) to branch narrative and effects.
+The forecast cache includes occurrence attributes, so an answer refreshes future effects.
+Costs are charged once and retained as operating expenses through reforecasting.
+
+The headless baseline bot explicitly selects the first free option. Add focused reducer tests
+for each consequential branch, including future effects, save and replay parity.

--- a/src/testing/Simulation.test.tsx
+++ b/src/testing/Simulation.test.tsx
@@ -1,3 +1,4 @@
+import { SCENARIO_CHOICES } from "../data/ScenarioChoices";
 import { CUSTOM_SCENARIO_ID, SCENARIOS } from "../data/Scenarios";
 import {
   DifficultyType,
@@ -33,6 +34,14 @@ function runMonths(state: GameType, months: number) {
   while (state.date.monthsElapsed < until) {
     tickState(state);
   }
+}
+
+// Mandatory baseline responses are recorded actions, but do not earn decision credit.
+function baselineChoiceActions(result: SimResultType, scenarioId: number) {
+  return SCENARIO_CHOICES.filter(
+    (choice) =>
+      choice.scenarioId === scenarioId && choice.atMonth < result.months.length,
+  ).length;
 }
 
 function describeViolations(result: SimResultType): string {
@@ -652,7 +661,9 @@ describe("simulation economics", () => {
         difficulty: "Intern",
       });
       expectNoViolations(passive);
-      expect(passive.actionCount).toBe(0);
+      expect(passive.actionCount).toBe(
+        baselineChoiceActions(passive, scenario.id),
+      );
       expect(passive.meaningfulDecisionCount).toBe(0);
       expect(passive.outcome).not.toBe("completed");
 
@@ -662,7 +673,9 @@ describe("simulation economics", () => {
         ...INTERN_ONE_BUILD_PLAYS[scenario.id],
       });
       expectNoViolations(active);
-      expect(active.actionCount).toBe(1);
+      expect(active.actionCount).toBe(
+        1 + baselineChoiceActions(active, scenario.id),
+      );
       expect(active.meaningfulDecisionCount).toBe(1);
       expect(active.builds).toHaveLength(1);
       expect(active.outcome).toBe("completed");
@@ -676,7 +689,9 @@ describe("simulation economics", () => {
         difficulty: "CEO",
       });
       expectNoViolations(passive);
-      expect(passive.actionCount).toBe(0);
+      expect(passive.actionCount).toBe(
+        baselineChoiceActions(passive, scenario.id),
+      );
       expect(passive.meaningfulDecisionCount).toBe(0);
       expect(passive.outcome).not.toBe("completed");
 

--- a/src/testing/Simulator.tsx
+++ b/src/testing/Simulator.tsx
@@ -1,3 +1,5 @@
+import { pendingScenarioChoice } from "../helpers/ScenarioChoices";
+import { chooseScenarioResponse } from "../reducers/GameActions";
 // The game reducer dispatches follow-up actions of its own (the construction complete snackbar,
 // the end of game dialogs), so it needs a live store to reach even though the simulation drives
 // the reducer directly. Importing Store creates and registers it.
@@ -525,6 +527,25 @@ export function runSimulation(options: SimOptionsType): SimResultType {
   // loop watches state directly instead and stops on the same conditions the player would hit:
   // monthsElapsed reaching the scenario duration, negative cash, or chronic blackouts.
   while (state.date.monthsElapsed < resolved.months) {
+    // The baseline bot explicitly chooses a free option; the game never defaults for a player.
+    const decision = pendingScenarioChoice(state);
+    if (decision && !state.replayPlayback) {
+      const choiceDifficulty = state.difficulty;
+      const option = decision.options.find(
+        (option) => option.cost(choiceDifficulty) === 0,
+      );
+      if (!option)
+        throw new Error("Simulation needs a choice policy for " + decision.id);
+      state = cloneDeep(
+        gameReducer(
+          state,
+          chooseScenarioResponse({
+            decisionId: decision.id,
+            optionId: option.id,
+          }),
+        ),
+      );
+    }
     tickState(state);
     ticks++;
 


### PR DESCRIPTION
Wildfire Emergency now opens a blocking modal at its December warning, wherever the player is in the game. The clock cannot advance and Escape, backdrop clicks, navigation shortcuts, and speed shortcuts cannot dismiss or bypass the choice. The player explicitly funds preparedness or keeps cash; the Events fallback panel and January default are removed. Selecting closes the modal and leaves play paused for inspection before resuming.

Mobile dialogs use 12px outer margins and aligned 16px content gutters. Options stack with distinct spacing between choices and cost captions kept close to their buttons. The redundant full-outage sentence is removed. A design subagent reviewed both the original and final layouts; a coder agent implemented the feedback.

Preparedness costs cash once and halves January/February physical disconnections and generator output losses, while normal restoration costs remain. The selected response persists in story occurrences and changes future forecasts and recovery narrative.

Other scenarios can add timed prompts through `ScenarioChoices.ts` with stable IDs, a trigger month, options, and costs. A shared selector queues unanswered choices, a shared reducer validates and records responses, and one global modal renders them. Future story phases read the selected option from `context.occurrences`. The authoring workflow is documented in `src/testing/README.md`. The baseline simulator explicitly selects a free option through the same recorded action; preserving the baseline does not add a meaningful-decision credit.

Save format advances to 7 and replay format to 10 because older runs could advance through unanswered prompts.

Validation:

- `npm run check`: types, lint, formatting, 113 Jest suites / 1,116 tests with coverage thresholds, and all scenario invariants (Jest capped at two workers locally).
- `npm run build`.
- Modal flow passed at 320, 390, 768, 1280, and 1440 px in light and dark modes; both existing wildfire briefing/onset checks passed. Responsive assertions verify popup width, title/body alignment, and button/cost grouping. Additional desktop/mobile runs verified the modal appears outside Events, freezes the displayed game state, traps focus, and preserves both outcomes.
- Reducer coverage includes duplicate and unaffordable responses, pending save/load, clock and speed blocking, one-time costs, forecast refresh, live/save/replay parity, and a choice authored for another scenario.

![Blocking choice over desktop Insights](https://github.com/user-attachments/assets/ca4c930c-8d0b-4767-8390-de0af7291ef8)

![Wider modal on a 320px screen](https://github.com/user-attachments/assets/23b5ee7d-fa39-474a-9234-76d6340b57f8)

![Mobile modal in dark mode](https://github.com/user-attachments/assets/5d9ec764-e2e9-4d81-a79c-66d6a9932182)
