### PR TITLE
Add configurable time-of-use and industrial curtailment windows

### DIFF
--- a/e2e/peak-demand.spec.ts
+++ b/e2e/peak-demand.spec.ts
@@ -29,13 +29,19 @@ for (const theme of ["light", "dark"]) {
       await expect(dialog).not.toContainText("Base rate:");
       await expect(dialog).not.toContainText("installed upgrades");
       const large = dialog.getByRole("radio", { name: "On", exact: true });
+      await expect(dialog.getByLabel("Daily window")).toHaveCount(0);
       await large.check();
+      const window = dialog.getByLabel("Daily window", { exact: true });
+      await expect(window).toBeVisible();
+      await window.selectOption(offer === "Time-of-use tariff" ? "22" : "9");
+      await expect(dialog).toContainText(offer === "Time-of-use tariff" ? "02:00–05:00" : "This load is eliminated");
       await dialog.getByRole("button", { name: "What is Customer programs?" }).click();
       const manual = page.getByRole("dialog", { name: "Manual help" });
       await expect(manual).toContainText("total energy use is unchanged");
       await page.keyboard.press("Escape");
       await expect(manual).toHaveCount(0);
       await expect(large).toBeChecked();
+      await expect(window).toHaveValue(offer === "Time-of-use tariff" ? "22" : "9");
       const apply = dialog.getByRole("button", {
         name: "Turn on next month",
         exact: true,
@@ -70,6 +76,13 @@ for (const theme of ["light", "dark"]) {
       await dialog
         .getByRole("button", { name: `${offer} · Off`, exact: true })
         .click();
+      await expect(window).toHaveValue(offer === "Time-of-use tariff" ? "22" : "9");
+      await window.selectOption("12");
+      const update = dialog.getByRole("button", { name: "Update next month", exact: true });
+      await expect(update).toBeEnabled({ timeout: 30000 });
+      await update.click();
+      await expect(dialog).toContainText("12:00–16:00");
+      await dialog.getByRole("button", { name: `${offer} · Off`, exact: true }).click();
       await dialog
         .getByRole("button", { name: "Cancel scheduled change" })
         .click();

--- a/e2e/peak-demand.spec.ts
+++ b/e2e/peak-demand.spec.ts
@@ -25,13 +25,19 @@ for (const theme of ["light", "dark"]) {
       await dialog
         .getByRole("button", { name: `${offer} · Off`, exact: true })
         .click();
-      await expect(dialog).toContainText("17:00–21:00");
-      await expect(dialog).toContainText("Base rate:");
+      await expect(dialog.getByRole("radio")).toHaveCount(2);
+      await expect(dialog).not.toContainText("Base rate:");
       await expect(dialog).not.toContainText("installed upgrades");
-      const large = dialog.getByRole("radio", { name: "Large · 50% enrolled" });
+      const large = dialog.getByRole("radio", { name: "On", exact: true });
       await large.check();
+      await dialog.getByRole("button", { name: "What is Customer programs?" }).click();
+      const manual = page.getByRole("dialog", { name: "Manual help" });
+      await expect(manual).toContainText("total energy use is unchanged");
+      await page.keyboard.press("Escape");
+      await expect(manual).toHaveCount(0);
+      await expect(large).toBeChecked();
       const apply = dialog.getByRole("button", {
-        name: "Start next month",
+        name: "Turn on next month",
         exact: true,
       });
       await expect(apply).toBeEnabled({ timeout: 30000 });
@@ -60,14 +66,14 @@ for (const theme of ["light", "dark"]) {
         ),
       });
       await apply.click();
-      await expect(dialog).toContainText("Large starts Feb 2020");
+      await expect(dialog).toContainText("On starts Feb 2020");
       await dialog
         .getByRole("button", { name: `${offer} · Off`, exact: true })
         .click();
       await dialog
         .getByRole("button", { name: "Cancel scheduled change" })
         .click();
-      await expect(dialog).not.toContainText("Large starts");
+      await expect(dialog).not.toContainText("On starts");
     }
     await page.keyboard.press("Escape");
     await expect(dialog).toHaveCount(0);

--- a/e2e/peak-demand.spec.ts
+++ b/e2e/peak-demand.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+
+for (const theme of ["light", "dark"]) {
+  test(`peak offers can be compared, scheduled and cancelled in ${theme}`, async ({
+    page,
+  }, testInfo) => {
+    await page.addInitScript((mode) => {
+      localStorage.clear();
+      localStorage.setItem("theme", mode);
+    }, theme);
+    await page.goto("/?scenario=106");
+    await page.getByRole("button", { name: "Start game", exact: true }).click();
+    const insights = page.locator(".insights:visible");
+    if (!(await insights.isVisible()))
+      await page.getByRole("button", { name: "Insights", exact: true }).click();
+    const entry = insights.getByRole("button", {
+      name: "Customer programs",
+      exact: true,
+    });
+    await entry.click();
+    const dialog = page.getByRole("dialog");
+    for (const offer of ["Time-of-use tariff", "Peak curtailment contracts"]) {
+      await dialog
+        .getByRole("button", { name: `${offer} · Off`, exact: true })
+        .click();
+      await expect(dialog).toContainText("17:00–21:00");
+      await expect(dialog).toContainText("Base rate:");
+      await expect(dialog).not.toContainText("installed upgrades");
+      const large = dialog.getByRole("radio", { name: "Large · 50% enrolled" });
+      await large.check();
+      const apply = dialog.getByRole("button", {
+        name: "Start next month",
+        exact: true,
+      });
+      await expect(apply).toBeEnabled({ timeout: 30000 });
+      await expect(dialog).toContainText("Peak demand:");
+      await expect(dialog).toContainText("Change in utility cash");
+      expect(
+        await dialog.evaluate((el) => el.scrollWidth - el.clientWidth),
+      ).toBeLessThanOrEqual(1);
+      expect((await apply.boundingBox())!.height).toBeGreaterThanOrEqual(44);
+      expect(
+        (await large.locator("..").locator("..").boundingBox())!.height,
+      ).toBeGreaterThanOrEqual(44);
+      await dialog.getByRole("heading", { level: 2 }).scrollIntoViewIfNeeded();
+      await dialog.locator(".MuiDialogContent-root").evaluate((el) => {
+        el.scrollTop = 0;
+      });
+      await page.screenshot({
+        path: testInfo.outputPath(
+          `${offer === "Time-of-use tariff" ? "tariff" : "contract"}-${theme}.png`,
+        ),
+      });
+      await dialog.getByText(/^Peak demand:/).scrollIntoViewIfNeeded();
+      await page.screenshot({
+        path: testInfo.outputPath(
+          `${offer === "Time-of-use tariff" ? "tariff" : "contract"}-preview-${theme}.png`,
+        ),
+      });
+      await apply.click();
+      await expect(dialog).toContainText("Large starts Feb 2020");
+      await dialog
+        .getByRole("button", { name: `${offer} · Off`, exact: true })
+        .click();
+      await dialog
+        .getByRole("button", { name: "Cancel scheduled change" })
+        .click();
+      await expect(dialog).not.toContainText("Large starts");
+    }
+    await page.keyboard.press("Escape");
+    await expect(dialog).toHaveCount(0);
+    await expect(entry).toBeFocused();
+  });
+}

--- a/e2e/peak-demand.spec.ts
+++ b/e2e/peak-demand.spec.ts
@@ -11,7 +11,9 @@ for (const theme of ["light", "dark"]) {
     await page.goto("/?scenario=106");
     await page.getByRole("button", { name: "Start game", exact: true }).click();
     const insights = page.locator(".insights:visible");
-    if (!(await insights.isVisible()))
+    if (page.viewportSize()!.width >= 1400)
+      await expect(insights).toBeVisible();
+    else
       await page.getByRole("button", { name: "Insights", exact: true }).click();
     const entry = insights.getByRole("button", {
       name: "Customer programs",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
+const port = process.env.E2E_PORT || "3000";
+const baseURL = `http://127.0.0.1:${port}`;
+
 export default defineConfig({
   testDir: ".",
   timeout: 45000,
@@ -9,7 +12,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? "github" : "list",
   use: {
-    baseURL: "http://127.0.0.1:3000",
+    baseURL,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
   },
@@ -51,13 +54,13 @@ export default defineConfig({
   ],
   webServer: {
     command: "npm start",
-    url: "http://127.0.0.1:3000",
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
     env: {
       BROWSER: "none",
       HOST: "127.0.0.1",
-      PORT: "3000",
+      PORT: port,
     },
   },
 });

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -38,7 +38,8 @@ import {
 // Version 9 is reserved for wildfire response actions. Version 10 adds operating
 // customer tariffs/contracts and their effective billed-price retention signal.
 // Version 11 shifts residential tariff energy to later hours instead of eliminating it.
-export const REPLAY_VERSION = 11;
+// Version 12 supports independently configurable four-hour customer demand windows.
+export const REPLAY_VERSION = 12;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -37,7 +37,8 @@ import {
 // Version 8 changes dispatch, neighboring emissions and resource/demand calibration.
 // Version 9 is reserved for wildfire response actions. Version 10 adds operating
 // customer tariffs/contracts and their effective billed-price retention signal.
-export const REPLAY_VERSION = 10;
+// Version 11 shifts residential tariff energy to later hours instead of eliminating it.
+export const REPLAY_VERSION = 11;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -35,7 +35,9 @@ import {
 // Version 7 corrects storage, solar, emissions and weather physics. Earlier action streams cannot
 // reproduce their recorded outcomes and must not be relabeled as current replays.
 // Version 8 changes dispatch, neighboring emissions and resource/demand calibration.
-export const REPLAY_VERSION = 8;
+// Version 9 is reserved for wildfire response actions. Version 10 adds operating
+// customer tariffs/contracts and their effective billed-price retention signal.
+export const REPLAY_VERSION = 10;
 
 /**
  * How many actions a run may record before recording is abandoned. A twenty year game is a few

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -1,4 +1,8 @@
-import { emptyPolicies, validPolicies } from "./helpers/Policies";
+import {
+  emptyPolicies,
+  validPolicies,
+  validDeferredResidential,
+} from "./helpers/Policies";
 import packageJson from "../package.json";
 import { MINUTES_PER_MONTH } from "./helpers/DateTime";
 import { isValidLocation } from "./helpers/Locations";
@@ -40,7 +44,8 @@ export const SAVE_KEY = "savedGame";
 // Version 6 separates reachable reserve and local/purchased emissions and recalibrates resources.
 // Version 7 adds operating tariffs/contracts and their recorded billing rates.
 // Version 8 conserves deferred residential tariff energy until later in the day.
-export const SAVE_VERSION = 8;
+// Version 9 retains configurable demand windows and cross-month recovery batches.
+export const SAVE_VERSION = 9;
 
 export interface SaveGameType {
   version: number;
@@ -372,16 +377,19 @@ export function parseSave(raw: unknown): SaveGameType | null {
   )
     return null;
   if (
-    game.timeline.some((t) =>
-      [
-        t.customerBillingRate,
-        t.deferredResidentialWh,
-        t.deferredResidentialWhStart,
-        t.shiftedResidentialW,
-      ].some(
-        (value) =>
-          value !== undefined && (!Number.isFinite(value) || value < 0),
-      ),
+    game.timeline.some(
+      (t) =>
+        !validDeferredResidential(t.deferredResidential) ||
+        !validDeferredResidential(t.deferredResidentialStart) ||
+        [
+          t.customerBillingRate,
+          t.deferredResidentialWh,
+          t.deferredResidentialWhStart,
+          t.shiftedResidentialW,
+        ].some(
+          (value) =>
+            value !== undefined && (!Number.isFinite(value) || value < 0),
+        ),
     )
   )
     return null;

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -38,7 +38,8 @@ export const SAVE_KEY = "savedGame";
 // Older snapshots contain forecasts and financial results calculated with different physics;
 // do not silently mix those results with the new simulation. Original files remain untouched.
 // Version 6 separates reachable reserve and local/purchased emissions and recalibrates resources.
-export const SAVE_VERSION = 6;
+// Version 7 adds operating tariffs/contracts and their recorded billing rates.
+export const SAVE_VERSION = 7;
 
 export interface SaveGameType {
   version: number;
@@ -366,6 +367,14 @@ export function parseSave(raw: unknown): SaveGameType | null {
     transmission?.lines.some(
       ({ corridorId }) =>
         !locationCorridors.some(({ id }) => id === corridorId),
+    )
+  )
+    return null;
+  if (
+    game.timeline.some(
+      (t) =>
+        t.customerBillingRate !== undefined &&
+        (!Number.isFinite(t.customerBillingRate) || t.customerBillingRate < 0),
     )
   )
     return null;

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -39,7 +39,8 @@ export const SAVE_KEY = "savedGame";
 // do not silently mix those results with the new simulation. Original files remain untouched.
 // Version 6 separates reachable reserve and local/purchased emissions and recalibrates resources.
 // Version 7 adds operating tariffs/contracts and their recorded billing rates.
-export const SAVE_VERSION = 7;
+// Version 8 conserves deferred residential tariff energy until later in the day.
+export const SAVE_VERSION = 8;
 
 export interface SaveGameType {
   version: number;
@@ -371,10 +372,16 @@ export function parseSave(raw: unknown): SaveGameType | null {
   )
     return null;
   if (
-    game.timeline.some(
-      (t) =>
-        t.customerBillingRate !== undefined &&
-        (!Number.isFinite(t.customerBillingRate) || t.customerBillingRate < 0),
+    game.timeline.some((t) =>
+      [
+        t.customerBillingRate,
+        t.deferredResidentialWh,
+        t.deferredResidentialWhStart,
+        t.shiftedResidentialW,
+      ].some(
+        (value) =>
+          value !== undefined && (!Number.isFinite(value) || value < 0),
+      ),
     )
   )
     return null;

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -385,6 +385,9 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     // The exponentially smoothed bill customers respond to, rather than the slider's latest value
     customerRate: number;
     customerBillingRate?: number; // Delivered-energy blended rate, including enrolled offers.
+    deferredResidentialWh?: number; // Unscaled representative-day energy awaiting late-evening use.
+    deferredResidentialWhStart?: number; // Queue before this tick, retained when forecasts trim prior history.
+    shiftedResidentialW?: number; // Returned enrolled residential load, billed at the late rate.
     supplyByFuel: FuelProductionType;
     /** Positive gross flow into/out of the player's grid during this tick. */
     importedW?: number;

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -384,6 +384,7 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     storageLossWh: number; // Charging conversion plus self-discharge / evaporation this tick
     // The exponentially smoothed bill customers respond to, rather than the slider's latest value
     customerRate: number;
+    customerBillingRate?: number; // Delivered-energy blended rate, including enrolled offers.
     supplyByFuel: FuelProductionType;
     /** Positive gross flow into/out of the player's grid during this tick. */
     importedW?: number;
@@ -859,12 +860,12 @@ export interface WorldEventStateType {
   checkedKeys: string[];
 }
 
-export type PolicyId = "efficiency" | "solar";
+export type PolicyId = "efficiency" | "solar" | "timeOfUse" | "curtailment";
 export type PolicyTier = "Off" | "Small" | "Large";
 export interface PolicyProgramType {
   tier: PolicyTier;
-  adoption: number; // Fraction of the authored potential installed; persists within the run.
-  spending: number; // Actual funded upgrades this month, in nominal dollars.
+  adoption: number; // Installed potential for rebates; current enrolled share for operating offers.
+  spending: number; // Funded upgrades this month; offer credits instead reduce billed revenue.
   pending?: { tier: PolicyTier; month: number };
 }
 export interface PoliciesType {

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -387,6 +387,8 @@ export type TickPresentFutureType = Partial<FuelPricesType> &
     customerBillingRate?: number; // Delivered-energy blended rate, including enrolled offers.
     deferredResidentialWh?: number; // Unscaled representative-day energy awaiting late-evening use.
     deferredResidentialWhStart?: number; // Queue before this tick, retained when forecasts trim prior history.
+    deferredResidential?: DeferredResidentialLoad[]; // Outstanding energy tied to its original recovery window.
+    deferredResidentialStart?: DeferredResidentialLoad[]; // Before this tick, for repeated forecasts.
     shiftedResidentialW?: number; // Returned enrolled residential load, billed at the late rate.
     supplyByFuel: FuelProductionType;
     /** Positive gross flow into/out of the player's grid during this tick. */
@@ -865,11 +867,17 @@ export interface WorldEventStateType {
 
 export type PolicyId = "efficiency" | "solar" | "timeOfUse" | "curtailment";
 export type PolicyTier = "Off" | "Small" | "Large";
+export interface DeferredResidentialLoad {
+  energyWh: number; // Unscaled representative-day energy.
+  recoveryStartMinute: number; // Absolute simulation minute, including across month boundaries.
+  recoveryEndMinute: number;
+}
 export interface PolicyProgramType {
   tier: PolicyTier;
+  startHour?: number; // Four-hour local-clock window; absent means 17 for earlier callers.
   adoption: number; // Installed potential for rebates; current enrolled share for operating offers.
   spending: number; // Funded upgrades this month; offer credits instead reduce billed revenue.
-  pending?: { tier: PolicyTier; month: number };
+  pending?: { tier: PolicyTier; month: number; startHour?: number };
 }
 export interface PoliciesType {
   month: number; // Last processed elapsed month; prevents duplicate enrollment and charges.
@@ -879,6 +887,7 @@ export interface PolicyChangeType {
   id: PolicyId;
   tier: PolicyTier;
   month: number;
+  startHour?: number;
 }
 export interface GameType {
   policies?: PoliciesType;

--- a/src/components/views/CustomerPrograms.test.tsx
+++ b/src/components/views/CustomerPrograms.test.tsx
@@ -12,10 +12,85 @@ import { PolicyId } from "../../Types";
 import { POLICIES } from "../../data/Policies";
 import { formatMoneyConcise } from "../../helpers/Format";
 import { emptyPolicies } from "../../helpers/Policies";
+import { suggestedPolicyStartHour } from "../../helpers/PolicyWindow";
 
 jest.mock("../../helpers/PolicyPreviewClient", () => ({
   createPolicyPreviewWorker: jest.fn(),
 }));
+
+test("window defaults to the forecast peak and only a fresh preview can schedule a changed window", () => {
+  jest.useFakeTimers();
+  const workers: Array<{
+    onmessage: ((event: { data: unknown }) => void) | null;
+    postMessage: jest.Mock;
+    terminate: jest.Mock;
+  }> = [];
+  const stub = jest
+    .spyOn(client, "createPolicyPreviewWorker")
+    .mockImplementation(() => {
+      const worker = {
+        onmessage: null,
+        postMessage: jest.fn(),
+        terminate: jest.fn(),
+      };
+      workers.push(worker);
+      return worker as unknown as Worker;
+    });
+  const game = createGame({ scenarioId: 106 });
+  const store = configureStore({
+    reducer: { game: gameReducer, ui: uiReducer },
+    preloadedState: { game },
+  });
+  const view = render(
+    <Provider store={store}>
+      <CustomerPrograms game={game} onViewDemand={jest.fn()} />
+    </Provider>,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Customer programs" }));
+  fireEvent.click(
+    screen.getByRole("button", { name: "Time-of-use tariff · Off" }),
+  );
+  expect(screen.queryByLabelText("Daily window")).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole("radio", { name: /^On$/ }));
+  expect(screen.getByLabelText("Daily window")).toHaveValue(
+    String(suggestedPolicyStartHour(game)),
+  );
+  act(() => jest.advanceTimersByTime(250));
+  const old = workers[workers.length - 1];
+  fireEvent.change(screen.getByLabelText("Daily window"), {
+    target: { value: "22" },
+  });
+  const result = previewPolicy(
+    game,
+    { id: "timeOfUse", tier: "Large", month: 1, startHour: 22 },
+    1,
+  );
+  act(() => old.onmessage!({ data: { result } }));
+  const apply = screen.getByRole("button", { name: "Turn on next month" });
+  expect(apply).toBeDisabled();
+  act(() => jest.advanceTimersByTime(250));
+  const worker = workers[workers.length - 1];
+  expect(worker.postMessage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      change: { id: "timeOfUse", tier: "Large", month: 1, startHour: 22 },
+    }),
+  );
+  act(() => worker.onmessage!({ data: { result } }));
+  fireEvent.click(apply);
+  expect(
+    store.getState().game.policies!.programs.timeOfUse.pending!.startHour,
+  ).toBe(22);
+  fireEvent.click(
+    screen.getByRole("button", { name: "Time-of-use tariff · Off" }),
+  );
+  expect(screen.getByLabelText("Daily window")).toHaveValue("22");
+  expect(
+    screen.getByRole("button", { name: "Update next month" }),
+  ).toBeDisabled();
+  view.unmount();
+  stub.mockRestore();
+  jest.useRealTimers();
+});
 
 test("stale and failed worker results cannot enable Apply, and closing terminates preview", () => {
   jest.useFakeTimers();

--- a/src/components/views/CustomerPrograms.test.tsx
+++ b/src/components/views/CustomerPrograms.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import gameReducer from "../../reducers/Game";
+import uiReducer from "../../reducers/UI";
 import { createGame } from "../../testing/Simulator";
 import * as client from "../../helpers/PolicyPreviewClient";
 import { previewPolicy } from "../../helpers/PolicyPreview";
@@ -43,7 +44,7 @@ test("stale and failed worker results cannot enable Apply, and closing terminate
     1,
   );
   const store = configureStore({
-    reducer: { game: gameReducer },
+    reducer: { game: gameReducer, ui: uiReducer },
     preloadedState: { game },
   });
   const view = render(
@@ -110,7 +111,7 @@ test.each<PolicyId>(["solar", "efficiency"])(
       changed: [47000000, 30000000],
     };
     const store = configureStore({
-      reducer: { game: gameReducer },
+      reducer: { game: gameReducer, ui: uiReducer },
       preloadedState: { game },
     });
     const view = render(
@@ -151,7 +152,7 @@ test("stopped funding describes retained upgrades without announcing another cha
   game.policies = emptyPolicies();
   game.policies.programs.efficiency.adoption = 0.05;
   const store = configureStore({
-    reducer: { game: gameReducer },
+    reducer: { game: gameReducer, ui: uiReducer },
     preloadedState: { game },
   });
   const view = render(

--- a/src/components/views/CustomerPrograms.tsx
+++ b/src/components/views/CustomerPrograms.tsx
@@ -27,7 +27,6 @@ import {
   policyAvailable,
   policyBudget,
   isOperatingPolicy,
-  participation,
 } from "../../helpers/Policies";
 import { getDateFromMinute, MINUTES_PER_MONTH } from "../../helpers/DateTime";
 import {
@@ -39,6 +38,10 @@ import { getScenario } from "../../data/Scenarios";
 import { createPolicyPreviewWorker } from "../../helpers/PolicyPreviewClient";
 import { PolicyPreviewResult } from "../../helpers/PolicyPreview";
 import PolicyDemandChart from "../base/PolicyDemandChart";
+import ManualLink from "../base/ManualLink";
+import { MANUAL_ENTRY } from "../../data/Manual";
+const programLabel = (id: PolicyId, tier: PolicyTier) =>
+  isOperatingPolicy(id) && tier !== "Off" ? "On" : tier;
 
 const labelMonth = (game: GameType, month: number) => {
   const d = getDateFromMinute(month * MINUTES_PER_MONTH, game.startingYear);
@@ -54,11 +57,12 @@ function Decision({
 }) {
   const game = useAppSelector((s) => s.game);
   const dispatch = useAppDispatch();
+  const manualOpen = useAppSelector((s) => !!s.ui.manualHelpEntry);
   const phone = useMediaQuery("(max-width:600px)");
   const token = React.useId();
   React.useEffect(() => {
     const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
+      if (event.key === "Escape" && !manualOpen) {
         event.preventDefault();
         event.stopPropagation();
         onClose();
@@ -66,7 +70,7 @@ function Decision({
     };
     document.addEventListener("keydown", closeOnEscape, true);
     return () => document.removeEventListener("keydown", closeOnEscape, true);
-  }, [onClose]);
+  }, [onClose, manualOpen]);
   const [selected, setSelected] = React.useState<PolicyId>();
   const [tier, setTier] = React.useState<PolicyTier>("Off");
   const [later, setLater] = React.useState(false);
@@ -144,8 +148,12 @@ function Decision({
       aria-labelledby="program-title"
       data-customer-programs="true"
     >
-      <DialogTitle id="program-title">
+      <DialogTitle
+        id="program-title"
+        sx={{ display: "flex", alignItems: "center", gap: 1 }}
+      >
         {selected ? POLICIES[selected].name : "Customer programs"}
+        <ManualLink entry={MANUAL_ENTRY.CUSTOMER_PROGRAMS} />
       </DialogTitle>
       <DialogContent
         dividers
@@ -166,12 +174,12 @@ function Decision({
                     setLater(false);
                   }}
                 >
-                  {POLICIES[id].name} · {programs[id].tier}
+                  {POLICIES[id].name} · {programLabel(id, programs[id].tier)}
                 </Button>
                 <Typography>{POLICIES[id].description}</Typography>
                 {programs[id].pending && (
                   <Typography variant="body2">
-                    {programs[id].pending!.tier} starts{" "}
+                    {programLabel(id, programs[id].pending!.tier)} starts{" "}
                     {labelMonth(game, programs[id].pending!.month)}
                   </Typography>
                 )}
@@ -184,7 +192,11 @@ function Decision({
           </Box>
         ) : (
           <Box sx={{ display: "grid", gap: 2 }}>
-            <Typography>{POLICIES[selected].mechanism}</Typography>
+            <Typography>
+              {operating
+                ? POLICIES[selected].description
+                : POLICIES[selected].mechanism}
+            </Typography>
             {!operating && (
               <Typography variant="body2">
                 {current!.adoption >= 1
@@ -199,12 +211,15 @@ function Decision({
               </Typography>
             )}
             <RadioGroup
-              row={!phone}
-              aria-label={operating ? "Enrollment" : "Monthly funding"}
-              value={tier}
+              row={operating || !phone}
+              aria-label={operating ? "Program status" : "Monthly funding"}
+              value={operating && tier !== "Off" ? "Large" : tier}
               onChange={(e) => setTier(e.target.value as PolicyTier)}
             >
-              {POLICY_TIERS.map((choice) => (
+              {(operating
+                ? (["Off", "Large"] as PolicyTier[])
+                : POLICY_TIERS
+              ).map((choice) => (
                 <FormControlLabel
                   key={choice}
                   value={choice}
@@ -212,19 +227,13 @@ function Decision({
                   sx={{ minHeight: 44, m: 0, flex: 1 }}
                   label={
                     operating
-                      ? `${choice} · ${participation(choice) * 100}% enrolled`
+                      ? programLabel(selected, choice)
                       : `${choice} · ${choice === "Off" ? "$0/month" : `up to ${formatMoneyConcise(policyBudget(game, selected, choice, effective))}/month`}`
                   }
                 />
               ))}
             </RadioGroup>
-            {operating ? (
-              <Typography variant="body2">
-                Off restores the base rate and uncurtailed consumption next
-                month. No installation fees. Bill changes are included in cash
-                estimates. All hours use the scenario's local clock, year-round.
-              </Typography>
-            ) : (
+            {!operating && (
               <>
                 <Typography variant="body2">
                   Off stops new spending; installed upgrades remain.
@@ -238,37 +247,16 @@ function Decision({
                 </Typography>
               </>
             )}
-            {operating && (
-              <Typography variant="body2">
-                Base rate: {formatMoneyConcise(game.dollarsPerkWh)}/kWh.
-                {selected === "timeOfUse" && (
-                  <>
-                    {" "}
-                    Enrolled rates:{" "}
-                    {formatMoneyConcise(game.dollarsPerkWh * 1.3)}/kWh evening;{" "}
-                    {formatMoneyConcise(game.dollarsPerkWh * 0.9)}/kWh
-                    overnight.
-                  </>
-                )}
-                {selected === "curtailment" && (
-                  <>
-                    {" "}
-                    Enrolled rate after credit:{" "}
-                    {formatMoneyConcise(game.dollarsPerkWh * 0.9)}/kWh all day.
-                  </>
-                )}
-              </Typography>
-            )}
             {effective >= end ? (
               <Alert severity="info">
-                This run ends before another funding change could take effect.
+                This run ends before another program change could take effect.
               </Alert>
             ) : (
               <>
                 <Typography component="h3" variant="subtitle1">
                   Estimated utility demand · {labelMonth(game, month)}
                 </Typography>
-                {end - 1 > effective && (
+                {!operating && end - 1 > effective && (
                   <Button onClick={() => setLater(!later)}>
                     {later
                       ? "First effective month"
@@ -302,21 +290,20 @@ function Decision({
                         Peak demand: {formatWatts(peakBefore)} →{" "}
                         {formatWatts(peakAfter)}
                       </Typography>
-                      <Typography>
-                        Electricity supplied:{" "}
-                        {formatWattHours(result.before.supplyWh)} →{" "}
-                        {formatWattHours(result.after.supplyWh)} in{" "}
-                        {labelMonth(game, month)}
-                      </Typography>
+                      {!operating && (
+                        <Typography>
+                          Electricity supplied:{" "}
+                          {formatWattHours(result.before.supplyWh)} →{" "}
+                          {formatWattHours(result.after.supplyWh)} in{" "}
+                          {labelMonth(game, month)}
+                        </Typography>
+                      )}
                       <Typography>
                         Change in utility cash from now through{" "}
                         {labelMonth(game, month)}:{" "}
                         {formatMoneyConcise(result.cashChange)}
                       </Typography>
-                      <Typography variant="body2">
-                        Includes program spending, billed sales after tariff
-                        adjustments and credits, and actual dispatch costs.
-                      </Typography>
+
                       {(formatWatts(peakBefore) === formatWatts(peakAfter) ||
                         Math.abs(peakAfter - peakBefore) <
                           peakBefore * 0.001) && (
@@ -330,36 +317,6 @@ function Decision({
                         </Typography>
                       )}
                     </Box>
-                    <details>
-                      <summary>Why this changes</summary>
-                      <Typography variant="body2">
-                        {POLICIES[selected].tradeoff}{" "}
-                        {!operating && (
-                          <>
-                            Budgets adjust with inflation. Spending pays only
-                            for new upgrades and stops at full adoption.
-                            Installed upgrades persist for this run.
-                          </>
-                        )}
-                      </Typography>
-                      <Typography variant="body2">
-                        Estimates hold weather, fuel prices, fleet, rate and
-                        customer assumptions, and other accepted programs
-                        constant.{" "}
-                        {operating ? (
-                          "Enrollment changes consumption and the effective billed rate. Credits apply proportionally to delivered eligible energy during shortages; unserved energy earns no revenue or credit. Avoided consumption is not shifted, and scheduled curtailment is not a reliability failure."
-                        ) : (
-                          <>
-                            Efficiency is a simplified end-use reduction for
-                            homes and businesses. Solar offsets their remaining
-                            load after efficiency; surplus is curtailed. No
-                            export payments or utility generation credits. Hint:
-                            compare daylight savings with the time of your
-                            shortage.
-                          </>
-                        )}
-                      </Typography>
-                    </details>
                     {result.after.cash < 0 && (
                       <Alert severity="warning">
                         Projected cash is negative. Existing debt rules still
@@ -412,7 +369,13 @@ function Decision({
               setSelected(undefined);
             }}
           >
-            {tier === "Off" ? "Stop next month" : "Start next month"}
+            {operating
+              ? tier === "Off"
+                ? "Turn off next month"
+                : "Turn on next month"
+              : tier === "Off"
+                ? "Stop next month"
+                : "Start next month"}
           </Button>
         )}
       </DialogActions>

--- a/src/components/views/CustomerPrograms.tsx
+++ b/src/components/views/CustomerPrograms.tsx
@@ -26,6 +26,8 @@ import {
   emptyPolicies,
   policyAvailable,
   policyBudget,
+  isOperatingPolicy,
+  participation,
 } from "../../helpers/Policies";
 import { getDateFromMinute, MINUTES_PER_MONTH } from "../../helpers/DateTime";
 import {
@@ -125,6 +127,7 @@ function Decision({
   }, [game, selected, tier, month, effective, end, key]);
   const programs = game.policies?.programs ?? emptyPolicies().programs;
   const current = selected ? programs[selected] : undefined;
+  const operating = selected ? isOperatingPolicy(selected) : false;
   const settled = preview?.key === key && preview.snapshot === game;
   const result = settled ? preview.result : undefined;
   const error = settled ? preview.error : undefined;
@@ -144,7 +147,13 @@ function Decision({
       <DialogTitle id="program-title">
         {selected ? POLICIES[selected].name : "Customer programs"}
       </DialogTitle>
-      <DialogContent dividers>
+      <DialogContent
+        dividers
+        sx={{
+          "& button": { minHeight: 44 },
+          "& summary": { minHeight: 44, cursor: "pointer" },
+        }}
+      >
         {!selected ? (
           <Box sx={{ display: "grid", gap: 2 }}>
             {POLICY_IDS.map((id) => (
@@ -169,27 +178,29 @@ function Decision({
               </Box>
             ))}
             <Typography variant="body2">
-              Funding continues monthly until changed. Installed upgrades stay
-              for the rest of this run, including after funding stops.
+              Changes start next month. Rebates install lasting upgrades;
+              tariffs and contracts apply only while enabled.
             </Typography>
           </Box>
         ) : (
           <Box sx={{ display: "grid", gap: 2 }}>
             <Typography>{POLICIES[selected].mechanism}</Typography>
-            <Typography variant="body2">
-              {current!.adoption >= 1
-                ? "Fully adopted"
-                : current!.adoption > 0
-                  ? current!.tier === "Off"
-                    ? "Installed upgrades retained"
-                    : "Building up"
-                  : "No funded upgrades yet"}{" "}
-              · {Math.round(current!.adoption * 100)}% of eligible potential
-              installed
-            </Typography>
+            {!operating && (
+              <Typography variant="body2">
+                {current!.adoption >= 1
+                  ? "Fully adopted"
+                  : current!.adoption > 0
+                    ? current!.tier === "Off"
+                      ? "Installed upgrades retained"
+                      : "Building up"
+                    : "No funded upgrades yet"}{" "}
+                · {Math.round(current!.adoption * 100)}% of eligible potential
+                installed
+              </Typography>
+            )}
             <RadioGroup
               row={!phone}
-              aria-label="Monthly funding"
+              aria-label={operating ? "Enrollment" : "Monthly funding"}
               value={tier}
               onChange={(e) => setTier(e.target.value as PolicyTier)}
             >
@@ -199,20 +210,55 @@ function Decision({
                   value={choice}
                   control={<Radio />}
                   sx={{ minHeight: 44, m: 0, flex: 1 }}
-                  label={`${choice} · ${choice === "Off" ? "$0/month" : `up to ${formatMoneyConcise(policyBudget(game, selected, choice, effective))}/month`}`}
+                  label={
+                    operating
+                      ? `${choice} · ${participation(choice) * 100}% enrolled`
+                      : `${choice} · ${choice === "Off" ? "$0/month" : `up to ${formatMoneyConcise(policyBudget(game, selected, choice, effective))}/month`}`
+                  }
                 />
               ))}
             </RadioGroup>
-            <Typography variant="body2">
-              Off stops new spending; installed upgrades remain.
-            </Typography>
-            <Typography variant="body2">
-              Small installs upgrades at a lower cost per upgrade. Large
-              installs them faster, at a higher cost per upgrade.
-            </Typography>
-            <Typography variant="body2">
-              Rebates cost money and reduce electricity sales.
-            </Typography>
+            {operating ? (
+              <Typography variant="body2">
+                Off restores the base rate and uncurtailed consumption next
+                month. No installation fees. Bill changes are included in cash
+                estimates. All hours use the scenario's local clock, year-round.
+              </Typography>
+            ) : (
+              <>
+                <Typography variant="body2">
+                  Off stops new spending; installed upgrades remain.
+                </Typography>
+                <Typography variant="body2">
+                  Small installs upgrades at a lower cost per upgrade. Large
+                  installs them faster, at a higher cost per upgrade.
+                </Typography>
+                <Typography variant="body2">
+                  Rebates cost money and reduce electricity sales.
+                </Typography>
+              </>
+            )}
+            {operating && (
+              <Typography variant="body2">
+                Base rate: {formatMoneyConcise(game.dollarsPerkWh)}/kWh.
+                {selected === "timeOfUse" && (
+                  <>
+                    {" "}
+                    Enrolled rates:{" "}
+                    {formatMoneyConcise(game.dollarsPerkWh * 1.3)}/kWh evening;{" "}
+                    {formatMoneyConcise(game.dollarsPerkWh * 0.9)}/kWh
+                    overnight.
+                  </>
+                )}
+                {selected === "curtailment" && (
+                  <>
+                    {" "}
+                    Enrolled rate after credit:{" "}
+                    {formatMoneyConcise(game.dollarsPerkWh * 0.9)}/kWh all day.
+                  </>
+                )}
+              </Typography>
+            )}
             {effective >= end ? (
               <Alert severity="info">
                 This run ends before another funding change could take effect.
@@ -245,10 +291,13 @@ function Decision({
                       changed={result.changed}
                     />
                     <Box role="status">
-                      <Typography>
-                        Program spending: {formatMoneyConcise(result.spending)}{" "}
-                        in {labelMonth(game, month)}
-                      </Typography>
+                      {!operating && (
+                        <Typography>
+                          Program spending:{" "}
+                          {formatMoneyConcise(result.spending)} in{" "}
+                          {labelMonth(game, month)}
+                        </Typography>
+                      )}
                       <Typography>
                         Peak demand: {formatWatts(peakBefore)} →{" "}
                         {formatWatts(peakAfter)}
@@ -265,36 +314,50 @@ function Decision({
                         {formatMoneyConcise(result.cashChange)}
                       </Typography>
                       <Typography variant="body2">
-                        Includes program spending, less electricity sold, and
-                        actual dispatch costs.
+                        Includes program spending, billed sales after tariff
+                        adjustments and credits, and actual dispatch costs.
                       </Typography>
                       {(formatWatts(peakBefore) === formatWatts(peakAfter) ||
                         Math.abs(peakAfter - peakBefore) <
                           peakBefore * 0.001) && (
                         <Typography variant="body2">
                           Little change in peak demand.{" "}
-                          {selected === "solar"
-                            ? "Daylight savings may leave the evening peak unchanged."
-                            : "Efficiency savings build gradually as upgrades are installed."}
+                          {operating
+                            ? "The contracted evening window may not match your peak; only eligible loads respond."
+                            : selected === "solar"
+                              ? "Daylight savings may leave the evening peak unchanged."
+                              : "Efficiency savings build gradually as upgrades are installed."}
                         </Typography>
                       )}
                     </Box>
                     <details>
                       <summary>Why this changes</summary>
                       <Typography variant="body2">
-                        {POLICIES[selected].tradeoff} Budgets adjust with
-                        inflation. Spending pays only for new upgrades and stops
-                        at full adoption. Installed upgrades persist for this
-                        run.
+                        {POLICIES[selected].tradeoff}{" "}
+                        {!operating && (
+                          <>
+                            Budgets adjust with inflation. Spending pays only
+                            for new upgrades and stops at full adoption.
+                            Installed upgrades persist for this run.
+                          </>
+                        )}
                       </Typography>
                       <Typography variant="body2">
                         Estimates hold weather, fuel prices, fleet, rate and
                         customer assumptions, and other accepted programs
-                        constant. Efficiency is a simplified end-use reduction
-                        for homes and businesses. Solar offsets their remaining
-                        load after efficiency; surplus is curtailed. No export
-                        payments or utility generation credits. Hint: compare
-                        daylight savings with the time of your shortage.
+                        constant.{" "}
+                        {operating ? (
+                          "Enrollment changes consumption and the effective billed rate. Credits apply proportionally to delivered eligible energy during shortages; unserved energy earns no revenue or credit. Avoided consumption is not shifted, and scheduled curtailment is not a reliability failure."
+                        ) : (
+                          <>
+                            Efficiency is a simplified end-use reduction for
+                            homes and businesses. Solar offsets their remaining
+                            load after efficiency; surplus is curtailed. No
+                            export payments or utility generation credits. Hint:
+                            compare daylight savings with the time of your
+                            shortage.
+                          </>
+                        )}
                       </Typography>
                     </details>
                     {result.after.cash < 0 && (
@@ -402,8 +465,10 @@ export default function CustomerPrograms({
       ) : (
         active > 0 && (
           <Typography variant="caption">
-            {active} program{active > 1 ? "s" : ""} active · up to{" "}
-            {formatMoneyConcise(budget)}/month
+            {active} program{active > 1 ? "s" : ""} active
+            {budget > 0 && (
+              <> · up to {formatMoneyConcise(budget)}/month in rebates</>
+            )}
           </Typography>
         )
       )}

--- a/src/components/views/CustomerPrograms.tsx
+++ b/src/components/views/CustomerPrograms.tsx
@@ -10,6 +10,7 @@ import {
   FormControlLabel,
   Radio,
   RadioGroup,
+  TextField,
   Typography,
   useMediaQuery,
 } from "@mui/material";
@@ -40,6 +41,10 @@ import { PolicyPreviewResult } from "../../helpers/PolicyPreview";
 import PolicyDemandChart from "../base/PolicyDemandChart";
 import ManualLink from "../base/ManualLink";
 import { MANUAL_ENTRY } from "../../data/Manual";
+import {
+  policyWindowLabel,
+  suggestedPolicyStartHour,
+} from "../../helpers/PolicyWindow";
 const programLabel = (id: PolicyId, tier: PolicyTier) =>
   isOperatingPolicy(id) && tier !== "Off" ? "On" : tier;
 
@@ -73,6 +78,7 @@ function Decision({
   }, [onClose, manualOpen]);
   const [selected, setSelected] = React.useState<PolicyId>();
   const [tier, setTier] = React.useState<PolicyTier>("Off");
+  const [startHour, setStartHour] = React.useState(17);
   const [later, setLater] = React.useState(false);
   const [preview, setPreview] = React.useState<{
     key: string;
@@ -90,7 +96,7 @@ function Decision({
   const end =
     getScenario(game.scenarioId, game.customScenario)?.durationMonths ?? 0;
   const month = later ? Math.min(effective + 11, end - 1) : effective;
-  const key = `${selected}/${tier}/${month}/${game.date.minute}`;
+  const key = `${selected}/${tier}/${startHour}/${month}/${game.date.minute}`;
   React.useEffect(() => {
     if (!selected || effective >= end) return;
     let worker: Worker | undefined;
@@ -112,7 +118,12 @@ function Decision({
         };
         worker.postMessage({
           game: JSON.parse(JSON.stringify(game)),
-          change: { id: selected, tier, month: effective },
+          change: {
+            id: selected,
+            tier,
+            month: effective,
+            ...(isOperatingPolicy(selected) ? { startHour } : {}),
+          },
           month,
         });
       } catch (_error) {
@@ -128,14 +139,18 @@ function Decision({
       window.clearTimeout(timer);
       worker?.terminate();
     };
-  }, [game, selected, tier, month, effective, end, key]);
+  }, [game, selected, tier, startHour, month, effective, end, key]);
   const programs = game.policies?.programs ?? emptyPolicies().programs;
   const current = selected ? programs[selected] : undefined;
   const operating = selected ? isOperatingPolicy(selected) : false;
   const settled = preview?.key === key && preview.snapshot === game;
   const result = settled ? preview.result : undefined;
   const error = settled ? preview.error : undefined;
-  const unchanged = tier === (current?.pending?.tier ?? current?.tier ?? "Off");
+  const unchanged =
+    tier === (current?.pending?.tier ?? current?.tier ?? "Off") &&
+    (!operating ||
+      tier === "Off" ||
+      startHour === (current?.pending?.startHour ?? current?.startHour ?? 17));
   const peakBefore = result ? Math.max(...result.current) : 0;
   const peakAfter = result ? Math.max(...result.changed) : 0;
   return (
@@ -171,6 +186,13 @@ function Decision({
                   onClick={() => {
                     setSelected(id);
                     setTier(programs[id].pending?.tier ?? programs[id].tier);
+                    setStartHour(
+                      programs[id].pending?.startHour ??
+                        programs[id].startHour ??
+                        (programs[id].tier !== "Off"
+                          ? 17
+                          : suggestedPolicyStartHour(game)),
+                    );
                     setLater(false);
                   }}
                 >
@@ -181,6 +203,18 @@ function Decision({
                   <Typography variant="body2">
                     {programLabel(id, programs[id].pending!.tier)} starts{" "}
                     {labelMonth(game, programs[id].pending!.month)}
+                    {isOperatingPolicy(id) &&
+                      programs[id].pending!.tier !== "Off" && (
+                        <>
+                          {" "}
+                          ·{" "}
+                          {policyWindowLabel(
+                            programs[id].pending!.startHour ??
+                              programs[id].startHour ??
+                              17,
+                          )}
+                        </>
+                      )}
                   </Typography>
                 )}
               </Box>
@@ -233,6 +267,30 @@ function Decision({
                 />
               ))}
             </RadioGroup>
+            {operating && tier !== "Off" && (
+              <TextField
+                select
+                fullWidth
+                label="Daily window"
+                value={startHour}
+                onChange={(event) => setStartHour(Number(event.target.value))}
+                slotProps={{
+                  select: { native: true },
+                  htmlInput: { style: { minHeight: 24 } },
+                }}
+                helperText={
+                  selected === "timeOfUse"
+                    ? `Use moves to ${policyWindowLabel((startHour + 4) % 24, 3)} afterward.`
+                    : undefined
+                }
+              >
+                {Array.from({ length: 24 }, (_, hour) => (
+                  <option key={hour} value={hour}>
+                    {policyWindowLabel(hour)}
+                  </option>
+                ))}
+              </TextField>
+            )}
             {!operating && (
               <>
                 <Typography variant="body2">
@@ -310,7 +368,7 @@ function Decision({
                         <Typography variant="body2">
                           Little change in peak demand.{" "}
                           {operating
-                            ? "The contracted evening window may not match your peak; only eligible loads respond."
+                            ? "Only eligible loads respond. Try a different daily window to target your peak."
                             : selected === "solar"
                               ? "Daylight savings may leave the evening peak unchanged."
                               : "Efficiency savings build gradually as upgrades are installed."}
@@ -364,7 +422,12 @@ function Decision({
             }
             onClick={() => {
               dispatch(
-                schedulePolicy({ id: selected, tier, month: effective }),
+                schedulePolicy({
+                  id: selected,
+                  tier,
+                  month: effective,
+                  ...(operating ? { startHour } : {}),
+                }),
               );
               setSelected(undefined);
             }}
@@ -372,7 +435,9 @@ function Decision({
             {operating
               ? tier === "Off"
                 ? "Turn off next month"
-                : "Turn on next month"
+                : (current?.pending?.tier ?? current?.tier) !== "Off"
+                  ? "Update next month"
+                  : "Turn on next month"
               : tier === "Off"
                 ? "Stop next month"
                 : "Start next month"}

--- a/src/components/views/Finances.tsx
+++ b/src/components/views/Finances.tsx
@@ -932,7 +932,7 @@ export default class Finances extends React.Component<Props, State> {
               variant="body2"
               color="textSecondary"
             >
-              Electricity Rate
+              Electricity Base Rate
               <ManualLink
                 entry={MANUAL_ENTRY.RATES}
                 label="electricity rates"
@@ -956,6 +956,15 @@ export default class Finances extends React.Component<Props, State> {
               )}
             </Typography>
             <div className="budgetSlider flex-newline">
+              {(game.policies?.programs.timeOfUse?.tier !== "Off" ||
+                game.policies?.programs.curtailment?.tier !== "Off") &&
+                game.policies && (
+                  <Typography variant="caption">
+                    Tariffs and credits adjust this base rate. The customer
+                    estimate assumes a flat rate; revenue and cash include
+                    active offers.
+                  </Typography>
+                )}
               <Slider
                 id="rateSlider"
                 disabled={!!game.replayPlayback}

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -1262,7 +1262,8 @@ export default class Insights extends React.Component<Props, State> {
           color="textSecondary"
           aria-hidden="true"
         >
-          Rate <strong>{formatMoneyConcise(game.dollarsPerkWh)}/kWh</strong>
+          Base rate{" "}
+          <strong>{formatMoneyConcise(game.dollarsPerkWh)}/kWh</strong>
           {scenario.ownership === "Investor" && (
             <>
               {" "}
@@ -1288,7 +1289,7 @@ export default class Insights extends React.Component<Props, State> {
           aria-hidden="true"
         >
           <span className="insightsRateMetric">
-            <span className="insightsRateMetricLabel">Rate</span>
+            <span className="insightsRateMetricLabel">Base rate</span>
             <strong className="insightsRateMetricValue">
               {formatRateCompact(game.dollarsPerkWh)}/kWh
             </strong>
@@ -1322,6 +1323,15 @@ export default class Insights extends React.Component<Props, State> {
         <span id="insightsRateSummary" className="srOnly">
           {rateSummary}
         </span>
+        {(game.policies?.programs.timeOfUse?.tier !== "Off" ||
+          game.policies?.programs.curtailment?.tier !== "Off") &&
+          game.policies && (
+            <Typography variant="caption">
+              Tariffs and credits adjust this base rate. Customer estimates here
+              assume a flat rate; use Customer programs for demand and cash with
+              offers.
+            </Typography>
+          )}
         <div
           className={`budgetSlider flex-newline ${
             this.state.leversOpen ? "" : "insightsRateSliderCollapsed"

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -676,6 +676,8 @@ function policySignature(game: GameType): string {
           program.adoption,
           program.spending,
           program.pending?.tier,
+          program.startHour,
+          program.pending?.startHour,
           program.pending?.month,
         ];
       }),

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -162,33 +162,38 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           electricity sold, so compare cash as well as peak demand.
         </p>
         <p>
-          Time-of-use tariffs enroll 25% (Small) or 50% (Large) of homes and
-          businesses. Enrolled users pay 30% above your base rate from
-          17:00–21:00, 10% below it from 00:00–06:00, and the base rate
-          otherwise. They forgo 20% of evening consumption by avoiding
-          discretionary uses. This model reduces energy consumption; it does not
-          move energy to another hour. The previous tick's effective billed rate
-          feeds customer price memory and retention, with one tick of delay.
+          Turn the time-of-use tariff On or Off. When on, half of homes
+          participate: they move 20% of their 17:00–21:00 electricity use to
+          21:00–24:00, such as charging cars later. The energy removed after
+          efficiency and rooftop solar is spread evenly over those later hours;
+          total energy use is unchanged. Businesses and transport-sector load
+          are not enrolled. Participants pay 30% above your base rate during the
+          peak, 10% below it from 21:00–24:00, and the base rate otherwise. All
+          returned energy receives the later discount. Higher bills can affect
+          customer retention through the previous tick's effective billed rate.
         </p>
         <p>
-          Peak curtailment contracts enroll 25% or 50% of industrial and
-          data-center load, including authored scenario additions. Participants
-          forgo 20% of demand from 17:00–21:00 every day, four hours maximum,
-          even when supply is adequate. In exchange, they receive a 10% credit
-          on electricity actually supplied all day. No delivery means no credit.
-          Supply and credits are allocated proportionally during shortages.
-          Contracted curtailment does not count as a blackout. There is no
-          effect without eligible load; transport is excluded. The tariff and
-          contract cover different sectors, so credits never stack on a
-          time-of-use rate.
+          Turn peak curtailment contracts On or Off. When on, half of industrial
+          and data-center load participates, including authored scenario
+          additions. Participants forgo 20% of demand from 17:00–21:00 every
+          day, four hours maximum, even when supply is adequate. In exchange,
+          they receive a 10% credit on electricity actually supplied all day. No
+          delivery means no credit. Supply and credits are allocated
+          proportionally during shortages. This load is eliminated, not shifted
+          to later hours. Contracted curtailment does not count as a blackout.
+          There is no effect without eligible load; transport is excluded. The
+          tariff and contract cover different sectors, so credits never stack on
+          a time-of-use rate.
         </p>
         <p>
           Both offers use fixed local-clock windows in every season, which may
           miss your grid's actual peak. There are no installation costs; compare
           demand and cash before committing. Changes start next month and
-          continue until changed. Off ends enrollment, bill adjustments and
-          consumption reductions next month; unlike rebates, these effects do
-          not persist.
+          continue until changed. Off ends enrollment, bill adjustments and load
+          changes next month; unlike rebates, these effects do not persist.
+          Estimates include billed sales, credits, spending and dispatch costs,
+          holding weather, fuel prices, fleet, base rate and other accepted
+          programs constant.
         </p>
       </div>
     ),

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -163,20 +163,22 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
         </p>
         <p>
           Turn the time-of-use tariff On or Off. When on, half of homes
-          participate: they move 20% of their 17:00–21:00 electricity use to
-          21:00–24:00, such as charging cars later. The energy removed after
-          efficiency and rooftop solar is spread evenly over those later hours;
-          total energy use is unchanged. Businesses and transport-sector load
-          are not enrolled. Participants pay 30% above your base rate during the
-          peak, 10% below it from 21:00–24:00, and the base rate otherwise. All
-          returned energy receives the later discount. Higher bills can affect
-          customer retention through the previous tick's effective billed rate.
+          participate: choose a four-hour daily window and they move 20% of that
+          electricity use into the following three hours, such as charging cars
+          later. For example, a 22:00–02:00 window shifts use to 02:00–05:00.
+          The energy removed after efficiency and rooftop solar is spread evenly
+          over those later hours; total energy use is unchanged. Businesses and
+          transport-sector load are not enrolled. Participants pay 30% above
+          your base rate during the chosen window, 10% below it during the
+          following three hours, and the base rate otherwise. All returned
+          energy receives the later discount. Higher bills can affect customer
+          retention through the previous tick's effective billed rate.
         </p>
         <p>
           Turn peak curtailment contracts On or Off. When on, half of industrial
           and data-center load participates, including authored scenario
-          additions. Participants forgo 20% of demand from 17:00–21:00 every
-          day, four hours maximum, even when supply is adequate. In exchange,
+          additions. Participants forgo 20% of demand during their own chosen
+          four-hour daily window, even when supply is adequate. In exchange,
           they receive a 10% credit on electricity actually supplied all day. No
           delivery means no credit. Supply and credits are allocated
           proportionally during shortages. This load is eliminated, not shifted
@@ -186,14 +188,19 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
           a time-of-use rate.
         </p>
         <p>
-          Both offers use fixed local-clock windows in every season, which may
-          miss your grid's actual peak. There are no installation costs; compare
-          demand and cash before committing. Changes start next month and
-          continue until changed. Off ends enrollment, bill adjustments and load
-          changes next month; unlike rebates, these effects do not persist.
-          Estimates include billed sales, credits, spending and dispatch costs,
-          holding weather, fuel prices, fleet, base rate and other accepted
-          programs constant.
+          Each program suggests a window around the forecast peak when first
+          opened. Keep it or choose any start hour; the window lasts four hours
+          and repeats on the scenario's local clock. Windows can cross midnight.
+          Compare the forecast before applying: shifting demand can create a
+          later peak, and your best window may change with the seasons. There
+          are no installation costs; compare demand and cash before committing.
+          Changes start next month and continue until changed. Off ends new
+          enrollment effects next month. Any already-shifted residential energy
+          still returns in its originally scheduled hours at the discounted
+          rate, even if you stop or change the window. Energy is preserved
+          across midnight and representative-month boundaries. Estimates include
+          billed sales, credits, spending and dispatch costs, holding weather,
+          fuel prices, fleet, base rate and other accepted programs constant.
         </p>
       </div>
     ),

--- a/src/data/Manual.tsx
+++ b/src/data/Manual.tsx
@@ -145,20 +145,52 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
   {
     title: "Customer programs",
     group: "Gameplay",
-    keywords: "efficiency rooftop solar rebates funding adoption demand",
+    keywords:
+      "efficiency rooftop solar rebates funding adoption demand time-of-use tariff curtailment contracts peak enrollment",
     entry: (
-      <p>
-        In Insights, Customer programs lets you fund efficiency or rooftop solar
-        rebates. Choose Off, Small, or Large and compare estimated utility
-        demand before applying next month. Funding persists until changed.
-        Charges pay only for new upgrades, up to the monthly budget, and stop at
-        full adoption. Off stops new adoption and spending; installed upgrades
-        stay for the rest of the run. Efficiency reduces residential and
-        commercial use. Solar offsets their remaining daylight load, with
-        surplus curtailed and no export payment. It does not directly cover an
-        evening peak. Lower demand also means less electricity sold, so compare
-        cash as well as peak demand.
-      </p>
+      <div>
+        <p>
+          In Insights, Customer programs lets you fund efficiency or rooftop
+          solar rebates. Choose Off, Small, or Large and compare estimated
+          utility demand before applying next month. Funding persists until
+          changed. Charges pay only for new upgrades, up to the monthly budget,
+          and stop at full adoption. Off stops new adoption and spending;
+          installed upgrades stay for the rest of the run. Efficiency reduces
+          residential and commercial use. Solar offsets their remaining daylight
+          load, with surplus curtailed and no export payment. It does not
+          directly cover an evening peak. Lower demand also means less
+          electricity sold, so compare cash as well as peak demand.
+        </p>
+        <p>
+          Time-of-use tariffs enroll 25% (Small) or 50% (Large) of homes and
+          businesses. Enrolled users pay 30% above your base rate from
+          17:00–21:00, 10% below it from 00:00–06:00, and the base rate
+          otherwise. They forgo 20% of evening consumption by avoiding
+          discretionary uses. This model reduces energy consumption; it does not
+          move energy to another hour. The previous tick's effective billed rate
+          feeds customer price memory and retention, with one tick of delay.
+        </p>
+        <p>
+          Peak curtailment contracts enroll 25% or 50% of industrial and
+          data-center load, including authored scenario additions. Participants
+          forgo 20% of demand from 17:00–21:00 every day, four hours maximum,
+          even when supply is adequate. In exchange, they receive a 10% credit
+          on electricity actually supplied all day. No delivery means no credit.
+          Supply and credits are allocated proportionally during shortages.
+          Contracted curtailment does not count as a blackout. There is no
+          effect without eligible load; transport is excluded. The tariff and
+          contract cover different sectors, so credits never stack on a
+          time-of-use rate.
+        </p>
+        <p>
+          Both offers use fixed local-clock windows in every season, which may
+          miss your grid's actual peak. There are no installation costs; compare
+          demand and cash before committing. Changes start next month and
+          continue until changed. Off ends enrollment, bill adjustments and
+          consumption reductions next month; unlike rebates, these effects do
+          not persist.
+        </p>
+      </div>
     ),
   },
   {
@@ -746,7 +778,10 @@ export const MANUAL_ENTRIES: ManualEntryType[] = [
         <p>
           Your rate is what you charge customers per kWh of electricity, and it
           creates nearly all of your revenue. Multiply this rate by the
-          electricity you sell to estimate your revenue. The game models each
+          electricity you sell to estimate your revenue with no customer offers.
+          Time-of-use tariffs and curtailment contracts adjust the base rate for
+          enrolled consumption; reported revenue already includes those rates
+          and credits and bills only electricity delivered. The game models each
           scenario's market and rules separately.
         </p>
         <p>

--- a/src/data/Policies.tsx
+++ b/src/data/Policies.tsx
@@ -16,20 +16,20 @@ export const POLICIES = {
   timeOfUse: {
     name: "Time-of-use tariff",
     description:
-      "Offer homes and businesses overnight discounts for higher evening rates.",
+      "Move home electricity use to later in the evening in exchange for a discount.",
     mechanism:
-      "Small enrolls 25% of homes and businesses; Large enrolls 50%. Participants pay 30% more from 17:00–21:00, 10% less from 00:00–06:00, and the base rate otherwise. They forgo 20% of evening consumption by avoiding discretionary uses; this energy is not shifted to another hour.",
+      "When on, half of homes participate. They shift 20% of their 17:00–21:00 electricity use to 21:00–24:00, such as charging cars later. Participants pay 30% more during the peak and 10% less afterward. Total energy use is unchanged.",
     tradeoff:
-      "Rates apply only to enrolled residential and commercial consumption actually supplied. Higher evening bills can affect customer retention. Fixed local-clock windows may miss your seasonal peak.",
+      "Rates apply only to enrolled residential consumption actually supplied. Higher evening bills can affect customer retention. Fixed local-clock windows may miss your seasonal peak.",
     cap: 0.2,
     costPerCustomer: 0,
   },
   curtailment: {
     name: "Peak curtailment contracts",
     description:
-      "Credit industrial users and data centers for scheduled evening curtailment.",
+      "Pay industrial users and data centers to use less electricity during the evening peak. This load is eliminated.",
     mechanism:
-      "Small enrolls 25% of industrial and data-center load; Large enrolls 50%. Enrolled loads forgo 20% of consumption from 17:00–21:00 every day (four hours maximum), for a 10% bill credit on their electricity actually supplied throughout the day. This is scheduled curtailment, even without a shortage.",
+      "When on, half of industrial and data-center load participates. Enrolled loads forgo 20% of consumption from 17:00–21:00 every day (four hours maximum), for a 10% bill credit on their electricity actually supplied throughout the day. This is scheduled curtailment, even without a shortage.",
     tradeoff:
       "Credits reduce sales revenue, including outside the curtailment window. Curtailment is agreed service, not a blackout. Contracts do not affect homes, businesses or transport, and do nothing without eligible industrial or data-center load.",
     cap: 0.2,

--- a/src/data/Policies.tsx
+++ b/src/data/Policies.tsx
@@ -16,20 +16,20 @@ export const POLICIES = {
   timeOfUse: {
     name: "Time-of-use tariff",
     description:
-      "Move home electricity use to later in the evening in exchange for a discount.",
+      "Move home electricity use out of your chosen peak hours in exchange for a discount.",
     mechanism:
-      "When on, half of homes participate. They shift 20% of their 17:00–21:00 electricity use to 21:00–24:00, such as charging cars later. Participants pay 30% more during the peak and 10% less afterward. Total energy use is unchanged.",
+      "When on, half of homes participate. Choose a four-hour daily window: participants shift 20% of that electricity use into the following three hours, such as charging cars later. They pay 30% more during the chosen peak window and 10% less during the following three hours. Total energy use is unchanged, including across midnight.",
     tradeoff:
-      "Rates apply only to enrolled residential consumption actually supplied. Higher evening bills can affect customer retention. Fixed local-clock windows may miss your seasonal peak.",
+      "Rates apply only to enrolled residential consumption actually supplied. Higher bills can affect customer retention. Compare the forecast: shifted consumption can create a later peak.",
     cap: 0.2,
     costPerCustomer: 0,
   },
   curtailment: {
     name: "Peak curtailment contracts",
     description:
-      "Pay industrial users and data centers to use less electricity during the evening peak. This load is eliminated.",
+      "Pay industrial users and data centers to use less electricity during your chosen peak hours. This load is eliminated.",
     mechanism:
-      "When on, half of industrial and data-center load participates. Enrolled loads forgo 20% of consumption from 17:00–21:00 every day (four hours maximum), for a 10% bill credit on their electricity actually supplied throughout the day. This is scheduled curtailment, even without a shortage.",
+      "When on, half of industrial and data-center load participates. Enrolled loads forgo 20% of consumption during your chosen four-hour daily window, for a 10% bill credit on their electricity actually supplied throughout the day. This is scheduled curtailment, even without a shortage.",
     tradeoff:
       "Credits reduce sales revenue, including outside the curtailment window. Curtailment is agreed service, not a blackout. Contracts do not affect homes, businesses or transport, and do nothing without eligible industrial or data-center load.",
     cap: 0.2,

--- a/src/data/Policies.tsx
+++ b/src/data/Policies.tsx
@@ -1,6 +1,11 @@
 import type { PolicyId, PolicyTier } from "../Types";
 
-export const POLICY_IDS: PolicyId[] = ["efficiency", "solar"];
+export const POLICY_IDS: PolicyId[] = [
+  "efficiency",
+  "solar",
+  "timeOfUse",
+  "curtailment",
+];
 export const POLICY_TIERS: PolicyTier[] = ["Off", "Small", "Large"];
 // Explicit launch availability: modern, longer scenarios and custom games. Historical
 // scenarios and introductory tutorials deliberately have no program entry.
@@ -8,6 +13,28 @@ export const POLICY_SCENARIOS = [
   100, 101, 104, 105, 106, 107, 108, 110, 111, 999,
 ];
 export const POLICIES = {
+  timeOfUse: {
+    name: "Time-of-use tariff",
+    description:
+      "Offer homes and businesses overnight discounts for higher evening rates.",
+    mechanism:
+      "Small enrolls 25% of homes and businesses; Large enrolls 50%. Participants pay 30% more from 17:00–21:00, 10% less from 00:00–06:00, and the base rate otherwise. They forgo 20% of evening consumption by avoiding discretionary uses; this energy is not shifted to another hour.",
+    tradeoff:
+      "Rates apply only to enrolled residential and commercial consumption actually supplied. Higher evening bills can affect customer retention. Fixed local-clock windows may miss your seasonal peak.",
+    cap: 0.2,
+    costPerCustomer: 0,
+  },
+  curtailment: {
+    name: "Peak curtailment contracts",
+    description:
+      "Credit industrial users and data centers for scheduled evening curtailment.",
+    mechanism:
+      "Small enrolls 25% of industrial and data-center load; Large enrolls 50%. Enrolled loads forgo 20% of consumption from 17:00–21:00 every day (four hours maximum), for a 10% bill credit on their electricity actually supplied throughout the day. This is scheduled curtailment, even without a shortage.",
+    tradeoff:
+      "Credits reduce sales revenue, including outside the curtailment window. Curtailment is agreed service, not a blackout. Contracts do not affect homes, businesses or transport, and do nothing without eligible industrial or data-center load.",
+    cap: 0.2,
+    costPerCustomer: 0,
+  },
   efficiency: {
     name: "Efficiency rebates",
     description: "Help homes and businesses use less electricity.",

--- a/src/helpers/DateTime.tsx
+++ b/src/helpers/DateTime.tsx
@@ -145,6 +145,9 @@ function accumulateTick(
   };
   // Runtime dispatch metadata uses symbol keys and must never enter a persisted chart record.
   const sample = Object.fromEntries(Object.entries(t)) as TickPresentFutureType;
+  // Recovery batches belong to resumable ticks, not averaged chart history.
+  delete sample.deferredResidential;
+  delete sample.deferredResidentialStart;
   sample.renewableCapacityFactors = factors;
   if (!summary.chartAverage) {
     summary.chartAverage = {

--- a/src/helpers/PeakDemand.test.tsx
+++ b/src/helpers/PeakDemand.test.tsx
@@ -91,17 +91,17 @@ test.each([0, 6 * 60, 17 * 60 - 1, 17 * 60, 21 * 60 - 1, 21 * 60, 1440])(
     const game = offers();
     const tick = demand(minute);
     const peak = minute >= 1020 && minute < 1260;
-    const overnight = minute % 1440 < 360;
+    const late = minute % 1440 >= 1260;
     applyPeakDemand(game, tick);
     expect(tick.demandByType.Residential).toBe(peak ? 90 : 100);
-    expect(tick.demandByType.Commercial).toBe(peak ? 90 : 100);
+    expect(tick.demandByType.Commercial).toBe(100);
     expect(tick.demandByType.Industrial).toBe(peak ? 95 : 100);
     expect(tick.demandByType["Data centers"]).toBe(peak ? 95 : 100);
     expect(tick.demandByType.Transportation).toBe(100);
     // Explicit enrolled/un-enrolled bills: contracts and TOU never share a sector.
     const bill = peak
-      ? 2 * (50 + 40 * 1.3) + 2 * (75 + 20 * 0.9) + 100
-      : 2 * (50 + 50 * (overnight ? 0.9 : 1)) + 2 * (75 + 25 * 0.9) + 100;
+      ? 50 + 40 * 1.3 + 100 + 2 * (75 + 20 * 0.9) + 100
+      : 50 + 50 * (late ? 0.9 : 1) + 100 + 2 * (75 + 25 * 0.9) + 100;
     const watts = Object.values(tick.demandByType).reduce((a, b) => a + b, 0);
     expect(customerBillingRate(game, tick) * watts).toBeCloseTo(
       bill * game.dollarsPerkWh,
@@ -130,7 +130,7 @@ test("season/month windows repeat; no enrolled load means no effect; rebates com
   };
   const before = cloneDeep(tick);
   applyPeakDemand(game, tick);
-  expect(tick).toEqual(before);
+  expect(tick.demandByType).toEqual(before.demandByType);
   expect(customerBillingRate(game, tick)).toBe(game.dollarsPerkWh);
   tick.demandByType.Transportation = 0;
   expect(customerBillingRate(game, tick)).toBe(game.dollarsPerkWh);
@@ -318,6 +318,112 @@ test("both offer actions cancel, save, resume and replay deterministically throu
   expect(
     decodeReplay({ ...serializeReplay(game), version: REPLAY_VERSION - 1 }),
   ).toBeNull();
-  expect(REPLAY_VERSION).toBe(10);
+  expect(REPLAY_VERSION).toBe(11);
   expect(decodeReplay(serializeReplay(game))).not.toBeNull();
 });
+
+test.each([false, true])(
+  "residential energy returns later after rebates=%s; industrial load never rebounds",
+  (rebates) => {
+    const game = offers();
+    if (rebates) {
+      game.policies!.programs.efficiency.adoption = 0.5;
+      game.policies!.programs.solar.adoption = 0.2;
+    }
+    let queued = 0,
+      residentialBefore = 0,
+      residentialAfter = 0,
+      industrialBefore = 0,
+      industrialAfter = 0;
+    for (let minute = 0; minute < 1440; minute += 15) {
+      const tick = demand(minute);
+      tick.demandByType.Residential = 100 + minute / 10;
+      tick.solarIrradianceWM2 = minute >= 360 && minute < 1200 ? 0.001 : 0;
+      applyPolicyDemand(game, tick);
+      const before = cloneDeep(tick.demandByType);
+      residentialBefore += before.Residential / 4;
+      industrialBefore += before.Industrial / 4;
+      applyPeakDemand(game, tick, queued);
+      queued = tick.deferredResidentialWh!;
+      residentialAfter += tick.demandByType.Residential / 4;
+      industrialAfter += tick.demandByType.Industrial / 4;
+      expect(tick.demandByType.Commercial).toBe(before.Commercial);
+      expect(
+        minute >= 1020 || tick.demandByType.Residential === before.Residential,
+      ).toBe(true);
+      // Each late tick must return load at the discount while industry never rebounds.
+      /* eslint-disable jest/no-conditional-expect */
+      if (minute >= 1260) {
+        expect(tick.demandByType.Residential).toBeGreaterThan(
+          before.Residential,
+        );
+        expect(tick.demandByType.Industrial).toBe(before.Industrial);
+        const expectedBill =
+          before.Residential * 0.95 +
+          tick.shiftedResidentialW! * 0.9 +
+          before.Commercial +
+          before.Industrial * 0.975 +
+          before["Data centers"] * 0.975 +
+          before.Transportation;
+        const total = Object.values(tick.demandByType).reduce(
+          (a, b) => a + b,
+          0,
+        );
+        expect(customerBillingRate(game, tick) * total).toBeCloseTo(
+          expectedBill * game.dollarsPerkWh,
+        );
+      }
+    }
+    /* eslint-enable jest/no-conditional-expect */
+    expect(queued).toBeCloseTo(0, 8);
+    expect(residentialAfter).toBeCloseTo(residentialBefore, 8);
+    expect(industrialBefore - industrialAfter).toBeCloseTo(20);
+  },
+);
+
+test.each([18 * 60, 22 * 60])(
+  "save and reforecast preserve queued energy at minute %i",
+  (minute) => {
+    let game = createGame({
+      scenarioId: 106,
+      seed: 4,
+      initialPrograms: { timeOfUse: "Large" },
+    });
+    month(game);
+    while (game.date.minute < 1440 + minute) tickState(game);
+    game = parseSave(JSON.parse(JSON.stringify(serializeSave(game))))!.game;
+    const now = getTimeFromTimeline(game.date.minute, game.timeline)!;
+    const rebuilt = generateNewTimeline(game, now.cash, now.customers);
+    const prior = game.timeline.findLast((t) => t.minute < game.date.minute)!;
+    const first = rebuilt[0];
+    const addedWh =
+      minute < 1260
+        ? ((first.demandByType.Residential / 0.9) * 0.1) / 4
+        : -first.shiftedResidentialW! / 4;
+    expect(first.deferredResidentialWh).toBeCloseTo(
+      prior.deferredResidentialWh! + addedWh,
+      6,
+    );
+    const replayedForecast = generateNewTimeline(
+      parseSave(JSON.parse(JSON.stringify(serializeSave(game))))!.game,
+      now.cash,
+      now.customers,
+    );
+    expect(rebuilt.map((t) => t.deferredResidentialWh)).toEqual(
+      replayedForecast.map((t) => t.deferredResidentialWh),
+    );
+    expect(
+      rebuilt.find((t) => t.minute % 1440 === 1425)!.deferredResidentialWh,
+    ).toBeCloseTo(0, 6);
+    game.timeline = rebuilt;
+    game = parseSave(JSON.parse(JSON.stringify(serializeSave(game))))!.game;
+    const rebuiltAgain = generateNewTimeline(game, now.cash, now.customers);
+    expect(rebuiltAgain[0].deferredResidentialWhStart).toBe(
+      first.deferredResidentialWhStart,
+    );
+    expect(rebuiltAgain[0].deferredResidentialWhStart).toBeGreaterThan(0);
+    const invalid = serializeSave(game);
+    invalid.game.timeline[0].deferredResidentialWh = -1;
+    expect(parseSave(invalid)).toBeNull();
+  },
+);

--- a/src/helpers/PeakDemand.test.tsx
+++ b/src/helpers/PeakDemand.test.tsx
@@ -35,7 +35,7 @@ import {
   TICKS_PER_HOUR,
   TICKS_PER_MONTH,
 } from "../Constants";
-import { GameType } from "../Types";
+import { GameType, DeferredResidentialLoad } from "../Types";
 import { parseSave, serializeSave, SAVE_VERSION } from "../SaveGame";
 import { decodeReplay, serializeReplay, REPLAY_VERSION } from "../Replay";
 
@@ -92,7 +92,7 @@ test.each([0, 6 * 60, 17 * 60 - 1, 17 * 60, 21 * 60 - 1, 21 * 60, 1440])(
     const tick = demand(minute);
     const peak = minute >= 1020 && minute < 1260;
     const late = minute % 1440 >= 1260;
-    applyPeakDemand(game, tick);
+    applyPeakDemand(game, tick, [], 1);
     expect(tick.demandByType.Residential).toBe(peak ? 90 : 100);
     expect(tick.demandByType.Commercial).toBe(100);
     expect(tick.demandByType.Industrial).toBe(peak ? 95 : 100);
@@ -318,7 +318,7 @@ test("both offer actions cancel, save, resume and replay deterministically throu
   expect(
     decodeReplay({ ...serializeReplay(game), version: REPLAY_VERSION - 1 }),
   ).toBeNull();
-  expect(REPLAY_VERSION).toBe(11);
+  expect(REPLAY_VERSION).toBe(12);
   expect(decodeReplay(serializeReplay(game))).not.toBeNull();
 });
 
@@ -330,8 +330,8 @@ test.each([false, true])(
       game.policies!.programs.efficiency.adoption = 0.5;
       game.policies!.programs.solar.adoption = 0.2;
     }
-    let queued = 0,
-      residentialBefore = 0,
+    let queued: DeferredResidentialLoad[] = [];
+    let residentialBefore = 0,
       residentialAfter = 0,
       industrialBefore = 0,
       industrialAfter = 0;
@@ -344,7 +344,7 @@ test.each([false, true])(
       residentialBefore += before.Residential / 4;
       industrialBefore += before.Industrial / 4;
       applyPeakDemand(game, tick, queued);
-      queued = tick.deferredResidentialWh!;
+      queued = tick.deferredResidential!;
       residentialAfter += tick.demandByType.Residential / 4;
       industrialAfter += tick.demandByType.Industrial / 4;
       expect(tick.demandByType.Commercial).toBe(before.Commercial);
@@ -375,7 +375,7 @@ test.each([false, true])(
       }
     }
     /* eslint-enable jest/no-conditional-expect */
-    expect(queued).toBeCloseTo(0, 8);
+    expect(queued).toEqual([]);
     expect(residentialAfter).toBeCloseTo(residentialBefore, 8);
     expect(industrialBefore - industrialAfter).toBeCloseTo(20);
   },

--- a/src/helpers/PeakDemand.test.tsx
+++ b/src/helpers/PeakDemand.test.tsx
@@ -1,0 +1,323 @@
+import cloneDeep from "lodash.clonedeep";
+import {
+  createGame,
+  createGameFromReplay,
+  runSimulation,
+} from "../testing/Simulator";
+import gameReducer, {
+  delta,
+  generateNewTimeline,
+  tickState,
+} from "../reducers/Game";
+import { schedulePolicy, cancelPolicy } from "../reducers/GameActions";
+import {
+  applyPeakDemand,
+  applyPolicyDemand,
+  customerBillingRate,
+  emptyPolicies,
+  advancePolicies,
+} from "./Policies";
+import { previewPolicy } from "./PolicyPreview";
+import {
+  updateCustomerRate,
+  nextCustomerCount,
+  customerMarketSizeAt,
+  getMarketRate,
+} from "./Customers";
+import { getScenario } from "../data/Scenarios";
+import {
+  getDateFromMinute,
+  getTimeFromTimeline,
+  MINUTES_PER_MONTH,
+} from "./DateTime";
+import {
+  GAME_TO_REAL_YEARS,
+  TICKS_PER_HOUR,
+  TICKS_PER_MONTH,
+} from "../Constants";
+import { GameType } from "../Types";
+import { parseSave, serializeSave, SAVE_VERSION } from "../SaveGame";
+import { decodeReplay, serializeReplay, REPLAY_VERSION } from "../Replay";
+
+let baseline: GameType;
+beforeAll(() => {
+  baseline = createGame({ scenarioId: 106, seed: 4 });
+});
+
+test.each([105, 106, 111])(
+  "active tariffs/contracts with rebates preserve all annual simulation invariants in scenario %i",
+  (scenarioId) => {
+    const result = runSimulation({
+      scenarioId,
+      seed: 4,
+      months: 12,
+      initialPrograms: {
+        timeOfUse: "Large",
+        curtailment: "Large",
+        efficiency: "Small",
+        solar: "Small",
+      },
+    });
+    expect(result.violations).toEqual([]);
+  },
+);
+function offers() {
+  const game = cloneDeep(baseline);
+  game.policies = emptyPolicies();
+  game.policies.programs.timeOfUse.tier = "Large";
+  game.policies.programs.curtailment.tier = "Small";
+  return game;
+}
+function demand(minute: number) {
+  const tick = cloneDeep(baseline.timeline[0]);
+  tick.minute = minute;
+  tick.demandByType = {
+    Residential: 100,
+    Commercial: 100,
+    Industrial: 100,
+    "Data centers": 100,
+    Transportation: 100,
+  };
+  return tick;
+}
+function month(game: GameType) {
+  const target = game.date.monthsElapsed + 1;
+  while (game.date.monthsElapsed < target) tickState(game);
+}
+
+test.each([0, 6 * 60, 17 * 60 - 1, 17 * 60, 21 * 60 - 1, 21 * 60, 1440])(
+  "local window and correctly weighted bills at minute %i",
+  (minute) => {
+    const game = offers();
+    const tick = demand(minute);
+    const peak = minute >= 1020 && minute < 1260;
+    const overnight = minute % 1440 < 360;
+    applyPeakDemand(game, tick);
+    expect(tick.demandByType.Residential).toBe(peak ? 90 : 100);
+    expect(tick.demandByType.Commercial).toBe(peak ? 90 : 100);
+    expect(tick.demandByType.Industrial).toBe(peak ? 95 : 100);
+    expect(tick.demandByType["Data centers"]).toBe(peak ? 95 : 100);
+    expect(tick.demandByType.Transportation).toBe(100);
+    // Explicit enrolled/un-enrolled bills: contracts and TOU never share a sector.
+    const bill = peak
+      ? 2 * (50 + 40 * 1.3) + 2 * (75 + 20 * 0.9) + 100
+      : 2 * (50 + 50 * (overnight ? 0.9 : 1)) + 2 * (75 + 25 * 0.9) + 100;
+    const watts = Object.values(tick.demandByType).reduce((a, b) => a + b, 0);
+    expect(customerBillingRate(game, tick) * watts).toBeCloseTo(
+      bill * game.dollarsPerkWh,
+    );
+  },
+);
+
+test("season/month windows repeat; no enrolled load means no effect; rebates compose before offers", () => {
+  const game = offers();
+  for (const m of [0, 6, 12]) {
+    const tick = demand(m * MINUTES_PER_MONTH + 18 * 60);
+    applyPeakDemand(game, tick);
+    expect(tick.demandByType.Residential).toBe(90);
+  }
+  const tick = demand(18 * 60);
+  game.policies!.programs.efficiency.adoption = 1;
+  applyPolicyDemand(game, tick);
+  applyPeakDemand(game, tick);
+  expect(tick.demandByType.Residential).toBe(72);
+  tick.demandByType = {
+    Residential: 0,
+    Commercial: 0,
+    Industrial: 0,
+    "Data centers": 0,
+    Transportation: 100,
+  };
+  const before = cloneDeep(tick);
+  applyPeakDemand(game, tick);
+  expect(tick).toEqual(before);
+  expect(customerBillingRate(game, tick)).toBe(game.dollarsPerkWh);
+  tick.demandByType.Transportation = 0;
+  expect(customerBillingRate(game, tick)).toBe(game.dollarsPerkWh);
+});
+
+test("Off removes all operating participation next month without changing installed rebates", () => {
+  const game = offers();
+  game.policies!.programs.efficiency.adoption = 0.3;
+  advancePolicies(game, 1);
+  expect(game.policies!.programs.timeOfUse.adoption).toBe(0.5);
+  expect(game.policies!.programs.curtailment.adoption).toBe(0.25);
+  for (const id of ["timeOfUse", "curtailment"] as const) {
+    game.policies!.programs[id].pending = { tier: "Off", month: 2 };
+  }
+  advancePolicies(game, 2);
+  for (const id of ["timeOfUse", "curtailment"] as const) {
+    expect(game.policies!.programs[id]).toEqual({
+      tier: "Off",
+      adoption: 0,
+      spending: 0,
+    });
+  }
+  const tick = demand(18 * 60);
+  applyPeakDemand(game, tick);
+  expect(tick.demandByType.Residential).toBe(100);
+  expect(customerBillingRate(game, tick)).toBe(game.dollarsPerkWh);
+  expect(game.policies!.programs.efficiency.adoption).toBe(0.3);
+});
+
+test("scheduled preview uses real demand/billing; even partial and zero supply bill only delivered energy", () => {
+  const change = { id: "timeOfUse", tier: "Large", month: 1 } as const;
+  const preview = previewPolicy(baseline, change, 1);
+  let game = cloneDeep(gameReducer(baseline, schedulePolicy(change)));
+  const now = game.timeline[0];
+  const forecast = generateNewTimeline(
+    game,
+    now.cash,
+    now.customers,
+    TICKS_PER_MONTH * 2,
+  );
+  expect(forecast.slice(TICKS_PER_MONTH).map((t) => t.demandW)).toEqual(
+    preview.changed,
+  );
+  expect(preview.spending).toBe(0);
+  expect(preview.current).not.toEqual(preview.changed);
+  game = cloneDeep(
+    gameReducer(
+      game,
+      schedulePolicy({ id: "curtailment", tier: "Large", month: 1 }),
+    ),
+  );
+  month(game);
+  // Force a genuine shortage, then remove all generators to exercise zero supply.
+  game.facilities.forEach((f) => {
+    f.peakW *= 0.1;
+  });
+  for (const empty of [false, true]) {
+    if (empty) game.facilities = [];
+    const start = getTimeFromTimeline(game.date.minute, game.timeline)!;
+    const ticks = generateNewTimeline(game, start.cash, start.customers);
+    expect(ticks.some((t) => t.supplyW < t.demandW)).toBe(true);
+    for (const t of ticks) {
+      const expected =
+        (((Math.min(t.supplyW, t.demandW) / TICKS_PER_HOUR) *
+          GAME_TO_REAL_YEARS) /
+          1000) *
+        t.customerBillingRate!;
+      expect(t.revenue - (t.revenueExports || 0)).toBeCloseTo(expected);
+      expect(t.customerBillingRate).toBeGreaterThanOrEqual(
+        game.dollarsPerkWh * 0.9,
+      );
+      expect(t.customerBillingRate).toBeLessThanOrEqual(
+        game.dollarsPerkWh * 1.3,
+      );
+    }
+  }
+});
+
+test("changing the base rate updates live bills immediately while recorded history stays unchanged", () => {
+  let game = createGame({
+    scenarioId: 106,
+    seed: 4,
+    initialPrograms: { timeOfUse: "Large", curtailment: "Small" },
+  });
+  month(game);
+  const history = cloneDeep(game.monthlyHistory);
+  game = cloneDeep(
+    gameReducer(game, delta({ dollarsPerkWh: game.dollarsPerkWh * 2 })),
+  );
+  tickState(game);
+  const tick = getTimeFromTimeline(game.date.minute, game.timeline)!;
+  expect(tick.customerBillingRate).toBe(customerBillingRate(game, tick));
+  expect(tick.revenue - (tick.revenueExports || 0)).toBeCloseTo(
+    (((Math.min(tick.supplyW, tick.demandW) / TICKS_PER_HOUR) *
+      GAME_TO_REAL_YEARS) /
+      1000) *
+      tick.customerBillingRate!,
+  );
+  expect(game.monthlyHistory).toEqual(history);
+});
+
+test("constant curtailment credits drive the same effective-price memory used for customer retention", () => {
+  const game = createGame({
+    scenarioId: 106,
+    seed: 4,
+    initialPrograms: { curtailment: "Large" },
+  });
+  month(game);
+  const scenario = getScenario(game.scenarioId)!;
+  const current = getTimeFromTimeline(game.date.minute, game.timeline)!;
+  const ticks = generateNewTimeline(game, current.cash, current.customers);
+  let checked = 0;
+  for (let i = 1; i < ticks.length; i++) {
+    const previous = ticks[i - 1];
+    const tick = ticks[i];
+    expect(previous.customerBillingRate).toBeLessThan(game.dollarsPerkWh);
+    expect(tick.customerRate).toBe(
+      updateCustomerRate(previous.customerRate, previous.customerBillingRate!),
+    );
+    if (tick.supplyW < tick.demandW) continue;
+    expect(tick.customers).toBe(
+      nextCustomerCount({
+        customers: previous.customers,
+        customerRate: tick.customerRate,
+        marketRate: getMarketRate(
+          scenario.dollarsPerkWh,
+          getDateFromMinute(tick.minute, game.startingYear),
+          game.startingYear,
+          game.seed,
+        ),
+        marketSize: customerMarketSizeAt(game.customerMarketSize, tick.minute),
+        ownership: scenario.ownership,
+      }),
+    );
+    checked++;
+  }
+  expect(checked).toBeGreaterThan(0);
+});
+
+test("both offer actions cancel, save, resume and replay deterministically through stopping", () => {
+  let game = cloneDeep(baseline);
+  for (const id of ["timeOfUse", "curtailment"] as const) {
+    const change = { id, tier: "Small", month: 1 } as const;
+    game = cloneDeep(gameReducer(game, schedulePolicy(change)));
+    expect(
+      gameReducer(game, cancelPolicy(change)).policies!.programs[id].pending,
+    ).toBeUndefined();
+    game = cloneDeep(game);
+  }
+  month(game);
+  const restored = parseSave(
+    JSON.parse(JSON.stringify(serializeSave(game))),
+  )!.game;
+  const continued = cloneDeep(game);
+  month(restored);
+  month(continued);
+  expect(restored.timeline.map((t) => [t.cash, t.customerBillingRate])).toEqual(
+    continued.timeline.map((t) => [t.cash, t.customerBillingRate]),
+  );
+  for (const id of ["timeOfUse", "curtailment"] as const) {
+    const change = { id, tier: "Off", month: 2 } as const;
+    game = cloneDeep(gameReducer(game, schedulePolicy(change)));
+  }
+  month(game);
+  const replay = createGameFromReplay(serializeReplay(game)!);
+  month(replay);
+  month(replay);
+  expect(replay.policies).toEqual(game.policies);
+  expect(
+    replay.timeline.map((t) => [t.cash, t.demandW, t.customerBillingRate]),
+  ).toEqual(
+    game.timeline.map((t) => [t.cash, t.demandW, t.customerBillingRate]),
+  );
+  expect(restored.timeline.map((t) => t.revenue)).toEqual(
+    parseSave(
+      JSON.parse(JSON.stringify(serializeSave(restored))),
+    )!.game.timeline.map((t) => t.revenue),
+  );
+  const invalid = serializeSave(restored);
+  invalid.game.timeline[0].customerBillingRate = -1;
+  expect(parseSave(invalid)).toBeNull();
+  expect(
+    parseSave({ ...serializeSave(game), version: SAVE_VERSION - 1 }),
+  ).toBeNull();
+  expect(
+    decodeReplay({ ...serializeReplay(game), version: REPLAY_VERSION - 1 }),
+  ).toBeNull();
+  expect(REPLAY_VERSION).toBe(10);
+  expect(decodeReplay(serializeReplay(game))).not.toBeNull();
+});

--- a/src/helpers/PeakWindows.test.tsx
+++ b/src/helpers/PeakWindows.test.tsx
@@ -1,0 +1,195 @@
+import cloneDeep from "lodash.clonedeep";
+import { createGame, createGameFromReplay } from "../testing/Simulator";
+import gameReducer, { generateNewTimeline, tickState } from "../reducers/Game";
+import { schedulePolicy, cancelPolicy } from "../reducers/GameActions";
+import { parseSave, serializeSave } from "../SaveGame";
+import { serializeReplay, decodeReplay } from "../Replay";
+import type { DeferredResidentialLoad, GameType } from "../Types";
+import {
+  applyPeakDemand,
+  customerBillingRate,
+  emptyPolicies,
+  validPolicyChange,
+  validPolicies,
+} from "./Policies";
+import { getTimeFromTimeline } from "./DateTime";
+import { previewPolicy } from "./PolicyPreview";
+import { policyWindowLabel, suggestedPolicyStartHour } from "./PolicyWindow";
+
+let baseline: GameType;
+beforeAll(() => {
+  baseline = createGame({ scenarioId: 106, seed: 4 });
+});
+
+test.each(Array.from({ length: 24 }, (_, hour) => hour))(
+  "window starting at %i conserves residential energy through midnight and stopping",
+  (startHour) => {
+    const game = cloneDeep(baseline);
+    game.policies = emptyPolicies();
+    game.policies.programs.timeOfUse = {
+      tier: "Large",
+      adoption: 0.5,
+      spending: 0,
+      startHour,
+    };
+    game.policies.programs.curtailment = {
+      tier: "Large",
+      adoption: 0.5,
+      spending: 0,
+      startHour,
+    };
+    let queue: DeferredResidentialLoad[] = [];
+    let residentialBefore = 0,
+      residentialAfter = 0,
+      industrialRemoved = 0;
+    for (let minute = 0; minute < 2880 + 420; minute += 15) {
+      if (minute === 2880) {
+        game.policies.programs.timeOfUse.tier = "Off";
+        game.policies.programs.curtailment.tier = "Off";
+      }
+      const tick = cloneDeep(baseline.timeline[0]);
+      tick.minute = minute;
+      const watts = 100 + (minute % 1440) / 10;
+      tick.demandByType = {
+        Residential: watts,
+        Commercial: 100,
+        Industrial: 100,
+        "Data centers": 100,
+        Transportation: 100,
+      };
+      applyPeakDemand(game, tick, queue);
+      queue = tick.deferredResidential!;
+      residentialBefore += watts / 4;
+      residentialAfter += tick.demandByType.Residential / 4;
+      industrialRemoved += (100 - tick.demandByType.Industrial) / 4;
+      expect(tick.demandByType.Commercial).toBe(100);
+      expect(tick.demandByType.Industrial).toBeLessThanOrEqual(100);
+      expect(customerBillingRate(game, tick)).toBeGreaterThanOrEqual(
+        game.dollarsPerkWh * 0.9,
+      );
+    }
+    expect(queue).toEqual([]);
+    expect(residentialAfter).toBeCloseTo(residentialBefore, 7);
+    expect(industrialRemoved).toBeCloseTo(80, 7);
+  },
+);
+
+test("independent windows bill recovered energy at a discount even during a new peak", () => {
+  const game = cloneDeep(baseline);
+  game.policies = emptyPolicies();
+  game.policies.programs.timeOfUse = {
+    tier: "Large",
+    adoption: 0.5,
+    spending: 0,
+    startHour: 0,
+  };
+  game.policies.programs.curtailment = {
+    tier: "Large",
+    adoption: 0.5,
+    spending: 0,
+    startHour: 8,
+  };
+  const tick = cloneDeep(baseline.timeline[0]);
+  tick.minute = 1440;
+  tick.demandByType = {
+    Residential: 100,
+    Commercial: 100,
+    Industrial: 100,
+    "Data centers": 100,
+    Transportation: 100,
+  };
+  applyPeakDemand(game, tick, [
+    { energyWh: 60, recoveryStartMinute: 1440, recoveryEndMinute: 1620 },
+  ]);
+  expect(tick.demandByType.Residential).toBe(110);
+  expect(tick.demandByType.Industrial).toBe(100);
+  // Residential: 50 ordinary + 40 peak-priced + 20 returned at discount.
+  const bill = 50 + 40 * 1.3 + 20 * 0.9 + 100 + 200 * 0.95 + 100;
+  expect(customerBillingRate(game, tick) * 510).toBeCloseTo(
+    game.dollarsPerkWh * bill,
+  );
+});
+
+test("window edits preview, cancel, save and replay across a month boundary", () => {
+  let game = cloneDeep(baseline);
+  const change = {
+    id: "timeOfUse",
+    tier: "Large",
+    month: 1,
+    startHour: 22,
+  } as const;
+  game = cloneDeep(gameReducer(game, schedulePolicy(change)));
+  expect(game.policies!.programs.timeOfUse.pending).toEqual({
+    tier: "Large",
+    month: 1,
+    startHour: 22,
+  });
+  const edit = { ...change, startHour: 9 };
+  game = cloneDeep(gameReducer(game, schedulePolicy(edit)));
+  expect(game.policies!.programs.timeOfUse.pending!.startHour).toBe(9);
+  expect(
+    gameReducer(game, cancelPolicy(change)).policies!.programs.timeOfUse
+      .pending,
+  ).toBeDefined();
+  game = cloneDeep(gameReducer(game, cancelPolicy(edit)));
+  expect(game.policies!.programs.timeOfUse.pending).toBeUndefined();
+  game = cloneDeep(gameReducer(game, schedulePolicy(change)));
+  while (game.date.minute < 2880) tickState(game);
+  expect(game.policies!.programs.timeOfUse.startHour).toBe(22);
+  const changedWindow = { ...change, month: 3, startHour: 10 };
+  const estimate = previewPolicy(game, changedWindow, 3);
+  expect(estimate.current).not.toEqual(estimate.changed);
+  game = parseSave(JSON.parse(JSON.stringify(serializeSave(game))))!.game;
+  const now = getTimeFromTimeline(game.date.minute, game.timeline)!;
+  expect(now.deferredResidentialWhStart).toBeGreaterThan(0);
+  game.timeline = generateNewTimeline(game, now.cash, now.customers);
+  const once = cloneDeep(game.timeline);
+  game = parseSave(JSON.parse(JSON.stringify(serializeSave(game))))!.game;
+  game.timeline = generateNewTimeline(game, now.cash, now.customers);
+  expect(game.timeline.map((t) => t.deferredResidential)).toEqual(
+    once.map((t) => t.deferredResidential),
+  );
+  const replay = createGameFromReplay(serializeReplay(game)!);
+  while (replay.date.minute < game.date.minute) tickState(replay);
+  expect(replay.policies).toEqual(game.policies);
+  expect(
+    getTimeFromTimeline(replay.date.minute, replay.timeline)!
+      .deferredResidential,
+  ).toEqual(now.deferredResidential);
+});
+
+test.each([-1, 24, 1.5, NaN, "22", null])(
+  "rejects invalid start hour %s",
+  (startHour) => {
+    expect(
+      validPolicyChange({
+        id: "timeOfUse",
+        tier: "Large",
+        month: 1,
+        startHour,
+      }),
+    ).toBe(false);
+    const policies = emptyPolicies();
+    Object.assign(policies.programs.timeOfUse, { startHour });
+    expect(validPolicies(policies, 0)).toBe(false);
+    const replay = serializeReplay(baseline)!;
+    replay.actions.push({
+      type: "schedulePolicy",
+      minute: 0,
+      payload: { id: "timeOfUse", tier: "Large", month: 1, startHour },
+    } as (typeof replay.actions)[number]);
+    expect(decodeReplay(replay)).toBeNull();
+  },
+);
+
+test("window suggestion covers upcoming peak; labels clarify midnight", () => {
+  const game = cloneDeep(baseline);
+  game.timeline = [
+    Object.assign(cloneDeep(game.timeline[0]), { minute: 600, demandW: 1000 }),
+    Object.assign(cloneDeep(game.timeline[0]), { minute: 1440, demandW: 800 }),
+    Object.assign(cloneDeep(game.timeline[0]), { minute: 2040, demandW: 100 }),
+  ];
+  expect(suggestedPolicyStartHour(game)).toBe(23);
+  expect(policyWindowLabel(22)).toBe("22:00–02:00 (next day)");
+  expect(policyWindowLabel(9)).toBe("09:00–13:00");
+});

--- a/src/helpers/Policies.tsx
+++ b/src/helpers/Policies.tsx
@@ -14,7 +14,7 @@ import {
   POLICY_FUNDING,
 } from "../data/Policies";
 import { getInflationIndex } from "../data/Economy";
-import { EQUATOR_RADIANCE } from "../Constants";
+import { EQUATOR_RADIANCE, TICK_MINUTES } from "../Constants";
 import { getDateFromMinute, MINUTES_PER_MONTH } from "./DateTime";
 
 export function emptyPolicies(month = 0): PoliciesType {
@@ -137,19 +137,39 @@ const peakHour = (minute: number) => {
   return localMinute >= 17 * 60 && localMinute < 21 * 60;
 };
 
-/** Contracted reductions remove only enrolled consumption, never create energy.
- * The simulated representative day is the local clock for each scenario month. */
-export function applyPeakDemand(game: GameType, tick: TickPresentFutureType) {
-  if (!peakHour(tick.minute)) return;
+/** Defer actual residential energy until later in the same representative day.
+ * Industrial curtailment is eliminated consumption and never enters the queue. */
+export function applyPeakDemand(
+  game: GameType,
+  tick: TickPresentFutureType,
+  deferredWh = 0,
+  stepMinutes = TICK_MINUTES,
+) {
+  const localMinute = tick.minute % MINUTES_PER_MONTH;
+  tick.deferredResidentialWh = localMinute === 0 ? 0 : deferredWh;
+  tick.deferredResidentialWhStart = tick.deferredResidentialWh;
+  tick.shiftedResidentialW = 0;
   const p = game.policies?.programs;
   const tariff =
     participation(p?.timeOfUse?.tier ?? "Off") * POLICIES.timeOfUse.cap;
   const contract =
     participation(p?.curtailment?.tier ?? "Off") * POLICIES.curtailment.cap;
-  tick.demandByType.Residential *= 1 - tariff;
-  tick.demandByType.Commercial *= 1 - tariff;
-  tick.demandByType.Industrial *= 1 - contract;
-  tick.demandByType["Data centers"] *= 1 - contract;
+  if (peakHour(tick.minute)) {
+    const removedW = tick.demandByType.Residential * tariff;
+    tick.demandByType.Residential -= removedW;
+    tick.deferredResidentialWh += (removedW * stepMinutes) / 60;
+    tick.demandByType.Industrial *= 1 - contract;
+    tick.demandByType["Data centers"] *= 1 - contract;
+  } else if (localMinute >= 21 * 60) {
+    const remainingMinutes = MINUTES_PER_MONTH - localMinute;
+    const returnedW = (tick.deferredResidentialWh * 60) / remainingMinutes;
+    tick.shiftedResidentialW = returnedW;
+    tick.demandByType.Residential += returnedW;
+    tick.deferredResidentialWh = Math.max(
+      0,
+      tick.deferredResidentialWh - (returnedW * stepMinutes) / 60,
+    );
+  }
 }
 
 /** Bill only delivered energy. After curtailment, enrolled users form a smaller
@@ -157,7 +177,10 @@ export function applyPeakDemand(game: GameType, tick: TickPresentFutureType) {
  * would over-credit them. The two offers apply to disjoint sectors. */
 export function customerBillingRate(
   game: GameType,
-  tick: Pick<TickPresentFutureType, "minute" | "demandByType">,
+  tick: Pick<
+    TickPresentFutureType,
+    "minute" | "demandByType" | "shiftedResidentialW"
+  >,
 ) {
   const p = game.policies?.programs;
   const enrolledTariff = participation(p?.timeOfUse?.tier ?? "Off");
@@ -167,11 +190,13 @@ export function customerBillingRate(
     peak ? (enrolled * 0.8) / (1 - enrolled * 0.2) : enrolled;
   const tariffDelta = peak
     ? 0.3
-    : tick.minute % MINUTES_PER_MONTH < 6 * 60
+    : tick.minute % MINUTES_PER_MONTH >= 21 * 60
       ? -0.1
       : 0;
-  const household =
-    tick.demandByType.Residential + tick.demandByType.Commercial;
+  const returnedW = tick.shiftedResidentialW ?? 0;
+  const enrolledResidentialW =
+    (tick.demandByType.Residential - returnedW) * fraction(enrolledTariff) +
+    returnedW;
   const industrial =
     tick.demandByType.Industrial + tick.demandByType["Data centers"];
   const total = Object.values(tick.demandByType).reduce(
@@ -182,7 +207,7 @@ export function customerBillingRate(
     game.dollarsPerkWh *
     (total > 0
       ? 1 +
-        (household * fraction(enrolledTariff) * tariffDelta -
+        (enrolledResidentialW * tariffDelta -
           industrial * fraction(enrolledContract) * 0.1) /
           total
       : 1)

--- a/src/helpers/Policies.tsx
+++ b/src/helpers/Policies.tsx
@@ -23,6 +23,8 @@ export function emptyPolicies(month = 0): PoliciesType {
     programs: {
       efficiency: { tier: "Off", adoption: 0, spending: 0 },
       solar: { tier: "Off", adoption: 0, spending: 0 },
+      timeOfUse: { tier: "Off", adoption: 0, spending: 0 },
+      curtailment: { tier: "Off", adoption: 0, spending: 0 },
     },
   };
 }
@@ -104,6 +106,11 @@ export function advancePolicies(game: GameType, month: number): PolicyId[] {
         delete s.pending;
         activated.push(id);
       }
+      if (isOperatingPolicy(id)) {
+        s.adoption = participation(s.tier);
+        s.spending = 0;
+        return;
+      }
       const increment = Math.min(
         1 - s.adoption,
         POLICY_FUNDING[s.tier].adoption,
@@ -118,6 +125,68 @@ export function advancePolicies(game: GameType, month: number): PolicyId[] {
     p.month = m;
   }
   return activated;
+}
+export const isOperatingPolicy = (id: PolicyId) =>
+  id === "timeOfUse" || id === "curtailment";
+export const participation = (tier: PolicyTier) =>
+  tier === "Large" ? 0.5 : tier === "Small" ? 0.25 : 0;
+
+const peakHour = (minute: number) => {
+  const localMinute =
+    ((minute % MINUTES_PER_MONTH) + MINUTES_PER_MONTH) % MINUTES_PER_MONTH;
+  return localMinute >= 17 * 60 && localMinute < 21 * 60;
+};
+
+/** Contracted reductions remove only enrolled consumption, never create energy.
+ * The simulated representative day is the local clock for each scenario month. */
+export function applyPeakDemand(game: GameType, tick: TickPresentFutureType) {
+  if (!peakHour(tick.minute)) return;
+  const p = game.policies?.programs;
+  const tariff =
+    participation(p?.timeOfUse?.tier ?? "Off") * POLICIES.timeOfUse.cap;
+  const contract =
+    participation(p?.curtailment?.tier ?? "Off") * POLICIES.curtailment.cap;
+  tick.demandByType.Residential *= 1 - tariff;
+  tick.demandByType.Commercial *= 1 - tariff;
+  tick.demandByType.Industrial *= 1 - contract;
+  tick.demandByType["Data centers"] *= 1 - contract;
+}
+
+/** Bill only delivered energy. After curtailment, enrolled users form a smaller
+ * fraction of each sector's remaining load, so discounting the original fraction
+ * would over-credit them. The two offers apply to disjoint sectors. */
+export function customerBillingRate(
+  game: GameType,
+  tick: Pick<TickPresentFutureType, "minute" | "demandByType">,
+) {
+  const p = game.policies?.programs;
+  const enrolledTariff = participation(p?.timeOfUse?.tier ?? "Off");
+  const enrolledContract = participation(p?.curtailment?.tier ?? "Off");
+  const peak = peakHour(tick.minute);
+  const fraction = (enrolled: number) =>
+    peak ? (enrolled * 0.8) / (1 - enrolled * 0.2) : enrolled;
+  const tariffDelta = peak
+    ? 0.3
+    : tick.minute % MINUTES_PER_MONTH < 6 * 60
+      ? -0.1
+      : 0;
+  const household =
+    tick.demandByType.Residential + tick.demandByType.Commercial;
+  const industrial =
+    tick.demandByType.Industrial + tick.demandByType["Data centers"];
+  const total = Object.values(tick.demandByType).reduce(
+    (sum, watts) => sum + watts,
+    0,
+  );
+  return (
+    game.dollarsPerkWh *
+    (total > 0
+      ? 1 +
+        (household * fraction(enrolledTariff) * tariffDelta -
+          industrial * fraction(enrolledContract) * 0.1) /
+          total
+      : 1)
+  );
 }
 export function applyPolicyDemand(game: GameType, tick: TickPresentFutureType) {
   const p = game.policies?.programs;

--- a/src/helpers/Policies.tsx
+++ b/src/helpers/Policies.tsx
@@ -1,5 +1,6 @@
 import type {
   GameType,
+  DeferredResidentialLoad,
   PoliciesType,
   PolicyChangeType,
   PolicyId,
@@ -41,6 +42,7 @@ export function validPolicyChange(value: unknown): value is PolicyChangeType {
     !!p &&
     POLICY_IDS.includes(p.id) &&
     POLICY_TIERS.includes(p.tier) &&
+    validStartHour(p.startHour) &&
     Number.isInteger(p.month) &&
     p.month > 0
   );
@@ -61,6 +63,7 @@ export function validPolicies(
       return (
         !!s &&
         POLICY_TIERS.includes(s.tier) &&
+        validStartHour(s.startHour) &&
         Number.isFinite(s.adoption) &&
         s.adoption >= 0 &&
         s.adoption <= 1 &&
@@ -103,6 +106,10 @@ export function advancePolicies(game: GameType, month: number): PolicyId[] {
       const s = p.programs[id];
       if (s.pending && s.pending.month <= m) {
         s.tier = s.pending.tier;
+        if (isOperatingPolicy(id)) {
+          if (s.pending.startHour === undefined) delete s.startHour;
+          else s.startHour = s.pending.startHour;
+        }
         delete s.pending;
         activated.push(id);
       }
@@ -131,45 +138,105 @@ export const isOperatingPolicy = (id: PolicyId) =>
 export const participation = (tier: PolicyTier) =>
   tier === "Large" ? 0.5 : tier === "Small" ? 0.25 : 0;
 
-const peakHour = (minute: number) => {
-  const localMinute =
-    ((minute % MINUTES_PER_MONTH) + MINUTES_PER_MONTH) % MINUTES_PER_MONTH;
-  return localMinute >= 17 * 60 && localMinute < 21 * 60;
-};
+const validStartHour = (hour: unknown) =>
+  hour === undefined ||
+  (typeof hour === "number" &&
+    Number.isInteger(hour) &&
+    hour >= 0 &&
+    hour < 24);
+export const policyStartHour = (program?: { startHour?: number }) =>
+  program?.startHour ?? 17;
+const windowOffset = (minute: number, startHour: number) =>
+  (((minute - startHour * 60) % MINUTES_PER_MONTH) + MINUTES_PER_MONTH) %
+  MINUTES_PER_MONTH;
+export const policyPeakHour = (minute: number, startHour = 17) =>
+  windowOffset(minute, startHour) < 240;
+export const samePolicyChoice = (
+  id: PolicyId,
+  a: { tier: PolicyTier; startHour?: number },
+  b: { tier: PolicyTier; startHour?: number },
+) =>
+  a.tier === b.tier &&
+  (!isOperatingPolicy(id) || policyStartHour(a) === policyStartHour(b));
 
-/** Defer actual residential energy until later in the same representative day.
- * Industrial curtailment is eliminated consumption and never enters the queue. */
+export function validDeferredResidential(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!Array.isArray(value)) return false;
+  return value.every(
+    (entry: DeferredResidentialLoad) =>
+      entry &&
+      Number.isFinite(entry.energyWh) &&
+      entry.energyWh >= 0 &&
+      Number.isInteger(entry.recoveryStartMinute) &&
+      entry.recoveryStartMinute >= 0 &&
+      entry.recoveryEndMinute === entry.recoveryStartMinute + 180,
+  );
+}
+
+/** Each batch keeps its original three-hour recovery window, including when
+ * a new month changes or disables the tariff. Industry never enters the queue. */
 export function applyPeakDemand(
   game: GameType,
   tick: TickPresentFutureType,
-  deferredWh = 0,
+  deferred: readonly DeferredResidentialLoad[] = [],
   stepMinutes = TICK_MINUTES,
 ) {
-  const localMinute = tick.minute % MINUTES_PER_MONTH;
-  tick.deferredResidentialWh = localMinute === 0 ? 0 : deferredWh;
-  tick.deferredResidentialWhStart = tick.deferredResidentialWh;
+  tick.deferredResidentialStart = deferred.map((entry) => ({ ...entry }));
+  tick.deferredResidentialWhStart = deferred.reduce(
+    (sum, entry) => sum + entry.energyWh,
+    0,
+  );
+  const queue = deferred.map((entry) => ({ ...entry }));
   tick.shiftedResidentialW = 0;
   const p = game.policies?.programs;
   const tariff =
     participation(p?.timeOfUse?.tier ?? "Off") * POLICIES.timeOfUse.cap;
   const contract =
     participation(p?.curtailment?.tier ?? "Off") * POLICIES.curtailment.cap;
-  if (peakHour(tick.minute)) {
+  if (policyPeakHour(tick.minute, policyStartHour(p?.timeOfUse))) {
     const removedW = tick.demandByType.Residential * tariff;
     tick.demandByType.Residential -= removedW;
-    tick.deferredResidentialWh += (removedW * stepMinutes) / 60;
+    const recoveryStartMinute =
+      tick.minute -
+      windowOffset(tick.minute, policyStartHour(p?.timeOfUse)) +
+      240;
+    if (removedW > 0) {
+      let batch = queue.find(
+        (entry) => entry.recoveryStartMinute === recoveryStartMinute,
+      );
+      if (!batch) {
+        batch = {
+          energyWh: 0,
+          recoveryStartMinute,
+          recoveryEndMinute: recoveryStartMinute + 180,
+        };
+        queue.push(batch);
+      }
+      batch.energyWh += (removedW * stepMinutes) / 60;
+    }
+  }
+  if (policyPeakHour(tick.minute, policyStartHour(p?.curtailment))) {
     tick.demandByType.Industrial *= 1 - contract;
     tick.demandByType["Data centers"] *= 1 - contract;
-  } else if (localMinute >= 21 * 60) {
-    const remainingMinutes = MINUTES_PER_MONTH - localMinute;
-    const returnedW = (tick.deferredResidentialWh * 60) / remainingMinutes;
-    tick.shiftedResidentialW = returnedW;
-    tick.demandByType.Residential += returnedW;
-    tick.deferredResidentialWh = Math.max(
-      0,
-      tick.deferredResidentialWh - (returnedW * stepMinutes) / 60,
-    );
   }
+  for (const batch of queue) {
+    const start = Math.max(tick.minute, batch.recoveryStartMinute);
+    const duration = Math.max(
+      0,
+      Math.min(tick.minute + stepMinutes, batch.recoveryEndMinute) - start,
+    );
+    if (duration === 0) continue;
+    const returnedWh =
+      (batch.energyWh * duration) / (batch.recoveryEndMinute - start);
+    tick.shiftedResidentialW += (returnedWh * 60) / stepMinutes;
+    batch.energyWh = Math.max(0, batch.energyWh - returnedWh);
+  }
+  tick.demandByType.Residential += tick.shiftedResidentialW;
+  tick.deferredResidential = queue.filter((entry) => entry.energyWh > 0);
+  tick.deferredResidentialWh = tick.deferredResidential.reduce(
+    (sum, entry) => sum + entry.energyWh,
+    0,
+  );
 }
 
 /** Bill only delivered energy. After curtailment, enrolled users form a smaller
@@ -185,18 +252,23 @@ export function customerBillingRate(
   const p = game.policies?.programs;
   const enrolledTariff = participation(p?.timeOfUse?.tier ?? "Off");
   const enrolledContract = participation(p?.curtailment?.tier ?? "Off");
-  const peak = peakHour(tick.minute);
-  const fraction = (enrolled: number) =>
+  const tariffOffset = windowOffset(tick.minute, policyStartHour(p?.timeOfUse));
+  const tariffPeak = tariffOffset < 240;
+  const contractPeak = policyPeakHour(
+    tick.minute,
+    policyStartHour(p?.curtailment),
+  );
+  const fraction = (enrolled: number, peak: boolean) =>
     peak ? (enrolled * 0.8) / (1 - enrolled * 0.2) : enrolled;
-  const tariffDelta = peak
+  const tariffDelta = tariffPeak
     ? 0.3
-    : tick.minute % MINUTES_PER_MONTH >= 21 * 60
+    : tariffOffset >= 240 && tariffOffset < 420
       ? -0.1
       : 0;
   const returnedW = tick.shiftedResidentialW ?? 0;
   const enrolledResidentialW =
-    (tick.demandByType.Residential - returnedW) * fraction(enrolledTariff) +
-    returnedW;
+    (tick.demandByType.Residential - returnedW) *
+    fraction(enrolledTariff, tariffPeak);
   const industrial =
     tick.demandByType.Industrial + tick.demandByType["Data centers"];
   const total = Object.values(tick.demandByType).reduce(
@@ -208,7 +280,8 @@ export function customerBillingRate(
     (total > 0
       ? 1 +
         (enrolledResidentialW * tariffDelta -
-          industrial * fraction(enrolledContract) * 0.1) /
+          returnedW * 0.1 -
+          industrial * fraction(enrolledContract, contractPeak) * 0.1) /
           total
       : 1)
   );

--- a/src/helpers/PolicyPreview.ts
+++ b/src/helpers/PolicyPreview.ts
@@ -6,7 +6,7 @@ import {
   MINUTES_PER_MONTH,
   summarizeTimeline,
 } from "./DateTime";
-import { advancePolicies, emptyPolicies } from "./Policies";
+import { advancePolicies, emptyPolicies, samePolicyChoice } from "./Policies";
 import { TICK_MINUTES } from "../Constants";
 
 export function previewPolicy(
@@ -17,8 +17,11 @@ export function previewPolicy(
   const draft = cloneDeep(game);
   draft.policies ??= emptyPolicies(game.date.monthsElapsed);
   const program = draft.policies.programs[change.id];
-  if (change.tier === program.tier) delete program.pending;
-  else program.pending = { tier: change.tier, month: change.month };
+  if (samePolicyChoice(change.id, change, program)) delete program.pending;
+  else {
+    const { id: _id, ...pending } = change;
+    program.pending = pending;
+  }
   const now = getTimeFromTimeline(game.date.minute, game.timeline);
   if (!now) throw new Error("No current simulation tick");
   const ticks = Math.ceil(

--- a/src/helpers/PolicyWindow.ts
+++ b/src/helpers/PolicyWindow.ts
@@ -1,0 +1,34 @@
+import type { GameType, PolicyId, PolicyTier } from "../Types";
+import { MINUTES_PER_MONTH } from "./DateTime";
+
+/** Start one hour before the forecast peak, keeping it inside the four-hour window. */
+export function suggestedPolicyStartHour(game: GameType): number {
+  const nextMonth = (game.date.monthsElapsed + 1) * MINUTES_PER_MONTH;
+  const upcoming = game.timeline.filter((tick) => tick.minute >= nextMonth);
+  const forecast = upcoming.length
+    ? upcoming.filter((tick) => tick.minute < nextMonth + MINUTES_PER_MONTH)
+    : game.timeline.filter((tick) => tick.minute >= game.date.minute);
+  const peak = forecast.reduce<(typeof forecast)[number] | undefined>(
+    (highest, tick) =>
+      !highest || tick.demandW > highest.demandW ? tick : highest,
+    undefined,
+  );
+  return peak
+    ? (Math.floor((peak.minute % MINUTES_PER_MONTH) / 60) + 23) % 24
+    : 17;
+}
+
+export function policyWindowLabel(startHour: number, hours = 4): string {
+  const clock = (hour: number) => `${String(hour % 24).padStart(2, "0")}:00`;
+  return `${clock(startHour)}–${clock(startHour + hours)}${startHour + hours >= 24 ? " (next day)" : ""}`;
+}
+
+export function policyChoiceLabel(
+  id: PolicyId,
+  choice?: { tier: PolicyTier; startHour?: number },
+): string {
+  if (!choice || choice.tier === "Off") return "Off";
+  return id === "timeOfUse" || id === "curtailment"
+    ? `On · ${policyWindowLabel(choice.startHour ?? 17)}`
+    : choice.tier;
+}

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -2117,7 +2117,12 @@ function getDemandW(
     game.loadAdditions,
   );
   applyPolicyDemand(game, now);
-  applyPeakDemand(game, now);
+  applyPeakDemand(
+    game,
+    now,
+    prev.deferredResidentialWh,
+    TICK_MINUTES * tickScale,
+  );
   now.customerBillingRate = customerBillingRate(game, now);
   return DEMAND_TYPES.reduce(
     (total, type) => total + now.demandByType[type],
@@ -2194,9 +2199,13 @@ function reforecastWeatherAndPrices(state: GameType): TickPresentFutureType[] {
 function reforecastDemand(
   state: GameType,
   tickScale = 1,
+  initialDeferredWh = 0,
 ): TickPresentFutureType[] {
   const projection = { ...state, policies: cloneDeep(state.policies) };
-  let prev = state.timeline[0];
+  let prev = {
+    ...state.timeline[0],
+    deferredResidentialWh: initialDeferredWh,
+  } as TickPresentFutureType;
   return state.timeline.map((t: TickPresentFutureType) => {
     if (t.minute >= state.date.minute) {
       const date = getDateFromMinute(t.minute, state.startingYear);
@@ -2213,6 +2222,7 @@ function reforecastDemand(
       prev = t;
       return t;
     }
+    prev = t;
     return t;
   });
 }
@@ -3128,7 +3138,17 @@ export function generateNewTimeline(
     } as TickPresentFutureType;
   }
   state.timeline = reforecastWeatherAndPrices(state);
-  state.timeline = reforecastDemand(state, tickScale);
+  const previousDemandTick = readOnlyState.timeline.findLast(
+    (tick) => tick.minute < state.date.minute,
+  );
+  state.timeline = reforecastDemand(
+    state,
+    tickScale,
+    previousDemandTick?.deferredResidentialWh ??
+      getTimeFromTimeline(state.date.minute, readOnlyState.timeline)
+        ?.deferredResidentialWhStart ??
+      0,
+  );
   state.timeline = reforecastSupply(state, true, stepMinutes);
   return state.timeline;
 }

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -7,8 +7,10 @@ import {
   emptyPolicies,
   policyAvailable,
   validPolicyChange,
+  samePolicyChoice,
 } from "../helpers/Policies";
 import { POLICIES, POLICY_IDS } from "../data/Policies";
+import { policyChoiceLabel } from "../helpers/PolicyWindow";
 import {
   schedulePolicy,
   cancelPolicy,
@@ -1443,27 +1445,37 @@ function applyPolicyEdit(
   )
     return false;
   const existing = state.policies?.programs[payload.id];
-  const before = existing?.pending?.tier ?? existing?.tier ?? "Off";
+  const before = policyChoiceLabel(payload.id, existing?.pending ?? existing);
   if (cancel) {
     if (
       !existing?.pending ||
       existing.pending.month !== payload.month ||
-      existing.pending.tier !== payload.tier
+      !samePolicyChoice(payload.id, existing.pending, payload)
     )
       return false;
     delete existing.pending;
   } else {
-    if (payload.tier === (existing?.pending?.tier ?? existing?.tier ?? "Off"))
+    if (
+      samePolicyChoice(
+        payload.id,
+        payload,
+        existing?.pending ?? existing ?? { tier: "Off" },
+      )
+    )
       return false;
     state.policies ??= emptyPolicies(state.date.monthsElapsed);
     const program = state.policies.programs[payload.id];
-    if (payload.tier === program.tier) delete program.pending;
-    else program.pending = { tier: payload.tier, month: payload.month };
+    if (samePolicyChoice(payload.id, payload, program)) delete program.pending;
+    else {
+      const { id: _id, ...pending } = payload;
+      program.pending = pending;
+    }
   }
-  const after = cancel
-    ? (existing?.tier ?? "Off")
-    : (state.policies!.programs[payload.id].pending?.tier ??
-      state.policies!.programs[payload.id].tier);
+  const program = state.policies!.programs[payload.id];
+  const after = policyChoiceLabel(
+    payload.id,
+    cancel ? existing : (program.pending ?? program),
+  );
   recordMeaningfulDecision(state, {
     lever: `policy:${payload.id.toLowerCase()}`,
     label: POLICIES[payload.id].name,
@@ -1715,7 +1727,7 @@ export function tickState(state: GameType) {
         logGameEvent(
           state,
           "WORLD_EVENT",
-          `${POLICIES[id].name}: ${state.policies!.programs[id].tier} starts this month.`,
+          `${POLICIES[id].name}: ${policyChoiceLabel(id, state.policies!.programs[id])} starts this month.`,
         ),
       );
       state.timeline = generateNewTimeline(state, cash, customers);
@@ -2120,7 +2132,7 @@ function getDemandW(
   applyPeakDemand(
     game,
     now,
-    prev.deferredResidentialWh,
+    prev.deferredResidential,
     TICK_MINUTES * tickScale,
   );
   now.customerBillingRate = customerBillingRate(game, now);
@@ -2199,12 +2211,12 @@ function reforecastWeatherAndPrices(state: GameType): TickPresentFutureType[] {
 function reforecastDemand(
   state: GameType,
   tickScale = 1,
-  initialDeferredWh = 0,
+  initialDeferred: TickPresentFutureType["deferredResidential"] = [],
 ): TickPresentFutureType[] {
   const projection = { ...state, policies: cloneDeep(state.policies) };
   let prev = {
     ...state.timeline[0],
-    deferredResidentialWh: initialDeferredWh,
+    deferredResidential: initialDeferred,
   } as TickPresentFutureType;
   return state.timeline.map((t: TickPresentFutureType) => {
     if (t.minute >= state.date.minute) {
@@ -3144,10 +3156,10 @@ export function generateNewTimeline(
   state.timeline = reforecastDemand(
     state,
     tickScale,
-    previousDemandTick?.deferredResidentialWh ??
+    previousDemandTick?.deferredResidential ??
       getTimeFromTimeline(state.date.minute, readOnlyState.timeline)
-        ?.deferredResidentialWhStart ??
-      0,
+        ?.deferredResidentialStart ??
+      [],
   );
   state.timeline = reforecastSupply(state, true, stepMinutes);
   return state.timeline;

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -2,6 +2,8 @@ import { getViableLocationCount } from "../data/FacilitySites";
 import {
   advancePolicies,
   applyPolicyDemand,
+  applyPeakDemand,
+  customerBillingRate,
   emptyPolicies,
   policyAvailable,
   validPolicyChange,
@@ -1463,11 +1465,8 @@ function applyPolicyEdit(
     : (state.policies!.programs[payload.id].pending?.tier ??
       state.policies!.programs[payload.id].tier);
   recordMeaningfulDecision(state, {
-    lever: `policy:${payload.id}`,
-    label:
-      payload.id === "efficiency"
-        ? "Fund efficiency rebates"
-        : "Fund rooftop solar rebates",
+    lever: `policy:${payload.id.toLowerCase()}`,
+    label: POLICIES[payload.id].name,
     kind: "policy",
     before,
     after,
@@ -1716,7 +1715,7 @@ export function tickState(state: GameType) {
         logGameEvent(
           state,
           "WORLD_EVENT",
-          `${POLICIES[id].name}: ${state.policies!.programs[id].tier} funding starts this month.`,
+          `${POLICIES[id].name}: ${state.policies!.programs[id].tier} starts this month.`,
         ),
       );
       state.timeline = generateNewTimeline(state, cash, customers);
@@ -2059,7 +2058,7 @@ function getDemandW(
     getScenario(game.scenarioId, game.customScenario) || SCENARIOS[0];
   now.customerRate = updateCustomerRate(
     prev.customerRate || game.customerRate,
-    game.dollarsPerkWh,
+    prev.customerBillingRate ?? game.dollarsPerkWh,
     tickScale,
   );
   now.customers = nextCustomerCount({
@@ -2118,6 +2117,8 @@ function getDemandW(
     game.loadAdditions,
   );
   applyPolicyDemand(game, now);
+  applyPeakDemand(game, now);
+  now.customerBillingRate = customerBillingRate(game, now);
   return DEMAND_TYPES.reduce(
     (total, type) => total + now.demandByType[type],
     0,
@@ -2698,7 +2699,11 @@ function updateSupplyFacilitiesFinances(
     (Math.min(now.supplyW, now.demandW) / ticksPerHour) * GAME_TO_REAL_YEARS;
   // Scale the representative simulated day to the real month it stands for.
   const demandWh = (now.demandW / ticksPerHour) * GAME_TO_REAL_YEARS;
-  const customerRevenue = (supplyWh / 1000) * state.dollarsPerkWh;
+  // Re-read the base rate for live slider edits; demand forecasts may have been
+  // generated before that edit. Forecast passes advance their own policy copy.
+  now.customerBillingRate = customerBillingRate(state, now);
+  const customerRevenue =
+    (supplyWh / 1000) * (now.customerBillingRate ?? state.dollarsPerkWh);
   const importedWh = (importedW / ticksPerHour) * GAME_TO_REAL_YEARS;
   const exportedWh = (exportedW / ticksPerHour) * GAME_TO_REAL_YEARS;
   const expensesImports = (importedWh / 1000000) * marketPricePerMWh;
@@ -2854,6 +2859,11 @@ function updateSupplyFacilitiesFinances(
     getScenario(state.scenarioId, state.customScenario) || SCENARIOS[0];
 
   // Save new financial info
+  now.customerRate = updateCustomerRate(
+    prev.customerRate || state.customerRate,
+    prev.customerBillingRate ?? state.dollarsPerkWh,
+    tickScale,
+  );
   now.customers = nextCustomerCount({
     customers: prev.customers,
     customerRate: now.customerRate,
@@ -2922,6 +2932,7 @@ function supplyForecastPass(
   // instead of ramping, and every reforecast silently aged construction and loans by a whole day.
   const newState = {
     ...state,
+    policies: cloneDeep(state.policies),
     facilities: cloneDeep(state.facilities),
     transmission: cloneDeep(state.transmission ?? emptyTransmissionState()),
   };
@@ -2939,6 +2950,7 @@ function supplyForecastPass(
   return newState.timeline.map((t: TickPresentFutureType) => {
     const sourceTick = t;
     if (t.minute >= state.date.minute) {
+      advancePolicies(newState, Math.floor(t.minute / MINUTES_PER_MONTH));
       t = { ...t };
       copyCommitmentMetadata(sourceTick, t);
       t = updateSupplyFacilitiesFinances(
@@ -3048,6 +3060,13 @@ export function generateNewTimeline(
   const currentCustomerRate =
     getTimeFromTimeline(readOnlyState.date.minute, readOnlyState.timeline)
       ?.customerRate || readOnlyState.customerRate;
+  // Retention responds to the last delivered-energy bill, with one tick of lag.
+  // Carry that signal across month boundaries and isolated forecast horizons.
+  const currentBillingRate =
+    getTimeFromTimeline(readOnlyState.date.minute, readOnlyState.timeline)
+      ?.customerBillingRate ??
+    readOnlyState.timeline.at(-1)?.customerBillingRate ??
+    readOnlyState.dollarsPerkWh;
   for (let i = 0; i < ticks; i++) {
     state.timeline[i] = {
       minute: state.date.minute + i * stepMinutes,
@@ -3067,6 +3086,7 @@ export function generateNewTimeline(
       cash,
       customers,
       customerRate: currentCustomerRate,
+      customerBillingRate: currentBillingRate,
       netWorth,
       revenue: 0,
       expensesFuel: 0,

--- a/src/testing/Invariants.tsx
+++ b/src/testing/Invariants.tsx
@@ -269,6 +269,27 @@ export function checkTick(
     );
   }
 
+  if (now.customerBillingRate !== undefined) {
+    const billedRevenue =
+      (((Math.min(now.supplyW, now.demandW) / TICKS_PER_HOUR) *
+        GAME_TO_REAL_YEARS) /
+        1000) *
+        now.customerBillingRate +
+      (now.revenueExports || 0);
+    if (
+      !isFinite_(now.customerBillingRate) ||
+      now.customerBillingRate < 0 ||
+      Math.abs(now.revenue - billedRevenue) >
+        Math.max(1, Math.abs(billedRevenue) * RELATIVE_TOLERANCE)
+    ) {
+      collector.add(
+        "revenue bills only delivered energy at the effective rate",
+        when,
+        `recorded revenue ${now.revenue}, delivered-energy bill ${billedRevenue}`,
+      );
+    }
+  }
+
   // Cash moves only by the tick's own revenue and expenses. Loan principal is spent but not
   // recorded on the tick, so the expected value is a range bounded by the outstanding payments.
   if (prev && !builtThisTick && isFinite_(now.cash) && isFinite_(prev.cash)) {


### PR DESCRIPTION
Customer programs add residential time-of-use pricing and industrial peak-curtailment contracts. Each stays Off/On, with one optional Daily window control when On. The four-hour window initially covers the forecast peak; players can choose any start hour, including windows crossing midnight. Existing active or scheduled choices are preserved. Demand and cash previews update when the window changes, and changes take effect next month. A (?) link opens detailed terms without discarding the choice.

Time-of-use enrolls half of residential demand: participants shift 20% of consumption during the chosen four hours into the following three hours. For example, 22:00–02:00 shifts use to 02:00–05:00. Participants pay 30% more during their peak window and 10% less afterward. Industrial/data-center curtailment has its own four-hour window and eliminates enrolled consumption without later rebound, with a 10% credit on delivered eligible electricity throughout the day. Commercial and transportation demand are unaffected by these offers; existing rebate funding choices remain unchanged.

Shifted residential energy retains its original return schedule and discount across midnight, representative-month boundaries, window edits, stopping TOU, saves, and repeated forecast rebuilds. Insights caches and event history reflect window-only changes. Save version 9 and replay version 12 reject incompatible earlier formats. The merged scenario-choice work is integrated, retaining its mandatory choices and replay validation.

Validation covers all 24 starting hours, energy conservation, independent industrial/residential windows and billing, scheduling/cancellation, save/replay, repeated forecasts, and stale preview protection. Browser coverage includes 320, 390, 768, 1280, and 1440 px in light/dark modes, with manual help and window edits.

- `npm run check` passed: types, lint, formatting, 115 suites / 1,171 tests with coverage thresholds, and all 18 scenario invariants (Jest capped at two workers).
- `npm run build` passed. All 30 production browser cases passed, covering programs and merged scenario choices; the test server was stopped.

![Configurable residential window crossing midnight](https://github.com/user-attachments/assets/308317d8-2c64-45c5-94b6-4c8d83ec06c5)

![Industrial curtailment window on mobile in dark mode](https://github.com/user-attachments/assets/3dbe3a8f-9bbc-491b-8b3d-dba4ba097a72)

