### PR TITLE
fix: patch SVGO for Dependabot alert #352

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16652,38 +16652,6 @@
         "postcss": "^8.2.15"
       }
     },
-    "node_modules/postcss-svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/postcss-svgo/node_modules/svgo": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.3.tgz",
-      "integrity": "sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "sax": "^1.5.0",
-        "stable": "^0.1.8"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/postcss-unique-selectors": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -144,9 +144,7 @@
     "fast-uri": "^3.1.6",
     "qs": "^6.16.0",
     "serialize-javascript": "^7.0.3",
-    "@svgr/plugin-svgo": {
-      "svgo": "^2.8.3"
-    },
+    "svgo": "^2.8.4",
     "react-scripts": {
       "resolve-url-loader": "5.0.0",
       "typescript": "$typescript",


### PR DESCRIPTION
Resolves [Dependabot alert #352](https://github.com/toddmedema/electrify/security/dependabot/352) (CVE-2026-84370 / GHSA-w27v-7q3p-w38r).

The CSS optimizer still resolved SVGO 2.8.3 even though the SVGR path already used patched 2.8.4. Replace the SVGR-only override with a shared `svgo: ^2.8.4` override so both build paths use the patched version, and remove the vulnerable duplicate from the lockfile.

Validation on Node 24.14.0:
- `npm ci`: passed; audit reports zero vulnerabilities.
- `npm ls svgo`: both build paths resolve to 2.8.4.
- `npm run check`: passed (119 suites, 1,149 tests, coverage gates, and every scenario invariant).
- `npm run build`: passed.
- Ad hoc regression check: the patched script-removal plugin removes executable links from namespace-prefixed anchors and URL schemes containing tabs, line feeds, or carriage returns.

Only dependency manifests change; no user-visible UI changes.
