### PR TITLE
Fix construction equity and validate imported game records

### DIFF
--- a/src/Replay.test.tsx
+++ b/src/Replay.test.tsx
@@ -9,6 +9,22 @@ import {
 } from "./Replay";
 import { GameType, ReplayActionType, ReplayType } from "./Types";
 
+const generatorQuote = {
+  name: "Oil",
+  description: "Generator",
+  available: true,
+  buildCost: 1000000,
+  annualOperatingCost: 1000,
+  peakW: 100000,
+  lifespanYears: 30,
+  yearsToBuild: 1,
+  fuel: "Oil",
+  maxPeakW: 1000000,
+  capacityFactor: 0.9,
+  spinMinutes: 1,
+  btuPerWh: 0.01,
+};
+
 // Only the two fields the recorder touches, so these tests don't need a whole simulation to run
 function aGame(minute: number, log?: ReplayActionType[]): GameType {
   return {
@@ -53,6 +69,71 @@ describe("recordedDelta", () => {
 });
 
 describe("recordReplayAction", () => {
+  it.each([
+    null,
+    {},
+    { ...generatorQuote, buildCost: undefined },
+    { ...generatorQuote, spinMinutes: NaN },
+    { ...generatorQuote, peakW: -1 },
+    { ...generatorQuote, fuel: "unknown" },
+  ])("rejects a malformed replay facility %p", (facility) => {
+    expect(
+      decodeReplay(
+        aReplay({
+          actions: [
+            {
+              minute: 0,
+              type: "buildFacility",
+              payload: { facility, financed: false },
+            },
+          ],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("round trips a complete storage quote", () => {
+    const facility = {
+      name: "Battery",
+      description: "Storage",
+      available: true,
+      buildCost: 1000000,
+      annualOperatingCost: 1000,
+      peakW: 250000,
+      lifespanYears: 15,
+      yearsToBuild: 1,
+      peakWh: 1000000,
+      maxPeakWh: 10000000,
+      roundTripEfficiency: 0.9,
+      hourlyLoss: 0.001,
+    };
+    const replay = aReplay({
+      actions: [
+        {
+          minute: 0,
+          type: "buildFacility",
+          payload: { facility, financed: false },
+        },
+      ],
+    });
+    expect(decodeReplay(encodeReplay(replay))).toEqual(replay);
+    expect(
+      decodeReplay(
+        aReplay({
+          actions: [
+            {
+              minute: 0,
+              type: "buildFacility",
+              payload: {
+                facility: { ...facility, hourlyLoss: undefined },
+                financed: false,
+              },
+            },
+          ],
+        }),
+      ),
+    ).toBeNull();
+  });
   it("does nothing when the run isn't being recorded", () => {
     const game = aGame(60);
     recordReplayAction(game, "sellFacility", 1);
@@ -86,6 +167,7 @@ describe("recordReplayAction", () => {
           type: "buildFacility",
           payload: {
             facility: {
+              ...generatorQuote,
               name: "Airborne Wind",
               fuel: "Airborne Wind",
               peakW: 1200000,
@@ -108,6 +190,7 @@ describe("recordReplayAction", () => {
           type: "buildFacility",
           payload: {
             facility: {
+              ...generatorQuote,
               name: "Oil",
               fuel: "Oil",
               peakW: 100000000,

--- a/src/Replay.tsx
+++ b/src/Replay.tsx
@@ -1,4 +1,5 @@
 import { validScenarioResponse } from "./helpers/ScenarioChoices";
+import { validBuildFacility } from "./helpers/BuildValidation";
 import { validPolicyChange } from "./helpers/Policies";
 import cloneDeep from "lodash.clonedeep";
 import packageJson from "../package.json";
@@ -206,6 +207,8 @@ function parseActions(raw: unknown): ReplayActionType[] | null {
       action.type === "chooseScenarioResponse" &&
       !validScenarioResponse(action.payload)
     )
+      return null;
+    if (action.type === "buildFacility" && !validBuildFacility(action.payload))
       return null;
     actions.push({
       minute: action.minute,

--- a/src/SaveGame.test.tsx
+++ b/src/SaveGame.test.tsx
@@ -58,6 +58,45 @@ describe("SaveGame", () => {
     );
   });
 
+  it.each(["active", "occurrences"] as const)(
+    "validates every persisted world-event %s entry",
+    (field) => {
+      const event = {
+        key: "test:1",
+        definitionId: "test",
+        startsMinute: 0,
+        endsMinute: 1440,
+        attributes: { choice: "repair", cost: 10, ids: [1, 2] },
+        effects: {
+          temperatureOffsetC: -2,
+          facilityOutputMultipliersById: { "1": 0.8 },
+        },
+        title: "Repairs",
+        forecastable: false,
+      };
+      const raw = JSON.parse(JSON.stringify(serializeSave(game)));
+      raw.game.worldEvents[field] = [event];
+      expect(parseSave(raw)?.game.worldEvents[field]).toEqual([event]);
+      for (const malformed of [
+        null,
+        {},
+        { ...event, attributes: null },
+        { ...event, effects: null },
+        { ...event, startsMinute: "0" },
+        { ...event, endsMinute: -1 },
+        { ...event, attributes: { ids: [null] } },
+        { ...event, effects: { demandMultiplier: "bad" } },
+        { ...event, effects: { facilityOutputMultipliersById: { "1": null } } },
+      ]) {
+        raw.game.worldEvents[field] = [malformed];
+        expect(parseSave(raw)).toBeNull();
+      }
+      raw.game.worldEvents[field] = [event];
+      raw.game.worldEvents.checkedKeys = [null];
+      expect(parseSave(raw)).toBeNull();
+    },
+  );
+
   it("round trips every monthly chart layer and rejects corrupt chart values", () => {
     const recorded = {
       ...game,

--- a/src/SaveGame.tsx
+++ b/src/SaveGame.tsx
@@ -4,6 +4,7 @@ import {
   validDeferredResidential,
 } from "./helpers/Policies";
 import packageJson from "../package.json";
+import { validWorldEvent } from "./helpers/WorldEventValidation";
 import { MINUTES_PER_MONTH } from "./helpers/DateTime";
 import { isValidLocation } from "./helpers/Locations";
 import {
@@ -318,7 +319,10 @@ export function parseSave(raw: unknown): SaveGameType | null {
     worldEvents === null ||
     !Array.isArray(worldEvents.active) ||
     !Array.isArray(worldEvents.occurrences) ||
-    !Array.isArray(worldEvents.checkedKeys)
+    !Array.isArray(worldEvents.checkedKeys) ||
+    !worldEvents.active.every(validWorldEvent) ||
+    !worldEvents.occurrences.every(validWorldEvent) ||
+    !worldEvents.checkedKeys.every((key) => typeof key === "string")
   ) {
     return null;
   }

--- a/src/helpers/BuildValidation.ts
+++ b/src/helpers/BuildValidation.ts
@@ -1,0 +1,83 @@
+import { FacilityShoppingType } from "../Types";
+
+function nonNegative(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+/** Shopping quotes travel through untrusted replay documents as well as the build dialog. */
+export function validBuildFacility(raw: unknown): raw is {
+  facility: FacilityShoppingType;
+  financed: boolean;
+} {
+  if (!raw || typeof raw !== "object") return false;
+  const payload = raw as Record<string, unknown>;
+  if (typeof payload.financed !== "boolean") return false;
+  if (!payload.facility || typeof payload.facility !== "object") return false;
+  const facility = payload.facility as Record<string, unknown>;
+  if (
+    typeof facility.name !== "string" ||
+    !facility.name.length ||
+    typeof facility.description !== "string" ||
+    typeof facility.available !== "boolean" ||
+    ![
+      "buildCost",
+      "annualOperatingCost",
+      "peakW",
+      "lifespanYears",
+      "yearsToBuild",
+    ].every((key) => nonNegative(facility[key])) ||
+    facility.peakW === 0 ||
+    facility.lifespanYears === 0 ||
+    [
+      "annualOutputDegradation",
+      "minimumStableOutput",
+      "costPerStart",
+      "variableOperatingCostPerMWh",
+      "reservoirCapacityWh",
+      "hydroWhPerMm",
+      "hydroMeanMonthlyInflowWh",
+      "viableLocationsRemaining",
+    ].some(
+      (key) => facility[key] !== undefined && !nonNegative(facility[key]),
+    ) ||
+    ["annualOutputDegradation", "minimumStableOutput"].some(
+      (key) => typeof facility[key] === "number" && facility[key] > 1,
+    ) ||
+    (facility.tracksStarts !== undefined &&
+      typeof facility.tracksStarts !== "boolean")
+  )
+    return false;
+  if (facility.peakWh !== undefined) {
+    return (
+      ["peakWh", "maxPeakWh", "roundTripEfficiency", "hourlyLoss"].every(
+        (key) => nonNegative(facility[key]),
+      ) &&
+      (facility.peakWh as number) > 0 &&
+      (facility.maxPeakWh as number) > 0 &&
+      (facility.roundTripEfficiency as number) > 0 &&
+      (facility.roundTripEfficiency as number) <= 1 &&
+      (facility.hourlyLoss as number) <= 1
+    );
+  }
+  return (
+    [
+      "Coal",
+      "Biomass",
+      "Wind",
+      "Offshore Wind",
+      "Airborne Wind",
+      "Sun",
+      "Natural Gas",
+      "Uranium",
+      "Oil",
+      "Geothermal",
+      "Hydro",
+    ].includes(facility.fuel as string) &&
+    ["maxPeakW", "capacityFactor", "spinMinutes", "btuPerWh"].every((key) =>
+      nonNegative(facility[key]),
+    ) &&
+    (facility.maxPeakW as number) > 0 &&
+    (facility.capacityFactor as number) <= 1 &&
+    (facility.spinMinutes as number) > 0
+  );
+}

--- a/src/helpers/WorldEventValidation.ts
+++ b/src/helpers/WorldEventValidation.ts
@@ -1,0 +1,88 @@
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function finite(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/** Validate persisted occurrences before simulation or story presentation dereferences them. */
+export function validWorldEvent(value: unknown): boolean {
+  if (!record(value)) return false;
+  if (
+    typeof value.key !== "string" ||
+    !value.key.length ||
+    typeof value.definitionId !== "string" ||
+    !value.definitionId.length ||
+    !finite(value.startsMinute) ||
+    value.startsMinute < 0 ||
+    !finite(value.endsMinute) ||
+    value.endsMinute < value.startsMinute ||
+    !record(value.attributes) ||
+    !record(value.effects)
+  )
+    return false;
+  if (
+    !Object.values(value.attributes).every(
+      (attribute) =>
+        typeof attribute === "string" ||
+        typeof attribute === "boolean" ||
+        finite(attribute) ||
+        (Array.isArray(attribute) &&
+          (attribute.every((entry) => typeof entry === "string") ||
+            attribute.every(finite))),
+    )
+  )
+    return false;
+  const scalarEffects = [
+    "temperatureOffsetC",
+    "demandMultiplier",
+    "hydroRunoffMultiplier",
+    "carbonFeePerKgCO2e",
+    "operatingExpensePerMonth",
+  ];
+  const mapEffects = [
+    "fuelPriceMultipliers",
+    "buildCostMultipliersByFuel",
+    "operatingCostMultipliersByFuel",
+    "facilityOutputMultipliersByFuel",
+    "facilityOutputMultipliersById",
+  ];
+  if (
+    !Object.entries(value.effects).every(([key, effect]) =>
+      scalarEffects.includes(key)
+        ? finite(effect) && (key === "temperatureOffsetC" || effect >= 0)
+        : mapEffects.includes(key) &&
+          record(effect) &&
+          Object.values(effect).every(
+            (amount) => finite(amount) && amount >= 0,
+          ),
+    )
+  )
+    return false;
+  if (
+    ["title", "message", "concept", "importance"].some(
+      (key) => value[key] !== undefined && typeof value[key] !== "string",
+    ) ||
+    (value.forecastable !== undefined &&
+      typeof value.forecastable !== "boolean")
+  )
+    return false;
+  if (value.actionTarget !== undefined) {
+    if (
+      !record(value.actionTarget) ||
+      !["FACILITIES", "INSIGHTS", "EVENTS"].includes(
+        value.actionTarget.card as string,
+      ) ||
+      ["view", "fuel", "layer"].some(
+        (key) =>
+          value.actionTarget &&
+          record(value.actionTarget) &&
+          value.actionTarget[key] !== undefined &&
+          typeof value.actionTarget[key] !== "string",
+      )
+    )
+      return false;
+  }
+  return true;
+}

--- a/src/reducers/BuildFacility.test.tsx
+++ b/src/reducers/BuildFacility.test.tsx
@@ -1,9 +1,16 @@
-import gameReducer, { buildFacility, generateNewTimeline } from "./Game";
-import { GENERATORS } from "../data/Facilities";
+import cloneDeep from "lodash.clonedeep";
+import gameReducer, {
+  buildFacility,
+  generateNewTimeline,
+  tickState,
+} from "./Game";
+import { GENERATORS, STORAGE } from "../data/Facilities";
+import { validBuildFacility } from "../helpers/BuildValidation";
+import { facilityCashBack } from "../helpers/Financials";
 import { getTimeFromTimeline } from "../helpers/DateTime";
 import { GameType, GeneratorShoppingType } from "../Types";
 import { createGame } from "../testing/Simulator";
-import { TICKS_PER_MONTH } from "../Constants";
+import { LOCATIONS, TICKS_PER_MONTH } from "../Constants";
 
 function aGeneratorToBuild(state: GameType): GeneratorShoppingType {
   const generator = GENERATORS(state, 500000000, [20], [500]).find(
@@ -21,6 +28,62 @@ function futureTicks(state: GameType) {
 }
 
 describe("buildFacility", () => {
+  it("accepts all authored generator and storage shopping models", () => {
+    const state = createGame({ scenarioId: 103 });
+    state.date.year = 2035;
+    state.location = { ...LOCATIONS.SF, offshore: true };
+    const quotes = [
+      ...GENERATORS(state, 50000000, [20], [500]),
+      ...STORAGE(state, 50000000),
+    ];
+    expect(quotes.length).toBeGreaterThan(10);
+    for (const facility of quotes) {
+      expect({
+        name: facility.name,
+        valid: validBuildFacility({ facility, financed: true }),
+      }).toEqual({ name: facility.name, valid: true });
+    }
+  });
+
+  it.each([false, true])(
+    "preserves project equity during construction (financed: %s)",
+    (financed) => {
+      const before = createGame({ scenarioId: 103 });
+      const generator = { ...aGeneratorToBuild(before), buildCost: 1000000 };
+      const initial = getTimeFromTimeline(before.date.minute, before.timeline)!;
+      const after = cloneDeep(
+        gameReducer(before, buildFacility({ facility: generator, financed })),
+      );
+      const purchased = getTimeFromTimeline(after.date.minute, after.timeline)!;
+      expect(purchased.netWorth).toBeCloseTo(initial.netWorth, 4);
+      const built = after.facilities.find((f) => f.name === generator.name)!;
+      // A persisted project may already have repaid principal; equity follows its actual debt.
+      if (financed) {
+        built.loanAmountLeft -= 100000;
+        purchased.cash -= 100000;
+      }
+      for (let i = 0; i < 4; i++) tickState(after);
+      const now = getTimeFromTimeline(after.date.minute, after.timeline)!;
+      expect(built.yearsToBuildLeft).toBeGreaterThan(0);
+      expect(now.netWorth).toBeCloseTo(
+        now.cash +
+          after.facilities.reduce(
+            (value, facility) => value + facilityCashBack(facility, now.minute),
+            0,
+          ),
+        4,
+      );
+    },
+  );
+
+  it("ignores malformed build payloads before charging cash or recording an action", () => {
+    const before = createGame({ scenarioId: 103 });
+    const after = gameReducer(
+      before,
+      buildFacility({ facility: {} as GeneratorShoppingType, financed: false }),
+    );
+    expect(after).toEqual(before);
+  });
   it("adds the facility and charges the down payment", () => {
     const before = createGame({ scenarioId: 103 });
     const generator = aGeneratorToBuild(before);

--- a/src/reducers/Game.tsx
+++ b/src/reducers/Game.tsx
@@ -1,4 +1,5 @@
 import { chooseScenarioResponse } from "./GameActions";
+import { validBuildFacility } from "../helpers/BuildValidation";
 import {
   pendingScenarioChoice,
   validScenarioResponse,
@@ -1217,6 +1218,7 @@ function applyBuildFacility(
   state: GameType,
   payload: BuildFacilityAction,
 ): boolean {
+  if (!validBuildFacility(payload)) return false;
   const built = payload.facility;
   const now = getTimeFromTimeline(state.date.minute, state.timeline);
   const amountDue = payload.financed
@@ -1560,13 +1562,7 @@ function applyReplayAction(state: GameType, entry: ReplayActionType) {
       applyPolicyEdit(state, payload, entry.type === "cancelPolicy");
       break;
     case "buildFacility": {
-      const build = payload as Partial<BuildFacilityAction>;
-      if (typeof build?.facility === "object" && build.facility !== null) {
-        applyBuildFacility(state, {
-          facility: build.facility,
-          financed: !!build.financed,
-        });
-      }
+      if (validBuildFacility(payload)) applyBuildFacility(state, payload);
       break;
     }
     case "buildTransmissionLine": {
@@ -3087,7 +3083,7 @@ function supplyForecastPass(
           t.customers = currentCustomers;
         }
         t.netWorth = getNetWorth(
-          newState.facilities,
+          state.facilities,
           t.cash,
           t.minute,
           // Just like currentCash, the live transmission balance already represents this tick.
@@ -3371,11 +3367,7 @@ function getNetWorth(
 ): number {
   let netWorth = cash;
   facilities.forEach((g: FacilityOperatingType) => {
-    if (g.yearsToBuildLeft > 0) {
-      netWorth += g.buildCost * DOWNPAYMENT_PERCENT;
-    } else {
-      netWorth += facilityCashBack(g, currentMinute);
-    }
+    netWorth += facilityCashBack(g, currentMinute);
   });
   transmissionLines.forEach((line) => {
     // The project is worth what has been paid for it at every construction stage. At purchase,


### PR DESCRIPTION
Cash-funded construction was valued at only 20% of its cost until completion, understating net worth; repaid construction principal was also omitted. Value facilities using cancellation equity and preserve live debt when recalculating the current tick.

Malformed replay builds could turn cash into NaN, and malformed world-event records in imported saves could crash simulation or event rendering. Validate shopping payloads before import/application and validate saved event records, attributes, and effects.

Validation:
- QA reproduced all three issues on master 96e603a, then independently verified the fixes in one coding/QA loop (85 focused tests passed).
- Regression coverage includes cash and financed construction, authored generator/storage quotes, malformed replay payloads, and valid/malformed saved events.
- Production build passed.

No interface layout or styling changes.

Full validation: npm run check passed (types, lint, formatting, covered Jest suite, and all scenario invariants). npm run build passed.
