### PR TITLE
Unify facilities and simplify desktop and mobile UI

### DIFF
--- a/e2e/app-spacing.spec.ts
+++ b/e2e/app-spacing.spec.ts
@@ -47,6 +47,7 @@ test("phone surfaces share stable gutters and compact chrome", async ({
   );
 
   await page.getByRole("button", { name: "Facilities", exact: true }).click();
+  await page.locator(".button-buildFacility").click();
   await page.getByRole("button", { name: "Storage" }).click();
   await expect(
     page.getByRole("heading", { name: "Build Storage" }),

--- a/e2e/build-options.spec.ts
+++ b/e2e/build-options.spec.ts
@@ -22,6 +22,7 @@ for (const theme of ["light", "dark"] as const) {
         .click();
     }
     for (const kind of ["Generator", "Storage"]) {
+      await page.locator(".button-buildFacility").click();
       await page.locator(`.button-build${kind}`).click();
       const cards = page.locator(".buildOption");
       const first = cards.first();
@@ -120,6 +121,7 @@ for (const theme of ["light", "dark"] as const) {
         .getByRole("button", { name: "Facilities", exact: true })
         .click();
     }
+    await page.locator(".button-buildFacility").click();
     await page.locator(".button-buildStorage").click();
     const battery = page.locator(".buildOption").filter({
       has: page.getByRole("button", { name: /Battery details/ }),

--- a/e2e/contextual-learning.spec.ts
+++ b/e2e/contextual-learning.spec.ts
@@ -18,6 +18,7 @@ for (const theme of ["light", "dark"] as const) {
         .getByRole("button", { name: "Facilities", exact: true })
         .click();
     }
+    await page.locator(".button-buildFacility").click();
     await page.locator(".button-buildStorage").click();
     const capacity = page.getByRole("slider", { name: /^Capacity/ });
     await capacity.focus();

--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -405,8 +405,7 @@ test("compact facility build buttons stay above the chart", async ({
     await page.getByRole("button", { name: "Facilities", exact: true }).click();
   }
   const buildButtons = [
-    facilities.getByRole("button", { name: "Generator" }),
-    facilities.getByRole("button", { name: "Storage" }),
+    facilities.getByRole("button", { name: "Build", exact: true }),
   ];
   const chart = facilities.locator("#chartSupplyDemand");
   await expect(chart).toBeVisible();
@@ -417,12 +416,12 @@ test("compact facility build buttons stay above the chart", async ({
   expect(chartBox).not.toBeNull();
   expect(buttonBoxes.every(Boolean)).toBe(true);
   buttonBoxes.forEach((box) => {
-    expect(box!.height).toBeLessThanOrEqual(32);
+    expect(box!.height).toBeGreaterThanOrEqual(44);
     expect(box!.y + box!.height).toBeLessThanOrEqual(chartBox!.y + 0.5);
   });
   expect(
     (await facilities.locator(".paneHeader").boundingBox())!.height,
-  ).toBeLessThanOrEqual(41); // 40px content plus the divider
+  ).toBeLessThanOrEqual(57); // Touch-sized Build action plus the divider
 });
 
 test("main-menu account actions follow the sound action", async ({

--- a/e2e/insights-responsive.spec.ts
+++ b/e2e/insights-responsive.spec.ts
@@ -238,7 +238,10 @@ test("insights header controls stay aligned in one compact row", async ({
     controls.map((control) => control.boundingBox()),
   );
   expect(boxes.every(Boolean)).toBe(true);
-  expect(boxes.every((box) => box!.height >= 36)).toBe(true);
+  const minimumControlHeight = testInfo.project.name.startsWith("mobile-")
+    ? 44
+    : 40;
+  expect(boxes.every((box) => box!.height >= minimumControlHeight)).toBe(true);
   expect(new Set(boxes.map((box) => box!.y)).size).toBe(1);
 
   const headerOverflow = await page
@@ -286,7 +289,7 @@ test("insights header controls stay aligned in one compact row", async ({
     expect(trackTitle).not.toBeNull();
     expect(leversBox!.height).toBeLessThanOrEqual(110);
     expect(metricsBox!.height).toBeGreaterThanOrEqual(44);
-    expect(metricsBox!.x - leversBox!.x).toBeCloseTo(12, 1);
+    expect(metricsBox!.x - leversBox!.x).toBeCloseTo(16, 1);
     expect(
       await levers.evaluate(
         (element) => element.scrollWidth - element.clientWidth,
@@ -408,6 +411,8 @@ test("compact facility build buttons stay above the chart", async ({
     facilities.getByRole("button", { name: "Build", exact: true }),
   ];
   const chart = facilities.locator("#chartSupplyDemand");
+  if (!(await chart.isVisible()))
+    await facilities.locator(".facilitySupplyDisclosure > summary").click();
   await expect(chart).toBeVisible();
   const chartBox = await chart.boundingBox();
   const buttonBoxes = await Promise.all(

--- a/e2e/mission-evidence.spec.ts
+++ b/e2e/mission-evidence.spec.ts
@@ -300,7 +300,8 @@ test("large text and landscape keep mission controls and navigation reachable", 
     await page.locator("#faciltiesNav:visible").scrollIntoViewIfNeeded();
     await page.locator("#faciltiesNav:visible").click();
     await settle(page);
-    await page.locator(".button-buildGenerator").scrollIntoViewIfNeeded();
+    await page.locator(".button-buildFacility").scrollIntoViewIfNeeded();
+    await page.locator(".button-buildFacility").click();
     await page.locator(".button-buildGenerator").click();
     await expect(page.locator(".buildOption").first()).toBeVisible();
     await page.getByRole("button", { name: "close", exact: true }).click();
@@ -343,12 +344,9 @@ test("projected sample evidence and a deliberate purchase retain the bounded inv
   await expect(page.locator(".missionRiskButton:visible")).toHaveAccessibleName(
     /Projected in this month's representative day/,
   );
-  await page.locator("#intertiesTab").click();
+  await page.locator(".transmissionFleet").scrollIntoViewIfNeeded();
   await page.locator(".missionRiskButton:visible").click();
-  await expect(page.locator("#plantsTab")).toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
+  await expect(page.locator("#chartSupplyDemand")).toBeVisible();
   await expect(page.locator(".operatingEvidence")).toBeFocused();
   await page.locator(".missionRiskButton:visible").click();
   await expect(page.locator(".operatingEvidence")).toBeFocused();

--- a/e2e/mission-evidence.spec.ts
+++ b/e2e/mission-evidence.spec.ts
@@ -42,11 +42,11 @@ for (const theme of ["light", "dark"]) {
     await expect(page.locator(".missionSummaryCopy:visible")).toContainText(
       "Cash ≥ $0 ($",
     );
-    const reorder = page.locator(".facilityReorderButton:visible");
+    const reorder = page.locator(".facilityActions:visible");
     if (info.project.name.startsWith("mobile")) {
       await expect(reorder).toHaveCount(0);
     } else {
-      await expect(reorder.first()).toBeVisible();
+      await expect(reorder).toHaveCount(0);
       const grid = await page.locator(".gridHealth:visible").boundingBox();
       const mission = await page
         .locator(".missionSummary:visible")
@@ -64,7 +64,9 @@ for (const theme of ["light", "dark"]) {
     await expect(dialog).toContainText("month-end");
     await page.keyboard.press("Escape");
     await expect(details).toBeFocused();
-    await page.locator(".facilityRow").filter({ hasText: "Coal" }).click();
+    await page
+      .getByRole("button", { name: "Inspect Coal", exact: true })
+      .click();
     await page.getByRole("button", { name: "Pause Coal", exact: true }).click();
     await page.getByRole("button", { name: "fast speed", exact: true }).click();
     await expect(page.locator(".gridHealth-blackout:visible")).toBeVisible();
@@ -82,6 +84,8 @@ for (const theme of ["light", "dark"]) {
     await expect(
       page.locator(".gridHealth-blackout:visible"),
     ).not.toContainText("Now");
+    if (!(await page.locator("#chartSupplyDemand").isVisible()))
+      await page.locator(".facilitySupplyDisclosure > summary").click();
     await expect(page.locator("#chartSupplyDemand")).toBeVisible();
     for (const speed of ["normal speed", "fast speed", "pause"]) {
       await page.getByRole("button", { name: speed, exact: true }).click();
@@ -335,7 +339,7 @@ test("projected sample evidence and a deliberate purchase retain the bounded inv
   await page.reload();
   await page.getByRole("button", { name: "Continue", exact: true }).click();
   await expect(page.locator(".missionSummary:visible")).toBeVisible();
-  await page.locator(".facilityRow").filter({ hasText: "Coal" }).click();
+  await page.getByRole("button", { name: "Inspect Coal", exact: true }).click();
   await page.getByRole("button", { name: "Pause Coal", exact: true }).click();
   await page.getByRole("button", { name: "Resume Coal", exact: true }).click();
   await expect(page.locator(".missionRiskButton:visible")).toContainText(
@@ -348,6 +352,12 @@ test("projected sample evidence and a deliberate purchase retain the bounded inv
   await page.locator(".missionRiskButton:visible").click();
   await expect(page.locator("#chartSupplyDemand")).toBeVisible();
   await expect(page.locator(".operatingEvidence")).toBeFocused();
+  if (info.project.name.startsWith("mobile-")) {
+    await page.locator(".facilitySupplyDisclosure > summary").click();
+    await expect(page.locator(".facilitySupplyDisclosure")).not.toHaveAttribute(
+      "open",
+    );
+  }
   await page.locator(".missionRiskButton:visible").click();
   await expect(page.locator(".operatingEvidence")).toBeFocused();
   await expect(page.locator(".operatingEvidence")).toContainText(

--- a/e2e/performance-responsive.spec.ts
+++ b/e2e/performance-responsive.spec.ts
@@ -57,8 +57,18 @@ test("chart-heavy controls remain responsive during pointer gestures", async ({
 
   // The expensive 20-year projection should retain its current preview during the drag and
   // commit exactly where the player releases, keeping the pointer path free of projection work.
-  await page.getByRole("combobox", { name: "Insight range" }).click();
-  await page.getByRole("option", { name: "Next 20 years" }).click();
+  await page
+    .getByRole("button", { name: "Fit full timeline", exact: true })
+    .click();
+  const firstChart = page
+    .locator(".insights .accessibleChart [role=img]")
+    .first();
+  await expect(firstChart).toHaveAttribute("data-viewport-min", "0");
+  // Each simulated day represents one month: the full forecast covers 240 months.
+  await expect(firstChart).toHaveAttribute(
+    "data-viewport-max",
+    String(20 * 12 * 24 * 60),
+  );
   const controls = page.getByRole("region", { name: "Planning controls" });
   const slider = controls.getByRole("slider");
   const sliderBox = await slider.boundingBox();

--- a/e2e/scenario-details.spec.ts
+++ b/e2e/scenario-details.spec.ts
@@ -45,6 +45,17 @@ for (const theme of ["light", "dark"] as const) {
       .getByRole("button", { name: "fast speed", exact: true })
       .first()
       .click();
+    // The preparedness decision pauses this scenario before the first month can finish.
+    const preparedness = page.getByRole("dialog", {
+      name: "Wildfire preparedness",
+    });
+    await expect(preparedness).toBeVisible();
+    await preparedness.getByRole("button", { name: "Keep cash" }).click();
+    await page
+      .locator("#appbar:visible")
+      .getByRole("button", { name: "fast speed", exact: true })
+      .first()
+      .click();
     // Wait for a real completed month, then stop the clock before inspecting its score.
     await expect(
       page.getByText("Wildfire emergency", { exact: true }),

--- a/e2e/simulation-assumptions.spec.ts
+++ b/e2e/simulation-assumptions.spec.ts
@@ -51,7 +51,8 @@ for (const theme of ["light", "dark"] as const) {
       await page
         .getByRole("button", { name: "Facilities", exact: true })
         .click();
-    await facilities.locator(".button-buildGenerator").click();
+    await page.locator(".button-buildFacility").click();
+    await page.locator(".button-buildGenerator").click();
     const first = page.locator(".buildOption").first();
     await first.getByRole("button", { name: /Show .* details/ }).click();
     await expect(first).toContainText("automatically retire at this age");
@@ -80,8 +81,10 @@ for (const theme of ["light", "dark"] as const) {
     await dialog.getByRole("button", { name: "close", exact: true }).click();
     await expect(dialog).not.toBeVisible();
     await page.getByRole("button", { name: "close", exact: true }).click();
-    await facilities.getByRole("tab", { name: "Interties" }).click();
-    const trade = facilities
+    await facilities.locator(".button-buildFacility").click();
+    await page.getByRole("button", { name: "Intertie", exact: true }).click();
+    const trade = page
+      .getByRole("dialog")
       .locator("details")
       .filter({ hasText: "How trading and purchased emissions are estimated" });
     expect(

--- a/e2e/transmission.spec.ts
+++ b/e2e/transmission.spec.ts
@@ -47,10 +47,26 @@ test("California players can build and understand an intertie", async ({
     page.getByText("Intertie approved — power can flow in 1 year."),
   ).toBeVisible();
   await expect(
-    facilities.getByText("Interties · Automatic trading"),
+    facilities
+      .getByText("Interties", { exact: false })
+      .filter({ hasText: "Automatic trading" }),
   ).toBeVisible();
   await expect(facilities.getByText("Building")).toBeVisible();
-  await facilities.locator(".tradingSummary > summary").click();
+  await expect(
+    facilities.getByText("Network trading", { exact: true }),
+  ).toHaveCount(1);
+  const line = facilities.locator(".transmissionLine").first();
+  const [rowBox, chevronBox] = await Promise.all([
+    line.locator(".facilityDisclosure").boundingBox(),
+    line.locator(".facilityChevron").boundingBox(),
+  ]);
+  expect(
+    Math.abs(
+      rowBox!.y + rowBox!.height / 2 - (chevronBox!.y + chevronBox!.height / 2),
+    ),
+  ).toBeLessThanOrEqual(1);
+  await facilities.locator(".tradingSummary > summary").focus();
+  await page.keyboard.press("Enter");
   await expect(facilities.getByLabel("Trading rule")).toContainText(
     "Buy for shortages, sell extra",
   );
@@ -109,19 +125,34 @@ test("unified facility rows support keyboard inspection and dispatch reordering"
   const originalFirstId = await rows
     .first()
     .getAttribute("data-rfd-draggable-id");
-  await expect(rows.first()).toHaveAttribute("role", "button");
-  await expect(rows.first()).toHaveAttribute("tabindex", "0");
+  await expect(rows.first().locator(".facilityDisclosure")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
   await facilities.getByRole("button", { name: "Build", exact: true }).focus();
   for (let step = 0; step < 12; step++) {
     await page.keyboard.press("Tab");
-    if (await rows.first().evaluate((row) => row === document.activeElement))
+    if (
+      await rows
+        .first()
+        .locator(".facilityDisclosure")
+        .evaluate((row) => row === document.activeElement)
+    )
       break;
   }
-  await expect(rows.first()).toBeFocused();
+  await expect(rows.first().locator(".facilityDisclosure")).toBeFocused();
   await page.keyboard.press("Enter");
-  await expect(rows.first()).toHaveAttribute("aria-expanded", "true");
+  await expect(rows.first().locator(".facilityDisclosure")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
   await page.keyboard.press("Enter");
-  await expect(rows.first()).toHaveAttribute("aria-expanded", "false");
+  await expect(rows.first().locator(".facilityDisclosure")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+  await page.keyboard.press("Enter");
+  await rows.first().locator(".facilityDragHandle").focus();
   await page.keyboard.press("Space");
   await page.keyboard.press("ArrowDown");
   await page.keyboard.press("Space");
@@ -129,6 +160,6 @@ test("unified facility rows support keyboard inspection and dispatch reordering"
     "data-rfd-draggable-id",
     originalFirstId!,
   );
-  await expect(rows.last()).toBeFocused();
+  await expect(rows.last().locator(".facilityDragHandle")).toBeFocused();
   await expect(facilities.locator(".transmissionFleet")).toBeVisible();
 });

--- a/e2e/transmission.spec.ts
+++ b/e2e/transmission.spec.ts
@@ -15,39 +15,45 @@ test("California players can build and understand an intertie", async ({
   if (!(await facilities.isVisible())) {
     await page.getByRole("button", { name: "Facilities", exact: true }).click();
   }
-  await facilities.getByRole("tab", { name: "Interties" }).click();
+  await facilities.getByRole("button", { name: "Build", exact: true }).click();
+  await page.getByRole("button", { name: "Intertie", exact: true }).click();
+  const projects = page.getByRole("dialog");
   await expect(
-    facilities.getByRole("heading", { name: "Share power with nearby grids" }),
+    projects.getByRole("heading", { name: "Share power with nearby grids" }),
   ).toBeVisible();
   await expect(
-    facilities.getByRole("heading", { name: "Pacific Northwest", exact: true }),
+    projects.getByRole("heading", { name: "Pacific Northwest", exact: true }),
   ).toBeVisible();
-  await expect(facilities.getByLabel("Trading rule")).toHaveCount(0);
-  await expect(facilities.getByText("Total cost").first()).toBeVisible();
+  await expect(projects.getByLabel("Trading rule")).toHaveCount(0);
+  await expect(projects.getByText("Total cost").first()).toBeVisible();
   await expect(
-    facilities.getByText("Pay $36M now · finance $144M").first(),
+    projects.getByText("Pay $36M now · finance $144M").first(),
   ).toBeVisible();
   if (testInfo.project.name === "mobile-320px") {
-    const firstBuild = facilities
+    const firstBuild = projects
       .getByRole("button", { name: "Approve Pacific Northwest intertie" })
       .first();
     const box = await firstBuild.boundingBox();
     expect(box).not.toBeNull();
-    expect(box!.y + box!.height).toBeLessThanOrEqual(512);
+    await firstBuild.scrollIntoViewIfNeeded();
+    await expect(firstBuild).toBeInViewport();
   }
 
-  await facilities
+  await projects
     .getByRole("button", { name: "Approve Pacific Northwest intertie" })
     .first()
     .click();
-  await expect(facilities.getByText("Your interties")).toBeVisible();
-  await expect(facilities.getByText("Building")).toBeVisible();
-  await expect(facilities.getByLabel("Trading rule")).toContainText(
-    "Buy for shortages, sell extra",
-  );
   await expect(
     page.getByText("Intertie approved — power can flow in 1 year."),
   ).toBeVisible();
+  await expect(
+    facilities.getByText("Interties · Automatic trading"),
+  ).toBeVisible();
+  await expect(facilities.getByText("Building")).toBeVisible();
+  await facilities.locator(".tradingSummary > summary").click();
+  await expect(facilities.getByLabel("Trading rule")).toContainText(
+    "Buy for shortages, sell extra",
+  );
   await expect(facilities.getByText("Northern intertie upgrade")).toHaveCount(
     1,
   );
@@ -88,4 +94,41 @@ test("island grids do not offer interties or power exchange", async ({
   await expect(
     insights.getByRole("heading", { name: "Power exchange" }),
   ).toHaveCount(0);
+});
+
+test("unified facility rows support keyboard inspection and dispatch reordering", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop-chromium");
+  await page.addInitScript(() => window.localStorage.clear());
+  await page.goto("/?scenario=100");
+  await page.getByRole("button", { name: "Start game", exact: true }).click();
+  const facilities = page.locator(".facilities:visible");
+  const rows = facilities.locator(".facilityRow");
+  await expect(rows).toHaveCount(2);
+  const originalFirstId = await rows
+    .first()
+    .getAttribute("data-rfd-draggable-id");
+  await expect(rows.first()).toHaveAttribute("role", "button");
+  await expect(rows.first()).toHaveAttribute("tabindex", "0");
+  await facilities.getByRole("button", { name: "Build", exact: true }).focus();
+  for (let step = 0; step < 12; step++) {
+    await page.keyboard.press("Tab");
+    if (await rows.first().evaluate((row) => row === document.activeElement))
+      break;
+  }
+  await expect(rows.first()).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(rows.first()).toHaveAttribute("aria-expanded", "true");
+  await page.keyboard.press("Enter");
+  await expect(rows.first()).toHaveAttribute("aria-expanded", "false");
+  await page.keyboard.press("Space");
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("Space");
+  await expect(rows.last()).toHaveAttribute(
+    "data-rfd-draggable-id",
+    originalFirstId!,
+  );
+  await expect(rows.last()).toBeFocused();
+  await expect(facilities.locator(".transmissionFleet")).toBeVisible();
 });

--- a/e2e/tutorial-auto-advance.spec.ts
+++ b/e2e/tutorial-auto-advance.spec.ts
@@ -76,7 +76,7 @@ for (const mission of [
           : "bar shows usable stored energy",
       );
     } else if (mission === "Forecasting") {
-      await page.locator(".facilityRow").first().click();
+      await page.locator(".facilityRow .facilityDisclosure").first().click();
       await page
         .getByRole("button", { name: "Pause Coal", exact: true })
         .click();

--- a/e2e/tutorial-auto-advance.spec.ts
+++ b/e2e/tutorial-auto-advance.spec.ts
@@ -48,6 +48,7 @@ for (const mission of [
       .click();
     const hud = page.locator(".tutorialHud");
     if (mission === "Generators" || mission === "Storage") {
+      await page.locator(".button-buildFacility").click();
       await page
         .locator(
           mission === "Generators"

--- a/e2e/tutorial-capstone.spec.ts
+++ b/e2e/tutorial-capstone.spec.ts
@@ -71,7 +71,9 @@ test("guided objective reaches a retryable capstone and succeeds", async ({
   // objective is docked outside the game surface, so the same control remains operable at every
   // viewport without a small-screen workaround.
   const naturalGas = page.locator(".facilityRow", { hasText: "Natural Gas" });
-  await naturalGas.click();
+  await naturalGas
+    .getByRole("button", { name: "Inspect Natural Gas", exact: true })
+    .click();
   await page.getByRole("button", { name: "Pause Natural Gas" }).click();
   await page.getByRole("button", { name: "fast speed" }).click();
   await expect(
@@ -85,9 +87,15 @@ test("guided objective reaches a retryable capstone and succeeds", async ({
   await expect(
     page.getByText("Your turn: keep the lights on for a full day"),
   ).toBeVisible();
+  await page
+    .getByRole("button", { name: "Inspect Natural Gas", exact: true })
+    .click();
   await expect(
     page.getByRole("button", { name: "Pause Natural Gas" }),
   ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Resume Natural Gas", exact: true }),
+  ).toHaveCount(0);
 
   await page.getByRole("button", { name: "fast speed" }).click();
   await expect(

--- a/e2e/tutorial-interties.spec.ts
+++ b/e2e/tutorial-interties.spec.ts
@@ -31,16 +31,16 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
   await page.getByRole("button", { name: "Start Interties" }).click();
 
   await expect(page.getByLabel("Objective 1 of 10")).toBeVisible();
-  await expect(page.locator("#intertiesTab")).toBeVisible();
+  await expect(page.locator(".button-buildFacility")).toBeVisible();
   if (testInfo.project.name.startsWith("mobile-")) {
-    for (const selector of ["#plantsTab", "#intertiesTab"]) {
+    for (const selector of [".button-buildFacility"]) {
       const tabBox = await page.locator(selector).boundingBox();
       expect(tabBox?.height).toBeGreaterThanOrEqual(44);
     }
   }
 
   // Opening the tab completes navigation without a redundant Next click.
-  await page.locator("#intertiesTab").click();
+  await page.locator(".button-buildFacility").click();
   await expect(page.getByLabel("Objective 2 of 10")).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Approve Pacific Northwest intertie" }),
@@ -58,22 +58,24 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
   await page.screenshot({ path: testInfo.outputPath("intertie-approved.png") });
 
   await page.getByRole("button", { name: "fast speed" }).click();
-  await expect(page.getByText(/Trading ·/)).toBeVisible({ timeout: 20000 });
+  await expect(page.getByText("Connected", { exact: true })).toBeVisible({
+    timeout: 20000,
+  });
   // Construction alone is not enough: the objective advances only after this explicit pause.
   await expect(page.getByLabel("Objective 3 of 10")).toBeVisible();
-  await page.getByRole("button", { name: "pause" }).click();
+  await page.getByRole("button", { name: "pause", exact: true }).click();
   await expect(page.getByLabel("Objective 4 of 10")).toBeVisible();
 
   await page.getByLabel("Trading rule").click();
   await page.getByRole("option", { name: "Buy for shortages only" }).click();
   await expect(page.getByLabel("Objective 5 of 10")).toBeVisible();
-  await page.locator("#plantsTab").click();
+  await page.getByRole("button", { name: "Next", exact: true }).click();
   await expect(page.getByLabel("Objective 6 of 10")).toBeVisible();
   await page.getByRole("button", { name: "Pause Natural Gas" }).click();
   await expect(page.getByLabel("Objective 7 of 10")).toBeVisible();
 
   await page.getByRole("button", { name: "fast speed" }).click();
-  await expect(page.getByText(/Trading · Importing/)).toBeVisible({
+  await expect(page.getByText(/Importing /)).toBeVisible({
     timeout: 10000,
   });
   // Wait for a full importing month to settle into history; seeing live flow alone must not
@@ -81,7 +83,7 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
   await expect(page.locator(".gameStatus")).toContainText("Mar 2020", {
     timeout: 20000,
   });
-  await page.getByRole("button", { name: "pause" }).click();
+  await page.getByRole("button", { name: "pause", exact: true }).click();
   await expect(page.getByLabel("Objective 8 of 10")).toBeVisible();
 
   const exchange = page.locator('[data-layer="powerExchange"]');
@@ -115,14 +117,13 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
   await expect(page.getByLabel("Objective 10 of 10")).toBeVisible();
 
   const facilities = page.locator(".facilities:visible");
-  await facilities.getByRole("tab", { name: "Interties" }).click();
   await facilities.getByLabel("Trading rule").click();
   await page.getByRole("option", { name: "No trading" }).click();
   await page.getByRole("button", { name: "fast speed" }).click();
   await expect(page.locator(".gameStatus")).toContainText("Apr 2020", {
     timeout: 15000,
   });
-  await page.getByRole("button", { name: "pause" }).click();
+  await page.getByRole("button", { name: "pause", exact: true }).click();
   await expect(page.getByLabel("Objective 10 of 10")).toBeVisible();
 
   await facilities.getByLabel("Trading rule").click();

--- a/e2e/unified-design.spec.ts
+++ b/e2e/unified-design.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+
+for (const theme of ["light", "dark"]) {
+  test(`unified facilities stay compact and disclose controls in ${theme}`, async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !["desktop-chromium", "mobile-390px", "mobile-320px"].includes(
+        testInfo.project.name,
+      ),
+    );
+    await page.addInitScript((mode) => {
+      localStorage.clear();
+      localStorage.setItem("theme", mode);
+    }, theme);
+    await page.goto("/?scenario=100");
+    await page.getByRole("button", { name: "Start game", exact: true }).click();
+    const pane = page.locator(".facilities:visible");
+    if (!(await pane.isVisible()))
+      await page
+        .getByRole("button", { name: "Facilities", exact: true })
+        .click();
+    const rows = pane.locator(".facilityRow");
+    const chart = pane.locator(".facilitySupplyDisclosure");
+    const phone = testInfo.project.name.startsWith("mobile-");
+    if (phone) {
+      await expect(chart).not.toHaveAttribute("open");
+      await expect(rows.nth(1)).toBeInViewport();
+      await expect(pane.locator(".transmissionFleet")).toBeInViewport();
+      await chart.locator(":scope > summary").click();
+      await expect(chart).toHaveAttribute("open");
+      await expect(pane.locator("#chartSupplyDemand")).toBeVisible();
+      await chart.locator(":scope > summary").click();
+      await expect(chart).not.toHaveAttribute("open");
+    } else await expect(chart).toHaveAttribute("open");
+    const first = rows.first();
+    const disclosure = first.locator(".facilityDisclosure");
+    await expect(first.locator(".facilityActions")).toHaveCount(0);
+    await disclosure.click();
+    await expect(disclosure).toHaveAttribute("aria-expanded", "true");
+    await expect(first.getByRole("button", { name: /^Pause / })).toBeVisible();
+    expect(await disclosure.locator("button").count()).toBe(0);
+    const bounds = await first
+      .getByRole("button", { name: /^Pause / })
+      .boundingBox();
+    expect(bounds!.height).toBeGreaterThanOrEqual(phone ? 44 : 40);
+    await disclosure.click();
+    await expect(first.locator(".facilityActions")).toHaveCount(0);
+    expect(
+      await pane.evaluate((el) => el.scrollWidth - el.clientWidth),
+    ).toBeLessThanOrEqual(1);
+  });
+}

--- a/e2e/wildfire-scenario.spec.ts
+++ b/e2e/wildfire-scenario.spec.ts
@@ -46,7 +46,7 @@ test("wildfire briefing and ongoing emergency stay usable", async ({
   ).toBeVisible({ timeout: 25000 });
   await expect(page.getByText("Wildfire emergency")).toBeVisible();
   await expect(page.getByText("Through Feb 2025")).toBeVisible();
-  await expect(page.getByText(/restoration costs \$1\.5M/)).toBeVisible();
+  await expect(page.getByText(/restoration costs \$0\.7M/)).toBeVisible();
   await expect(page.getByText("Red-flag warning")).toBeVisible();
 
   const horizontalOverflow = await page

--- a/public/legal.css
+++ b/public/legal.css
@@ -5,14 +5,13 @@
   --brand-deep: #064a87;
   --brand-wash: rgba(0, 132, 248, 0.1);
   --page: #f2f7fb;
-  --surface: rgba(255, 255, 255, 0.9);
+  --surface: #ffffff;
   --surface-solid: #ffffff;
   --surface-soft: #eaf3fa;
   --text: #17212b;
   --text-muted: #5b6875;
   --border: rgba(27, 66, 96, 0.14);
-  --shadow:
-    0 22px 55px rgba(33, 77, 111, 0.1), 0 2px 8px rgba(33, 77, 111, 0.05);
+  --shadow: none;
   --max-width: 70rem;
   --reading-width: 45rem;
 }
@@ -24,13 +23,13 @@
     --brand-deep: #b8ddfa;
     --brand-wash: rgba(100, 181, 246, 0.13);
     --page: #0d141a;
-    --surface: rgba(23, 32, 40, 0.92);
+    --surface: #172028;
     --surface-solid: #172028;
     --surface-soft: #111c24;
     --text: #f2f6f9;
     --text-muted: #a9b6c1;
     --border: rgba(179, 211, 235, 0.16);
-    --shadow: 0 24px 60px rgba(0, 0, 0, 0.28), 0 2px 8px rgba(0, 0, 0, 0.2);
+    --shadow: none;
   }
 }
 
@@ -101,8 +100,7 @@ a:hover {
   z-index: 20;
   padding-top: env(safe-area-inset-top);
   border-bottom: 1px solid var(--border);
-  background: color-mix(in srgb, var(--page) 84%, transparent);
-  backdrop-filter: blur(16px);
+  background: var(--page);
 }
 
 .topbar__inner {

--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -285,24 +285,77 @@ export function createAppTheme(mode: ThemeModeType): Theme {
           : { default: "#ffffff", paper: "#ffffff" },
     },
     typography: {
-      fontSize: 15,
-      body1: {
-        lineHeight: 1.35,
+      fontFamily: "Roboto, Arial, sans-serif",
+      fontSize: 14,
+      h6: { fontSize: "1.25rem", fontWeight: 600, lineHeight: 1.3 },
+      subtitle1: { fontSize: "1rem", fontWeight: 600, lineHeight: 1.4 },
+      subtitle2: { fontSize: "1rem", fontWeight: 600, lineHeight: 1.4 },
+      body1: { fontSize: "0.9375rem", lineHeight: 1.45 },
+      body2: { fontSize: "0.875rem", lineHeight: 1.45 },
+      caption: { fontSize: "0.8125rem", lineHeight: 1.4 },
+      overline: {
+        fontSize: "0.8125rem",
+        fontWeight: 600,
+        lineHeight: 1.4,
+        textTransform: "none",
+        letterSpacing: 0,
       },
     },
     shape: {
-      borderRadius: 6,
+      borderRadius: 8,
     },
     components: {
       MuiButton: {
+        defaultProps: { disableElevation: true },
         styleOverrides: {
           root: {
             minHeight: 40,
+            "@media (pointer: coarse)": { minHeight: 44 },
             fontWeight: 600,
             textTransform: "none",
             touchAction: "manipulation",
           },
         },
+      },
+      MuiIconButton: {
+        styleOverrides: {
+          root: {
+            minWidth: 40,
+            minHeight: 40,
+            "@media (pointer: coarse)": { minWidth: 44, minHeight: 44 },
+          },
+        },
+      },
+      MuiInputBase: {
+        styleOverrides: {
+          root: {
+            minHeight: 40,
+            "@media (pointer: coarse)": { minHeight: 44 },
+          },
+        },
+      },
+      MuiDialog: {
+        styleOverrides: {
+          paper: {
+            borderRadius: 8,
+            "@media (max-width:599px)": {
+              margin: 12,
+              width: "calc(100% - 24px)",
+              maxHeight: "calc(100% - 24px)",
+            },
+          },
+          paperFullScreen: {
+            margin: 0,
+            width: "100%",
+            maxHeight: "100%",
+            borderRadius: 0,
+          },
+        },
+      },
+      MuiDialogTitle: { styleOverrides: { root: { padding: 16 } } },
+      MuiDialogContent: { styleOverrides: { root: { padding: 16 } } },
+      MuiDialogActions: {
+        styleOverrides: { root: { padding: 16, gap: 8, flexWrap: "wrap" } },
       },
       MuiButtonBase: {
         defaultProps: {

--- a/src/app.scss
+++ b/src/app.scss
@@ -943,7 +943,7 @@ $pane_header_height: 40px;
 .facilities .paneHeader {
   gap: 8px;
 
-  .button-buildGenerator {
+  .button-buildFacility {
     margin-left: auto;
   }
 }
@@ -4167,5 +4167,97 @@ $sizemap: (
   .manual-link-text,
   .manual-related-link.MuiButton-root {
     min-height: 44px;
+  }
+}
+
+// Plants and interties share one scroll region; only dispatchable rows can move.
+.facilitySectionLabel {
+  display: block;
+  padding: 8px 16px;
+  color: var(--font-color-faded);
+}
+.facilityBuildChoices {
+  display: grid;
+  gap: 12px;
+  padding-top: 8px;
+  .MuiButton-root {
+    min-height: 48px;
+    justify-content: flex-start;
+  }
+}
+.transmissionFleet {
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 12px;
+}
+.tradingSummary {
+  margin: 0 16px 8px;
+  > summary {
+    min-height: 44px;
+    cursor: pointer;
+    padding: 8px 0;
+  }
+  .tradingSummaryRule {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--font-color-faded);
+    padding: 4px 0;
+  }
+  .tradingPolicy {
+    margin: 8px 0;
+  }
+}
+.transmissionLine {
+  border-top: 1px solid var(--border-subtle);
+  > summary {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    min-height: 44px;
+    cursor: pointer;
+    list-style: none;
+  }
+  > summary::-webkit-details-marker {
+    display: none;
+  }
+  > summary::after {
+    content: "+";
+    color: var(--font-color-faded);
+  }
+  &[open] > summary::after {
+    content: "−";
+  }
+  .transmissionLineText {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    gap: 4px;
+  }
+}
+.transmissionLineDetails {
+  padding: 0 16px 16px 68px;
+  display: grid;
+  gap: 8px;
+}
+@media (max-width: 599px) {
+  .transmissionLine > summary {
+    gap: 8px;
+    padding: 12px;
+    flex-wrap: wrap;
+  }
+  .transmissionLine .transmissionLineText {
+    flex-basis: calc(100% - 64px);
+  }
+  .transmissionLine .MuiChip-root {
+    margin-left: 48px;
+  }
+  .transmissionLineDetails {
+    padding: 0 12px 12px;
+  }
+}
+@media (pointer: coarse) {
+  .base_main .facilities .MuiToolbar-root.paneHeader {
+    min-height: 52px !important;
   }
 }

--- a/src/app.scss
+++ b/src/app.scss
@@ -39,7 +39,7 @@
   --capacity-bar: #212121; /* grey900 */
   --shadow-ring: rgba(0, 0, 0, 0.15);
   --tooltip-border: rgba(0, 0, 0, 0.2);
-  --tooltip-bg: rgba(255, 255, 255, 0.96);
+  --tooltip-bg: #ffffff;
   --tooltip-shadow: rgba(15, 23, 42, 0.16);
   --cursor-line: #757575; /* grey600 */
   --chart-surface: #ffffff;
@@ -72,7 +72,7 @@
   --capacity-bar: #e0e0e0;
   --shadow-ring: rgba(0, 0, 0, 0.72);
   --tooltip-border: rgba(148, 163, 184, 0.24);
-  --tooltip-bg: rgba(17, 24, 32, 0.94);
+  --tooltip-bg: #111820;
   --tooltip-shadow: rgba(0, 0, 0, 0.45);
   --cursor-line: rgba(106, 184, 247, 0.55);
   --chart-surface: #0f161f;
@@ -1134,6 +1134,7 @@ $pane_header_height: 40px;
 }
 
 .insightsHeader {
+  --insights-control-size: 40px;
   gap: 8px;
 
   > h6 {
@@ -1153,16 +1154,16 @@ $pane_header_height: 40px;
   .headerControl {
     width: 180px;
     min-width: 112px;
-    height: 36px;
+    height: var(--insights-control-size);
     flex: 0 1 180px;
     margin-left: 0;
   }
 
   .insightsLayerControls {
-    width: 36px;
-    height: 36px;
-    min-width: 36px !important;
-    min-height: 36px !important;
+    width: 64px;
+    height: var(--insights-control-size);
+    min-width: 64px !important;
+    min-height: var(--insights-control-size) !important;
     flex: 0 0 auto;
     color: $interactive_blue;
   }
@@ -1184,10 +1185,10 @@ $pane_header_height: 40px;
 
   .insightsPresetSave,
   .insightsPresetActions {
-    width: 36px;
-    height: 36px;
-    min-width: 36px !important;
-    min-height: 36px !important;
+    width: var(--insights-control-size);
+    height: var(--insights-control-size);
+    min-width: var(--insights-control-size) !important;
+    min-height: var(--insights-control-size) !important;
     flex: 0 0 auto;
     color: $interactive_blue;
   }
@@ -1213,7 +1214,7 @@ $pane_header_height: 40px;
   flex: 0 0 auto;
   padding: 1px 5px;
   border-radius: 999px;
-  font-size: 0.65rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   line-height: 1.45;
 }
@@ -1367,7 +1368,7 @@ $pane_header_height: 40px;
 .insightEventRailLabel {
   flex: 0 0 auto;
   color: $font_color_faded;
-  font-size: 0.72rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   letter-spacing: 0.02em;
   text-transform: uppercase;
@@ -1425,7 +1426,7 @@ $pane_header_height: 40px;
   border-radius: 50%;
   background: $interactive_blue;
   color: white;
-  font-size: 0.68rem;
+  font-size: 0.8125rem;
   font-weight: 800;
 }
 
@@ -1490,10 +1491,9 @@ $pane_header_height: 40px;
 
 @media screen and (max-width: 700px) {
   .base_main .MuiToolbar-root.insightsHeader {
-    // Toolbar min-height is content height; the 8px padding is added around it. Match the
-    // 36px controls instead of accidentally adding another 16px of empty height.
-    min-height: 36px !important;
-    padding: 8px !important;
+    // Match the shared touch target size without adding an empty band around the controls.
+    min-height: var(--insights-control-size) !important;
+    padding: 4px 8px !important;
   }
 
   .insightsHeader > h6 {
@@ -1502,7 +1502,7 @@ $pane_header_height: 40px;
 
   .insightsHeaderControls {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 36px;
+    grid-template-columns: minmax(0, 1fr) 64px;
     width: 100%;
     gap: 4px;
     margin-left: 0;
@@ -1527,8 +1527,8 @@ $pane_header_height: 40px;
     }
 
     .insightsLayerControls {
-      width: 36px;
-      height: 36px;
+      width: 64px;
+      height: var(--insights-control-size);
     }
   }
 
@@ -1672,7 +1672,7 @@ $pane_header_height: 40px;
 
     .insightsRateMetricLabel {
       color: var(--text-secondary);
-      font-size: 0.6rem;
+      font-size: 0.8125rem;
       line-height: 1.15;
       text-transform: uppercase;
       letter-spacing: 0.02em;
@@ -1706,7 +1706,7 @@ $pane_header_height: 40px;
 
     .insightsRateMarkMobile {
       display: inline;
-      font-size: 0.65rem;
+      font-size: 0.8125rem;
       white-space: nowrap;
     }
   }
@@ -1981,7 +1981,7 @@ $pane_header_height: 40px;
   line-height: 1.45;
   white-space: pre;
   pointer-events: none;
-  backdrop-filter: blur(10px);
+  backdrop-filter: none;
 }
 
 // The canvas is transparent, so one quiet surface behind it frames the axes and plot together.
@@ -2170,7 +2170,7 @@ html[data-theme="dark"] .uplot {
     min-width: 0;
     flex: 1;
     padding: 5px 6px;
-    font-size: 0.72rem;
+    font-size: 0.8125rem;
     line-height: 1.25;
   }
 
@@ -3107,7 +3107,7 @@ html[data-theme="dark"] .uplot {
   .tutorialSpotlightEyebrow {
     margin-bottom: 2px;
     color: $interactive_blue;
-    font-size: 0.7rem;
+    font-size: 0.8125rem;
     font-weight: 700;
     letter-spacing: 0.055em;
     text-transform: uppercase;
@@ -3242,7 +3242,7 @@ html[data-theme="dark"] .uplot {
     .missionThemeTag {
       height: 20px;
       color: $font_color_faded;
-      font-size: 0.68rem;
+      font-size: 0.8125rem;
 
       .MuiChip-label {
         padding: 0 7px;
@@ -3380,7 +3380,7 @@ html[data-theme="dark"] .uplot {
     }
 
     .MuiSlider-markLabel {
-      font-size: 0.7rem;
+      font-size: 0.8125rem;
     }
   }
 
@@ -3459,7 +3459,7 @@ html[data-theme="dark"] .uplot {
     background: var(--bg-sunken);
 
     .eventLogItem {
-      border-style: dashed;
+      border-style: solid;
       border-left: 4px solid $interactive_blue;
       background: var(--bg-primary);
 
@@ -3744,7 +3744,7 @@ html[data-theme="dark"] .uplot {
   background: var(--tooltip-bg);
   box-shadow: 0 3px 12px var(--tooltip-shadow);
   color: $font_color_primary;
-  backdrop-filter: blur(10px);
+  backdrop-filter: none;
 }
 
 .tutorialHudHeader {
@@ -4259,5 +4259,500 @@ $sizemap: (
 @media (pointer: coarse) {
   .base_main .facilities .MuiToolbar-root.paneHeader {
     min-height: 52px !important;
+  }
+}
+
+// A shared solid, restrained presentation for the game and its standalone screens.
+.facilitySupplyDisclosure {
+  flex: 0 0 auto;
+  > summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 44px;
+    padding: 0 16px;
+    cursor: pointer;
+    list-style: none;
+    border-bottom: 1px solid var(--border-subtle);
+    font-weight: 600;
+  }
+  > summary::-webkit-details-marker {
+    display: none;
+  }
+  &[open] > summary > svg {
+    transform: rotate(180deg);
+  }
+}
+@media (min-width: 600px) {
+  .facilitySupplyDisclosure > summary {
+    display: none;
+  }
+}
+.facilities .tradingSummary {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-primary);
+}
+.facilities .facilitySectionLabel {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 16px 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--font-color-primary);
+}
+.facilitySectionLabel > span {
+  font-size: 0.8125rem;
+  font-weight: 400;
+  color: var(--font-color-faded);
+}
+.facilityRowHeader {
+  display: flex;
+  align-items: center;
+}
+.facilityDisclosure {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  min-height: 64px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  &:hover {
+    background: var(--bg-raised);
+  }
+  &[aria-expanded="true"] .facilityChevron {
+    transform: rotate(180deg);
+  }
+  .facilityChevron {
+    flex-shrink: 0;
+    width: 20px;
+    color: var(--font-color-faded);
+  }
+}
+.base_main .facilityDisclosure .facility {
+  width: 100%;
+  padding: 12px 16px;
+  gap: 8px;
+}
+.facilityDisclosure .MuiListItemAvatar-root {
+  min-width: 48px;
+}
+.facilityDisclosure .MuiListItemText-root {
+  margin: 0;
+  min-width: 0;
+}
+.facilityDisclosure .MuiListItemText-primary {
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+.facilityDisclosure .MuiListItemText-secondary {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+.base_main .facilityActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  padding: 0 16px 8px;
+  opacity: 1;
+  visibility: visible;
+}
+.base_main .facilityDragHandle {
+  margin: 4px 16px;
+}
+.base_main .facilityDetails {
+  padding: 8px 16px 16px;
+}
+.transmissionFleet {
+  margin-top: 0;
+}
+.transmissionLine > .facilityDisclosure {
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-subtle);
+}
+.transmissionLine .transmissionListIcon {
+  margin-right: 8px;
+}
+.transmissionLine .transmissionLineText > span:first-child {
+  font-size: 1rem;
+  font-weight: 600;
+}
+.transmissionLine .MuiChip-root {
+  margin: 0;
+}
+.transmissionLine .transmissionLineDetails {
+  padding: 0 16px 16px;
+}
+.transmissionPanel {
+  padding: 0;
+  background: transparent;
+}
+.transmissionMetrics {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+.transmissionProject {
+  padding: 16px;
+  border-radius: 8px;
+}
+.transmissionIntro h6 {
+  font-size: 1rem;
+}
+.base_main #menuCard #logo {
+  margin-top: auto;
+  padding-top: 32px;
+}
+.base_main #menuCard #centeredMenu {
+  flex: 0 0 auto;
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+.base_main #menuCard .mainMenuFooter {
+  margin-top: auto;
+}
+.screenCatalog > .cardList,
+.screenCatalog > .constructionHeader,
+.screenCatalog > .MuiToolbar-root,
+.screenCatalog > .generatorComparison,
+.screenCatalog > .buildOptionHelp {
+  width: 100%;
+  max-width: 1040px;
+  margin-left: auto;
+  margin-right: auto;
+  box-sizing: border-box;
+}
+.screenManual > .cardList,
+.screenManual > .MuiToolbar-root {
+  width: 100%;
+  max-width: 880px;
+  margin-left: auto;
+  margin-right: auto;
+  box-sizing: border-box;
+}
+.screenCustom > .MuiToolbar-root {
+  width: 100%;
+  max-width: 992px;
+  margin-left: auto;
+  margin-right: auto;
+  box-sizing: border-box;
+}
+.base_main .manual-entry,
+.base_main .buildOption {
+  box-shadow: none;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+}
+.base_main .manual-group,
+.base_main .tutorialSpotlightEyebrow,
+.base_main .missionSectionHeader {
+  text-transform: none;
+  letter-spacing: 0;
+}
+.base_main .customSetupColumns {
+  box-sizing: border-box;
+  padding: 0 16px;
+  gap: 16px;
+}
+.base_main .customSetupSectionHeading {
+  padding: 8px 0;
+}
+.base_main .customSetupOutlook {
+  margin-left: 0;
+  margin-right: 0;
+  border-radius: 8px;
+}
+.base_main .customSetupSettings #gameSetupTable {
+  width: 100%;
+  margin: 0;
+}
+.base_main .customSetupSettings #gameSetupTable td {
+  padding: 8px 0;
+}
+.base_main .customSetupSettings #gameSetupTable td + td {
+  padding-left: 12px;
+}
+.base_main .customFacilityPicker {
+  padding: 8px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.base_main .customFacilityPicker .MuiInputBase-root {
+  flex: 1 1 120px;
+}
+.base_main .customFacilityPicker .MuiSelect-select {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+.decisionImpact {
+  padding: 16px;
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.decisionImpact > h3 {
+  margin-bottom: 8px;
+}
+.decisionImpactFacts {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+.decisionImpactFact {
+  padding: 12px 0;
+  border: 0;
+  border-top: 1px solid var(--border-subtle);
+  border-radius: 0;
+  background: transparent;
+  gap: 12px;
+}
+.decisionImpactFact > div {
+  display: grid;
+  grid-template-columns: minmax(100px, 0.7fr) minmax(0, 1.3fr);
+  gap: 4px 12px;
+}
+.decisionImpactFact
+  > div
+  > .MuiTypography-caption:last-child:not(:first-child) {
+  grid-column: 2;
+}
+.MuiDialog-paper .noPadding > .decisionImpact {
+  margin: 0;
+}
+.buildOption .MuiCardHeader-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+.buildOption .MuiCardHeader-root {
+  padding: 16px;
+}
+.buildOption .buildOptionMetrics {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+.buildOption .buildOptionFooter {
+  padding: 8px 16px 12px;
+}
+.forecastScope > summary {
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+}
+.forecastScope > summary::before {
+  content: "›";
+  margin-right: 8px;
+}
+.forecastScope[open] > summary::before {
+  transform: rotate(90deg);
+}
+.insights .insightsLevers {
+  padding: 0 16px 12px;
+}
+.insights .insightsTrackHeader {
+  padding: 0 16px;
+}
+.insights .insightsTrackHeader > h6 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+.insights .insightsTrackActions .MuiIconButton-root {
+  color: var(--font-color-faded);
+}
+.insights .insightsRateMetricLabel,
+.insights .insightsRateMarkMobile,
+.insightsPresetMenuHint,
+.insightsPresetCustomized {
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.insights .insightsRateMetricValue {
+  font-size: 0.9375rem;
+}
+.customerProgramChoice {
+  border-bottom: 1px solid var(--border-subtle);
+}
+.customerProgramChoiceButton.MuiButton-root {
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 0;
+  color: var(--font-color-primary);
+}
+.customerProgramChoiceButton > span:first-child {
+  display: grid;
+  gap: 8px;
+}
+.customerProgramChoiceButton > span:last-child {
+  font-size: 24px;
+  color: var(--interactive-blue);
+}
+.base_main .eventLogItem {
+  border-style: solid;
+  border-radius: 8px;
+}
+.tutorialHud {
+  padding: calc(8px + env(safe-area-inset-top)) 16px 8px;
+  background: var(--bg-primary);
+  box-shadow: none;
+  backdrop-filter: none;
+}
+.tutorialHudContent {
+  margin-top: 4px;
+}
+.tutorialHudFooter {
+  gap: 4px;
+}
+.missionSummary {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+@media (max-width: 599px) {
+  .decisionImpactFact > div {
+    grid-template-columns: 1fr;
+  }
+  .decisionImpactFact
+    > div
+    > .MuiTypography-caption:last-child:not(:first-child) {
+    grid-column: 1;
+  }
+  .transmissionLine > .facilityDisclosure {
+    flex-wrap: wrap;
+  }
+  .transmissionLine .transmissionLineText {
+    flex-basis: calc(100% - 80px);
+  }
+  .transmissionLine .MuiChip-root {
+    margin-left: 56px;
+  }
+  .transmissionLine .facilityChevron {
+    margin-left: auto;
+  }
+  .insights .insightsRateMetric {
+    padding: 0 8px;
+  }
+  .insights .insightsRateMetrics {
+    padding: 0;
+  }
+}
+@media (max-width: 359px) {
+  .MuiDialogActions-root {
+    align-items: stretch;
+  }
+  .MuiDialogActions-root > .MuiButton-root {
+    flex: 1 1 100%;
+    margin: 0;
+  }
+  .facilitySectionLabel {
+    flex-wrap: wrap;
+  }
+}
+
+// Final alignment corrections: target the standalone screens' nested header toolbars.
+.screenCatalog > #topbar > .MuiToolbar-root,
+.screenManual > #topbar > .MuiToolbar-root,
+.screenCustom > #topbar > .MuiToolbar-root {
+  box-sizing: border-box;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+.screenCatalog > #topbar > .MuiToolbar-root {
+  max-width: 1040px;
+}
+.screenManual > #topbar > .MuiToolbar-root {
+  max-width: 880px;
+}
+.screenCustom > #topbar > .MuiToolbar-root {
+  max-width: 992px;
+}
+.base_main #manual .manual-group {
+  text-transform: none;
+  letter-spacing: 0;
+}
+.base_main .manual-entry .MuiAccordionSummary-content > .MuiTypography-root {
+  font-size: 1rem;
+  font-weight: 600;
+}
+.facilities .tradingSummary > summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 64px;
+  padding: 8px 0;
+  list-style: none;
+}
+.facilities .tradingSummary > summary::-webkit-details-marker {
+  display: none;
+}
+.facilities .tradingSummary .networkTradingCopy {
+  flex: 1;
+  min-width: 0;
+}
+.facilities .tradingSummary .networkTradingHeading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 4px 12px;
+  flex-wrap: wrap;
+}
+.networkTradingHeading > strong {
+  font-size: 1rem;
+  font-weight: 600;
+}
+.networkTradingFlow {
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+.facilities .tradingSummary .tradingSummaryRule {
+  padding: 4px 0 0;
+  font-size: 0.8125rem;
+}
+.facilities .tradingSummary .facilityChevron {
+  flex: 0 0 20px;
+  width: 20px;
+  color: var(--font-color-faded);
+}
+.facilities .tradingSummary[open] .facilityChevron {
+  transform: rotate(180deg);
+}
+.transmissionLine > .facilityDisclosure {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) 20px;
+  align-items: center;
+  gap: 8px;
+}
+.transmissionLine .transmissionLineText {
+  min-width: 0;
+}
+.transmissionLine .transmissionLineText > .MuiTypography-body2 {
+  font-size: 0.8125rem;
+}
+.transmissionLine .facilityChevron {
+  margin-left: 0;
+}
+
+@media (pointer: coarse) {
+  .insightsHeader {
+    --insights-control-size: 44px;
   }
 }

--- a/src/components/base/ChartFinances.tsx
+++ b/src/components/base/ChartFinances.tsx
@@ -22,6 +22,7 @@ export interface Props {
   height?: number;
   id?: string;
   title: string;
+  hideTitle?: boolean;
   timeline: ChartData[];
   format: (n: number) => number | string;
   /**
@@ -174,7 +175,7 @@ const ChartFinances = (props: Props): React.JSX.Element => {
 
   const state: State = {
     timeline: props.timeline,
-    title: props.title,
+    title: props.hideTitle ? "" : props.title,
     format: props.format,
     range: [rangeMin, rangeMax],
     domain: padRange(domainMin, domainMax),

--- a/src/components/base/DecisionImpactPreview.tsx
+++ b/src/components/base/DecisionImpactPreview.tsx
@@ -19,7 +19,7 @@ export default function DecisionImpactPreview({
 }: DecisionImpactPreviewProps): React.JSX.Element {
   return (
     <section className="decisionImpact" aria-label="Expected impact">
-      <Typography variant="overline" component="h3">
+      <Typography variant="subtitle2" component="h3">
         What changes
       </Typography>
       <div className="decisionImpactFacts">

--- a/src/components/base/ForecastScope.tsx
+++ b/src/components/base/ForecastScope.tsx
@@ -3,10 +3,20 @@ import { Box, Typography } from "@mui/material";
 /** Keep model limits beside the results, with details available when needed. */
 export default function ForecastScope() {
   return (
-    <Box component="details" sx={{ mx: 2, my: 1, color: "text.secondary" }}>
+    <Box
+      component="details"
+      className="forecastScope"
+      sx={{ mx: 2, my: 0, color: "text.secondary" }}
+    >
       <Box
         component="summary"
-        sx={{ cursor: "pointer", minHeight: 44, py: 1, fontSize: "0.875rem" }}
+        sx={{
+          cursor: "pointer",
+          minHeight: 44,
+          py: 1,
+          boxSizing: "border-box",
+          fontSize: "0.875rem",
+        }}
       >
         Estimates · one representative day per month
       </Box>

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -154,7 +154,7 @@ export function GeneratorBuildItem(
   const compareAction = props.onCompare && canBuild && (
     <Button
       size="small"
-      variant={props.compared ? "contained" : "outlined"}
+      variant={props.compared ? "contained" : "text"}
       aria-pressed={props.compared}
       aria-label={`Compare ${generator.name}`}
       disabled={props.compareDisabled && !props.compared}
@@ -182,7 +182,7 @@ export function GeneratorBuildItem(
             <Button
               className="buy-button"
               size="small"
-              variant="contained"
+              variant="outlined"
               color="primary"
               onClick={toggleOpen}
               disabled={!canBuild}
@@ -590,7 +590,7 @@ export function GeneratorBuildItem(
           </Button>
           <Button
             color="primary"
-            variant="contained"
+            variant="outlined"
             onClick={(e: React.MouseEvent<HTMLElement>) =>
               submitPurchase(true, e)
             }
@@ -790,7 +790,7 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
   return (
     <div
       id="topbar"
-      className="flexContainer"
+      className="flexContainer screenCatalog"
       ref={evidenceAnchor}
       tabIndex={-1}
       aria-label="Generator build options"

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -117,7 +117,7 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
             <Button
               aria-label={`Review purchase of ${storage.name}`}
               size="small"
-              variant="contained"
+              variant="outlined"
               color="primary"
               onClick={toggleOpen}
               disabled={downpayment > cash || !buildable}
@@ -378,7 +378,7 @@ function StorageBuildItem(props: StorageBuildItemProps): React.JSX.Element {
           </Button>
           <Button
             color="primary"
-            variant="contained"
+            variant="outlined"
             onClick={(e: React.MouseEvent<HTMLElement>) =>
               submitPurchase(true, e)
             }
@@ -449,7 +449,7 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
   );
 
   return (
-    <div id="topbar" className="flexContainer">
+    <div id="topbar" className="flexContainer screenCatalog">
       <ConstructionBuildHeader
         concept="storage"
         title="Build Storage"

--- a/src/components/views/CustomGame.tsx
+++ b/src/components/views/CustomGame.tsx
@@ -453,7 +453,7 @@ export default function CustomGame(props: Props): React.JSX.Element {
   };
 
   return (
-    <div id="listCard" className="flexContainer">
+    <div id="listCard" className="flexContainer screenCustom">
       <div id="topbar">
         <Toolbar>
           <IconButton

--- a/src/components/views/CustomerPrograms.tsx
+++ b/src/components/views/CustomerPrograms.tsx
@@ -180,8 +180,12 @@ function Decision({
         {!selected ? (
           <Box sx={{ display: "grid", gap: 2 }}>
             {POLICY_IDS.map((id) => (
-              <Box key={id}>
+              <Box key={id} className="customerProgramChoice">
                 <Button
+                  className="customerProgramChoiceButton"
+                  aria-label={`${POLICIES[id].name} · ${programLabel(id, programs[id].tier)}`}
+                  aria-describedby={`program-description-${id}`}
+                  fullWidth
                   sx={{ minHeight: 44, textAlign: "left" }}
                   onClick={() => {
                     setSelected(id);
@@ -196,9 +200,22 @@ function Decision({
                     setLater(false);
                   }}
                 >
-                  {POLICIES[id].name} · {programLabel(id, programs[id].tier)}
+                  <span>
+                    <strong>
+                      {POLICIES[id].name} ·{" "}
+                      {programLabel(id, programs[id].tier)}
+                    </strong>
+                    <Typography
+                      id={`program-description-${id}`}
+                      component="span"
+                      variant="body2"
+                      color="textSecondary"
+                    >
+                      {POLICIES[id].description}
+                    </Typography>
+                  </span>
+                  <span aria-hidden>›</span>
                 </Button>
-                <Typography>{POLICIES[id].description}</Typography>
                 {programs[id].pending && (
                   <Typography variant="body2">
                     {programLabel(id, programs[id].pending!.tier)} starts{" "}

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -9,6 +9,7 @@ import uiReducer from "../../reducers/UI";
 import { createGame } from "../../testing/Simulator";
 import { FacilityOperatingType, GameType } from "../../Types";
 import Facilities from "./Facilities";
+import { TRANSMISSION_CORRIDORS } from "../../data/AdjacentMarkets";
 
 // The pane renders its own supply chart, which jsdom never lays out; nothing here waits on
 // anything, so a ceiling this high is a hang detector rather than something a loaded machine trips
@@ -327,7 +328,9 @@ describe("the interties view", () => {
   it("explains and offers California connection projects", async () => {
     const game = playedGame(0);
     renderFacilities(game, null);
-    await user.click(screen.getByRole("tab", { name: "Interties" }));
+    await user.click(screen.getByRole("button", { name: "Build" }));
+    if (screen.queryByRole("button", { name: "Intertie" }))
+      await user.click(screen.getByRole("button", { name: "Intertie" }));
     expect(
       screen.getByText("Share power with nearby grids"),
     ).toBeInTheDocument();
@@ -351,17 +354,16 @@ describe("the interties view", () => {
     }
   });
 
-  it("gives Mission 7 stable Plants and Interties tabs", () => {
+  it("shows one list and one build action in Mission 7", () => {
     renderFacilities(createGame({ scenarioId: 112 }), null);
-
-    expect(screen.getByRole("tab", { name: "Plants" })).toHaveAttribute(
-      "id",
-      "plantsTab",
-    );
-    expect(screen.getByRole("tab", { name: "Interties" })).toHaveAttribute(
-      "id",
-      "intertiesTab",
-    );
+    expect(screen.queryByRole("tablist")).toBeNull();
+    expect(screen.getByRole("button", { name: "Build" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Plants & storage · Dispatch order"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Interties · Automatic trading"),
+    ).toBeInTheDocument();
   });
 
   it("does not render an empty interties destination where no corridor exists", () => {
@@ -378,7 +380,9 @@ describe("the interties view", () => {
     game.location = { ...game.location, id: "Dublin", name: "Dublin" };
     renderFacilities(game, null);
 
-    await user.click(screen.getByRole("tab", { name: "Interties" }));
+    await user.click(screen.getByRole("button", { name: "Build" }));
+    if (screen.queryByRole("button", { name: "Intertie" }))
+      await user.click(screen.getByRole("button", { name: "Intertie" }));
 
     expect(screen.getByText("Great Britain")).toBeInTheDocument();
     expect(screen.getByText("Continental Europe")).toBeInTheDocument();
@@ -386,7 +390,9 @@ describe("the interties view", () => {
 
   it("gives the guided northern approval a stable target and specific name", async () => {
     renderFacilities(createGame({ scenarioId: 112 }), null);
-    await user.click(screen.getByRole("tab", { name: "Interties" }));
+    await user.click(screen.getByRole("button", { name: "Build" }));
+    if (screen.queryByRole("button", { name: "Intertie" }))
+      await user.click(screen.getByRole("button", { name: "Intertie" }));
 
     const approval = screen.getByRole("button", {
       name: "Approve Pacific Northwest intertie",
@@ -396,5 +402,60 @@ describe("the interties view", () => {
       screen.getByTestId("transmission-project-california-north"),
     ).toHaveAttribute("data-corridor-id", "california-north");
     expect(screen.queryByText("Desert Southwest")).toBeNull();
+  });
+});
+
+describe("unified connections", () => {
+  function connectedGame(): GameType {
+    const game = playedGame(0);
+    game.transmission!.lines = TRANSMISSION_CORRIDORS.filter((corridor) =>
+      corridor.id.startsWith("california-"),
+    ).map((corridor, i) => ({
+      id: i + 1,
+      corridorId: corridor.id,
+      name: corridor.name,
+      capacityW: corridor.capacityW,
+      buildCost: corridor.buildCost,
+      annualOperatingCost: corridor.annualOperatingCost,
+      yearsToBuildLeft: i,
+      minuteCreated: game.date.minute,
+      financed: true,
+      loanAmountLeft: 1000,
+      loanMonthlyPayment: 10,
+      interestRate: game.interestRate,
+    }));
+    return game;
+  }
+
+  it("keeps connections outside dispatch and reports network flow only once", async () => {
+    const game = connectedGame();
+    renderFacilities(game, null);
+    expect(rows()).toHaveLength(game.facilities.length);
+    // These assertions inspect the drag-library boundary, which has no accessible role.
+    /* eslint-disable testing-library/no-node-access */
+    const connections = document.querySelectorAll(".transmissionLine");
+    expect(connections).toHaveLength(2);
+    expect(document.querySelectorAll(".tradingSummary")).toHaveLength(1);
+    expect(connections[0].querySelector("[data-rfd-draggable-id]")).toBeNull();
+    /* eslint-enable testing-library/no-node-access */
+    expect(connections[0]).toHaveTextContent("Connected");
+    expect(connections[1]).toHaveTextContent("Building");
+    await user.click(screen.getByText(game.transmission!.lines[0].name));
+    expect(connections[0]).toHaveAttribute("open");
+    expect(connections[0]).toHaveTextContent("Loan balance");
+  });
+
+  it("permits inspecting replay connections but disables trading and building", async () => {
+    const game = connectedGame();
+    game.replayPlayback = {
+      actions: [],
+      index: 0,
+    } as GameType["replayPlayback"];
+    renderFacilities(game, null);
+    expect(screen.queryByRole("button", { name: "Build" })).toBeNull();
+    await user.click(screen.getByText("No power flowing"));
+    expect(
+      screen.getByRole("combobox", { name: "Trading rule" }),
+    ).toHaveAttribute("aria-disabled", "true");
   });
 });

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -54,26 +54,32 @@ function renderFacilities(
     onSell: jest.fn(),
   };
   const store = configureStore({ reducer: { ui: uiReducer } });
-  render(
-    <Facilities
-      game={game}
-      selectedFacilityId={selectedFacilityId}
-      onGeneratorBuild={() => undefined}
-      onStorageBuild={() => undefined}
-      onTransmissionBuild={() => undefined}
-      onTradingPolicy={() => undefined}
-      onSell={handlers.onSell}
-      onTogglePause={() => undefined}
-      onPause={handlers.onPause}
-      onReprioritize={handlers.onReprioritize}
-      onFacilityDragStart={() => undefined}
-      onFacilityDragEnd={() => undefined}
-      onSelect={handlers.onSelect}
-    />,
-    {
-      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-    },
-  );
+  function ControlledFacilities() {
+    const [selected, setSelected] = React.useState(selectedFacilityId);
+    return (
+      <Facilities
+        game={game}
+        selectedFacilityId={selected}
+        onGeneratorBuild={() => undefined}
+        onStorageBuild={() => undefined}
+        onTransmissionBuild={() => undefined}
+        onTradingPolicy={() => undefined}
+        onSell={handlers.onSell}
+        onTogglePause={() => undefined}
+        onPause={handlers.onPause}
+        onReprioritize={handlers.onReprioritize}
+        onFacilityDragStart={() => undefined}
+        onFacilityDragEnd={() => undefined}
+        onSelect={(id) => {
+          handlers.onSelect(id);
+          setSelected(id);
+        }}
+      />
+    );
+  }
+  render(<ControlledFacilities />, {
+    wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+  });
   return handlers;
 }
 
@@ -81,7 +87,9 @@ function renderFacilities(
 // rather than by a role -- and asking testing-library for a role by name computes an accessible
 // name for every candidate, which over a rendered pane costs about a second a call
 function rows(): HTMLElement[] {
-  return Array.from(document.querySelectorAll<HTMLElement>(".facilityRow"));
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(".facilityRow .facilityDisclosure"),
+  );
 }
 
 describe("the fleet list", () => {
@@ -194,13 +202,18 @@ describe("the fleet list", () => {
    * once the list has scrolled.
    */
   it("reorders from the row's own arrows", async () => {
-    const { onReprioritize } = renderFacilities(game, null);
+    const { onReprioritize } = renderFacilities(game, game.facilities[1].id);
     await user.click(
       screen.getByLabelText(
         `Move ${game.facilities[1].name} earlier in the dispatch order`,
       ),
     );
     expect(onReprioritize).toHaveBeenCalledWith(1, -1);
+    await user.click(
+      screen.getByRole("button", {
+        name: `Inspect ${game.facilities[0].name}`,
+      }),
+    );
 
     await user.click(
       screen.getByLabelText(
@@ -210,14 +223,19 @@ describe("the fleet list", () => {
     expect(onReprioritize).toHaveBeenCalledWith(0, 1);
   });
 
-  it("offers no way to move the ends of the list past themselves", () => {
-    renderFacilities(game, null);
+  it("offers no way to move the ends of the list past themselves", async () => {
+    renderFacilities(game, game.facilities[0].id);
     const last = game.facilities.length - 1;
     expect(
       screen.getByLabelText(
         `Move ${game.facilities[0].name} earlier in the dispatch order`,
       ),
     ).toBeDisabled();
+    await user.click(
+      screen.getByRole("button", {
+        name: `Inspect ${game.facilities[last].name}`,
+      }),
+    );
     expect(
       screen.getByLabelText(
         `Move ${game.facilities[last].name} later in the dispatch order`,
@@ -226,7 +244,7 @@ describe("the fleet list", () => {
   });
 
   it("does not select the row when a row action is used", async () => {
-    const { onSelect } = renderFacilities(game, null);
+    const { onSelect } = renderFacilities(game, game.facilities[1].id);
     await user.click(
       screen.getByLabelText(
         `Move ${game.facilities[1].name} earlier in the dispatch order`,
@@ -294,6 +312,9 @@ describe("the fleet list", () => {
     const onePlant = createGame({ scenarioId: 5 });
     const { onPause } = renderFacilities(onePlant, null);
     const facility = onePlant.facilities[0];
+    await user.click(
+      screen.getByRole("button", { name: `Inspect ${facility.name}` }),
+    );
 
     await user.click(screen.getByLabelText(`Pause ${facility.name}`));
     expect(onPause).toHaveBeenCalledWith(facility.id, facility.name);
@@ -301,7 +322,7 @@ describe("the fleet list", () => {
 
   it("can sell the only facility left in a fleet", async () => {
     const onePlant = createGame({ scenarioId: 5 });
-    const { onSell } = renderFacilities(onePlant, null);
+    const { onSell } = renderFacilities(onePlant, onePlant.facilities[0].id);
     const facility = onePlant.facilities[0];
 
     await user.click(screen.getByLabelText(`Sell ${facility.name}`));
@@ -358,12 +379,8 @@ describe("the interties view", () => {
     renderFacilities(createGame({ scenarioId: 112 }), null);
     expect(screen.queryByRole("tablist")).toBeNull();
     expect(screen.getByRole("button", { name: "Build" })).toBeInTheDocument();
-    expect(
-      screen.getByText("Plants & storage · Dispatch order"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Interties · Automatic trading"),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Plants & storage/)).toBeInTheDocument();
+    expect(screen.getByText(/Interties/)).toBeInTheDocument();
   });
 
   it("does not render an empty interties destination where no corridor exists", () => {
@@ -441,7 +458,11 @@ describe("unified connections", () => {
     expect(connections[0]).toHaveTextContent("Connected");
     expect(connections[1]).toHaveTextContent("Building");
     await user.click(screen.getByText(game.transmission!.lines[0].name));
-    expect(connections[0]).toHaveAttribute("open");
+    expect(
+      screen.getByRole("button", {
+        name: `Inspect ${game.transmission!.lines[0].name}`,
+      }),
+    ).toHaveAttribute("aria-expanded", "true");
     expect(connections[0]).toHaveTextContent("Loan balance");
   });
 

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -8,13 +8,13 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  IconButton,
   List,
   ListItem,
   ListItemAvatar,
   ListItemText,
   Toolbar,
   Typography,
+  useMediaQuery,
 } from "@mui/material";
 import CancelIcon from "@mui/icons-material/Cancel";
 import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
@@ -54,7 +54,10 @@ import FacilityDetails from "../base/FacilityDetails";
 import GameCard from "../base/GameCard";
 import ConceptIcon from "../base/ConceptIcon";
 import { combineStoryEffects } from "../../data/WorldEvents";
-import TransmissionPanel from "./TransmissionPanel";
+import TransmissionPanel, {
+  TransmissionTradingSummary,
+} from "./TransmissionPanel";
+import { getScenario } from "../../data/Scenarios";
 import { TradingPolicyType } from "../../Types";
 import { corridorsForLocation } from "../../data/AdjacentMarkets";
 
@@ -158,84 +161,64 @@ function FacilityActions(props: {
     readOnly,
     spotInList,
   } = props;
+  if (readOnly) return null;
   const underConstruction = facility.yearsToBuildLeft > 0;
   return (
-    <span className="facilityActions">
-      {!readOnly && listLength > 1 && (
+    <div className="facilityActions">
+      {!underConstruction && (
+        <Button
+          startIcon={
+            <ConceptIcon concept={facility.paused ? "play" : "pause"} />
+          }
+          aria-label={
+            facility.paused
+              ? "Resume " + facility.name
+              : "Pause " + facility.name
+          }
+          onClick={() =>
+            facility.paused
+              ? onTogglePause(facility.id)
+              : onPause(facility.id, facility.name)
+          }
+        >
+          {facility.paused ? "Resume" : "Pause"}
+        </Button>
+      )}
+      <Button
+        startIcon={underConstruction ? <CancelIcon /> : <DeleteForeverIcon />}
+        aria-label={
+          (underConstruction ? "Cancel construction of " : "Sell ") +
+          facility.name
+        }
+        onClick={onOpenSell}
+      >
+        {underConstruction ? "Cancel construction" : "Sell"}
+      </Button>
+      {listLength > 1 && (
         <>
-          <IconButton
-            onClick={(e) => {
-              e.stopPropagation();
-              onReprioritize(spotInList, -1);
-            }}
-            aria-label={`Move ${facility.name} earlier in the dispatch order`}
-            className="facilityReorderButton"
+          <Button
+            startIcon={<KeyboardArrowUpIcon />}
+            aria-label={
+              "Move " + facility.name + " earlier in the dispatch order"
+            }
             disabled={spotInList === 0}
-            edge="end"
-            color="primary"
-            size="small"
+            onClick={() => onReprioritize(spotInList, -1)}
           >
-            <KeyboardArrowUpIcon />
-          </IconButton>
-          <IconButton
-            onClick={(e) => {
-              e.stopPropagation();
-              onReprioritize(spotInList, 1);
-            }}
-            aria-label={`Move ${facility.name} later in the dispatch order`}
-            className="facilityReorderButton"
+            Move up
+          </Button>
+          <Button
+            startIcon={<KeyboardArrowDownIcon />}
+            aria-label={
+              "Move " + facility.name + " later in the dispatch order"
+            }
             disabled={spotInList === listLength - 1}
-            edge="end"
-            color="primary"
-            size="small"
+            onClick={() => onReprioritize(spotInList, 1)}
           >
-            <KeyboardArrowDownIcon />
-          </IconButton>
+            Move down
+          </Button>
         </>
       )}
-      {!readOnly && !underConstruction && !facility.paused && (
-        <IconButton
-          onClick={(e) => {
-            e.stopPropagation();
-            onPause(facility.id, facility.name);
-          }}
-          aria-label={`Pause ${facility.name}`}
-          edge="end"
-          color="primary"
-          size="small"
-        >
-          <ConceptIcon concept="pause" />
-        </IconButton>
-      )}
-      {!readOnly && facility.paused && (
-        <IconButton
-          onClick={(e) => {
-            e.stopPropagation();
-            onTogglePause(facility.id);
-          }}
-          aria-label={`Resume ${facility.name}`}
-          edge="end"
-          color="primary"
-          size="small"
-        >
-          <ConceptIcon concept="play" />
-        </IconButton>
-      )}
-      {!readOnly && (
-        <IconButton
-          onClick={(e) => {
-            e.stopPropagation();
-            onOpenSell();
-          }}
-          aria-label={`${underConstruction ? "Cancel construction of" : "Sell"} ${facility.name}`}
-          edge="end"
-          color="primary"
-          size="small"
-        >
-          {underConstruction ? <CancelIcon /> : <DeleteForeverIcon />}
-        </IconButton>
-      )}
-    </span>
+    </div>
   );
 }
 
@@ -328,168 +311,178 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
       draggableId={"f" + facility.id}
       index={props.spotInList}
       isDragDisabled={readOnly}
+      disableInteractiveElementBlocking
     >
       {(provided, snapshot) => (
-        // Selecting is on the row rather than on a control inside it: the icon buttons were
-        // the only thing a click did anything to, which is the opposite of what a list of
-        // rows leads a mouse to expect. dragHandleProps already makes this focusable and
-        // announces it as a button, so only a read-only row - which gets none of them - has
-        // to say so itself. dnd owns Space (lift) and the arrows (move), leaving Enter free
         <div
           ref={provided.innerRef}
           {...provided.draggableProps}
-          {...provided.dragHandleProps}
           className={selected ? "facilityRow selected" : "facilityRow"}
           data-fuel={fuel}
-          role={provided.dragHandleProps?.role ?? "button"}
-          tabIndex={provided.dragHandleProps?.tabIndex ?? 0}
-          aria-label={`Inspect ${facility.name}`}
-          aria-expanded={selected}
-          onClick={() => onSelect(selected ? null : facility.id)}
-          onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
-            if (e.target !== e.currentTarget) return;
-            if (e.key === "Enter" || (readOnly && e.key === " ")) {
-              e.preventDefault();
-              onSelect(selected ? null : facility.id);
-            }
-          }}
           style={getDraggableStyle(
             snapshot.isDragging,
             provided.draggableProps.style,
           )}
         >
-          {/* v9 dropped ListItem's `disabled` prop; it only ever dimmed the row, which is
+          <div className="facilityRowHeader">
+            <button
+              type="button"
+              className="facilityDisclosure"
+              aria-label={"Inspect " + facility.name}
+              aria-expanded={selected}
+              onClick={() => onSelect(selected ? null : facility.id)}
+            >
+              {/* v9 dropped ListItem's `disabled` prop; it only ever dimmed the row, which is
               all under-construction facilities need here. */}
-          <ListItem
-            className="facility"
-            sx={
-              underConstruction
-                ? { opacity: (theme) => theme.palette.action.disabledOpacity }
-                : undefined
-            }
-            secondaryAction={
-              <MemoizedFacilityActions
-                facility={facility}
-                listLength={props.listLength}
-                readOnly={readOnly}
-                spotInList={spotInList}
-                onPause={onPause}
-                onReprioritize={onReprioritize}
-                onTogglePause={onTogglePause}
-                onOpenSell={toggleDialog}
-              />
-            }
-          >
-            {!readOnly && (
-              <DragIndicatorIcon
-                className="draggable-indicator"
-                color="primary"
-              />
-            )}
-            {/* Tinted by fuel so the list reads as the same dispatch stack the supply-by-fuel
-                chart draws, and transitioned in CSS so ramping is visible as movement */}
-            {!underConstruction && (
-              <div
-                className="outputProgressBar"
-                style={{
-                  transform: `scaleX(${outputFraction})`,
-                  background: withAlpha(accentColor, 0.18),
-                }}
-              />
-            )}
-            <ListItemAvatar>
-              <div>
-                <Avatar
-                  className={facility.currentWh === 0 ? "offline" : ""}
-                  alt={facility.name}
-                  src={`/images/${facilityIconName(facility)}.svg`}
-                />
-                {facility.peakWh > 0 && !underConstruction && (
-                  <div className="capacityProgressBar">
-                    <div
-                      className="capacityProgressBarFill"
-                      style={{
-                        transform: `scaleY(${facility.currentWh / facility.peakWh})`,
-                        backgroundColor:
-                          activity === "CHARGING"
-                            ? chartPalette().storage
-                            : undefined,
-                      }}
-                    />
-                  </div>
-                )}
-                <div
-                  className="facilityActivity"
-                  role="img"
-                  aria-label={`${facility.name} ${ACTIVITY_LABELS[activity]}`}
-                >
-                  {activityIcon(activity, accentColor)}
-                </div>
-              </div>
-            </ListItemAvatar>
-            <ListItemText
-              primary={
-                <>
-                  {facility.name}
-                  {storyOutputMultiplier < 1 && (
-                    <Chip
-                      className="storyDerateBadge"
-                      color="warning"
-                      size="small"
-                      label={`Limited to ${Math.round(storyOutputMultiplier * 100)}%`}
-                      aria-label={`Temporarily limited to ${Math.round(storyOutputMultiplier * 100)}% of rated output`}
-                    />
-                  )}
-                </>
-              }
-              secondary={secondaryText}
-            />
-            {open && (
-              // Inside the row, so without this every click in the confirmation dialog also
-              // lands on the row behind it and toggles the selection
-              <Dialog
-                open
-                onClose={toggleDialog}
-                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+              <ListItem
+                className="facility"
+                sx={
+                  underConstruction
+                    ? {
+                        opacity: (theme) =>
+                          theme.palette.action.disabledOpacity,
+                      }
+                    : undefined
+                }
+                component="span"
               >
-                <DialogTitle>
-                  {underConstruction ? "Cancel construction of" : "Sell"}{" "}
-                  {facility.peakWh
-                    ? formatWattHours(facility.peakWh)
-                    : formatWatts(facility.peakW)}{" "}
-                  {facility.name.toLowerCase()} facility?
-                </DialogTitle>
-                <DialogContent>
-                  <DialogContentText>
-                    You will receive{" "}
-                    {formatMoneyConcise(
-                      facilityCashBack(facility, game.date.minute),
-                    )}
-                    {facility.loanAmountLeft > 0
-                      ? ` and the rest will go towards paying off the remaining loan balance of ${formatMoneyConcise(facility.loanAmountLeft)}`
-                      : ""}
-                    .
-                  </DialogContentText>
-                </DialogContent>
-                <DialogActions>
-                  <Button onClick={toggleDialog} color="primary">
-                    Nevermind
-                  </Button>
-                  <Button
-                    onClick={() => {
-                      props.onSell(facility.id);
-                      toggleDialog();
+                {/* Tinted by fuel so the list reads as the same dispatch stack the supply-by-fuel
+                chart draws, and transitioned in CSS so ramping is visible as movement */}
+                {!underConstruction && (
+                  <div
+                    className="outputProgressBar"
+                    style={{
+                      transform: `scaleX(${outputFraction})`,
+                      background: withAlpha(accentColor, 0.18),
                     }}
-                    color="primary"
-                    variant="contained"
-                    autoFocus
-                  >
-                    {underConstruction ? "Cancel construction" : "Sell"}
-                  </Button>
-                </DialogActions>
-              </Dialog>
-            )}
-          </ListItem>
+                  />
+                )}
+                <ListItemAvatar>
+                  <div>
+                    <Avatar
+                      className={facility.currentWh === 0 ? "offline" : ""}
+                      alt={facility.name}
+                      src={`/images/${facilityIconName(facility)}.svg`}
+                    />
+                    {facility.peakWh > 0 && !underConstruction && (
+                      <div className="capacityProgressBar">
+                        <div
+                          className="capacityProgressBarFill"
+                          style={{
+                            transform: `scaleY(${facility.currentWh / facility.peakWh})`,
+                            backgroundColor:
+                              activity === "CHARGING"
+                                ? chartPalette().storage
+                                : undefined,
+                          }}
+                        />
+                      </div>
+                    )}
+                    <div
+                      className="facilityActivity"
+                      role="img"
+                      aria-label={`${facility.name} ${ACTIVITY_LABELS[activity]}`}
+                    >
+                      {activityIcon(activity, accentColor)}
+                    </div>
+                  </div>
+                </ListItemAvatar>
+                <ListItemText
+                  slotProps={{
+                    primary: { component: "span" },
+                    secondary: { component: "span" },
+                  }}
+                  primary={
+                    <>
+                      {facility.name}
+                      {storyOutputMultiplier < 1 && (
+                        <Chip
+                          className="storyDerateBadge"
+                          color="warning"
+                          size="small"
+                          label={`Limited to ${Math.round(storyOutputMultiplier * 100)}%`}
+                          aria-label={`Temporarily limited to ${Math.round(storyOutputMultiplier * 100)}% of rated output`}
+                        />
+                      )}
+                    </>
+                  }
+                  secondary={`${secondaryText} · ${ACTIVITY_LABELS[activity]}`}
+                />
+                <KeyboardArrowDownIcon
+                  className="facilityChevron"
+                  aria-hidden
+                />
+              </ListItem>
+            </button>
+          </div>
+          {open && (
+            // Inside the row, so without this every click in the confirmation dialog also
+            // lands on the row behind it and toggles the selection
+            <Dialog
+              open
+              onClose={toggleDialog}
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            >
+              <DialogTitle>
+                {underConstruction ? "Cancel construction of" : "Sell"}{" "}
+                {facility.peakWh
+                  ? formatWattHours(facility.peakWh)
+                  : formatWatts(facility.peakW)}{" "}
+                {facility.name.toLowerCase()} facility?
+              </DialogTitle>
+              <DialogContent>
+                <DialogContentText>
+                  You will receive{" "}
+                  {formatMoneyConcise(
+                    facilityCashBack(facility, game.date.minute),
+                  )}
+                  {facility.loanAmountLeft > 0
+                    ? ` and the rest will go towards paying off the remaining loan balance of ${formatMoneyConcise(facility.loanAmountLeft)}`
+                    : ""}
+                  .
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={toggleDialog} color="primary">
+                  Nevermind
+                </Button>
+                <Button
+                  onClick={() => {
+                    props.onSell(facility.id);
+                    toggleDialog();
+                  }}
+                  color="primary"
+                  variant="contained"
+                  autoFocus
+                >
+                  {underConstruction ? "Cancel construction" : "Sell"}
+                </Button>
+              </DialogActions>
+            </Dialog>
+          )}
+          {!readOnly && (
+            <Button
+              style={{ display: selected ? undefined : "none" }}
+              {...provided.dragHandleProps}
+              className="facilityDragHandle"
+              aria-label={"Reorder " + facility.name}
+              startIcon={<DragIndicatorIcon />}
+            >
+              Drag to reorder
+            </Button>
+          )}
+          {selected && (
+            <MemoizedFacilityActions
+              facility={facility}
+              listLength={props.listLength}
+              readOnly={readOnly}
+              spotInList={spotInList}
+              onPause={onPause}
+              onReprioritize={onReprioritize}
+              onTogglePause={onTogglePause}
+              onOpenSell={toggleDialog}
+            />
+          )}
           {selected && (
             <FacilityDetails
               facility={facility}
@@ -501,6 +494,54 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
         </div>
       )}
     </Draggable>
+  );
+}
+
+function FacilitySupplyChart({
+  game,
+  forceOpen,
+  anchor,
+}: {
+  game: GameType;
+  forceOpen: boolean;
+  anchor: React.RefObject<HTMLDivElement>;
+}) {
+  const phone = useMediaQuery("(max-width:599px)");
+  const [expanded, setExpanded] = React.useState(false);
+  React.useEffect(() => {
+    if (forceOpen) setExpanded(true);
+  }, [forceOpen]);
+  const open = !phone || expanded || forceOpen;
+  return (
+    <details className="facilitySupplyDisclosure" open={open}>
+      <summary
+        onClick={(event) => {
+          event.preventDefault();
+          setExpanded(!open);
+        }}
+      >
+        Supply & demand <KeyboardArrowDownIcon aria-hidden />
+      </summary>
+      <div
+        ref={anchor}
+        tabIndex={-1}
+        className="operatingEvidence"
+        aria-label="Supply and demand evidence: this month's representative day"
+      >
+        <div className="operatingSampleLabel">
+          This month's representative day · Supply — solid · Demand – – dashed ·
+          W
+        </div>
+        <ChartSupplyDemand
+          height={180}
+          timeline={game.timeline}
+          currentMinute={game.date.minute}
+          location={game.location}
+          legend
+          startingYear={game.startingYear}
+        />
+      </div>
+    </details>
   );
 }
 
@@ -539,11 +580,15 @@ export interface Props extends StateProps, DispatchProps {}
 
 export default class Facilities extends React.Component<
   Props,
-  { buildOpen: boolean; buildInterties: boolean }
+  { buildOpen: boolean; buildInterties: boolean; revealChart: boolean }
 > {
   constructor(props: Props) {
     super(props);
-    this.state = { buildOpen: false, buildInterties: false };
+    this.state = {
+      buildOpen: false,
+      buildInterties: false,
+      revealChart: false,
+    };
     this.onBeforeDragStart = this.onBeforeDragStart.bind(this);
     this.onDragEnd = this.onDragEnd.bind(this);
   }
@@ -560,7 +605,11 @@ export default class Facilities extends React.Component<
   // refreshes/sec. Intermediate simulation ticks still run; the pane simply presents the newest.
   public shouldComponentUpdate(
     nextProps: Props,
-    nextState: Readonly<{ buildOpen: boolean; buildInterties: boolean }>,
+    nextState: Readonly<{
+      buildOpen: boolean;
+      buildInterties: boolean;
+      revealChart: boolean;
+    }>,
   ) {
     if (this.dragging) {
       return false;
@@ -583,6 +632,12 @@ export default class Facilities extends React.Component<
   }
 
   public componentDidUpdate(previousProps: Props) {
+    if (
+      !this.props.evidenceRequest &&
+      previousProps.evidenceRequest &&
+      this.state.revealChart
+    )
+      this.setState({ revealChart: false });
     this.resolveEvidence();
     this.throttle.rendered(this.props.game.date.minute);
     if (
@@ -613,6 +668,10 @@ export default class Facilities extends React.Component<
       )
     )
       return;
+    if (!this.state.revealChart) {
+      this.setState({ revealChart: true });
+      return;
+    }
     this.props.onEvidenceReady?.(request, this.evidenceAnchor.current);
   }
 
@@ -686,25 +745,21 @@ export default class Facilities extends React.Component<
             )}
           </Toolbar>
           <>
-            <div
-              ref={this.evidenceAnchor}
-              tabIndex={-1}
-              className="operatingEvidence"
-              aria-label="Supply and demand evidence: this month's representative day"
-            >
-              <div className="operatingSampleLabel">
-                This month's representative day · Supply — solid · Demand – –
-                dashed · W
-              </div>
-              <ChartSupplyDemand
-                height={180}
-                timeline={game.timeline}
-                currentMinute={game.date.minute}
-                location={game.location}
-                legend
-                startingYear={game.startingYear}
+            <FacilitySupplyChart
+              game={game}
+              anchor={this.evidenceAnchor}
+              forceOpen={
+                this.state.revealChart ||
+                getScenario(game.scenarioId)?.tutorialSteps?.[game.tutorialStep]
+                  ?.target === "#chartSupplyDemand"
+              }
+            />
+            {intertiesAvailable && (
+              <TransmissionTradingSummary
+                game={game}
+                onPolicy={onTradingPolicy}
               />
-            </div>
+            )}
             <List dense className="scrollable unifiedFacilitiesList">
               {intertiesAvailable && (
                 <Typography
@@ -712,7 +767,7 @@ export default class Facilities extends React.Component<
                   className="facilitySectionLabel"
                   variant="overline"
                 >
-                  Plants & storage · Dispatch order
+                  Plants & storage <span>Dispatch order</span>
                 </Typography>
               )}
               <DragDropContext
@@ -733,7 +788,15 @@ export default class Facilities extends React.Component<
                             onPause={onPause}
                             onReprioritize={onReprioritize}
                             onSelect={onSelect}
-                            selected={selectedFacilityId === g.id}
+                            selected={
+                              (game.scenarioId === 5 &&
+                                [0, 4].includes(game.tutorialStep)) ||
+                              selectedFacilityId === g.id ||
+                              (game.scenarioId === 112 &&
+                                game.tutorialStep === 5 &&
+                                "fuel" in g &&
+                                g.fuel === "Natural Gas")
+                            }
                             storyOutputMultiplier={storyOutputMultiplierForFacility(
                               g,
                               storyEffects,

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -14,8 +14,6 @@ import {
   ListItemAvatar,
   ListItemText,
   Toolbar,
-  Tab,
-  Tabs,
   Typography,
 } from "@mui/material";
 import CancelIcon from "@mui/icons-material/Cancel";
@@ -343,12 +341,14 @@ function FacilityListItem(props: FacilityListItemProps): React.JSX.Element {
           {...provided.dragHandleProps}
           className={selected ? "facilityRow selected" : "facilityRow"}
           data-fuel={fuel}
-          role={provided.dragHandleProps ? undefined : "button"}
-          tabIndex={provided.dragHandleProps ? undefined : 0}
+          role={provided.dragHandleProps?.role ?? "button"}
+          tabIndex={provided.dragHandleProps?.tabIndex ?? 0}
+          aria-label={`Inspect ${facility.name}`}
           aria-expanded={selected}
           onClick={() => onSelect(selected ? null : facility.id)}
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
-            if (e.key === "Enter") {
+            if (e.target !== e.currentTarget) return;
+            if (e.key === "Enter" || (readOnly && e.key === " ")) {
               e.preventDefault();
               onSelect(selected ? null : facility.id);
             }
@@ -539,11 +539,11 @@ export interface Props extends StateProps, DispatchProps {}
 
 export default class Facilities extends React.Component<
   Props,
-  { view: "PLANTS" | "INTERTIES" }
+  { buildOpen: boolean; buildInterties: boolean }
 > {
   constructor(props: Props) {
     super(props);
-    this.state = { view: "PLANTS" };
+    this.state = { buildOpen: false, buildInterties: false };
     this.onBeforeDragStart = this.onBeforeDragStart.bind(this);
     this.onDragEnd = this.onDragEnd.bind(this);
   }
@@ -560,7 +560,7 @@ export default class Facilities extends React.Component<
   // refreshes/sec. Intermediate simulation ticks still run; the pane simply presents the newest.
   public shouldComponentUpdate(
     nextProps: Props,
-    nextState: Readonly<{ view: "PLANTS" | "INTERTIES" }>,
+    nextState: Readonly<{ buildOpen: boolean; buildInterties: boolean }>,
   ) {
     if (this.dragging) {
       return false;
@@ -588,13 +588,10 @@ export default class Facilities extends React.Component<
     if (
       this.props.game.scenarioId === 112 &&
       this.props.game.tutorialStep !== previousProps.game.tutorialStep &&
-      [1, 6].includes(this.props.game.tutorialStep) &&
-      this.state.view !== "INTERTIES"
+      this.props.game.tutorialStep === 1 &&
+      !this.props.game.transmission?.lines.length
     ) {
-      // If Next was tapped before opening the first tab, reveal the gated approval instead of
-      // stranding it off-screen. The same transition brings the live flow label into view after
-      // Natural Gas is paused, so "Importing" is something the learner can actually observe.
-      this.setState({ view: "INTERTIES" });
+      this.setState({ buildOpen: true, buildInterties: true });
     }
   }
 
@@ -616,10 +613,6 @@ export default class Facilities extends React.Component<
       )
     )
       return;
-    if (this.state.view !== "PLANTS") {
-      this.setState({ view: "PLANTS" });
-      return;
-    }
     this.props.onEvidenceReady?.(request, this.evidenceAnchor.current);
   }
 
@@ -657,7 +650,6 @@ export default class Facilities extends React.Component<
     const intertiesAvailable = !!(
       game.transmission && corridorsForLocation(game.location).length
     );
-    const activeView = intertiesAvailable ? this.state.view : "PLANTS";
     const storyEffects = combineStoryEffects(
       game.worldEvents.active.filter(
         (event) =>
@@ -673,118 +665,182 @@ export default class Facilities extends React.Component<
             other panes' headers and the build buttons stay put as the fleet scrolls */}
           <Toolbar className="paneHeader">
             <Typography variant="h6">Facilities</Typography>
-            {!readOnly && activeView === "PLANTS" && (
-              <>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  color="primary"
-                  onClick={onGeneratorBuild}
-                  className="button-buildGenerator"
-                  startIcon={
-                    <ConceptIcon concept="generator" fontSize="small" />
-                  }
-                >
-                  Generator
-                </Button>
-                <Button
-                  size="small"
-                  variant="outlined"
-                  color="primary"
-                  onClick={onStorageBuild}
-                  className="button-buildStorage"
-                  startIcon={<ConceptIcon concept="storage" fontSize="small" />}
-                >
-                  Storage
-                </Button>
-              </>
+            {!readOnly && (
+              <Button
+                variant="contained"
+                color="primary"
+                className="button-buildFacility"
+                startIcon={<ConceptIcon concept="build" fontSize="small" />}
+                onClick={() =>
+                  this.setState({
+                    buildOpen: true,
+                    buildInterties:
+                      game.scenarioId === 112 &&
+                      game.tutorialStep <= 1 &&
+                      !game.transmission?.lines.length,
+                  })
+                }
+              >
+                Build
+              </Button>
             )}
           </Toolbar>
-          {intertiesAvailable && (
-            <Tabs
-              value={activeView}
-              onChange={(_event, view) => this.setState({ view })}
-              aria-label="Facility type"
-              className="facilityTabs"
-              variant="fullWidth"
+          <>
+            <div
+              ref={this.evidenceAnchor}
+              tabIndex={-1}
+              className="operatingEvidence"
+              aria-label="Supply and demand evidence: this month's representative day"
             >
-              <Tab id="plantsTab" value="PLANTS" label="Plants" />
-              <Tab id="intertiesTab" value="INTERTIES" label="Interties" />
-            </Tabs>
-          )}
-          {activeView === "PLANTS" ? (
-            <>
-              <div
-                ref={this.evidenceAnchor}
-                tabIndex={-1}
-                className="operatingEvidence"
-                aria-label="Supply and demand evidence: this month's representative day"
-              >
-                <div className="operatingSampleLabel">
-                  This month's representative day · Supply — solid · Demand – –
-                  dashed · W
-                </div>
-                <ChartSupplyDemand
-                  height={180}
-                  timeline={game.timeline}
-                  currentMinute={game.date.minute}
-                  location={game.location}
-                  legend
-                  startingYear={game.startingYear}
-                />
+              <div className="operatingSampleLabel">
+                This month's representative day · Supply — solid · Demand – –
+                dashed · W
               </div>
-              <List dense className="scrollable">
-                <DragDropContext
-                  onBeforeDragStart={this.onBeforeDragStart}
-                  onDragEnd={this.onDragEnd}
+              <ChartSupplyDemand
+                height={180}
+                timeline={game.timeline}
+                currentMinute={game.date.minute}
+                location={game.location}
+                legend
+                startingYear={game.startingYear}
+              />
+            </div>
+            <List dense className="scrollable unifiedFacilitiesList">
+              {intertiesAvailable && (
+                <Typography
+                  id="dispatch-order"
+                  className="facilitySectionLabel"
+                  variant="overline"
                 >
-                  <Droppable droppableId="droppable">
-                    {(provided) => (
-                      <div {...provided.droppableProps} ref={provided.innerRef}>
-                        {game.facilities.map(
-                          (g: FacilityOperatingType, i: number) => (
-                            <FacilityListItem
-                              facility={g}
-                              game={game}
-                              key={g.id}
-                              onSell={onSell}
-                              onTogglePause={onTogglePause}
-                              onPause={onPause}
-                              onReprioritize={onReprioritize}
-                              onSelect={onSelect}
-                              selected={selectedFacilityId === g.id}
-                              storyOutputMultiplier={storyOutputMultiplierForFacility(
-                                g,
-                                storyEffects,
-                              )}
-                              spotInList={i}
-                              listLength={facilitiesCount}
-                              readOnly={readOnly}
-                            />
-                          ),
-                        )}
-                        {provided.placeholder}
-                      </div>
+                  Plants & storage · Dispatch order
+                </Typography>
+              )}
+              <DragDropContext
+                onBeforeDragStart={this.onBeforeDragStart}
+                onDragEnd={this.onDragEnd}
+              >
+                <Droppable droppableId="droppable">
+                  {(provided) => (
+                    <div {...provided.droppableProps} ref={provided.innerRef}>
+                      {game.facilities.map(
+                        (g: FacilityOperatingType, i: number) => (
+                          <FacilityListItem
+                            facility={g}
+                            game={game}
+                            key={g.id}
+                            onSell={onSell}
+                            onTogglePause={onTogglePause}
+                            onPause={onPause}
+                            onReprioritize={onReprioritize}
+                            onSelect={onSelect}
+                            selected={selectedFacilityId === g.id}
+                            storyOutputMultiplier={storyOutputMultiplierForFacility(
+                              g,
+                              storyEffects,
+                            )}
+                            spotInList={i}
+                            listLength={facilitiesCount}
+                            readOnly={readOnly}
+                          />
+                        ),
+                      )}
+                      {provided.placeholder}
+                    </div>
+                  )}
+                </Droppable>
+              </DragDropContext>
+              {facilitiesCount < 2 && !readOnly && (
+                <Typography
+                  color="textSecondary"
+                  variant="body2"
+                  style={{ textAlign: "center", marginTop: "12px" }}
+                >
+                  Choose Build to add a generator or storage.
+                </Typography>
+              )}
+              {intertiesAvailable && (
+                <TransmissionPanel
+                  game={game}
+                  onBuild={onTransmissionBuild}
+                  onPolicy={onTradingPolicy}
+                />
+              )}
+            </List>
+          </>
+          {!readOnly && this.state.buildOpen && (
+            <Dialog
+              open
+              onClose={() => this.setState({ buildOpen: false })}
+              fullWidth
+              maxWidth="sm"
+            >
+              <DialogTitle>
+                {this.state.buildInterties
+                  ? "Build an intertie"
+                  : "Build a facility"}
+              </DialogTitle>
+              <DialogContent>
+                {this.state.buildInterties ? (
+                  <TransmissionPanel
+                    game={game}
+                    projectsOnly
+                    onPolicy={onTradingPolicy}
+                    onBuild={(id, financed) => {
+                      onTransmissionBuild(id, financed);
+                      this.setState({ buildOpen: false });
+                    }}
+                  />
+                ) : (
+                  <div className="facilityBuildChoices">
+                    <Button
+                      className="button-buildGenerator"
+                      variant="outlined"
+                      startIcon={<ConceptIcon concept="generator" />}
+                      onClick={onGeneratorBuild}
+                    >
+                      Generator
+                    </Button>
+                    <Button
+                      className="button-buildStorage"
+                      variant="outlined"
+                      startIcon={<ConceptIcon concept="storage" />}
+                      onClick={onStorageBuild}
+                    >
+                      Storage
+                    </Button>
+                    {intertiesAvailable && (
+                      <Button
+                        className="button-buildIntertie"
+                        variant="outlined"
+                        startIcon={
+                          <img
+                            src="/images/transmission.svg"
+                            width="24"
+                            height="24"
+                            alt=""
+                          />
+                        }
+                        onClick={() => this.setState({ buildInterties: true })}
+                      >
+                        Intertie
+                      </Button>
                     )}
-                  </Droppable>
-                </DragDropContext>
-                {facilitiesCount < 2 && !readOnly && (
-                  <Typography
-                    color="textSecondary"
-                    variant="body2"
-                    style={{ textAlign: "center", marginTop: "12px" }}
-                  >
-                    (click "Generator" or "Storage" to build more)
-                  </Typography>
+                  </div>
                 )}
-              </List>
-            </>
-          ) : (
-            <TransmissionPanel
-              game={game}
-              onBuild={onTransmissionBuild}
-              onPolicy={onTradingPolicy}
-            />
+              </DialogContent>
+              <DialogActions>
+                {this.state.buildInterties && (
+                  <Button
+                    onClick={() => this.setState({ buildInterties: false })}
+                  >
+                    Back
+                  </Button>
+                )}
+                <Button onClick={() => this.setState({ buildOpen: false })}>
+                  Close
+                </Button>
+              </DialogActions>
+            </Dialog>
           )}
         </>
       </GameCard>

--- a/src/components/views/Insights.test.tsx
+++ b/src/components/views/Insights.test.tsx
@@ -30,6 +30,8 @@ jest.mock("../base/GameCard", () => ({
 }));
 
 interface ChartMockProps {
+  title?: string;
+  hideTitle?: boolean;
   id?: string;
   syncKey?: string;
   timeline?: unknown[];
@@ -105,11 +107,19 @@ it("refreshes paused projections when a customer program is scheduled, replaced,
 
 jest.mock("../base/ChartFinances", () => ({
   __esModule: true,
-  default: ({ id, syncKey, timeline, domain }: ChartMockProps) => (
+  default: ({
+    id,
+    syncKey,
+    timeline,
+    domain,
+    title,
+    hideTitle,
+  }: ChartMockProps) => (
     <div
       role="img"
       id={id}
       data-testid={id}
+      data-visible-title={hideTitle ? "" : title}
       data-sync-key={syncKey}
       data-points={timeline?.length}
       data-domain={domainValue(domain)}
@@ -401,10 +411,10 @@ describe("Insights layers", () => {
     );
     expect(
       screen.getByTestId("chartInsightsInflationInterestPlotinflationRate"),
-    ).toBeInTheDocument();
+    ).toHaveAttribute("data-visible-title", "Inflation");
     expect(
       screen.getByTestId("chartInsightsInflationInterestPlotinterestRate"),
-    ).toBeInTheDocument();
+    ).toHaveAttribute("data-visible-title", "Interest rate");
   });
 
   it("starts new players on the five-chart overview in priority order", () => {

--- a/src/components/views/Insights.tsx
+++ b/src/components/views/Insights.tsx
@@ -33,7 +33,6 @@ import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import CloseIcon from "@mui/icons-material/Close";
 import AddIcon from "@mui/icons-material/Add";
-import LayersIcon from "@mui/icons-material/Layers";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import FitScreenIcon from "@mui/icons-material/FitScreen";
 import SaveIcon from "@mui/icons-material/Save";
@@ -1758,6 +1757,7 @@ export default class Insights extends React.Component<Props, State> {
       body = (
         <>
           <ChartFinances
+            hideTitle
             id={chartId}
             height={140}
             timeline={financeSeries(
@@ -2436,19 +2436,23 @@ export default class Insights extends React.Component<Props, State> {
                 </Tooltip>
               </div>
               <Tooltip title={`Choose layers (${visible.length} shown)`}>
-                <IconButton
+                <Button
                   id="insightsLayersButton"
                   className="insightsLayerControls"
                   size="small"
                   onClick={() =>
                     this.setState({ layersOpen: !this.state.layersOpen })
                   }
-                  aria-label={`Layers (${visible.length} shown)`}
+                  aria-label={
+                    this.state.layersOpen
+                      ? "Done choosing layers"
+                      : `Layers (${visible.length} shown)`
+                  }
                   aria-expanded={this.state.layersOpen}
                   aria-controls="insightsLayerPanel"
                 >
-                  <LayersIcon fontSize="small" />
-                </IconButton>
+                  {this.state.layersOpen ? "Done" : "Layers"}
+                </Button>
               </Tooltip>
             </div>
             <Menu

--- a/src/components/views/Manual.tsx
+++ b/src/components/views/Manual.tsx
@@ -295,7 +295,7 @@ export default function Manual(props: Props): React.JSX.Element {
   const pinned = matches.filter((entry: ManualEntryType) => entry.pinned);
 
   return (
-    <div className="flexContainer" id="gameCard">
+    <div className="flexContainer screenManual" id="gameCard">
       <div id="topbar">
         <Toolbar>
           <IconButton

--- a/src/components/views/NewGame.tsx
+++ b/src/components/views/NewGame.tsx
@@ -315,7 +315,7 @@ export default function NewGame(props: Props): React.JSX.Element {
   )!.label;
 
   return (
-    <div id="listCard" className="flexContainer">
+    <div id="listCard" className="flexContainer screenCatalog">
       <div id="topbar">
         <Toolbar>
           <IconButton

--- a/src/components/views/TransmissionPanel.tsx
+++ b/src/components/views/TransmissionPanel.tsx
@@ -1,6 +1,7 @@
 import ManualLink from "../base/ManualLink";
 import { MANUAL_ENTRY } from "../../data/Manual";
 import * as React from "react";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import {
   Button,
   Chip,
@@ -37,13 +38,75 @@ export interface TransmissionPanelProps {
   onPolicy: (policy: TradingPolicyType) => void;
 }
 
+export function TransmissionTradingSummary({
+  game,
+  onPolicy,
+}: Pick<TransmissionPanelProps, "game" | "onPolicy">) {
+  const state = game.transmission;
+  const now = getTimeFromTimeline(game.date.minute, game.timeline);
+  const readOnly = !!game.replayPlayback;
+  if (!state?.lines.length) return null;
+  return (
+    <details
+      className="tradingSummary"
+      open={
+        game.scenarioId === 112 && [3, 9].includes(game.tutorialStep)
+          ? true
+          : undefined
+      }
+    >
+      <summary>
+        <span className="networkTradingCopy">
+          <span className="networkTradingHeading">
+            <strong>Network trading</strong>
+            <span className="networkTradingFlow">
+              {(now?.importedW || 0) > 0
+                ? "Importing " + formatWatts(now!.importedW || 0)
+                : (now?.exportedW || 0) > 0
+                  ? "Exporting " + formatWatts(now!.exportedW || 0)
+                  : "No power flowing"}
+            </span>
+          </span>
+          <span className="tradingSummaryRule">
+            {POLICY_LABELS[state.tradingPolicy]}
+          </span>
+        </span>
+        <KeyboardArrowDownIcon className="facilityChevron" aria-hidden />
+      </summary>
+      <FormControl fullWidth size="small" className="tradingPolicy">
+        <InputLabel id="trading-policy-label">Trading rule</InputLabel>
+        <Select
+          labelId="trading-policy-label"
+          label="Trading rule"
+          value={state.tradingPolicy}
+          disabled={readOnly}
+          onChange={(event) =>
+            onPolicy(event.target.value as TradingPolicyType)
+          }
+        >
+          {Object.entries(POLICY_LABELS).map(([value, label]) => (
+            <MenuItem key={value} value={value}>
+              {label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <Typography variant="caption" color="textSecondary">
+        One rule for all connections. Imports depend on line capacity and
+        neighboring supply.
+      </Typography>
+      <ManualLink entry={MANUAL_ENTRY.INTERTIES} text="How interties work" />
+    </details>
+  );
+}
+
 export default function TransmissionPanel({
   game,
   onBuild,
-  onPolicy,
   projectsOnly = false,
 }: TransmissionPanelProps) {
   const units = useUnits();
+  const [selectedLine, setSelectedLine] = React.useState<number | null>(null);
   const state = game.transmission ?? { tradingPolicy: "BALANCED", lines: [] };
   const availableCorridors = corridorsForLocation(game.location);
   const now = getTimeFromTimeline(game.date.minute, game.timeline);
@@ -87,9 +150,9 @@ export default function TransmissionPanel({
           <Typography
             id="your-interties-title"
             className="facilitySectionLabel"
-            variant="overline"
+            variant="subtitle2"
           >
-            Interties · Automatic trading
+            Interties <span>Automatic trading</span>
           </Typography>
           {!state.lines.length && (
             <Typography
@@ -100,55 +163,6 @@ export default function TransmissionPanel({
               No connections yet. Choose Build to connect a nearby grid.
             </Typography>
           )}
-          {!!state.lines.length && (
-            <details
-              className="tradingSummary"
-              open={
-                game.scenarioId === 112 && [3, 9].includes(game.tutorialStep)
-                  ? true
-                  : undefined
-              }
-            >
-              <summary>
-                <span>
-                  {(now?.importedW || 0) > 0
-                    ? "Importing " + formatWatts(now!.importedW || 0)
-                    : (now?.exportedW || 0) > 0
-                      ? "Exporting " + formatWatts(now!.exportedW || 0)
-                      : "No power flowing"}
-                </span>
-                <span className="tradingSummaryRule">
-                  {POLICY_LABELS[state.tradingPolicy]}
-                </span>
-              </summary>
-              <FormControl fullWidth size="small" className="tradingPolicy">
-                <InputLabel id="trading-policy-label">Trading rule</InputLabel>
-                <Select
-                  labelId="trading-policy-label"
-                  label="Trading rule"
-                  value={state.tradingPolicy}
-                  disabled={readOnly}
-                  onChange={(event) =>
-                    onPolicy(event.target.value as TradingPolicyType)
-                  }
-                >
-                  {Object.entries(POLICY_LABELS).map(([value, label]) => (
-                    <MenuItem key={value} value={value}>
-                      {label}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-              <Typography variant="caption" color="textSecondary">
-                One rule for all connections. Imports depend on line capacity
-                and neighboring supply.
-              </Typography>
-              <ManualLink
-                entry={MANUAL_ENTRY.INTERTIES}
-                text="How interties work"
-              />
-            </details>
-          )}
           {state.lines.map((line) => {
             const market = adjacentMarketForCorridor(line.corridorId);
             const rating = now
@@ -156,8 +170,16 @@ export default function TransmissionPanel({
               : line.capacityW;
             const building = line.yearsToBuildLeft > 0;
             return (
-              <details key={line.id} className="transmissionLine">
-                <summary>
+              <div key={line.id} className="transmissionLine">
+                <button
+                  type="button"
+                  className="facilityDisclosure"
+                  aria-label={"Inspect " + line.name}
+                  aria-expanded={selectedLine === line.id}
+                  onClick={() =>
+                    setSelectedLine(selectedLine === line.id ? null : line.id)
+                  }
+                >
                   <img
                     className="transmissionListIcon"
                     src="/images/transmission.svg"
@@ -175,38 +197,44 @@ export default function TransmissionPanel({
                           (line.yearsToBuildLeft <= 1 ? " year" : " years") +
                           " remaining"
                         : formatWatts(rating) + " available"}
+                      {" · "}
+                      <span className="transmissionLineStatus">
+                        {building ? "Building" : "Connected"}
+                      </span>
                     </Typography>
                   </span>
-                  <Chip
-                    size="small"
-                    variant="outlined"
-                    label={building ? "Building" : "Connected"}
+                  <KeyboardArrowDownIcon
+                    className="facilityChevron"
+                    aria-hidden
                   />
-                </summary>
-                <div className="transmissionLineDetails">
-                  <Typography variant="body2">
-                    {market?.name} · {formatWatts(line.capacityW)} rated
-                    capacity
-                  </Typography>
-                  <Typography variant="body2" color="textSecondary">
-                    {building
-                      ? "Power can flow when construction finishes."
-                      : "Available capacity changes with weather. Trading is automatic across the network."}
-                  </Typography>
-                  {line.loanAmountLeft > 0 && (
+                </button>
+                {selectedLine === line.id && (
+                  <div className="transmissionLineDetails">
                     <Typography variant="body2">
-                      Loan balance {formatMoneyConcise(line.loanAmountLeft)} ·
-                      Monthly payments during construction and operation
+                      {market?.name} · {formatWatts(line.capacityW)} rated
+                      capacity
                     </Typography>
-                  )}
-                  {market && (
-                    <Typography variant="caption" color="textSecondary">
-                      Purchased emissions:{" "}
-                      {formatMass(market.emissionsKgco2ePerMWh, units)}/MWh CO2e
+                    <Typography variant="body2" color="textSecondary">
+                      {building
+                        ? "Power can flow when construction finishes."
+                        : "Available capacity changes with weather. Trading is automatic across the network."}
                     </Typography>
-                  )}
-                </div>
-              </details>
+                    {line.loanAmountLeft > 0 && (
+                      <Typography variant="body2">
+                        Loan balance {formatMoneyConcise(line.loanAmountLeft)} ·
+                        Monthly payments during construction and operation
+                      </Typography>
+                    )}
+                    {market && (
+                      <Typography variant="caption" color="textSecondary">
+                        Purchased emissions:{" "}
+                        {formatMass(market.emissionsKgco2ePerMWh, units)}/MWh
+                        CO2e
+                      </Typography>
+                    )}
+                  </div>
+                )}
+              </div>
             );
           })}
         </section>

--- a/src/components/views/TransmissionPanel.tsx
+++ b/src/components/views/TransmissionPanel.tsx
@@ -6,10 +6,6 @@ import {
   Chip,
   FormControl,
   InputLabel,
-  List,
-  ListItem,
-  ListItemAvatar,
-  ListItemText,
   MenuItem,
   Select,
   Typography,
@@ -36,6 +32,7 @@ const POLICY_LABELS: Record<TradingPolicyType, string> = {
 
 export interface TransmissionPanelProps {
   game: GameType;
+  projectsOnly?: boolean;
   onBuild: (corridorId: string, financed: boolean) => void;
   onPolicy: (policy: TradingPolicyType) => void;
 }
@@ -44,6 +41,7 @@ export default function TransmissionPanel({
   game,
   onBuild,
   onPolicy,
+  projectsOnly = false,
 }: TransmissionPanelProps) {
   const units = useUnits();
   const state = game.transmission ?? { tradingPolicy: "BALANCED", lines: [] };
@@ -68,86 +66,156 @@ export default function TransmissionPanel({
   }
 
   return (
-    <div className="transmissionPanel scrollable">
-      <section className="transmissionIntro">
-        <img src="/images/transmission.svg" alt="Two grids exchanging power" />
-        <div>
-          <Typography variant="h6">Share power with nearby grids</Typography>
-          <Typography variant="body2" color="textSecondary">
-            Buy backup; sell extra. Imports are limited.
-          </Typography>
-        </div>
-      </section>
-
-      {!!state.lines.length && (
-        <section aria-labelledby="your-interties-title">
-          <Typography id="your-interties-title" variant="subtitle2">
-            Your interties
-          </Typography>
-          <List dense disablePadding>
-            {state.lines.map((line) => {
-              const market = adjacentMarketForCorridor(line.corridorId);
-              const rating = now
-                ? transmissionRatingW(line, now)
-                : line.capacityW;
-              const building = line.yearsToBuildLeft > 0;
-              const direction =
-                (now?.importedW || 0) > (now?.exportedW || 0)
-                  ? "Importing"
-                  : (now?.exportedW || 0) > (now?.importedW || 0)
-                    ? "Exporting"
-                    : "Standing by";
-              return (
-                <ListItem key={line.id} className="transmissionLine">
-                  <ListItemAvatar>
-                    <img
-                      className="transmissionListIcon"
-                      src="/images/transmission.svg"
-                      alt=""
-                    />
-                  </ListItemAvatar>
-                  <ListItemText
-                    primary={line.name}
-                    secondary={
-                      building
-                        ? `${line.yearsToBuildLeft.toFixed(1)} ${line.yearsToBuildLeft <= 1 ? "year" : "years"} until power can flow · Monthly loan payments`
-                        : `${formatWatts(rating)} available now · ${market?.name}`
-                    }
-                  />
-                  <Chip
-                    size="small"
-                    color={building ? "default" : "success"}
-                    label={building ? "Building" : `Trading · ${direction}`}
-                  />
-                </ListItem>
-              );
-            })}
-          </List>
+    <div className={projectsOnly ? "transmissionPanel" : "transmissionFleet"}>
+      {projectsOnly && (
+        <section className="transmissionIntro">
+          <img
+            src="/images/transmission.svg"
+            alt="Two grids exchanging power"
+          />
+          <div>
+            <Typography variant="h6">Share power with nearby grids</Typography>
+            <Typography variant="body2" color="textSecondary">
+              Buy backup; sell extra. Imports are limited.
+            </Typography>
+          </div>
         </section>
       )}
 
-      {!!state.lines.length && (
-        <FormControl fullWidth size="small" className="tradingPolicy">
-          <InputLabel id="trading-policy-label">Trading rule</InputLabel>
-          <Select
-            labelId="trading-policy-label"
-            label="Trading rule"
-            value={state.tradingPolicy}
-            disabled={readOnly}
-            onChange={(event) =>
-              onPolicy(event.target.value as TradingPolicyType)
-            }
+      {!projectsOnly && (
+        <section aria-labelledby="your-interties-title">
+          <Typography
+            id="your-interties-title"
+            className="facilitySectionLabel"
+            variant="overline"
           >
-            {Object.entries(POLICY_LABELS).map(([value, label]) => (
-              <MenuItem key={value} value={value}>
-                {label}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+            Interties · Automatic trading
+          </Typography>
+          {!state.lines.length && (
+            <Typography
+              variant="body2"
+              color="textSecondary"
+              sx={{ px: 2, pb: 2 }}
+            >
+              No connections yet. Choose Build to connect a nearby grid.
+            </Typography>
+          )}
+          {!!state.lines.length && (
+            <details
+              className="tradingSummary"
+              open={
+                game.scenarioId === 112 && [3, 9].includes(game.tutorialStep)
+                  ? true
+                  : undefined
+              }
+            >
+              <summary>
+                <span>
+                  {(now?.importedW || 0) > 0
+                    ? "Importing " + formatWatts(now!.importedW || 0)
+                    : (now?.exportedW || 0) > 0
+                      ? "Exporting " + formatWatts(now!.exportedW || 0)
+                      : "No power flowing"}
+                </span>
+                <span className="tradingSummaryRule">
+                  {POLICY_LABELS[state.tradingPolicy]}
+                </span>
+              </summary>
+              <FormControl fullWidth size="small" className="tradingPolicy">
+                <InputLabel id="trading-policy-label">Trading rule</InputLabel>
+                <Select
+                  labelId="trading-policy-label"
+                  label="Trading rule"
+                  value={state.tradingPolicy}
+                  disabled={readOnly}
+                  onChange={(event) =>
+                    onPolicy(event.target.value as TradingPolicyType)
+                  }
+                >
+                  {Object.entries(POLICY_LABELS).map(([value, label]) => (
+                    <MenuItem key={value} value={value}>
+                      {label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Typography variant="caption" color="textSecondary">
+                One rule for all connections. Imports depend on line capacity
+                and neighboring supply.
+              </Typography>
+              <ManualLink
+                entry={MANUAL_ENTRY.INTERTIES}
+                text="How interties work"
+              />
+            </details>
+          )}
+          {state.lines.map((line) => {
+            const market = adjacentMarketForCorridor(line.corridorId);
+            const rating = now
+              ? transmissionRatingW(line, now)
+              : line.capacityW;
+            const building = line.yearsToBuildLeft > 0;
+            return (
+              <details key={line.id} className="transmissionLine">
+                <summary>
+                  <img
+                    className="transmissionListIcon"
+                    src="/images/transmission.svg"
+                    alt=""
+                  />
+                  <span className="transmissionLineText">
+                    <span>{line.name}</span>
+                    <Typography
+                      component="span"
+                      variant="body2"
+                      color="textSecondary"
+                    >
+                      {building
+                        ? line.yearsToBuildLeft.toFixed(1) +
+                          (line.yearsToBuildLeft <= 1 ? " year" : " years") +
+                          " remaining"
+                        : formatWatts(rating) + " available"}
+                    </Typography>
+                  </span>
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    label={building ? "Building" : "Connected"}
+                  />
+                </summary>
+                <div className="transmissionLineDetails">
+                  <Typography variant="body2">
+                    {market?.name} · {formatWatts(line.capacityW)} rated
+                    capacity
+                  </Typography>
+                  <Typography variant="body2" color="textSecondary">
+                    {building
+                      ? "Power can flow when construction finishes."
+                      : "Available capacity changes with weather. Trading is automatic across the network."}
+                  </Typography>
+                  {line.loanAmountLeft > 0 && (
+                    <Typography variant="body2">
+                      Loan balance {formatMoneyConcise(line.loanAmountLeft)} ·
+                      Monthly payments during construction and operation
+                    </Typography>
+                  )}
+                  {market && (
+                    <Typography variant="caption" color="textSecondary">
+                      Purchased emissions:{" "}
+                      {formatMass(market.emissionsKgco2ePerMWh, units)}/MWh CO2e
+                    </Typography>
+                  )}
+                </div>
+              </details>
+            );
+          })}
+        </section>
       )}
 
-      {!!unbuiltCorridors.length && (
+      {projectsOnly && !unbuiltCorridors.length && (
+        <Typography>All available connections have been approved.</Typography>
+      )}
+      {projectsOnly && !!unbuiltCorridors.length && (
         <section aria-labelledby="intertie-projects-title">
           <Typography id="intertie-projects-title" variant="subtitle2">
             Connection projects
@@ -240,39 +308,47 @@ export default function TransmissionPanel({
           </div>
         </section>
       )}
-      <ManualLink entry={MANUAL_ENTRY.INTERTIES} text="How interties work" />
-      <details>
-        <summary style={{ minHeight: 44, cursor: "pointer" }}>
-          How trading and purchased emissions are estimated
-        </summary>
-        <Typography variant="body2" color="textSecondary" sx={{ my: 1 }}>
-          Buy backup during shortages; sell surplus after customers and storage.
-          Trading is automatic, limited by line capacity and neighboring supply;
-          imports are not guaranteed backup. Prices and flows are simplified
-          estimates, not a least-cost dispatch or a network engineering study.
-          Imported emissions count toward your total; the game's carbon fee
-          applies to your local plants.
-        </Typography>
-        {Array.from(new Set(corridors.map((corridor) => corridor.id))).map(
-          (id) => {
-            const market = adjacentMarketForCorridor(id);
-            return market ? (
-              <Typography key={id} variant="body2" sx={{ my: 1 }}>
-                {market.name}: {formatMass(market.emissionsKgco2ePerMWh, units)}
-                /MWh CO2e · {market.emissionsBasis}.{" "}
-                <a
-                  aria-label={`Source for ${market.name} emissions`}
-                  href={market.emissionsSource}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Source
-                </a>
-              </Typography>
-            ) : null;
-          },
-        )}
-      </details>
+      {projectsOnly && (
+        <>
+          <ManualLink
+            entry={MANUAL_ENTRY.INTERTIES}
+            text="How interties work"
+          />
+          <details>
+            <summary style={{ minHeight: 44, cursor: "pointer" }}>
+              How trading and purchased emissions are estimated
+            </summary>
+            <Typography variant="body2" color="textSecondary" sx={{ my: 1 }}>
+              Buy backup during shortages; sell surplus after customers and
+              storage. Trading is automatic, limited by line capacity and
+              neighboring supply; imports are not guaranteed backup. Prices and
+              flows are simplified estimates, not a least-cost dispatch or a
+              network engineering study. Imported emissions count toward your
+              total; the game's carbon fee applies to your local plants.
+            </Typography>
+            {Array.from(new Set(corridors.map((corridor) => corridor.id))).map(
+              (id) => {
+                const market = adjacentMarketForCorridor(id);
+                return market ? (
+                  <Typography key={id} variant="body2" sx={{ my: 1 }}>
+                    {market.name}:{" "}
+                    {formatMass(market.emissionsKgco2ePerMWh, units)}
+                    /MWh CO2e · {market.emissionsBasis}.{" "}
+                    <a
+                      aria-label={`Source for ${market.name} emissions`}
+                      href={market.emissionsSource}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Source
+                    </a>
+                  </Typography>
+                ) : null;
+              },
+            )}
+          </details>
+        </>
+      )}
     </div>
   );
 }

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -197,12 +197,12 @@ export const SCENARIOS = [
       {
         skipBeacon: true, // causes tutorial to auto-start
         card: "FACILITIES",
-        target: ".button-buildGenerator",
+        target: ".button-buildFacility",
         advanceOn: (s: AppStateType) => s.card.name === "BUILD_GENERATORS",
         content: (
           <TutorialPrompt
             concepts={["build", "generator"]}
-            text="Open the generator shop."
+            text="Choose Build, then Generator to open the shop."
           />
         ),
       },
@@ -291,12 +291,12 @@ export const SCENARIOS = [
       {
         skipBeacon: true, // causes tutorial to auto-start
         card: "FACILITIES",
-        target: ".button-buildStorage",
+        target: ".button-buildFacility",
         advanceOn: (s: AppStateType) => s.card.name === "BUILD_STORAGE",
         content: (
           <TutorialPrompt
             concepts={["build", "storage"]}
-            text="Store spare power for when you need it - open the storage shop."
+            text="Store spare power for later. Choose Build, then Storage."
           />
         ),
       },
@@ -722,12 +722,12 @@ export const SCENARIOS = [
       {
         skipBeacon: true,
         card: "FACILITIES",
-        target: "#intertiesTab",
-        continueOnClick: "#intertiesTab",
+        target: ".button-buildFacility",
+        continueOnClick: ".button-buildFacility",
         content: (
           <TutorialPrompt
             concepts={["supply", "demand"]}
-            text="Tap Interties to see links to neighboring grids."
+            text="Choose Build to add a connection to a neighboring grid."
           />
         ),
       },
@@ -751,10 +751,10 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["construction", "time"]}
-            text="Run time until the line says Trading, then pause."
+            text="Run time until the line says Connected, then pause."
           />
         ),
-        hint: "Tap 1× or fast speed, watch Building change to Trading, then tap pause.",
+        hint: "Tap 1× or fast speed, watch Building change to Connected, then tap pause.",
       },
       {
         card: "FACILITIES",
@@ -770,12 +770,11 @@ export const SCENARIOS = [
       },
       {
         card: "FACILITIES",
-        target: "#plantsTab",
-        continueOnClick: "#plantsTab",
+        target: "#dispatch-order",
         content: (
           <TutorialPrompt
             concepts={["generator", "pause"]}
-            text="Tap Plants to return to your power plants."
+            text="Plants and interties share one list. Plants run in dispatch order; interties trade automatically."
           />
         ),
       },
@@ -809,7 +808,7 @@ export const SCENARIOS = [
             text="Run until you see Importing, then pause; the line can cover only up to its available capacity."
           />
         ),
-        hint: "If time is paused, tap 1× or fast speed; the line must say Trading.",
+        hint: "If time is paused, tap 1× or fast speed; the line must say Connected.",
       },
       {
         card: "INSIGHTS",


### PR DESCRIPTION
Plants, storage, and interties now share one Facilities list. A single Build action opens generator, storage, and connection projects; the network's aggregate flow and trading rule remain reachable above the dispatch list. Native inspection controls, separate drag handles, labeled management actions, and updated tutorials preserve keyboard and touch operation.

The desktop and mobile interface also gets a consistent type scale, solid surfaces, aligned standalone screens, simpler purchase summaries, clearer program choices, and quieter Insights/Events controls. On phones, supply/demand is a one-tap disclosure that opens for tutorial and evidence targets. Financial consequences, chart summaries, and scenario decisions stay available.

The implementation includes two functional QA correction rounds, a three-designer consensus pass, and the panel's final correction pass. Simulation formulas and save/replay versions are unchanged.

Validation:

- `npm run check`: types, lint, formatting, 122 Jest suites / 1,174 tests, and every simulation scenario passed; all invariants held.
- `npm run build`: passed after the final spacing correction.
- Full Playwright matrix: 335 cases across 320px, 390px, tablet, and two desktop widths; 245 passed including corrected-case reruns, 90 intentional viewport skips. The initial run flagged six cases: control alignment and stale expectations for inspection, wildfire costs, and timeline controls. All six passed after correction; the full matrix was not repeated afterward.
- Additional focused keyboard, light/dark, purchase, intertie, tutorial, and evidence checks passed. Screenshots below were inspected for layout and extraneous content.

### Screenshots

Desktop, light theme:

![Combined Facilities and desktop interface](https://github.com/user-attachments/assets/9dc5b2eb-b95a-4216-8280-b18f77230664)

Mobile, dark theme:

![Combined Facilities on mobile](https://github.com/user-attachments/assets/7d23e24f-20c4-4cba-85b7-30bda3254b7a)

Mobile purchase review:

![Simplified mobile purchase review](https://github.com/user-attachments/assets/a3cd3d93-11fc-4661-b320-36e0b47cdc81)
