### PR TITLE
Store display names directly on user profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,16 @@ Once functionality is verified, you can deploy prod with the same script.
 The app supports the [Redux DevTools browser
 extension](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)
 for inspecting application state.
+
+### Display-name storage
+
+Player names live in `users/{uid}.displayName`. Display names are not unique;
+Firebase Auth UIDs identify accounts. Scores retain a display-name copy for efficient
+leaderboard reads, with best-effort backfilling when a player renames themselves.
+
+When deploying the removal of username reservations, deploy the new client before
+removing the `usernames` security-rule match. Older cached clients cannot save names
+after those rules are removed and must reload. Existing profiles already contain
+their names, so no data migration is needed. Legacy `usernames` documents and
+`displayNameLower` profile fields are unused and may be removed separately with
+admin tooling after rollout; deploying rules does not delete stored data.

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -49,16 +49,6 @@ service cloud.firestore {
       allow delete: if false;
     }
 
-    // The uniqueness guarantee for display names, claimed by document id. `create` already fails
-    // on an existing document, so a name can only be taken once; a claim is never updated, only
-    // released by its owner when they move to a different name.
-    match /usernames/{nameLower} {
-      allow read: if true;
-      allow create: if isSignedIn() && request.resource.data.uid == request.auth.uid;
-      allow delete: if isSignedIn() && resource.data.uid == request.auth.uid;
-      allow update: if false;
-    }
-
     // Publicly readable: hiding the board from logged-out players inverts the incentive to sign
     // up, since seeing named strangers above you is the reason to bother.
     match /scores/{scoreId} {

--- a/src/components/base/DisplayNameDialog.test.tsx
+++ b/src/components/base/DisplayNameDialog.test.tsx
@@ -56,22 +56,18 @@ describe("DisplayNameDialog", () => {
     expect(screen.getByText(/letters, numbers/)).toBeInTheDocument();
   });
 
-  /**
-   * Uniqueness can only be decided by the claim transaction, so a name that looked fine here can
-   * still come back taken. That has to leave the dialog open with the name still in the box -- a
-   * collision needs another try, not a dismissal.
-   */
-  it("stays open and explains itself when the name is already taken", async () => {
+  /** A failed profile write must leave the dialog open so the player can retry. */
+  it("stays open and explains itself when saving fails", async () => {
     const onClose = jest.fn();
     renderDialog({
-      onSave: async () => "That name is taken. Please pick another.",
+      onSave: async () => "Couldn't save that name. Please try again.",
       onClose,
     });
 
     await userEvent.type(nameField(), "Ada");
     await userEvent.click(screen.getByText("Save"));
 
-    expect(await screen.findByText(/taken/)).toBeInTheDocument();
+    expect(await screen.findByText(/try again/)).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
     expect(nameField().value).toBe("Ada");
   });

--- a/src/components/base/DisplayNameDialog.tsx
+++ b/src/components/base/DisplayNameDialog.tsx
@@ -34,7 +34,7 @@ export interface Props extends StateProps, DispatchProps {}
  * Picks the name that shows up on the leaderboard.
  *
  * Its own dialog rather than the shared ui.dialog, which only carries a title and a message: this
- * one has a text field whose error comes back from a Firestore transaction, so it has to be able
+ * one has a text field whose error comes back from a Firestore write, so it has to be able
  * to fail and stay open.
  */
 export default function DisplayNameDialog(props: Props): React.JSX.Element {
@@ -61,7 +61,7 @@ export default function DisplayNameDialog(props: Props): React.JSX.Element {
     setSaving(true);
     onSave(name).then((failure) => {
       setSaving(false);
-      // Left open on failure: a taken name needs another try, not a dismissal
+      // Left open on failure: a failed save needs another try, not a dismissal
       setError(failure);
       if (!failure) {
         onClose();

--- a/src/components/base/DisplayNameDialogContainer.tsx
+++ b/src/components/base/DisplayNameDialogContainer.tsx
@@ -1,6 +1,6 @@
 import { connect } from "react-redux";
 import type { AppDispatch } from "../../Store";
-import { claimDisplayName, delta } from "../../reducers/User";
+import { saveDisplayName, delta } from "../../reducers/User";
 import { snackbarOpen } from "../../reducers/UI";
 import { AppStateType } from "../../Types";
 import DisplayNameDialog, {
@@ -19,8 +19,8 @@ const mapStateToProps = (state: AppStateType): StateProps => {
 const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => {
   return {
     onSave: async (name: string) => {
-      const result = await dispatch(claimDisplayName(name));
-      if (claimDisplayName.rejected.match(result)) {
+      const result = await dispatch(saveDisplayName(name));
+      if (saveDisplayName.rejected.match(result)) {
         // rejectWithValue carries the reason the player can act on; anything else means the thunk
         // itself threw, which it is not supposed to
         return result.payload || "Couldn't save that name. Please try again.";

--- a/src/helpers/DisplayName.test.tsx
+++ b/src/helpers/DisplayName.test.tsx
@@ -1,6 +1,5 @@
 import {
   DISPLAY_NAME_MAX_LENGTH,
-  displayNameKey,
   normalizeDisplayName,
   suggestDisplayName,
   validateDisplayName,
@@ -34,15 +33,6 @@ describe("validateDisplayName", () => {
     rejected.forEach(([name, message]) => {
       expect(validateDisplayName(name)).toMatch(message);
     });
-  });
-});
-
-describe("displayNameKey", () => {
-  // The claim document is what makes a name unique, so two names that differ only in case or
-  // padding have to land on the same key or both get claimed
-  it("folds case and padding together", () => {
-    expect(displayNameKey("  Ada  ")).toBe("ada");
-    expect(displayNameKey("ADA")).toBe(displayNameKey("ada"));
   });
 });
 

--- a/src/helpers/DisplayName.tsx
+++ b/src/helpers/DisplayName.tsx
@@ -26,11 +26,6 @@ export function normalizeDisplayName(raw: string): string {
   return raw.trim();
 }
 
-/** The key a name is claimed under, so that Ada and ada cannot both exist. */
-export function displayNameKey(name: string): string {
-  return normalizeDisplayName(name).toLowerCase();
-}
-
 /**
  * Why a name cannot be used, or undefined when it can. A message rather than a boolean, because
  * every caller has to tell the player what to change.

--- a/src/reducers/User.test.tsx
+++ b/src/reducers/User.test.tsx
@@ -1,6 +1,6 @@
 import { configureStore } from "@reduxjs/toolkit";
 import userReducer, {
-  claimDisplayName,
+  saveDisplayName,
   fetchGlobalRank,
   loadProfile,
   logout,
@@ -15,7 +15,6 @@ const mockGetDoc = jest.fn();
 const mockGetDocs = jest.fn();
 const mockSetDoc = jest.fn();
 const mockGetCount = jest.fn();
-const mockRunTransaction = jest.fn();
 const mockBatchUpdate = jest.fn();
 const mockBatchCommit = jest.fn();
 const mockSignOut = jest.fn();
@@ -30,7 +29,6 @@ jest.mock("firebase/firestore", () => ({
   limit: (n: number) => ({ limit: n }),
   orderBy: (field: string) => ({ orderBy: field }),
   query: (...parts: unknown[]) => ({ parts }),
-  runTransaction: (_db: unknown, fn: unknown) => mockRunTransaction(fn),
   serverTimestamp: () => "SERVER_TIMESTAMP",
   setDoc: (...args: unknown[]) => mockSetDoc(...args),
   where: (field: string, op: string, value: unknown) => ({ field, op, value }),
@@ -76,21 +74,6 @@ function aSubmission(replay?: ReplayType, score = 420) {
 
 function writesTo(name: string) {
   return mockAddDoc.mock.calls.filter((call) => call[0].name === name);
-}
-
-/** A transaction that finds the claim document already held by `uid`, or by nobody. */
-function transactionSeeing(holder?: string) {
-  const get = jest.fn().mockResolvedValue({
-    exists: () => holder !== undefined,
-    data: () => ({ uid: holder }),
-  });
-  const set = jest.fn();
-  const del = jest.fn();
-  mockRunTransaction.mockImplementation(
-    (fn: (t: unknown) => Promise<void>) =>
-      fn({ get, set, delete: del }) as Promise<void>,
-  );
-  return { get, set, delete: del };
 }
 
 function silenceWarnings() {
@@ -279,70 +262,63 @@ describe("loadProfile", () => {
   });
 });
 
-describe("claimDisplayName", () => {
-  it("claims a free name and writes it to the profile", async () => {
-    const transaction = transactionSeeing(undefined);
+describe("saveDisplayName", () => {
+  it("saves a normalized name only on the profile and merges other fields", async () => {
     const store = makeStore(SIGNED_IN);
-    await store.dispatch(claimDisplayName("  Ada Lovelace "));
-
+    await store.dispatch(saveDisplayName("  Ada Lovelace "));
+    expect(mockSetDoc).toHaveBeenCalledTimes(1);
+    expect(mockSetDoc).toHaveBeenCalledWith(
+      { path: "users/player-1" },
+      { displayName: "Ada Lovelace", updatedAt: "SERVER_TIMESTAMP" },
+      { merge: true },
+    );
+    expect(mockGetDoc).not.toHaveBeenCalled();
     expect(store.getState().user.displayName).toBe("Ada Lovelace");
     expect(store.getState().user.needsDisplayName).toBe(false);
-    // Claimed lowercased, so Ada and ada cannot both be taken
-    expect(transaction.set.mock.calls[0][0].path).toBe(
-      "usernames/ada lovelace",
-    );
-    expect(transaction.set.mock.calls[1][0].path).toBe("users/player-1");
   });
 
-  it("releases the old claim when renaming, in the same transaction", async () => {
-    const transaction = transactionSeeing(undefined);
-    await makeStore({ ...SIGNED_IN, displayName: "Ada" }).dispatch(
-      claimDisplayName("Grace"),
-    );
-    expect(transaction.delete).toHaveBeenCalledWith({ path: "usernames/ada" });
+  it("allows two players to save the same name", async () => {
+    const first = makeStore(SIGNED_IN);
+    const second = makeStore({ uid: "player-2" });
+    await first.dispatch(saveDisplayName("Ada"));
+    await second.dispatch(saveDisplayName("Ada"));
+    expect(first.getState().user.displayName).toBe("Ada");
+    expect(second.getState().user.displayName).toBe("Ada");
+    expect(mockSetDoc.mock.calls.map(([ref]) => ref.path)).toEqual([
+      "users/player-1",
+      "users/player-2",
+    ]);
   });
 
-  // Re-saving the same name is a no-op, not a self-collision that would release the claim the
-  // player is standing on
-  it("doesn't release the claim when the name hasn't changed", async () => {
-    const transaction = transactionSeeing("player-1");
+  it("renames a profile, including case-only changes", async () => {
     const store = makeStore({ ...SIGNED_IN, displayName: "Ada" });
-    await store.dispatch(claimDisplayName("ada"));
-
-    expect(transaction.delete).not.toHaveBeenCalled();
+    await store.dispatch(saveDisplayName("ada"));
     expect(store.getState().user.displayName).toBe("ada");
-  });
-
-  it("fails cleanly on a name someone else holds, leaving the old one in place", async () => {
-    transactionSeeing("someone-else");
-    const store = makeStore({ ...SIGNED_IN, displayName: "Ada" });
-    const result = await store.dispatch(claimDisplayName("Grace"));
-
-    expect(claimDisplayName.rejected.match(result)).toBe(true);
-    expect(result.payload).toMatch(/taken/);
-    expect(store.getState().user.displayName).toBe("Ada");
+    await store.dispatch(saveDisplayName("Grace"));
+    expect(store.getState().user.displayName).toBe("Grace");
   });
 
   it("rejects an invalid name without touching Firestore", async () => {
-    const result = await makeStore(SIGNED_IN).dispatch(claimDisplayName("!!"));
-    expect(claimDisplayName.rejected.match(result)).toBe(true);
-    expect(mockRunTransaction).not.toHaveBeenCalled();
+    const result = await makeStore(SIGNED_IN).dispatch(saveDisplayName("!!"));
+    expect(saveDisplayName.rejected.match(result)).toBe(true);
+    expect(mockSetDoc).not.toHaveBeenCalled();
   });
 
   it("rejects when nobody is logged in", async () => {
-    const result = await makeStore().dispatch(claimDisplayName("Ada"));
-    expect(claimDisplayName.rejected.match(result)).toBe(true);
+    const result = await makeStore().dispatch(saveDisplayName("Ada"));
+    expect(saveDisplayName.rejected.match(result)).toBe(true);
     expect(result.payload).toMatch(/logged in/);
   });
 
-  it("reports a failed write rather than pretending the name was claimed", async () => {
+  it("reports a failed write rather than changing the previous name", async () => {
     const warn = silenceWarnings();
-    mockRunTransaction.mockRejectedValue(new Error("unavailable"));
-    const store = makeStore(SIGNED_IN);
-    const result = await store.dispatch(claimDisplayName("Ada"));
+    mockSetDoc.mockRejectedValueOnce(new Error("unavailable"));
+    const store = makeStore({ ...SIGNED_IN, displayName: "Grace" });
+    const result = await store.dispatch(saveDisplayName("Ada"));
 
-    expect(claimDisplayName.rejected.match(result)).toBe(true);
-    expect(store.getState().user.displayName).toBeUndefined();
+    expect(saveDisplayName.rejected.match(result)).toBe(true);
+    expect(store.getState().user.displayName).toBe("Grace");
+    expect(mockGetDocs).not.toHaveBeenCalled();
     warn.mockRestore();
   });
 
@@ -350,17 +326,15 @@ describe("claimDisplayName", () => {
   // refreshed
   it("keeps the name when backfilling old scores fails", async () => {
     const warn = silenceWarnings();
-    transactionSeeing(undefined);
     mockGetDocs.mockRejectedValue(new Error("permission-denied"));
     const store = makeStore(SIGNED_IN);
-    await store.dispatch(claimDisplayName("Ada"));
+    await store.dispatch(saveDisplayName("Ada"));
 
     expect(store.getState().user.displayName).toBe("Ada");
     warn.mockRestore();
   });
 
   it("rewrites the name on the player's own old scores", async () => {
-    transactionSeeing(undefined);
     mockGetDocs.mockResolvedValue({
       empty: false,
       docs: [],
@@ -369,7 +343,7 @@ describe("claimDisplayName", () => {
         fn({ ref: "scores/b" });
       },
     });
-    await makeStore(SIGNED_IN).dispatch(claimDisplayName("Ada"));
+    await makeStore(SIGNED_IN).dispatch(saveDisplayName("Ada"));
     // The backfill is deliberately not awaited by the thunk
     await new Promise((resolve) => setTimeout(resolve, 0));
 

--- a/src/reducers/User.tsx
+++ b/src/reducers/User.tsx
@@ -17,7 +17,6 @@ import {
   getDocs,
   limit,
   query,
-  runTransaction,
   serverTimestamp,
   setDoc,
   where,
@@ -25,7 +24,6 @@ import {
 } from "firebase/firestore";
 import { getDb, logout as signOutOfFirebase } from "../Globals";
 import {
-  displayNameKey,
   normalizeDisplayName,
   validateDisplayName,
 } from "../helpers/DisplayName";
@@ -45,10 +43,6 @@ interface UserSliceStateType {
 // convenience, so the cost of keeping them fresh is capped rather than unbounded -- and a
 // Firestore batch tops out at 500 writes anyway
 const RENAME_BACKFILL_LIMIT = 100;
-
-// Thrown inside the claim transaction, which is the only place that can tell "someone else has
-// this name" apart from "the write failed"
-const NAME_TAKEN = "display-name-taken";
 
 export interface HighscoreSubmissionType {
   score: number;
@@ -189,8 +183,7 @@ export interface ProfileType {
 
 /**
  * Reads users/{uid} on login, creating it when it isn't there yet. A new profile is created empty
- * rather than with a guessed name: a name has to be unique, and only the claim transaction below
- * can make that true.
+ * so the player can choose their public name.
  */
 export const loadProfile = createAsyncThunk<
   ProfileType,
@@ -206,17 +199,13 @@ export const loadProfile = createAsyncThunk<
   return { displayName: data.displayName, bests: data.bests };
 });
 
-/**
- * Claims a name, or explains why it couldn't be. The document under `usernames` is what makes a
- * name unique -- created only when absent, inside a transaction, so two players racing for the
- * same name cannot both win it.
- */
-export const claimDisplayName = createAsyncThunk<
+/** Saves the public display name on the player profile. Names need not be unique. */
+export const saveDisplayName = createAsyncThunk<
   string,
   string,
   { state: UserSliceStateType; rejectValue: string }
->("user/claimDisplayName", async (requested, { getState, rejectWithValue }) => {
-  const { uid, displayName: previous } = getState().user;
+>("user/saveDisplayName", async (requested, { getState, rejectWithValue }) => {
+  const { uid } = getState().user;
   if (!uid) {
     return rejectWithValue("You need to be logged in to pick a name.");
   }
@@ -225,39 +214,18 @@ export const claimDisplayName = createAsyncThunk<
     return rejectWithValue(invalid);
   }
   const name = normalizeDisplayName(requested);
-  const key = displayNameKey(name);
   const db = getDb();
   try {
-    await runTransaction(db, async (transaction) => {
-      const claim = doc(db, "usernames", key);
-      const existing = await transaction.get(claim);
-      if (existing.exists() && existing.data().uid !== uid) {
-        throw new Error(NAME_TAKEN);
-      }
-      transaction.set(claim, { uid, createdAt: serverTimestamp() });
-      // The old claim is released in the same transaction, so a rename can never leave the player
-      // holding two names or -- worse -- none
-      if (previous && displayNameKey(previous) !== key) {
-        transaction.delete(doc(db, "usernames", displayNameKey(previous)));
-      }
-      transaction.set(
-        doc(db, "users", uid),
-        {
-          displayName: name,
-          displayNameLower: key,
-          updatedAt: serverTimestamp(),
-        },
-        { merge: true },
-      );
-    });
+    await setDoc(
+      doc(db, "users", uid),
+      { displayName: name, updatedAt: serverTimestamp() },
+      { merge: true },
+    );
   } catch (err) {
-    if (err instanceof Error && err.message === NAME_TAKEN) {
-      return rejectWithValue("That name is taken. Please pick another.");
-    }
-    console.warn("Couldn't claim the name: ", err);
+    console.warn("Couldn't save the name: ", err);
     return rejectWithValue("Couldn't save that name. Please try again.");
   }
-  // Deliberately not awaited: the name is the player's the moment the transaction commits, and
+  // Deliberately not awaited: the name is the player's the moment the profile write completes, and
   // refreshing their old rows is cosmetic
   void backfillScoreNames(uid, name);
   return name;
@@ -325,7 +293,7 @@ export const userSlice = createSlice({
         console.warn("Couldn't load your profile: ", action.error.message);
         state.profileLoaded = true;
       })
-      .addCase(claimDisplayName.fulfilled, (state, action) => {
+      .addCase(saveDisplayName.fulfilled, (state, action) => {
         state.displayName = action.payload;
         state.needsDisplayName = false;
       })


### PR DESCRIPTION
Saving a leaderboard name currently writes both a user profile and a separate username reservation. Store it directly in `users/{uid}.displayName` with a merge write instead. Display names may be shared; Firebase Auth UIDs continue to identify accounts.

Removes the reservation transaction, lowercase key helper/field writes, and `usernames` security rules. Keeps name validation, profile fields, leaderboard name copies, and best-effort score backfilling. Tests cover shared names, normalized saves, renames, failed writes, and dialog retry behavior. There are no visual interface changes.

Rollout: deploy the client before removing reservation rules. Older cached clients must reload to save names after rule removal. Existing profiles already hold their names; no migration is required. Legacy reservation documents and lowercase fields are unused and can be cleaned up separately with admin tooling. This PR does not delete production data.

Validation: Node 24 with npm ci; npm run check passed (types, lint, formatting, covered Jest suite, and all scenario simulations); npm run build compiled successfully.
