### PR TITLE
Advance tutorials automatically from player actions

### DIFF
--- a/e2e/tutorial-auto-advance.spec.ts
+++ b/e2e/tutorial-auto-advance.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+
+for (const mission of [
+  "Generators",
+  "Storage",
+  "Pricing",
+  "Finances",
+  "Forecasting",
+]) {
+  test(`${mission} advances from game controls`, async ({ page }, testInfo) => {
+    await page.addInitScript(
+      ({ lesson, theme }) => {
+        localStorage.clear();
+        localStorage.setItem("theme", theme);
+        localStorage.setItem(
+          "plays",
+          JSON.stringify({
+            plays: [0, 1, 2, 4, 3, 5]
+              .slice(
+                0,
+                [
+                  "Electricity",
+                  "Generators",
+                  "Storage",
+                  "Finances",
+                  "Pricing",
+                  "Forecasting",
+                ].indexOf(lesson),
+              )
+              .map((scenarioId) => ({
+                scenarioId,
+                date: "2026-09-10",
+              })),
+          }),
+        );
+      },
+      {
+        lesson: mission,
+        theme: testInfo.project.name.startsWith("mobile-") ? "dark" : "light",
+      },
+    );
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: "Start playing", exact: true })
+      .click();
+    await page
+      .getByRole("button", { name: `Start ${mission}`, exact: true })
+      .click();
+    const hud = page.locator(".tutorialHud");
+    if (mission === "Generators" || mission === "Storage") {
+      await page
+        .locator(
+          mission === "Generators"
+            ? ".button-buildGenerator"
+            : ".button-buildStorage",
+        )
+        .click();
+      await expect(hud).toContainText(
+        mission === "Generators" ? "Compare cost" : "Choose storage",
+      );
+      await page
+        .getByRole("button", { name: /Review purchase of/ })
+        .first()
+        .click();
+      // Opening a purchase review does not mean a purchase succeeded.
+      await expect(hud).toContainText(
+        mission === "Generators" ? "Compare cost" : "Choose storage",
+      );
+      await page
+        .getByRole("button", { name: "Take loan", exact: true })
+        .click();
+      await expect(hud).toContainText(
+        mission === "Generators"
+          ? "Construction has started"
+          : "bar shows usable stored energy",
+      );
+    } else if (mission === "Forecasting") {
+      await page.locator(".facilityRow").first().click();
+      await page
+        .getByRole("button", { name: "Pause Coal", exact: true })
+        .click();
+      await expect(page.getByLabel("Objective 2 of 9")).toBeVisible();
+    } else {
+      const nav = page.locator("#insightsNav");
+      if (await nav.isVisible()) {
+        await nav.click();
+      } else {
+        // The desktop pane is already visible, so its explanation must remain dismissible.
+        await hud.getByRole("button", { name: "Next" }).click();
+      }
+      if (mission === "Pricing") {
+        await expect(hud).toContainText("Lower the rate");
+        const rate = page.locator("#rateSlider input");
+        await rate.focus();
+        await rate.press("ArrowLeft");
+        await expect(hud).toContainText("Watch how customer growth");
+      } else {
+        await expect(hud).toContainText("Choose a financial measure");
+        await page
+          .getByRole("button", { name: "Zoom in", exact: true })
+          .click();
+        await expect(hud).toContainText("Choose a preset question");
+        await page.locator("#insightsLayersButton").click();
+        await expect(hud).toContainText("Tap 1× to run a month");
+      }
+    }
+    await expect(page.locator(".buildOption")).toHaveCount(0);
+    await page.screenshot({
+      path: testInfo.outputPath(`${mission}-advanced.png`),
+    });
+  });
+}

--- a/e2e/tutorial-interties.spec.ts
+++ b/e2e/tutorial-interties.spec.ts
@@ -39,8 +39,9 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
     }
   }
 
-  // The explicit copy plus automatic recovery means an eager Next cannot strand the build gate.
-  await page.getByRole("button", { name: "Next" }).click();
+  // Opening the tab completes navigation without a redundant Next click.
+  await page.locator("#intertiesTab").click();
+  await expect(page.getByLabel("Objective 2 of 10")).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Approve Pacific Northwest intertie" }),
   ).toBeVisible();
@@ -50,6 +51,8 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
     .click();
   await expect(page.getByText("Building")).toBeVisible();
   await expect(page.getByLabel("Objective 3 of 10")).toBeVisible();
+  await expect(page.locator(".MuiSnackbar-root")).toHaveCount(0);
+  await page.screenshot({ path: testInfo.outputPath("intertie-approved.png") });
 
   await page.getByRole("button", { name: "fast speed" }).click();
   await expect(page.getByText(/Trading ·/)).toBeVisible({ timeout: 20000 });
@@ -62,7 +65,7 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
   await page.getByRole("option", { name: "Buy for shortages only" }).click();
   await expect(page.getByLabel("Objective 5 of 10")).toBeVisible();
   await page.locator("#plantsTab").click();
-  await page.getByRole("button", { name: "Next" }).click();
+  await expect(page.getByLabel("Objective 6 of 10")).toBeVisible();
   await page.getByRole("button", { name: "Pause Natural Gas" }).click();
   await expect(page.getByLabel("Objective 7 of 10")).toBeVisible();
 

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -610,6 +610,10 @@ export interface TutorialStepType {
   // cheap field reads. Tutorial scenarios have fixed authored starting states, so
   // predicates are absolute (e.g. facilities.length >= 2), never relative to step entry
   advanceOn?: (state: AppStateType) => boolean;
+  // Explanations still offer Next, but completed deeds can move them along too.
+  continueOn?: (state: AppStateType) => boolean;
+  // Presentation-only controls. Game mutations use predicates to exclude rejected actions.
+  continueOnClick?: string;
   // Gate for deeds that leave no distinguishable state behind (a drag re-order, a pause
   // toggle): advance when an action with one of these types is dispatched. Either gate
   // field alone makes the step gated; both may be combined (OR)

--- a/src/components/base/TutorialHud.test.tsx
+++ b/src/components/base/TutorialHud.test.tsx
@@ -36,6 +36,74 @@ function props(overrides: Partial<TutorialHudProps> = {}): TutorialHudProps {
 }
 
 describe("TutorialHud", () => {
+  it("continues on explicit UI controls, including keyboard activation, and cleans up", async () => {
+    const user = userEvent.setup();
+    const hudProps = props({ step: objective({ continueOnClick: "#tab" }) });
+    const { rerender } = render(
+      <>
+        <button id="tab">
+          <span>Interties</span>
+        </button>
+        <button>Unrelated</button>
+        <TutorialHud {...hudProps} />
+      </>,
+    );
+    await user.click(screen.getByText("Unrelated"));
+    expect(hudProps.onNext).not.toHaveBeenCalled();
+    screen.getByRole("button", { name: "Interties" }).focus();
+    await user.keyboard("{Enter}");
+    expect(hudProps.onNext).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Next" })).toBeVisible();
+    rerender(
+      <>
+        <button id="tab">Interties</button>
+        <TutorialHud {...hudProps} step={objective()} />
+      </>,
+    );
+    await user.click(screen.getByText("Interties"));
+    expect(hudProps.onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores disabled controls and cancels a click when its action removes the objective", async () => {
+    const user = userEvent.setup();
+    const hudProps = props({ step: objective({ continueOnClick: "#tab" }) });
+    const { rerender } = render(
+      <>
+        <button id="tab" disabled>
+          Interties
+        </button>
+        <TutorialHud {...hudProps} />
+      </>,
+    );
+    await user.click(screen.getByText("Interties"));
+    expect(hudProps.onNext).not.toHaveBeenCalled();
+    rerender(
+      <>
+        <button id="tab" onClick={() => rerender(<span>Finished</span>)}>
+          Interties
+        </button>
+        <TutorialHud {...hudProps} />
+      </>,
+    );
+    await user.click(screen.getByText("Interties"));
+    expect(hudProps.onNext).not.toHaveBeenCalled();
+  });
+
+  it("does not count a click on a required purchase gate", async () => {
+    const user = userEvent.setup();
+    const hudProps = props({
+      step: objective({ continueOnClick: "button", advanceOn: () => false }),
+    });
+    render(
+      <>
+        <button>Buy</button>
+        <TutorialHud {...hudProps} />
+      </>,
+    );
+    await user.click(screen.getByRole("button", { name: "Buy" }));
+    expect(hudProps.onNext).not.toHaveBeenCalled();
+  });
+
   it("exposes the current objective, progress and ordinary navigation", async () => {
     const user = userEvent.setup();
     const hudProps = props({ canGoBack: true, stepIndex: 1 });

--- a/src/components/base/TutorialHud.tsx
+++ b/src/components/base/TutorialHud.tsx
@@ -44,6 +44,36 @@ export default function TutorialHud({
   React.useEffect(() => setHintVisible(false), [stepIndex]);
 
   React.useEffect(() => {
+    if (!step.continueOnClick || isGatedStep(step)) {
+      return;
+    }
+    let active = true;
+    const onClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      const control = target.closest(step.continueOnClick!);
+      if (!control || control.matches(":disabled, [aria-disabled='true']")) {
+        return;
+      }
+      // Capture the current step before React handles the control. Cancel if its normal
+      // action already advanced the tutorial or unmounted this objective.
+      queueMicrotask(() => {
+        if (active && !event.defaultPrevented) {
+          active = false;
+          onNext();
+        }
+      });
+    };
+    document.addEventListener("click", onClick, true);
+    return () => {
+      active = false;
+      document.removeEventListener("click", onClick, true);
+    };
+  }, [step, onNext]);
+
+  React.useEffect(() => {
     if (!target || step.capstone) {
       return;
     }

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -2172,7 +2172,7 @@ export default class Insights extends React.Component<Props, State> {
                         id as DefaultInsightPresetId
                       ];
                     return (
-                      <MenuItem key={id} value={id}>
+                      <MenuItem key={id} value={id} data-insight-preset={id}>
                         <span>{preset.label}</span>
                         {modified && (
                           <span className="insightsPresetMenuHint">
@@ -2189,7 +2189,11 @@ export default class Insights extends React.Component<Props, State> {
                     </ListSubheader>
                   )}
                   {this.state.presetLibrary.custom.map((preset) => (
-                    <MenuItem key={preset.id} value={`saved:${preset.id}`}>
+                    <MenuItem
+                      key={preset.id}
+                      value={`saved:${preset.id}`}
+                      data-insight-preset={preset.id}
+                    >
                       <span className="insightsPresetMenuName">
                         {preset.name}
                       </span>

--- a/src/data/Scenarios.test.tsx
+++ b/src/data/Scenarios.test.tsx
@@ -71,10 +71,10 @@ describe("tutorial mission metadata", () => {
     const firstStep = finances.tutorialSteps![0];
 
     expect(
-      firstStep.advanceOn?.({ card: { name: "INSIGHTS" } } as AppStateType),
+      firstStep.continueOn?.({ card: { name: "INSIGHTS" } } as AppStateType),
     ).toBe(true);
     expect(
-      firstStep.advanceOn?.({ card: { name: "FACILITIES" } } as AppStateType),
+      firstStep.continueOn?.({ card: { name: "FACILITIES" } } as AppStateType),
     ).toBe(false);
   });
 

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -209,6 +209,8 @@ export const SCENARIOS = [
       {
         card: { name: "BUILD_GENERATORS", dontRemember: true },
         target: ".build-list-item",
+        continueOn: (s: AppStateType) => s.game.facilities.length >= 2,
+        continueOnClick: ".buildOption .expand-details",
         content: (
           <TutorialPrompt
             concepts={["money", "time", "fuel"]}
@@ -394,7 +396,7 @@ export const SCENARIOS = [
         skipBeacon: true, // causes tutorial to auto-start
         card: "FACILITIES",
         target: "#insightsNav",
-        advanceOn: (s: AppStateType) => s.card.name === "INSIGHTS",
+        continueOn: (s: AppStateType) => s.card.name === "INSIGHTS",
         content: (
           <TutorialPrompt
             concepts={["finances", "money"]}
@@ -414,6 +416,8 @@ export const SCENARIOS = [
       {
         card: "INSIGHTS",
         target: "#chartFinances",
+        continueOnClick:
+          ".insightsViewportToolbar button, [data-insight-preset]",
         content: (
           <TutorialPrompt
             concepts={["forecast", "money"]}
@@ -424,6 +428,7 @@ export const SCENARIOS = [
       {
         card: "INSIGHTS",
         target: ".insightsLayerControls",
+        continueOnClick: "#insightsLayersButton, [data-insight-preset]",
         content: (
           <TutorialPrompt
             concepts={["finances"]}
@@ -488,6 +493,8 @@ export const SCENARIOS = [
         skipBeacon: true, // causes tutorial to auto-start
         card: "FACILITIES",
         target: "#insightsNav",
+        continueOn: (s: AppStateType) =>
+          s.card.name === "INSIGHTS" || s.game.dollarsPerkWh < 0.07,
         content: (
           <TutorialPrompt
             concepts={["rate", "customers"]}
@@ -572,7 +579,8 @@ export const SCENARIOS = [
         skipBeacon: true, // causes tutorial to auto-start
         card: "FACILITIES",
         target: ".facility",
-        advanceOnAction: "game/togglePauseFacility",
+        advanceOn: (s: AppStateType) =>
+          s.game.facilities.some((facility) => facility.paused),
         content: (
           <TutorialPrompt
             concepts={["pause", "generator"]}
@@ -715,10 +723,11 @@ export const SCENARIOS = [
         skipBeacon: true,
         card: "FACILITIES",
         target: "#intertiesTab",
+        continueOnClick: "#intertiesTab",
         content: (
           <TutorialPrompt
             concepts={["supply", "demand"]}
-            text="Tap Interties to see links to neighboring grids, then tap Next."
+            text="Tap Interties to see links to neighboring grids."
           />
         ),
       },
@@ -762,10 +771,11 @@ export const SCENARIOS = [
       {
         card: "FACILITIES",
         target: "#plantsTab",
+        continueOnClick: "#plantsTab",
         content: (
           <TutorialPrompt
             concepts={["generator", "pause"]}
-            text="Tap Plants to return to your power plants, then tap Next."
+            text="Tap Plants to return to your power plants."
           />
         ),
       },

--- a/src/reducers/Tutorial.test.tsx
+++ b/src/reducers/Tutorial.test.tsx
@@ -133,6 +133,19 @@ function tutorialStore(
 }
 
 describe("tutorialGateMiddleware", () => {
+  it("continues an explanation after a successful deed and skips its already-completed gate", () => {
+    const satisfied = (state: AppStateType) => state.game.dollarsPerkWh < 0.07;
+    const store = tutorialStore([
+      { ...informational(), continueOn: satisfied },
+      { ...informational(), advanceOn: satisfied },
+      informational(),
+    ]);
+    store.dispatch({ type: "test/rejected-purchase" });
+    expect(store.getState().game.tutorialStep).toBe(0);
+    store.dispatch({ type: "test/satisfy-predicate" });
+    expect(store.getState().game.tutorialStep).toBe(2);
+  });
+
   beforeEach(() => {
     window.localStorage.clear();
   });

--- a/src/reducers/Tutorial.tsx
+++ b/src/reducers/Tutorial.tsx
@@ -151,7 +151,7 @@ export const tutorialGateMiddleware: Middleware =
         );
         const steps = scenario && scenario.tutorialSteps;
         const step = steps && steps[stepIndex];
-        if (!step || !isGatedStep(step)) {
+        if (!step || (!isGatedStep(step) && !step.continueOn)) {
           break;
         }
         const byAction = freshAction && matchesActionGate(step, actionType);
@@ -160,6 +160,7 @@ export const tutorialGateMiddleware: Middleware =
         try {
           byState = !!(
             (step.advanceOn && step.advanceOn(state)) ||
+            (step.continueOn && step.continueOn(state)) ||
             (step.capstone && step.capstone.success(state))
           );
           capstoneFailed = !!(


### PR DESCRIPTION
Tutorials now follow the player's actions without requiring a redundant Next click. Opening Interties or Plants advances Mission 7, and approving the connection continues through the existing successful-purchase gate.

The review also fixes early generator purchases and opening details, Pricing navigation and early rate changes, Finances chart/layer/preset controls, and Forecasting's pause check. Explanatory steps retain Next, including desktop Finances where Insights is already visible. Purchase reviews and rejected actions do not count as completed purchases; click listeners are scoped to the current objective and cleaned up on transitions.

Validation: Node 24 with npm ci; 51 focused tests passed; tutorial browser coverage across all seven missions on desktop and mobile (including dark mode); production build passed; all scenario simulation invariants passed. Final npm run check passed, including types, lint, formatting, all 119 covered Jest suites, and every scenario through the headless simulation.

Desktop: Interties approval automatically reaches the construction objective.

![Interties after approval](https://github.com/user-attachments/assets/ef09c1d4-a6c4-4a23-a3e5-1a08b7c3c4e2)

Mobile dark mode: purchasing during the comparison step automatically reaches construction.

![Generator purchase advances the tutorial](https://github.com/user-attachments/assets/0d6280d9-5b86-4ad3-a2da-9db6765421b5)

