### PR TITLE
Preview generator and storage investment plans before buying

### DIFF
--- a/e2e/investment-plan.spec.ts
+++ b/e2e/investment-plan.spec.ts
@@ -10,6 +10,12 @@ for (const theme of ["light", "dark"]) {
     }, theme);
     await page.goto("/?scenario=106");
     await page.getByRole("button", { name: "Start game", exact: true }).click();
+    await expect(
+      page
+        .locator("#facilitiesPane:visible")
+        .or(page.getByRole("button", { name: "Facilities", exact: true }))
+        .first(),
+    ).toBeVisible();
     if (!(await page.locator("#facilitiesPane").isVisible()))
       await page
         .getByRole("button", { name: "Facilities", exact: true })

--- a/e2e/investment-plan.spec.ts
+++ b/e2e/investment-plan.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "@playwright/test";
+
+for (const theme of ["light", "dark"]) {
+  test(`investment sandbox works on this viewport in ${theme}`, async ({
+    page,
+  }, testInfo) => {
+    await page.addInitScript((mode) => {
+      localStorage.clear();
+      localStorage.setItem("theme", mode);
+    }, theme);
+    await page.goto("/?scenario=106");
+    await page.getByRole("button", { name: "Start game", exact: true }).click();
+    if (!(await page.locator("#facilitiesPane").isVisible()))
+      await page
+        .getByRole("button", { name: "Facilities", exact: true })
+        .click();
+    await page.locator(".button-buildGenerator").click();
+    await page
+      .getByRole("button", { name: "Test an investment plan", exact: true })
+      .click();
+    const dialog = page.getByRole("dialog", {
+      name: "Test an investment plan",
+    });
+    await expect(dialog).toContainText("Game paused. Planning from");
+    await dialog
+      .getByRole("combobox", { name: "Facility", exact: true })
+      .click();
+    await page.getByRole("option", { name: /Solar/ }).first().click();
+    await dialog.getByRole("spinbutton").fill("1");
+    await dialog.getByRole("combobox", { name: "Payment" }).click();
+    await page.getByRole("option", { name: /Loan/ }).click();
+    await dialog.getByRole("button", { name: "Add to plan (0/8)" }).click();
+    await dialog.getByRole("combobox", { name: "Asset type" }).click();
+    await page.getByRole("option", { name: "Storage", exact: true }).click();
+    await dialog
+      .getByRole("combobox", { name: "Facility", exact: true })
+      .click();
+    await page.getByRole("option", { name: "Battery", exact: true }).click();
+    await dialog.getByRole("combobox", { name: "Payment" }).click();
+    await page.getByRole("option", { name: /Loan/ }).click();
+    await dialog.getByRole("button", { name: "Add to plan (1/8)" }).click();
+    await expect(
+      dialog.getByRole("region", { name: "Proposed purchases" }),
+    ).toContainText("Battery");
+    await dialog
+      .getByRole("button", { name: "Compare plan", exact: true })
+      .click();
+    const comparison = dialog.getByRole("region", {
+      name: "Investment comparison",
+    });
+    await expect(comparison).toBeVisible({ timeout: 60000 });
+    await expect(comparison).toContainText("Ending net worth (includes debt)");
+    expect(
+      await dialog.evaluate((el) => el.scrollWidth - el.clientWidth),
+    ).toBeLessThanOrEqual(1);
+    for (const button of await dialog.getByRole("button").all())
+      expect((await button.boundingBox())!.height).toBeGreaterThanOrEqual(44);
+    await comparison.scrollIntoViewIfNeeded();
+    await page.screenshot({
+      path: testInfo.outputPath(`investment-${theme}.png`),
+    });
+    await dialog.getByRole("button", { name: /Remove purchase 2/ }).click();
+    await expect(comparison).toHaveCount(0);
+    await dialog.getByRole("button", { name: "Close sandbox" }).click();
+    await expect(dialog).toHaveCount(0);
+    await page
+      .getByRole("button", { name: "Test an investment plan", exact: true })
+      .click();
+    await expect(
+      page.getByRole("region", { name: "Proposed purchases" }),
+    ).toHaveCount(0);
+  });
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
+const port = process.env.E2E_PORT || "3000";
+const baseURL = `http://127.0.0.1:${port}`;
+
 export default defineConfig({
   testDir: ".",
   timeout: 45000,
@@ -9,7 +12,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? "github" : "list",
   use: {
-    baseURL: "http://127.0.0.1:3000",
+    baseURL,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
   },
@@ -51,13 +54,13 @@ export default defineConfig({
   ],
   webServer: {
     command: "npm start",
-    url: "http://127.0.0.1:3000",
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
     env: {
       BROWSER: "none",
       HOST: "127.0.0.1",
-      PORT: "3000",
+      PORT: port,
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
       "!src/react-app-env.d.ts",
       "!src/helpers/CustomGameForecastClient.ts",
       "!src/helpers/PolicyPreviewClient.ts",
+      "!src/helpers/InvestmentPreviewClient.ts",
       "!src/workers/**/*.ts",
       "!src/testing/SimCli.tsx"
     ],

--- a/src/components/base/InvestmentPlanner.test.tsx
+++ b/src/components/base/InvestmentPlanner.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { store } from "../../Store";
+import { createGame } from "../../testing/Simulator";
+import InvestmentPlanner from "./InvestmentPlanner";
+import { createInvestmentPreviewWorker } from "../../helpers/InvestmentPreviewClient";
+
+jest.mock("../../helpers/InvestmentPreviewClient", () => ({
+  createInvestmentPreviewWorker: jest.fn(),
+}));
+
+test("mixed-plan editing invalidates pending workers and closing restores a clean sandbox", () => {
+  const fake = {
+    postMessage: jest.fn(),
+    terminate: jest.fn(),
+    onmessage: undefined as undefined | ((event: { data: unknown }) => void),
+  };
+  (createInvestmentPreviewWorker as jest.Mock).mockReturnValue(fake);
+  const game = createGame({ scenarioId: 106 });
+  render(
+    <Provider store={store}>
+      <InvestmentPlanner game={game} />
+    </Provider>,
+  );
+  fireEvent.click(
+    screen.getByRole("button", { name: "Test an investment plan" }),
+  );
+  const dialog = screen.getByRole("dialog");
+  const choose = (label: string, option: string) => {
+    fireEvent.mouseDown(within(dialog).getByRole("combobox", { name: label }));
+    fireEvent.click(screen.getByRole("option", { name: option }));
+  };
+  choose("Facility", "Solar");
+  fireEvent.click(
+    within(dialog).getByRole("button", { name: "Add to plan (0/8)" }),
+  );
+  choose("Asset type", "Storage");
+  choose("Facility", "Battery");
+  fireEvent.click(
+    within(dialog).getByRole("button", { name: "Add to plan (1/8)" }),
+  );
+  fireEvent.click(within(dialog).getByRole("button", { name: "Compare plan" }));
+  expect(fake.postMessage.mock.calls[0][0].purchases).toHaveLength(2);
+  const receive = fake.onmessage!;
+  fireEvent.click(
+    within(dialog).getByRole("button", { name: /Remove purchase 2/ }),
+  );
+  expect(fake.terminate).toHaveBeenCalled();
+  receive({ data: { error: "Stale response" } });
+  expect(screen.queryByText("Stale response")).not.toBeInTheDocument();
+  fireEvent.keyDown(document, { key: "Escape" });
+  expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  fireEvent.click(
+    screen.getByRole("button", { name: "Test an investment plan" }),
+  );
+  expect(
+    screen.queryByRole("region", { name: "Proposed purchases" }),
+  ).not.toBeInTheDocument();
+});

--- a/src/components/base/InvestmentPlanner.tsx
+++ b/src/components/base/InvestmentPlanner.tsx
@@ -1,0 +1,439 @@
+import * as React from "react";
+import cloneDeep from "lodash.clonedeep";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+  useMediaQuery,
+} from "@mui/material";
+import { useAppDispatch } from "../../Store";
+import {
+  openPolicyDecision,
+  closePolicyDecision,
+} from "../../reducers/GameActions";
+import { GameType } from "../../Types";
+import {
+  DOWNPAYMENT_PERCENT,
+  TICKS_PER_YEAR,
+  TICK_MINUTES,
+} from "../../Constants";
+import {
+  getMonthYearFromMinute,
+  getTimeFromTimeline,
+} from "../../helpers/DateTime";
+import { formatMoneyConcise } from "../../helpers/Format";
+import {
+  investmentCatalog,
+  InvestmentPurchase,
+  InvestmentPreviewResult,
+} from "../../helpers/InvestmentPreview";
+import { createInvestmentPreviewWorker } from "../../helpers/InvestmentPreviewClient";
+
+function dateLabel(minute: number, game: GameType) {
+  const date = getMonthYearFromMinute(minute, game.startingYear);
+  return new Date(Date.UTC(date.year, date.monthNumber - 1)).toLocaleDateString(
+    "en",
+    { month: "short", year: "numeric", timeZone: "UTC" },
+  );
+}
+
+function Planner({ game, onClose }: { game: GameType; onClose: () => void }) {
+  const dispatch = useAppDispatch();
+  const token = React.useId();
+  React.useEffect(() => {
+    dispatch(openPolicyDecision(token));
+    return () => {
+      dispatch(closePolicyDecision(token));
+    };
+  }, [dispatch, token]);
+  React.useEffect(() => {
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", closeOnEscape, true);
+    return () => document.removeEventListener("keydown", closeOnEscape, true);
+  }, [onClose]);
+  const mobile = useMediaQuery("(max-width:599px)");
+  const [kind, setKind] =
+    React.useState<InvestmentPurchase["kind"]>("generator");
+  const [capacity, setCapacity] = React.useState("10");
+  const [name, setName] = React.useState("");
+  const [financed, setFinanced] = React.useState(false);
+  const [purchases, setPurchases] = React.useState<InvestmentPurchase[]>([]);
+  const [years, setYears] = React.useState(3);
+  const [result, setResult] = React.useState<InvestmentPreviewResult>();
+  const [error, setError] = React.useState("");
+  const [busy, setBusy] = React.useState(false);
+  const worker = React.useRef<Worker>();
+  const cancel = React.useCallback(() => {
+    worker.current?.terminate();
+    worker.current = undefined;
+    setBusy(false);
+    setResult(undefined);
+    setError("");
+  }, []);
+  React.useEffect(() => () => worker.current?.terminate(), []);
+  const catalog = investmentCatalog(game, kind, Number(capacity));
+  const selected = catalog.find((f) => f.name === name);
+  const upfront = purchases.reduce((total, purchase) => {
+    const quote = investmentCatalog(
+      game,
+      purchase.kind,
+      purchase.capacity,
+    ).find((f) => f.name === purchase.name)!;
+    return (
+      total + quote.buildCost * (purchase.financed ? DOWNPAYMENT_PERCENT : 1)
+    );
+  }, 0);
+  const availableCash =
+    getTimeFromTimeline(game.date.minute, game.timeline)?.cash ?? 0;
+  const valid =
+    selected?.available &&
+    selected.viableLocationsRemaining !== 0 &&
+    ("maxPeakWh" in selected
+      ? selected.peakWh! <= selected.maxPeakWh
+      : selected.peakW <= selected.maxPeakW);
+  const run = () => {
+    cancel();
+    setBusy(true);
+    try {
+      const active = createInvestmentPreviewWorker();
+      worker.current = active;
+      active.onmessage = (event) => {
+        if (worker.current !== active) return;
+        setResult(event.data.result);
+        setError(event.data.error || "");
+        setBusy(false);
+        active.terminate();
+        worker.current = undefined;
+      };
+      active.onerror = () => {
+        if (worker.current === active) {
+          cancel();
+          setError("The projection could not finish. Please try again.");
+        }
+      };
+      active.postMessage({ game, purchases, years });
+    } catch (_error) {
+      cancel();
+      setError("The projection could not start. Please try again.");
+    }
+  };
+  const first = (minute: number | null) =>
+    minute === null ? "None in this horizon" : dateLabel(minute, game);
+  const metrics = result
+    ? [
+        [
+          "First shortage",
+          first(result.before.firstShortage),
+          first(result.after.firstShortage),
+        ],
+        [
+          "Unserved energy",
+          `${(result.before.shortageWh / 1e9).toFixed(2)} GWh`,
+          `${(result.after.shortageWh / 1e9).toFixed(2)} GWh`,
+        ],
+        [
+          "Ending cash",
+          formatMoneyConcise(result.before.cash),
+          formatMoneyConcise(result.after.cash),
+        ],
+        [
+          "Lowest cash",
+          formatMoneyConcise(result.before.minimumCash),
+          formatMoneyConcise(result.after.minimumCash),
+        ],
+        [
+          "Ending net worth (includes debt)",
+          formatMoneyConcise(result.before.netWorth),
+          formatMoneyConcise(result.after.netWorth),
+        ],
+        [
+          "Emissions",
+          `${(result.before.kgco2e / 1000).toFixed(0)} t CO₂e`,
+          `${(result.after.kgco2e / 1000).toFixed(0)} t CO₂e`,
+        ],
+      ]
+    : [];
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      fullScreen={mobile}
+      fullWidth
+      maxWidth="md"
+      aria-labelledby="investment-title"
+      sx={{
+        "& button": { minHeight: 44 },
+        "& .MuiInputBase-root": { minHeight: 44 },
+      }}
+    >
+      <DialogTitle id="investment-title">Test an investment plan</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <Typography variant="body2">
+            Game paused. Planning from {dateLabel(game.date.minute, game)}. Add
+            generators and storage, then compare with making no new purchases.
+            Nothing here spends your live cash.
+          </Typography>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+              gap: 2,
+            }}
+          >
+            <TextField
+              select
+              label="Asset type"
+              value={kind}
+              onChange={(e) => {
+                setKind(e.target.value as InvestmentPurchase["kind"]);
+                setName("");
+              }}
+            >
+              <MenuItem value="generator">Generator</MenuItem>
+              <MenuItem value="storage">Storage</MenuItem>
+            </TextField>
+            <TextField
+              label={
+                kind === "generator" ? "Capacity (MW)" : "Energy capacity (MWh)"
+              }
+              type="number"
+              value={capacity}
+              onChange={(e) => setCapacity(e.target.value)}
+              slotProps={{ htmlInput: { min: 1, max: 10000, step: 1 } }}
+              helperText="1–10,000; availability depends on asset and year"
+            />
+            <TextField
+              select
+              label="Facility"
+              value={selected ? name : ""}
+              onChange={(e) => setName(e.target.value)}
+            >
+              {catalog.map((f) => (
+                <MenuItem key={f.name} value={f.name}>
+                  {f.name}
+                  {!f.available ? " (not available yet)" : ""}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              select
+              label="Payment"
+              value={financed ? "loan" : "cash"}
+              onChange={(e) => setFinanced(e.target.value === "loan")}
+            >
+              <MenuItem value="cash">Pay cash</MenuItem>
+              <MenuItem value="loan">
+                Loan ({DOWNPAYMENT_PERCENT * 100}% down)
+              </MenuItem>
+            </TextField>
+          </Box>
+          {selected && (
+            <Typography variant="body2">
+              {formatMoneyConcise(selected.buildCost)} total ·{" "}
+              {formatMoneyConcise(
+                selected.buildCost * (financed ? DOWNPAYMENT_PERCENT : 1),
+              )}{" "}
+              due now · online in {Math.round(selected.yearsToBuild * 12)}{" "}
+              months.{!valid && " Unavailable at this capacity or location."}
+            </Typography>
+          )}
+          <Button
+            variant="outlined"
+            disabled={!valid || purchases.length >= 8}
+            onClick={() => {
+              cancel();
+              setPurchases([
+                ...purchases,
+                { kind, name, capacity: Number(capacity), financed },
+              ]);
+            }}
+          >
+            Add to plan ({purchases.length}/8)
+          </Button>
+          {purchases.length > 0 && (
+            <Stack
+              component="section"
+              aria-label="Proposed purchases"
+              spacing={1}
+            >
+              <Typography variant="h6">Proposed purchases</Typography>
+              {purchases.map((p, i) => {
+                const quote = investmentCatalog(game, p.kind, p.capacity).find(
+                  (f) => f.name === p.name,
+                )!;
+                return (
+                  <Box
+                    key={i}
+                    sx={{ borderBottom: 1, borderColor: "divider", pb: 1 }}
+                  >
+                    <Typography>
+                      {i + 1}. {p.name} · {p.capacity}{" "}
+                      {p.kind === "storage" ? "MWh" : "MW"}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {p.financed ? "Loan" : "Cash"} ·{" "}
+                      {formatMoneyConcise(
+                        quote.buildCost *
+                          (p.financed ? DOWNPAYMENT_PERCENT : 1),
+                      )}{" "}
+                      now · online{" "}
+                      {dateLabel(
+                        game.date.minute +
+                          quote.yearsToBuild * TICKS_PER_YEAR * TICK_MINUTES,
+                        game,
+                      )}
+                    </Typography>
+                    <Button
+                      onClick={() => {
+                        cancel();
+                        setPurchases(
+                          purchases.filter((_, index) => index !== i),
+                        );
+                      }}
+                      aria-label={`Remove purchase ${i + 1}: ${p.name}`}
+                    >
+                      Remove
+                    </Button>
+                  </Box>
+                );
+              })}
+            </Stack>
+          )}
+          <TextField
+            select
+            label="Projection horizon"
+            value={years}
+            onChange={(e) => {
+              cancel();
+              setYears(Number(e.target.value));
+            }}
+          >
+            {[1, 3, 5].map((n) => (
+              <MenuItem key={n} value={n}>
+                {n} game year{n > 1 ? "s" : ""}
+              </MenuItem>
+            ))}
+          </TextField>
+          <Typography variant="body2">
+            Plan due now: {formatMoneyConcise(upfront)} · Available cash:{" "}
+            {formatMoneyConcise(availableCash)}.
+          </Typography>
+          {upfront > availableCash && (
+            <Alert severity="warning">
+              The upfront cost exceeds your cash. Remove a purchase and add it
+              again with a loan, or reduce its capacity.
+            </Alert>
+          )}
+          <Button
+            variant="contained"
+            disabled={purchases.length === 0 || busy}
+            onClick={run}
+          >
+            {busy ? "Simulating…" : "Compare plan"}
+          </Button>
+          {busy && (
+            <Typography role="status">
+              Simulating both paths. You can keep editing or close this sandbox.
+            </Typography>
+          )}
+          {error && <Alert severity="error">{error}</Alert>}
+          {result && (
+            <Stack
+              component="section"
+              aria-label="Investment comparison"
+              spacing={1}
+            >
+              <Typography variant="h6">
+                Comparison through{" "}
+                {dateLabel(
+                  game.date.minute + years * TICKS_PER_YEAR * TICK_MINUTES,
+                  game,
+                )}
+              </Typography>
+              <Typography variant="body2">
+                Cash difference:{" "}
+                {formatMoneyConcise(result.after.cash - result.before.cash)}.
+                Net worth difference:{" "}
+                {formatMoneyConcise(
+                  result.after.netWorth - result.before.netWorth,
+                )}
+                .
+              </Typography>
+              {result.after.minimumCash < 0 && (
+                <Alert severity="warning">
+                  This plan runs out of cash within the horizon.
+                </Alert>
+              )}
+              {metrics.map(([label, before, after]) => (
+                <Box
+                  key={label}
+                  sx={{ borderBottom: 1, borderColor: "divider", py: 1 }}
+                >
+                  <Typography sx={{ fontWeight: 600 }}>{label}</Typography>
+                  <Box
+                    sx={{
+                      display: "grid",
+                      gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+                      gap: 1,
+                    }}
+                  >
+                    <Typography variant="body2">
+                      No purchases: {before}
+                    </Typography>
+                    <Typography variant="body2">Your plan: {after}</Typography>
+                  </Box>
+                </Box>
+              ))}
+            </Stack>
+          )}
+          <Typography variant="body2" color="text.secondary">
+            Uses the game’s simulation for construction delays, dispatch,
+            storage charging, operating costs, loan payments, emissions and
+            scheduled effects. Both paths use the same weather and seed, with
+            the current retail electricity rate, programs and dispatch choices
+            held as decisions. Future market prices and demand still evolve. All
+            proposed purchases begin at the snapshot date, in the listed order.
+            Projections continue through cash shortages and do not predict
+            firing or victory. To build, close this sandbox and review each
+            purchase in the catalog.
+          </Typography>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close sandbox</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default function InvestmentPlanner({ game }: { game: GameType }) {
+  const [snapshot, setSnapshot] = React.useState<GameType>();
+  return (
+    <>
+      <Button
+        sx={{ minHeight: 44, m: 1 }}
+        onClick={() => setSnapshot(cloneDeep(game))}
+      >
+        Test an investment plan
+      </Button>
+      {snapshot && (
+        <Planner game={snapshot} onClose={() => setSnapshot(undefined)} />
+      )}
+    </>
+  );
+}

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -61,6 +61,7 @@ import {
 } from "../base/BuildAvailability";
 import BuildMetric from "../base/BuildMetric";
 import ConstructionBuildHeader from "../base/ConstructionBuildHeader";
+import InvestmentPlanner from "../base/InvestmentPlanner";
 
 interface GeneratorBuildItemProps {
   cash: number;
@@ -781,6 +782,7 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
         onSliderChange={setSliderTick}
         onSortChange={(value) => setSort(value as GeneratorSortKey)}
       />
+      <InvestmentPlanner game={game} />
       <GeneratorComparison
         generators={comparedGenerators}
         onClear={() => setComparedNames([])}

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -41,6 +41,7 @@ import {
 } from "../base/BuildAvailability";
 import BuildMetric from "../base/BuildMetric";
 import ConstructionBuildHeader from "../base/ConstructionBuildHeader";
+import InvestmentPlanner from "../base/InvestmentPlanner";
 import { GameType, StorageShoppingType } from "../../Types";
 
 interface StorageBuildItemProps {
@@ -464,6 +465,7 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
         onSliderChange={setSliderTick}
         onSortChange={(value) => setSort(value as StorageSortKey)}
       />
+      <InvestmentPlanner game={game} />
       <Box className="buildOptionHelp">
         <ManualLink
           entry={MANUAL_ENTRY.POWER_AND_ENERGY}

--- a/src/helpers/InvestmentPreview.test.tsx
+++ b/src/helpers/InvestmentPreview.test.tsx
@@ -1,0 +1,121 @@
+import cloneDeep from "lodash.clonedeep";
+import { createGame } from "../testing/Simulator";
+import {
+  investmentCatalog,
+  InvestmentPurchase,
+  previewInvestments,
+  stageInvestments,
+} from "./InvestmentPreview";
+import { getTimeFromTimeline } from "./DateTime";
+import { buildFacility, generateNewTimeline } from "../reducers/Game";
+import gameReducer from "../reducers/Game";
+import { TICKS_PER_YEAR } from "../Constants";
+import { store } from "../Store";
+
+const solar: InvestmentPurchase = {
+  kind: "generator",
+  name: "Solar PV",
+  capacity: 1,
+  financed: false,
+};
+const battery: InvestmentPurchase = {
+  kind: "storage",
+  name: "Battery",
+  capacity: 1,
+  financed: true,
+};
+function game() {
+  const state = createGame({ scenarioId: 106, seed: 123 });
+  getTimeFromTimeline(state.date.minute, state.timeline)!.cash = 1e10;
+  return state;
+}
+
+test("stages mixed purchases through the real reducer without touching live state or dispatch", () => {
+  const state = game();
+  const original = cloneDeep(state);
+  const dispatch = jest.spyOn(store, "dispatch");
+  // Select the authored solar name instead of relying on a UI alias.
+  solar.name = investmentCatalog(state, "generator", 1).find(
+    (f) => f.fuel === "Sun",
+  )!.name;
+  const staged = stageInvestments(state, [solar, battery]);
+  expect(staged.facilities).toHaveLength(state.facilities.length + 2);
+  expect(
+    staged.facilities.find(
+      (f) => f.id === Math.max(...staged.facilities.map((f) => f.id)),
+    ),
+  ).toMatchObject({ name: "Battery", currentWh: 0 });
+  expect(
+    staged.facilities.find((f) => f.name === "Battery")!.loanAmountLeft,
+  ).toBeGreaterThan(0);
+  expect(state).toEqual(original);
+  expect(dispatch).not.toHaveBeenCalled();
+  dispatch.mockRestore();
+});
+
+test("baseline and planned cash/net worth match the actual forecast with construction and financing", () => {
+  const state = game();
+  const facility = investmentCatalog(state, "storage", 1).find(
+    (f) => f.name === "Battery",
+  )!;
+  const built = gameReducer(state, buildFacility({ facility, financed: true }));
+  const now = getTimeFromTimeline(built.date.minute, built.timeline)!;
+  const timeline = generateNewTimeline(
+    built,
+    now.cash,
+    now.customers,
+    TICKS_PER_YEAR + 1,
+  );
+  const preview = previewInvestments(state, [battery], 1);
+  expect(preview.after.cash).toBe(timeline[timeline.length - 1].cash);
+  expect(preview.after.netWorth).toBe(timeline[timeline.length - 1].netWorth);
+  // The transaction balance belongs in the cash minimum even though the
+  // already-happened current tick must not contribute energy or emissions.
+  expect(Math.min(...timeline.slice(1).map((t) => t.cash))).toBeGreaterThan(
+    now.cash,
+  );
+  expect(preview.after.minimumCash).toBe(now.cash);
+  expect(previewInvestments(state, [battery], 1)).toEqual(preview);
+  expect(previewInvestments(state, [], 1).before).toEqual(
+    previewInvestments(state, [], 1).after,
+  );
+});
+
+test("rejects invalid horizons, capacities, unavailable facilities and unaffordable combined purchases", () => {
+  const state = game();
+  expect(investmentCatalog(state, "storage", NaN)).toEqual([]);
+  expect(investmentCatalog(state, "generator", 0)).toEqual([]);
+  expect(investmentCatalog(state, "generator", 10001)).toEqual([]);
+  expect(() => previewInvestments(state, [], 2)).toThrow("horizon");
+  expect(() => stageInvestments(state, Array(9).fill(battery))).toThrow(
+    "8 purchases",
+  );
+  expect(() =>
+    stageInvestments(state, [{ ...battery, name: "Missing" }]),
+  ).toThrow("unavailable");
+  const cashPurchase = { ...battery, financed: false };
+  const price = investmentCatalog(state, "storage", 1).find(
+    (f) => f.name === "Battery",
+  )!.buildCost;
+  getTimeFromTimeline(state.date.minute, state.timeline)!.cash = price * 1.5;
+  expect(() => stageInvestments(state, [cashPurchase, cashPurchase])).toThrow(
+    "Not enough cash",
+  );
+});
+
+test("an unfinished reactor costs cash but cannot prevent shortages or change dispatch emissions", () => {
+  const state = game();
+  state.difficulty = "CEO";
+  const reactor: InvestmentPurchase = {
+    kind: "generator",
+    name: "Nuclear",
+    capacity: 1,
+    financed: false,
+  };
+  const staged = stageInvestments(state, [reactor]);
+  expect(staged.facilities[0].yearsToBuildLeft).toBeGreaterThan(1);
+  const result = previewInvestments(state, [reactor], 1);
+  expect(result.after.shortageWh).toBe(result.before.shortageWh);
+  expect(result.after.kgco2e).toBe(result.before.kgco2e);
+  expect(result.after.cash).toBeLessThan(result.before.cash);
+});

--- a/src/helpers/InvestmentPreview.ts
+++ b/src/helpers/InvestmentPreview.ts
@@ -1,0 +1,120 @@
+import cloneDeep from "lodash.clonedeep";
+import { GAME_TO_REAL_YEARS, TICK_MINUTES, TICKS_PER_YEAR } from "../Constants";
+import { GENERATORS, STORAGE } from "../data/Facilities";
+import gameReducer, {
+  buildFacility,
+  generateNewTimeline,
+} from "../reducers/Game";
+import { GameType, TickPresentFutureType } from "../Types";
+import { getTimeFromTimeline } from "./DateTime";
+
+export interface InvestmentPurchase {
+  kind: "generator" | "storage";
+  name: string;
+  capacity: number;
+  financed: boolean;
+}
+
+export function investmentCatalog(
+  game: GameType,
+  kind: InvestmentPurchase["kind"],
+  capacity: number,
+) {
+  if (!Number.isFinite(capacity) || capacity < 1 || capacity > 10000) return [];
+  const timeline = game.timeline;
+  return kind === "storage"
+    ? STORAGE(game, capacity * 1e6)
+    : GENERATORS(
+        game,
+        capacity * 1e6,
+        timeline.map((t) => t.windKph),
+        timeline.map((t) => t.solarIrradianceWM2),
+        timeline.flatMap((t) =>
+          t.windOffshoreKph === undefined ? [] : [t.windOffshoreKph],
+        ),
+        timeline.map((t) => t.windAirborneKph),
+      );
+}
+
+export function stageInvestments(
+  game: GameType,
+  purchases: InvestmentPurchase[],
+): GameType {
+  if (purchases.length > 8) throw new Error("Test up to 8 purchases at once.");
+  let draft = cloneDeep(game);
+  for (const purchase of purchases) {
+    const facility = investmentCatalog(
+      draft,
+      purchase.kind,
+      purchase.capacity,
+    ).find((f) => f.name === purchase.name);
+    if (
+      !facility ||
+      !facility.available ||
+      facility.viableLocationsRemaining === 0 ||
+      ("maxPeakWh" in facility
+        ? facility.peakWh! > facility.maxPeakWh
+        : facility.peakW > facility.maxPeakW)
+    ) {
+      throw new Error(
+        `${purchase.name} is unavailable at this capacity or has no sites left.`,
+      );
+    }
+    const next = gameReducer(
+      draft,
+      buildFacility({ facility, financed: purchase.financed }),
+    );
+    if (next.facilities.length !== draft.facilities.length + 1) {
+      throw new Error(
+        `Not enough cash for ${purchase.name}. Reduce the plan or choose a loan.`,
+      );
+    }
+    draft = next;
+  }
+  return draft;
+}
+
+function summarize(timeline: TickPresentFutureType[], startingCash: number) {
+  const last = timeline[timeline.length - 1];
+  return {
+    cash: last.cash,
+    netWorth: last.netWorth,
+    minimumCash: Math.min(startingCash, ...timeline.map((t) => t.cash)),
+    firstShortage:
+      timeline.find((t) => t.demandW - t.supplyW > 1)?.minute ?? null,
+    shortageWh: timeline.reduce(
+      (total, t) =>
+        total +
+        ((Math.max(0, t.demandW - t.supplyW) * TICK_MINUTES) / 60) *
+          GAME_TO_REAL_YEARS,
+      0,
+    ),
+    kgco2e: timeline.reduce((total, t) => total + t.kgco2e, 0),
+  };
+}
+
+/** Shared simulation forecast: construction, dispatch, storage, debt and story effects. */
+export function previewInvestments(
+  game: GameType,
+  purchases: InvestmentPurchase[],
+  years: number,
+) {
+  if (![1, 3, 5].includes(years))
+    throw new Error("Choose a 1, 3 or 5 year horizon.");
+  const draft = stageInvestments(game, purchases);
+  const project = (state: GameType) => {
+    const now = getTimeFromTimeline(state.date.minute, state.timeline);
+    if (!now) throw new Error("No current simulation tick.");
+    return summarize(
+      generateNewTimeline(
+        state,
+        now.cash,
+        now.customers,
+        years * TICKS_PER_YEAR + 1,
+      ).slice(1),
+      now.cash,
+    );
+  };
+  return { before: project(game), after: project(draft) };
+}
+export type InvestmentPreviewResult = ReturnType<typeof previewInvestments>;

--- a/src/helpers/InvestmentPreviewClient.ts
+++ b/src/helpers/InvestmentPreviewClient.ts
@@ -1,0 +1,5 @@
+export function createInvestmentPreviewWorker(): Worker {
+  return new Worker(
+    new URL("../workers/InvestmentPreview.worker.ts", import.meta.url),
+  );
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,6 +1,14 @@
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
+jest.mock("./helpers/InvestmentPreviewClient", () => ({
+  createInvestmentPreviewWorker: () => ({
+    onmessage: null,
+    onerror: null,
+    postMessage: () => undefined,
+    terminate: () => undefined,
+  }),
+}));
 jest.mock("./helpers/PolicyPreviewClient", () => ({
   createPolicyPreviewWorker: () => ({
     onmessage: null,

--- a/src/workers/InvestmentPreview.worker.ts
+++ b/src/workers/InvestmentPreview.worker.ts
@@ -1,0 +1,39 @@
+import { initEconomy } from "../data/Economy";
+import { initFuelPrices } from "../data/FuelPrices";
+import { initWeather } from "../data/Weather";
+import {
+  InvestmentPurchase,
+  previewInvestments,
+} from "../helpers/InvestmentPreview";
+import { GameType } from "../Types";
+
+const worker = globalThis as unknown as Worker;
+const load = (initialize: (done: (error?: string) => void) => void) =>
+  new Promise<void>((resolve, reject) =>
+    initialize((error) => (error ? reject(new Error(error)) : resolve())),
+  );
+worker.onmessage = async (
+  event: MessageEvent<{
+    game: GameType;
+    purchases: InvestmentPurchase[];
+    years: number;
+  }>,
+) => {
+  try {
+    const { game, purchases, years } = event.data;
+    await Promise.all([
+      load(initEconomy),
+      load(initFuelPrices),
+      load((done) => initWeather(game.location, done)),
+    ]);
+    worker.postMessage({ result: previewInvestments(game, purchases, years) });
+  } catch (error) {
+    worker.postMessage({
+      error:
+        error instanceof Error
+          ? error.message
+          : "Could not test this plan. Please try again.",
+    });
+  }
+};
+export {};


### PR DESCRIPTION
Players can now test a mixed generator/storage investment plan before spending live cash. Both build catalogs open a paused sandbox where up to eight proposed purchases can use cash or financing; the UI shows commissioning dates and the combined upfront cost against available cash.

A worker applies the real build actions to a private game snapshot and compares the existing full-cadence simulation over one, three, or five years. Results show first shortage, unserved energy, ending and minimum cash, net worth including debt, and emissions. Construction delays, storage dispatch, operating costs, loans, and scheduled effects use the same simulation as the game. Closing the sandbox leaves purchases unchanged; actual investments still use the existing purchase flow.

The UI explains forecast assumptions, terminates obsolete workers, and owns a pause token while open. Desktop comparisons use paired columns; mobile uses a full-screen, vertically scrolling dialog with stacked comparisons and a reachable 44 px close action. This feature does not change save or replay formats.

Validation:

- Two design/code/independent-QA loops completed. The second corrected minimum cash to include the instant after purchase while excluding the already-completed tick from future energy/emissions totals.
- Focused tests cover live-state isolation, mixed purchases and financing, joint affordability, deterministic forecasts, construction delays, stale worker results, cancellation, and closing/reopening the sandbox.
- Six feature browser cases passed at 320, 390, and 1440 px in light and dark modes, including touch targets, overflow checks, and real mixed-plan results.
- `npm run check` passed: types, lint, formatting, 113 Jest suites / 1,103 tests, coverage thresholds, and every scenario's invariants. Jest workers were capped at two for this local run.
- `npm run build` passed. Production smoke checks passed at 1440 px/light and 390 px/dark using actual worker comparisons, with no page errors and clean browser/server shutdown.

![Desktop investment comparison](https://github.com/user-attachments/assets/53e7590b-faa0-4722-8052-c69a3ea9771d)

![Mobile proposed investment plan in dark mode](https://github.com/user-attachments/assets/7981e4c8-7ee5-48cf-aad6-b7dfe942c5c2)

![Mobile investment comparison in dark mode](https://github.com/user-attachments/assets/b85c127d-8e2c-4d4b-8c20-5a308c1f6833)
