### PR TITLE
Combine build catalogs with Generators, Storage and Interties tabs

### DIFF
--- a/e2e/app-spacing.spec.ts
+++ b/e2e/app-spacing.spec.ts
@@ -48,12 +48,14 @@ test("phone surfaces share stable gutters and compact chrome", async ({
 
   await page.getByRole("button", { name: "Facilities", exact: true }).click();
   await page.locator(".button-buildFacility").click();
-  await page.getByRole("button", { name: "Storage" }).click();
+  await page.getByRole("tab", { name: "Storage", exact: true }).click();
   await expect(
-    page.getByRole("heading", { name: "Build Storage" }),
+    page.getByRole("tab", { name: "Storage", selected: true }),
   ).toBeVisible();
   await page.waitForTimeout(400);
-  await expectNoHorizontalOverflow(page.locator(".constructionHeader"));
+  for (const header of await page.locator(".constructionHeader").all()) {
+    await expectNoHorizontalOverflow(header);
+  }
 
   const closeButton = await page
     .getByRole("button", { name: "close" })

--- a/e2e/contextual-learning.spec.ts
+++ b/e2e/contextual-learning.spec.ts
@@ -34,9 +34,20 @@ for (const theme of ["light", "dark"] as const) {
     }
     const first = page.locator(".buildOption").first();
     const metrics = await first.locator(".buildOptionMetrics").innerText();
-    const help = page
-      .getByRole("button", { name: /power, energy & duration/i })
-      .first();
+    await expect(
+      page.getByRole("button", {
+        name: /power, energy & duration|charging & losses/i,
+      }),
+    ).toHaveCount(0);
+    await page
+      .locator('.buildOption button[aria-label^="Review purchase of"]:enabled')
+      .first()
+      .click();
+    const purchase = page.getByRole("dialog");
+    const help = purchase.getByRole("button", {
+      name: "Power, energy & duration",
+      exact: true,
+    });
     await expect(help).toBeVisible();
     expect((await help.boundingBox())!.height).toBeGreaterThanOrEqual(
       testInfo.project.use.hasTouch ? 44 : 40,
@@ -80,28 +91,11 @@ for (const theme of ["light", "dark"] as const) {
     await manual.getByRole("button", { name: "back", exact: true }).click();
     await expect(manual).not.toBeVisible();
     await expect(help).toBeFocused();
-    await expect(capacity).toHaveAttribute("aria-valuenow", selectedCapacity!);
-    await expect(first.locator(".buildOptionMetrics")).toHaveText(metrics, {
-      useInnerText: true,
-    });
-    if (await sort.isVisible()) {
-      await expect(sort).toContainText("Build Time");
-    } else {
-      await expect(
-        page.getByRole("button", { name: "Sort facilities: Build Time" }),
-      ).toBeVisible();
-    }
     // A second lookup must close to the same draft without creating a history loop.
     await help.click();
     await expect(manual).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(manual).not.toBeVisible();
-    await expect(capacity).toHaveAttribute("aria-valuenow", selectedCapacity!);
-    await page
-      .locator('.buildOption button[aria-label^="Review purchase of"]:enabled')
-      .first()
-      .click();
-    const purchase = page.getByRole("dialog");
     await expect(purchase).toContainText("Loan option");
     const purchaseHelp = purchase.getByRole("button", {
       name: "Power, energy & duration",
@@ -115,6 +109,18 @@ for (const theme of ["light", "dark"] as const) {
     await expect(purchase).toContainText("Loan option");
     await purchase.getByRole("button", { name: "close", exact: true }).click();
     await expect(purchase).not.toBeVisible();
+    await expect(capacity).toHaveAttribute("aria-valuenow", selectedCapacity!);
+    await expect(first.locator(".buildOptionMetrics")).toHaveText(metrics, {
+      useInnerText: true,
+    });
+    if (await sort.isVisible()) {
+      await expect(sort).toContainText("Build Time");
+    } else {
+      await expect(
+        page.getByRole("button", { name: "Sort facilities: Build Time" }),
+      ).toBeVisible();
+    }
+
     await page.getByRole("button", { name: "close", exact: true }).click();
     await expect(page.getByRole("group", { name: "game speed" })).toBeVisible();
   });

--- a/e2e/simulation-assumptions.spec.ts
+++ b/e2e/simulation-assumptions.spec.ts
@@ -82,9 +82,9 @@ for (const theme of ["light", "dark"] as const) {
     await expect(dialog).not.toBeVisible();
     await page.getByRole("button", { name: "close", exact: true }).click();
     await facilities.locator(".button-buildFacility").click();
-    await page.getByRole("button", { name: "Intertie", exact: true }).click();
+    await page.getByRole("tab", { name: "Interties", exact: true }).click();
     const trade = page
-      .getByRole("dialog")
+      .getByRole("tabpanel", { name: "Interties" })
       .locator("details")
       .filter({ hasText: "How trading and purchased emissions are estimated" });
     expect(
@@ -99,7 +99,9 @@ for (const theme of ["light", "dark"] as const) {
       trade.getByRole("link", { name: /Source for/ }).first(),
     ).toHaveAttribute("href", /https:\/\//);
     expect(
-      await facilities.evaluate((el) => el.scrollWidth - el.clientWidth),
+      await page
+        .getByRole("tabpanel", { name: "Interties" })
+        .evaluate((el) => el.scrollWidth - el.clientWidth),
     ).toBeLessThanOrEqual(1);
     if (
       reviewDir &&

--- a/e2e/transmission.spec.ts
+++ b/e2e/transmission.spec.ts
@@ -16,8 +16,8 @@ test("California players can build and understand an intertie", async ({
     await page.getByRole("button", { name: "Facilities", exact: true }).click();
   }
   await facilities.getByRole("button", { name: "Build", exact: true }).click();
-  await page.getByRole("button", { name: "Intertie", exact: true }).click();
-  const projects = page.getByRole("dialog");
+  await page.getByRole("tab", { name: "Interties", exact: true }).click();
+  const projects = page.getByRole("tabpanel", { name: "Interties" });
   await expect(
     projects.getByRole("heading", { name: "Share power with nearby grids" }),
   ).toBeVisible();
@@ -31,7 +31,9 @@ test("California players can build and understand an intertie", async ({
   ).toBeVisible();
   if (testInfo.project.name === "mobile-320px") {
     const firstBuild = projects
-      .getByRole("button", { name: "Approve Pacific Northwest intertie" })
+      .getByRole("button", {
+        name: "Review purchase of Pacific Northwest intertie",
+      })
       .first();
     const box = await firstBuild.boundingBox();
     expect(box).not.toBeNull();
@@ -40,8 +42,14 @@ test("California players can build and understand an intertie", async ({
   }
 
   await projects
-    .getByRole("button", { name: "Approve Pacific Northwest intertie" })
+    .getByRole("button", {
+      name: "Review purchase of Pacific Northwest intertie",
+    })
     .first()
+    .click();
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "Take loan" })
     .click();
   await expect(
     page.getByText("Intertie approved — power can flow in 1 year."),

--- a/e2e/transmission.spec.ts
+++ b/e2e/transmission.spec.ts
@@ -20,7 +20,10 @@ test("California players can build and understand an intertie", async ({
   const projects = page.getByRole("tabpanel", { name: "Interties" });
   await expect(
     projects.getByRole("heading", { name: "Share power with nearby grids" }),
-  ).toBeVisible();
+  ).toHaveCount(0);
+  await expect(
+    projects.getByRole("heading", { name: "Connection projects" }),
+  ).toHaveCount(0);
   await expect(
     projects.getByRole("heading", { name: "Pacific Northwest", exact: true }),
   ).toBeVisible();
@@ -171,3 +174,58 @@ test("unified facility rows support keyboard inspection and dispatch reordering"
   await expect(rows.last().locator(".facilityDragHandle")).toBeFocused();
   await expect(facilities.locator(".transmissionFleet")).toBeVisible();
 });
+
+for (const theme of ["light", "dark"] as const) {
+  test(`intertie review stays at the top right in ${theme}`, async ({
+    page,
+  }, testInfo) => {
+    await page.addInitScript((mode) => {
+      localStorage.clear();
+      localStorage.setItem("theme", mode);
+    }, theme);
+    await page.goto("/?scenario=100");
+    await page.getByRole("button", { name: "Start game", exact: true }).click();
+    await expect(page.getByRole("group", { name: "game speed" })).toBeVisible();
+    const facilities = page.locator(".facilities:visible");
+    if (!(await facilities.isVisible())) {
+      await page
+        .getByRole("button", { name: "Facilities", exact: true })
+        .click();
+    }
+    await facilities
+      .getByRole("button", { name: "Build", exact: true })
+      .click();
+    await page.getByRole("tab", { name: "Interties", exact: true }).click();
+    for (const card of await page.locator(".transmissionProject").all()) {
+      const heading = card.locator(".transmissionProjectHeading");
+      const review = heading.getByRole("button", {
+        name: /Review purchase of/,
+      });
+      await expect(
+        review.locator('[data-testid="ShoppingCartIcon"]'),
+      ).toBeVisible();
+      const title = heading.getByRole("heading");
+      const titleBox = (await title.boundingBox())!;
+      const buttonBox = (await review.boundingBox())!;
+      const headerBox = (await heading.boundingBox())!;
+      const metadataBox = (await card
+        .locator(".transmissionProjectMetadata")
+        .boundingBox())!;
+      expect(buttonBox.x).toBeGreaterThanOrEqual(titleBox.x + titleBox.width);
+      expect(buttonBox.x + buttonBox.width).toBeCloseTo(
+        headerBox.x + headerBox.width,
+        0,
+      );
+      expect(buttonBox.y + buttonBox.height).toBeLessThanOrEqual(metadataBox.y);
+      expect(buttonBox.height).toBeGreaterThanOrEqual(
+        testInfo.project.use.hasTouch ? 44 : 40,
+      );
+      expect(
+        await card.evaluate((el) => el.scrollWidth - el.clientWidth),
+      ).toBeLessThanOrEqual(1);
+      await expect(card.locator(".transmissionProjectMetadata")).toContainText(
+        /route/,
+      );
+    }
+  });
+}

--- a/e2e/tutorial-auto-advance.spec.ts
+++ b/e2e/tutorial-auto-advance.spec.ts
@@ -49,13 +49,9 @@ for (const mission of [
     const hud = page.locator(".tutorialHud");
     if (mission === "Generators" || mission === "Storage") {
       await page.locator(".button-buildFacility").click();
-      await page
-        .locator(
-          mission === "Generators"
-            ? ".button-buildGenerator"
-            : ".button-buildStorage",
-        )
-        .click();
+      if (mission === "Storage") {
+        await page.getByRole("tab", { name: "Storage", exact: true }).click();
+      }
       await expect(hud).toContainText(
         mission === "Generators" ? "Compare cost" : "Choose storage",
       );

--- a/e2e/tutorial-interties.spec.ts
+++ b/e2e/tutorial-interties.spec.ts
@@ -41,13 +41,23 @@ test("Mission 7 teaches limited two-way interties without trapping recovery", as
 
   // Opening the tab completes navigation without a redundant Next click.
   await page.locator(".button-buildFacility").click();
+  await page.getByRole("tab", { name: "Interties", exact: true }).click();
   await expect(page.getByLabel("Objective 2 of 10")).toBeVisible();
   await expect(
-    page.getByRole("button", { name: "Approve Pacific Northwest intertie" }),
+    page.getByRole("button", {
+      name: "Review purchase of Pacific Northwest intertie",
+    }),
   ).toBeVisible();
   await expect(page.getByText("Pay $36M now · finance $144M")).toBeVisible();
   await page
-    .getByRole("button", { name: "Approve Pacific Northwest intertie" })
+    .getByRole("button", {
+      name: "Review purchase of Pacific Northwest intertie",
+    })
+    .click();
+  await expect(page.getByLabel("Objective 2 of 10")).toBeVisible();
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "Take loan" })
     .click();
   await expect(page.getByText("Building")).toBeVisible();
   await expect(page.getByLabel("Objective 3 of 10")).toBeVisible();

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -165,6 +165,7 @@ export interface DifficultyMultipliersType {
 export type CardNameType =
   | "BUILD_GENERATORS"
   | "BUILD_STORAGE"
+  | "BUILD_INTERTIES"
   | "FACILITIES"
   | "INSIGHTS"
   | "EVENTS"

--- a/src/app.scss
+++ b/src/app.scss
@@ -4176,15 +4176,6 @@ $sizemap: (
   padding: 8px 16px;
   color: var(--font-color-faded);
 }
-.facilityBuildChoices {
-  display: grid;
-  gap: 12px;
-  padding-top: 8px;
-  .MuiButton-root {
-    min-height: 48px;
-    justify-content: flex-start;
-  }
-}
 .transmissionFleet {
   border-top: 1px solid var(--border-subtle);
   margin-top: 12px;
@@ -4754,5 +4745,44 @@ $sizemap: (
 @media (pointer: coarse) {
   .insightsHeader {
     --insights-control-size: 44px;
+  }
+}
+// One catalog shell keeps navigation fixed while each category scrolls below it.
+.constructionTabs {
+  border-bottom: $border_accent;
+
+  .MuiTab-root {
+    min-width: 0;
+    min-height: 48px;
+    padding: $space-2;
+    text-transform: none;
+  }
+
+  .Mui-selected {
+    font-weight: 700;
+  }
+}
+
+.constructionPanel {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto;
+
+  > .screenCatalog {
+    min-height: 0;
+  }
+}
+
+.constructionInterties {
+  padding: $space-4 $space-2;
+
+  .transmissionIntro,
+  #intertie-projects-title {
+    margin-left: $space-2;
+    margin-right: $space-2;
   }
 }

--- a/src/app.scss
+++ b/src/app.scss
@@ -966,7 +966,6 @@ $pane_header_height: 40px;
   background: var(--bg-sunken);
 }
 
-.transmissionIntro,
 .powerExchangeHero {
   display: flex;
   align-items: center;
@@ -986,11 +985,6 @@ $pane_header_height: 40px;
   background: var(--bg-primary);
 }
 
-.transmissionPanel section > h6,
-.transmissionPanel section > .MuiTypography-subtitle2 {
-  margin-bottom: 8px;
-}
-
 .transmissionProjects {
   display: grid;
   gap: 12px;
@@ -1008,8 +1002,33 @@ $pane_header_height: 40px;
 .transmissionProjectHeading {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
+
+  .MuiTypography-root {
+    min-width: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    overflow-wrap: anywhere;
+  }
+
+  .MuiButton-root {
+    flex-shrink: 0;
+    min-height: 40px;
+  }
+}
+
+.transmissionProjectMetadata {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+@media (pointer: coarse) {
+  .transmissionProjectHeading .MuiButton-root {
+    min-height: 44px;
+  }
 }
 
 .transmissionMetrics,
@@ -1067,32 +1086,6 @@ $pane_header_height: 40px;
   .transmissionPanel {
     gap: 8px;
     padding: 12px;
-  }
-
-  .transmissionIntro {
-    img {
-      width: 40px;
-      height: 40px;
-      flex-basis: 40px;
-    }
-
-    h6 {
-      font-size: 1.125rem;
-      line-height: 1.35;
-    }
-  }
-
-  .transmissionProject {
-    gap: 8px;
-    padding: 8px;
-
-    // On the shortest supported phone, the intro teaches the decision and the market card keeps
-    // the identifying facts. Omitting this secondary flavor copy leaves the build decision and
-    // its financing above the persistent navigation instead of making the player hunt for it.
-    > .MuiTypography-body2,
-    .transmissionProjectHeading .MuiTypography-caption {
-      display: none;
-    }
   }
 
   .powerExchangeMetrics {
@@ -4405,9 +4398,6 @@ $sizemap: (
   padding: 16px;
   border-radius: 8px;
 }
-.transmissionIntro h6 {
-  font-size: 1rem;
-}
 .base_main #menuCard #logo {
   margin-top: auto;
   padding-top: 32px;
@@ -4779,10 +4769,4 @@ $sizemap: (
 
 .constructionInterties {
   padding: $space-4 $space-2;
-
-  .transmissionIntro,
-  #intertie-projects-title {
-    margin-left: $space-2;
-    margin-right: $space-2;
-  }
 }

--- a/src/components/Compositor.tsx
+++ b/src/components/Compositor.tsx
@@ -32,8 +32,7 @@ import EventLogContainer from "./views/EventLogContainer";
 import NavigationContainer from "./base/NavigationContainer";
 import GameAppBarContainer from "./base/GameAppBar";
 import VictoryDialogContainer from "./base/VictoryDialogContainer";
-import BuildGeneratorsContainer from "./views/BuildGeneratorsContainer";
-import BuildStorageContainer from "./views/BuildStorageContainer";
+import BuildFacilities from "./views/BuildFacilities";
 import CustomGameContainer from "./views/CustomGameContainer";
 import FacilitiesContainer from "./views/FacilitiesContainer";
 import InsightsContainer from "./views/InsightsContainer";
@@ -435,9 +434,9 @@ export default class Compositor extends React.Component<Props, {}> {
     }
     switch (this.props.card.name) {
       case "BUILD_GENERATORS":
-        return <BuildGeneratorsContainer />;
       case "BUILD_STORAGE":
-        return <BuildStorageContainer />;
+      case "BUILD_INTERTIES":
+        return <BuildFacilities />;
       case "INSIGHTS":
         return <InsightsContainer />;
       case "EVENTS":
@@ -511,13 +510,15 @@ export default class Compositor extends React.Component<Props, {}> {
     const transitionKey =
       this.props.card.name === "LOADING"
         ? `LOADING:${this.props.card.ts}`
-        : !isNavCard(this.props.card.name)
-          ? this.props.card.name
-          : isDesktopScreen()
-            ? DESKTOP_PANES_KEY
-            : isPaneLayout()
-              ? TABLET_PANES_KEY
-              : this.props.card.name;
+        : this.props.card.name.startsWith("BUILD_")
+          ? "BUILD_FACILITIES"
+          : !isNavCard(this.props.card.name)
+            ? this.props.card.name
+            : isDesktopScreen()
+              ? DESKTOP_PANES_KEY
+              : isPaneLayout()
+                ? TABLET_PANES_KEY
+                : this.props.card.name;
     const transitionNodeRef = this.nodeRefFor(transitionKey);
 
     // See https://medium.com/lalilo/dynamic-transitions-with-react-router-and-react-transition-group-69ab795815c9

--- a/src/components/CompositorContainer.tsx
+++ b/src/components/CompositorContainer.tsx
@@ -24,7 +24,9 @@ const mapStateToProps = (state: AppStateType): StateProps => {
   } else if (isNavCard(state.card.name)) {
     transition = "nav";
   } else if (
-    ["BUILD_GENERATORS", "BUILD_STORAGE"].indexOf(state.card.name) !== -1
+    ["BUILD_GENERATORS", "BUILD_STORAGE", "BUILD_INTERTIES"].indexOf(
+      state.card.name,
+    ) !== -1
   ) {
     // modals that should fade in / out instead of slide
     transition = "nav";

--- a/src/components/base/ConstructionBuildHeader.tsx
+++ b/src/components/base/ConstructionBuildHeader.tsx
@@ -17,6 +17,7 @@ import { formatMoneyStable } from "../../helpers/Format";
 import ConceptIcon from "./ConceptIcon";
 
 interface Props {
+  hideTitle?: boolean;
   concept: ConceptNameType;
   title: string;
   cash: number;
@@ -58,29 +59,31 @@ export default function ConstructionBuildHeader(
 
   return (
     <header className="constructionHeader">
-      <Toolbar className="constructionTitleBar">
-        <Typography variant="h6" className="constructionTitle">
-          <span className="iconLabel">
-            <ConceptIcon concept={props.concept} fontSize="small" />
-            {props.title}
-          </span>
-          <span
-            className="weak constructionCash"
-            aria-label={`Available cash ${formatMoneyStable(props.cash)}`}
+      {!props.hideTitle && (
+        <Toolbar className="constructionTitleBar">
+          <Typography variant="h6" className="constructionTitle">
+            <span className="iconLabel">
+              <ConceptIcon concept={props.concept} fontSize="small" />
+              {props.title}
+            </span>
+            <span
+              className="weak constructionCash"
+              aria-label={`Available cash ${formatMoneyStable(props.cash)}`}
+            >
+              {formatMoneyStable(props.cash)} cash
+            </span>
+          </Typography>
+          <IconButton
+            id="close-button"
+            color="primary"
+            onClick={props.onClose}
+            aria-label="close"
+            size="large"
           >
-            {formatMoneyStable(props.cash)} cash
-          </span>
-        </Typography>
-        <IconButton
-          id="close-button"
-          color="primary"
-          onClick={props.onClose}
-          aria-label="close"
-          size="large"
-        >
-          <CloseIcon />
-        </IconButton>
-      </Toolbar>
+            <CloseIcon />
+          </IconButton>
+        </Toolbar>
+      )}
       <div className="constructionControls">
         <Typography
           id="construction-capacity"

--- a/src/components/views/BuildFacilities.test.tsx
+++ b/src/components/views/BuildFacilities.test.tsx
@@ -1,0 +1,71 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import cardReducer, { initialCard } from "../../reducers/Card";
+import uiReducer from "../../reducers/UI";
+import { createGame } from "../../testing/Simulator";
+import BuildFacilities from "./BuildFacilities";
+
+jest.mock("./BuildGeneratorsContainer", () => () => (
+  <div>Generator catalog</div>
+));
+jest.mock("./BuildStorageContainer", () => () => <div>Storage catalog</div>);
+
+function setup() {
+  const game = createGame({ scenarioId: 103 });
+  game.location = { ...game.location, id: "HNL", name: "Honolulu, HI" };
+  const store = configureStore({
+    reducer: { game: () => game, card: cardReducer, ui: uiReducer },
+    preloadedState: {
+      card: {
+        ...initialCard,
+        name: "BUILD_GENERATORS" as const,
+        history: ["FACILITIES" as const],
+      },
+    },
+  });
+  render(
+    <Provider store={store}>
+      <BuildFacilities />
+    </Provider>,
+  );
+  return store;
+}
+
+it("shares one build screen, defaults to generators and keeps tab changes out of navigation history", () => {
+  const store = setup();
+  expect(screen.getByRole("tab", { name: "Generators" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  expect(screen.getAllByRole("button", { name: "close" })).toHaveLength(1);
+  expect(
+    screen.getByRole("tabpanel", { name: "Generators" }),
+  ).toHaveTextContent("Generator catalog");
+  const browserHistoryLength = window.history.length;
+  fireEvent.click(screen.getByRole("tab", { name: "Storage" }));
+  expect(screen.getByRole("tabpanel", { name: "Storage" })).toHaveTextContent(
+    "Storage catalog",
+  );
+  fireEvent.click(screen.getByRole("tab", { name: "Interties" }));
+  expect(screen.getByRole("tabpanel", { name: "Interties" })).toHaveTextContent(
+    "No intertie projects are available in this region.",
+  );
+  expect(store.getState().card.history).toHaveLength(1);
+  expect(window.history.length).toBe(browserHistoryLength);
+  fireEvent.click(screen.getByRole("button", { name: "close" }));
+  expect(store.getState().card.name).toBe("FACILITIES");
+});
+
+it("supports standard keyboard navigation between build tabs", async () => {
+  setup();
+  const user = userEvent.setup({ delay: null });
+  act(() => screen.getByRole("tab", { name: "Generators" }).focus());
+  await user.keyboard("{ArrowRight}{Enter}");
+  expect(screen.getByRole("tab", { name: "Storage" })).toHaveFocus();
+  expect(screen.getByRole("tab", { name: "Storage" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+});

--- a/src/components/views/BuildFacilities.tsx
+++ b/src/components/views/BuildFacilities.tsx
@@ -1,0 +1,129 @@
+import * as React from "react";
+import { IconButton, Tab, Tabs, Toolbar, Typography } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { useAppDispatch, useAppSelector } from "../../Store";
+import { navigate } from "../../reducers/Card";
+import { buildTransmissionLine, setTradingPolicy } from "../../reducers/Game";
+import { snackbarOpen } from "../../reducers/UI";
+import {
+  corridorsForLocation,
+  TRANSMISSION_CORRIDORS,
+} from "../../data/AdjacentMarkets";
+import { getTimeFromTimeline } from "../../helpers/DateTime";
+import { formatMoneyStable } from "../../helpers/Format";
+import ConceptIcon from "../base/ConceptIcon";
+import BuildGeneratorsContainer from "./BuildGeneratorsContainer";
+import BuildStorageContainer from "./BuildStorageContainer";
+import TransmissionPanel from "./TransmissionPanel";
+
+const categories = [
+  ["BUILD_GENERATORS", "Generators", "Generator"],
+  ["BUILD_STORAGE", "Storage", "Storage"],
+  ["BUILD_INTERTIES", "Interties", "Intertie"],
+] as const;
+
+export default function BuildFacilities(): React.JSX.Element {
+  const dispatch = useAppDispatch();
+  const game = useAppSelector((state) => state.game);
+  const card = useAppSelector((state) => state.card.name);
+  const active =
+    categories.find(([name]) => name === card)?.[0] || "BUILD_GENERATORS";
+  const cash = getTimeFromTimeline(game.date.minute, game.timeline)?.cash || 0;
+  const close = () => dispatch(navigate("FACILITIES"));
+  const intertiesAvailable =
+    !!game.transmission && corridorsForLocation(game.location).length > 0;
+
+  return (
+    <div id="topbar" className="flexContainer screenCatalog buildFacilities">
+      <header className="constructionHeader">
+        <Toolbar className="constructionTitleBar">
+          <Typography variant="h6" className="constructionTitle">
+            <span className="iconLabel">
+              <ConceptIcon concept="build" fontSize="small" />
+              Build
+            </span>
+            <span
+              className="weak constructionCash"
+              aria-label={`Available cash ${formatMoneyStable(cash)}`}
+            >
+              {formatMoneyStable(cash)} cash
+            </span>
+          </Typography>
+          <IconButton
+            id="close-button"
+            color="primary"
+            onClick={close}
+            aria-label="close"
+            size="large"
+          >
+            <CloseIcon />
+          </IconButton>
+        </Toolbar>
+        <Tabs
+          className="constructionTabs"
+          value={active}
+          variant="fullWidth"
+          aria-label="Build categories"
+          onChange={(_event, value) =>
+            dispatch(
+              navigate({
+                name: value,
+                dontRemember: true,
+                replaceCurrentCard: true,
+                skipBrowserHistory: true,
+              }),
+            )
+          }
+        >
+          {categories.map(([name, label, className]) => (
+            <Tab
+              key={name}
+              id={`tab-${name}`}
+              aria-controls={`panel-${name}`}
+              value={name}
+              label={label}
+              className={`button-build${className}`}
+            />
+          ))}
+        </Tabs>
+      </header>
+      <div
+        role="tabpanel"
+        id={`panel-${active}`}
+        aria-labelledby={`tab-${active}`}
+        className="constructionPanel"
+      >
+        {active === "BUILD_GENERATORS" && <BuildGeneratorsContainer embedded />}
+        {active === "BUILD_STORAGE" && <BuildStorageContainer embedded />}
+        {active === "BUILD_INTERTIES" && (
+          <div className="scrollable constructionInterties">
+            {intertiesAvailable ? (
+              <TransmissionPanel
+                game={game}
+                projectsOnly
+                onPolicy={(policy) => dispatch(setTradingPolicy(policy))}
+                onBuild={(corridorId, financed) => {
+                  dispatch(buildTransmissionLine({ corridorId, financed }));
+                  const corridor = TRANSMISSION_CORRIDORS.find(
+                    ({ id }) => id === corridorId,
+                  );
+                  if (corridor)
+                    dispatch(
+                      snackbarOpen(
+                        `Intertie approved — power can flow in ${corridor.yearsToBuild} year${corridor.yearsToBuild === 1 ? "" : "s"}.`,
+                      ),
+                    );
+                  close();
+                }}
+              />
+            ) : (
+              <Typography color="textSecondary">
+                No intertie projects are available in this region.
+              </Typography>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/views/BuildGenerators.tsx
+++ b/src/components/views/BuildGenerators.tsx
@@ -693,7 +693,9 @@ export interface DispatchProps {
   onBack: () => void;
 }
 
-export interface Props extends StateProps, DispatchProps {}
+export interface Props extends StateProps, DispatchProps {
+  embedded?: boolean;
+}
 
 export default function BuildGenerators(props: Props): React.JSX.Element {
   const { evidenceRequest, facilityDragActive, onEvidenceReady } = props;
@@ -789,7 +791,7 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
 
   return (
     <div
-      id="topbar"
+      id={props.embedded ? undefined : "topbar"}
       className="flexContainer screenCatalog"
       ref={evidenceAnchor}
       tabIndex={-1}
@@ -813,6 +815,7 @@ export default function BuildGenerators(props: Props): React.JSX.Element {
           </Typography>
         )}
       <ConstructionBuildHeader
+        hideTitle={props.embedded}
         concept="generator"
         title="Build Generator"
         cash={cash}

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -425,7 +425,9 @@ export interface DispatchProps {
   onBack: () => void;
 }
 
-export interface Props extends StateProps, DispatchProps {}
+export interface Props extends StateProps, DispatchProps {
+  embedded?: boolean;
+}
 
 export default function StorageBuildDialog(props: Props): React.JSX.Element {
   const { game, onBack } = props;
@@ -449,8 +451,12 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
   );
 
   return (
-    <div id="topbar" className="flexContainer screenCatalog">
+    <div
+      id={props.embedded ? undefined : "topbar"}
+      className="flexContainer screenCatalog"
+    >
       <ConstructionBuildHeader
+        hideTitle={props.embedded}
         concept="storage"
         title="Build Storage"
         cash={cash}

--- a/src/components/views/BuildStorage.tsx
+++ b/src/components/views/BuildStorage.tsx
@@ -470,16 +470,6 @@ export default function StorageBuildDialog(props: Props): React.JSX.Element {
         onSliderChange={setSliderTick}
         onSortChange={(value) => setSort(value as StorageSortKey)}
       />
-      <Box className="buildOptionHelp">
-        <ManualLink
-          entry={MANUAL_ENTRY.POWER_AND_ENERGY}
-          text="Power, energy & duration"
-        />
-        <ManualLink
-          entry={MANUAL_ENTRY.ROUND_TRIP_EFFICIENCY}
-          text="Charging & losses"
-        />
-      </Box>
       <List dense className="scrollable cardList">
         {storage.map((g: StorageShoppingType, i: number) => (
           <StorageBuildItem

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -9,6 +9,7 @@ import uiReducer from "../../reducers/UI";
 import { createGame } from "../../testing/Simulator";
 import { FacilityOperatingType, GameType } from "../../Types";
 import Facilities from "./Facilities";
+import TransmissionPanel from "./TransmissionPanel";
 import { TRANSMISSION_CORRIDORS } from "../../data/AdjacentMarkets";
 
 // The pane renders its own supply chart, which jsdom never lays out; nothing here waits on
@@ -345,20 +346,30 @@ describe("the fleet list", () => {
   });
 });
 
+function renderProjects(game: GameType, onBuild = jest.fn()) {
+  return render(
+    <Provider store={configureStore({ reducer: { ui: uiReducer } })}>
+      <TransmissionPanel
+        game={game}
+        projectsOnly
+        onBuild={onBuild}
+        onPolicy={jest.fn()}
+      />
+    </Provider>,
+  );
+}
+
 describe("the interties view", () => {
   it("explains and offers California connection projects", async () => {
     const game = playedGame(0);
-    renderFacilities(game, null);
-    await user.click(screen.getByRole("button", { name: "Build" }));
-    if (screen.queryByRole("button", { name: "Intertie" }))
-      await user.click(screen.getByRole("button", { name: "Intertie" }));
+    renderProjects(game);
     expect(
       screen.getByText("Share power with nearby grids"),
     ).toBeInTheDocument();
     expect(screen.getByText("Pacific Northwest")).toBeInTheDocument();
     expect(screen.queryByLabelText("Trading rule")).toBeNull();
     expect(
-      screen.getAllByRole("button", { name: /Approve .* intertie/ }),
+      screen.getAllByRole("button", { name: /Review purchase of .* intertie/ }),
     ).not.toHaveLength(0);
     expect(screen.getAllByText("Total cost")).toHaveLength(2);
     expect(
@@ -395,30 +406,40 @@ describe("the interties view", () => {
   it("shows researched local market names outside California", async () => {
     const game = createGame({ scenarioId: 103 });
     game.location = { ...game.location, id: "Dublin", name: "Dublin" };
-    renderFacilities(game, null);
-
-    await user.click(screen.getByRole("button", { name: "Build" }));
-    if (screen.queryByRole("button", { name: "Intertie" }))
-      await user.click(screen.getByRole("button", { name: "Intertie" }));
+    renderProjects(game);
 
     expect(screen.getByText("Great Britain")).toBeInTheDocument();
     expect(screen.getByText("Continental Europe")).toBeInTheDocument();
   });
 
   it("gives the guided northern approval a stable target and specific name", async () => {
-    renderFacilities(createGame({ scenarioId: 112 }), null);
-    await user.click(screen.getByRole("button", { name: "Build" }));
-    if (screen.queryByRole("button", { name: "Intertie" }))
-      await user.click(screen.getByRole("button", { name: "Intertie" }));
+    renderProjects(createGame({ scenarioId: 112 }));
 
     const approval = screen.getByRole("button", {
-      name: "Approve Pacific Northwest intertie",
+      name: "Review purchase of Pacific Northwest intertie",
     });
-    expect(approval).toHaveAttribute("id", "approve-intertie-california-north");
+    expect(approval).toHaveAttribute("id", "review-intertie-california-north");
     expect(
       screen.getByTestId("transmission-project-california-north"),
     ).toHaveAttribute("data-corridor-id", "california-north");
     expect(screen.queryByText("Desert Southwest")).toBeNull();
+  });
+
+  it("reviews and cancels before committing a financed intertie", async () => {
+    const onBuild = jest.fn();
+    renderProjects(createGame({ scenarioId: 112 }), onBuild);
+    const review = screen.getByRole("button", {
+      name: "Review purchase of Pacific Northwest intertie",
+    });
+    await user.click(review);
+    expect(onBuild).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toHaveTextContent("Loan option");
+    await user.click(screen.getByRole("button", { name: "close" }));
+    expect(onBuild).not.toHaveBeenCalled();
+    await user.click(review);
+    await user.click(screen.getByRole("button", { name: "Take loan" }));
+    expect(onBuild).toHaveBeenCalledTimes(1);
+    expect(onBuild).toHaveBeenCalledWith("california-north", true);
   });
 });
 

--- a/src/components/views/Facilities.test.tsx
+++ b/src/components/views/Facilities.test.tsx
@@ -364,8 +364,9 @@ describe("the interties view", () => {
     const game = playedGame(0);
     renderProjects(game);
     expect(
-      screen.getByText("Share power with nearby grids"),
-    ).toBeInTheDocument();
+      screen.queryByText("Share power with nearby grids"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Connection projects")).not.toBeInTheDocument();
     expect(screen.getByText("Pacific Northwest")).toBeInTheDocument();
     expect(screen.queryByLabelText("Trading rule")).toBeNull();
     expect(

--- a/src/components/views/Facilities.tsx
+++ b/src/components/views/Facilities.tsx
@@ -580,13 +580,11 @@ export interface Props extends StateProps, DispatchProps {}
 
 export default class Facilities extends React.Component<
   Props,
-  { buildOpen: boolean; buildInterties: boolean; revealChart: boolean }
+  { revealChart: boolean }
 > {
   constructor(props: Props) {
     super(props);
     this.state = {
-      buildOpen: false,
-      buildInterties: false,
       revealChart: false,
     };
     this.onBeforeDragStart = this.onBeforeDragStart.bind(this);
@@ -606,8 +604,6 @@ export default class Facilities extends React.Component<
   public shouldComponentUpdate(
     nextProps: Props,
     nextState: Readonly<{
-      buildOpen: boolean;
-      buildInterties: boolean;
       revealChart: boolean;
     }>,
   ) {
@@ -640,14 +636,6 @@ export default class Facilities extends React.Component<
       this.setState({ revealChart: false });
     this.resolveEvidence();
     this.throttle.rendered(this.props.game.date.minute);
-    if (
-      this.props.game.scenarioId === 112 &&
-      this.props.game.tutorialStep !== previousProps.game.tutorialStep &&
-      this.props.game.tutorialStep === 1 &&
-      !this.props.game.transmission?.lines.length
-    ) {
-      this.setState({ buildOpen: true, buildInterties: true });
-    }
   }
 
   public componentDidMount() {
@@ -699,7 +687,6 @@ export default class Facilities extends React.Component<
       onPause,
       onReprioritize,
       onSelect,
-      onStorageBuild,
       onTransmissionBuild,
       onTradingPolicy,
       selectedFacilityId,
@@ -730,15 +717,7 @@ export default class Facilities extends React.Component<
                 color="primary"
                 className="button-buildFacility"
                 startIcon={<ConceptIcon concept="build" fontSize="small" />}
-                onClick={() =>
-                  this.setState({
-                    buildOpen: true,
-                    buildInterties:
-                      game.scenarioId === 112 &&
-                      game.tutorialStep <= 1 &&
-                      !game.transmission?.lines.length,
-                  })
-                }
+                onClick={onGeneratorBuild}
               >
                 Build
               </Button>
@@ -830,81 +809,6 @@ export default class Facilities extends React.Component<
               )}
             </List>
           </>
-          {!readOnly && this.state.buildOpen && (
-            <Dialog
-              open
-              onClose={() => this.setState({ buildOpen: false })}
-              fullWidth
-              maxWidth="sm"
-            >
-              <DialogTitle>
-                {this.state.buildInterties
-                  ? "Build an intertie"
-                  : "Build a facility"}
-              </DialogTitle>
-              <DialogContent>
-                {this.state.buildInterties ? (
-                  <TransmissionPanel
-                    game={game}
-                    projectsOnly
-                    onPolicy={onTradingPolicy}
-                    onBuild={(id, financed) => {
-                      onTransmissionBuild(id, financed);
-                      this.setState({ buildOpen: false });
-                    }}
-                  />
-                ) : (
-                  <div className="facilityBuildChoices">
-                    <Button
-                      className="button-buildGenerator"
-                      variant="outlined"
-                      startIcon={<ConceptIcon concept="generator" />}
-                      onClick={onGeneratorBuild}
-                    >
-                      Generator
-                    </Button>
-                    <Button
-                      className="button-buildStorage"
-                      variant="outlined"
-                      startIcon={<ConceptIcon concept="storage" />}
-                      onClick={onStorageBuild}
-                    >
-                      Storage
-                    </Button>
-                    {intertiesAvailable && (
-                      <Button
-                        className="button-buildIntertie"
-                        variant="outlined"
-                        startIcon={
-                          <img
-                            src="/images/transmission.svg"
-                            width="24"
-                            height="24"
-                            alt=""
-                          />
-                        }
-                        onClick={() => this.setState({ buildInterties: true })}
-                      >
-                        Intertie
-                      </Button>
-                    )}
-                  </div>
-                )}
-              </DialogContent>
-              <DialogActions>
-                {this.state.buildInterties && (
-                  <Button
-                    onClick={() => this.setState({ buildInterties: false })}
-                  >
-                    Back
-                  </Button>
-                )}
-                <Button onClick={() => this.setState({ buildOpen: false })}>
-                  Close
-                </Button>
-              </DialogActions>
-            </Dialog>
-          )}
         </>
       </GameCard>
     );

--- a/src/components/views/TransmissionPanel.tsx
+++ b/src/components/views/TransmissionPanel.tsx
@@ -2,9 +2,15 @@ import ManualLink from "../base/ManualLink";
 import { MANUAL_ENTRY } from "../../data/Manual";
 import * as React from "react";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import CloseIcon from "@mui/icons-material/Close";
 import {
   Button,
   Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
   FormControl,
   InputLabel,
   MenuItem,
@@ -23,6 +29,7 @@ import { getMonthlyPayment } from "../../helpers/Financials";
 import { GameType, TradingPolicyType } from "../../Types";
 import { formatMass } from "../../helpers/Units";
 import { useUnits } from "../base/UnitsContext";
+import DecisionImpactPreview from "../base/DecisionImpactPreview";
 
 const POLICY_LABELS: Record<TradingPolicyType, string> = {
   BALANCED: "Buy for shortages, sell extra",
@@ -107,6 +114,7 @@ export default function TransmissionPanel({
 }: TransmissionPanelProps) {
   const units = useUnits();
   const [selectedLine, setSelectedLine] = React.useState<number | null>(null);
+  const [reviewId, setReviewId] = React.useState<string | null>(null);
   const state = game.transmission ?? { tradingPolicy: "BALANCED", lines: [] };
   const availableCorridors = corridorsForLocation(game.location);
   const now = getTimeFromTimeline(game.date.minute, game.timeline);
@@ -123,6 +131,14 @@ export default function TransmissionPanel({
     (corridor) =>
       !state.lines.some(({ corridorId }) => corridorId === corridor.id),
   );
+  const review = unbuiltCorridors.find(({ id }) => id === reviewId);
+  const reviewMarket = review && adjacentMarketForCorridor(review.id);
+  const reviewDownpayment = (review?.buildCost || 0) * DOWNPAYMENT_PERCENT;
+  const approve = (financed: boolean) => {
+    if (!review) return;
+    onBuild(review.id, financed);
+    setReviewId(null);
+  };
 
   if (!corridors.length) {
     return null;
@@ -312,14 +328,14 @@ export default function TransmissionPanel({
                   </dl>
                   {!readOnly && (
                     <Button
-                      id={`approve-intertie-${corridor.id}`}
-                      aria-label={`Approve ${market?.name} intertie`}
+                      id={`review-intertie-${corridor.id}`}
+                      aria-label={`Review purchase of ${market?.name} intertie`}
                       fullWidth
-                      variant="contained"
+                      variant="outlined"
                       disabled={!now || now.cash < downpayment}
-                      onClick={() => onBuild(corridor.id, true)}
+                      onClick={() => setReviewId(corridor.id)}
                     >
-                      Approve intertie
+                      Review
                     </Button>
                   )}
                   {!readOnly && (
@@ -376,6 +392,79 @@ export default function TransmissionPanel({
             )}
           </details>
         </>
+      )}
+      {review && (
+        <Dialog
+          open
+          onClose={() => setReviewId(null)}
+          fullWidth
+          maxWidth="sm"
+          aria-labelledby="intertie-review-title"
+        >
+          <DialogTitle id="intertie-review-title">
+            Build {reviewMarket?.name} intertie?
+            <IconButton
+              aria-label="close"
+              onClick={() => setReviewId(null)}
+              className="top-right"
+              size="large"
+            >
+              <CloseIcon />
+            </IconButton>
+          </DialogTitle>
+          <DialogContent className="noPadding">
+            <DecisionImpactPreview
+              facts={[
+                {
+                  concept: "money",
+                  label: "Cash purchase",
+                  value: `${formatMoneyConcise(now?.cash || 0)} → ${formatMoneyConcise((now?.cash || 0) - review.buildCost)}`,
+                },
+                {
+                  concept: "finances",
+                  label: "Loan option",
+                  value: `${formatMoneyConcise(reviewDownpayment)} now + ${formatMoneyConcise(getMonthlyPayment(review.buildCost - reviewDownpayment, game.interestRate, LOAN_MONTHS))}/mo`,
+                  detail: `Payments start during construction. Loan term: ${LOAN_MONTHS / 12} years. Interest rate: ${(game.interestRate * 100).toFixed(2)}%.`,
+                },
+                {
+                  concept: "money",
+                  label: "Estimated upkeep",
+                  value: `${formatMoneyConcise(review.annualOperatingCost / 12)}/mo`,
+                  detail: "Electricity purchases and loan payments are extra.",
+                },
+                {
+                  concept: "time",
+                  label: "Online in",
+                  value: `${Math.round(review.yearsToBuild * 12)} months`,
+                },
+                {
+                  concept: "supply",
+                  label: "Connection capacity",
+                  value: formatWatts(review.capacityW),
+                  detail:
+                    "Imports depend on neighboring supply and line conditions; backup is not guaranteed.",
+                },
+              ]}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button
+              variant="contained"
+              disabled={readOnly || !now || now.cash < review.buildCost}
+              onClick={() => approve(false)}
+            >
+              Pay cash
+            </Button>
+            <Button
+              id={`approve-intertie-${review.id}`}
+              variant="outlined"
+              disabled={readOnly || !now || now.cash < reviewDownpayment}
+              onClick={() => approve(true)}
+            >
+              Take loan
+            </Button>
+          </DialogActions>
+        </Dialog>
       )}
     </div>
   );

--- a/src/components/views/TransmissionPanel.tsx
+++ b/src/components/views/TransmissionPanel.tsx
@@ -29,6 +29,7 @@ import { getMonthlyPayment } from "../../helpers/Financials";
 import { GameType, TradingPolicyType } from "../../Types";
 import { formatMass } from "../../helpers/Units";
 import { useUnits } from "../base/UnitsContext";
+import ConceptIcon from "../base/ConceptIcon";
 import DecisionImpactPreview from "../base/DecisionImpactPreview";
 
 const POLICY_LABELS: Record<TradingPolicyType, string> = {
@@ -146,21 +147,6 @@ export default function TransmissionPanel({
 
   return (
     <div className={projectsOnly ? "transmissionPanel" : "transmissionFleet"}>
-      {projectsOnly && (
-        <section className="transmissionIntro">
-          <img
-            src="/images/transmission.svg"
-            alt="Two grids exchanging power"
-          />
-          <div>
-            <Typography variant="h6">Share power with nearby grids</Typography>
-            <Typography variant="body2" color="textSecondary">
-              Buy backup; sell extra. Imports are limited.
-            </Typography>
-          </div>
-        </section>
-      )}
-
       {!projectsOnly && (
         <section aria-labelledby="your-interties-title">
           <Typography
@@ -260,10 +246,7 @@ export default function TransmissionPanel({
         <Typography>All available connections have been approved.</Typography>
       )}
       {projectsOnly && !!unbuiltCorridors.length && (
-        <section aria-labelledby="intertie-projects-title">
-          <Typography id="intertie-projects-title" variant="subtitle2">
-            Connection projects
-          </Typography>
+        <section aria-label="Connection projects">
           <div className="transmissionProjects">
             {unbuiltCorridors.map((corridor) => {
               const market = adjacentMarketForCorridor(corridor.id);
@@ -277,14 +260,27 @@ export default function TransmissionPanel({
                   key={corridor.id}
                 >
                   <div className="transmissionProjectHeading">
-                    <div>
-                      <Typography variant="subtitle1">
-                        {market?.name}
-                      </Typography>
-                      <Typography variant="caption" color="textSecondary">
-                        {corridor.name}
-                      </Typography>
-                    </div>
+                    <Typography variant="subtitle1">{market?.name}</Typography>
+                    {!readOnly && (
+                      <Button
+                        id={`review-intertie-${corridor.id}`}
+                        aria-label={`Review purchase of ${market?.name} intertie`}
+                        size="small"
+                        startIcon={
+                          <ConceptIcon concept="buy" fontSize="small" />
+                        }
+                        variant="outlined"
+                        disabled={!now || now.cash < downpayment}
+                        onClick={() => setReviewId(corridor.id)}
+                      >
+                        Review
+                      </Button>
+                    )}
+                  </div>
+                  <div className="transmissionProjectMetadata">
+                    <Typography variant="caption" color="textSecondary">
+                      {corridor.name}
+                    </Typography>
                     <Chip
                       size="small"
                       variant="outlined"
@@ -326,18 +322,6 @@ export default function TransmissionPanel({
                       </dd>
                     </div>
                   </dl>
-                  {!readOnly && (
-                    <Button
-                      id={`review-intertie-${corridor.id}`}
-                      aria-label={`Review purchase of ${market?.name} intertie`}
-                      fullWidth
-                      variant="outlined"
-                      disabled={!now || now.cash < downpayment}
-                      onClick={() => setReviewId(corridor.id)}
-                    >
-                      Review
-                    </Button>
-                  )}
                   {!readOnly && (
                     <Typography variant="caption" color="textSecondary">
                       Pay {formatMoneyConcise(downpayment)} now · finance{" "}

--- a/src/data/Scenarios.tsx
+++ b/src/data/Scenarios.tsx
@@ -202,7 +202,7 @@ export const SCENARIOS = [
         content: (
           <TutorialPrompt
             concepts={["build", "generator"]}
-            text="Choose Build, then Generator to open the shop."
+            text="Choose Build to open the generator shop."
           />
         ),
       },
@@ -723,22 +723,22 @@ export const SCENARIOS = [
         skipBeacon: true,
         card: "FACILITIES",
         target: ".button-buildFacility",
-        continueOnClick: ".button-buildFacility",
+        advanceOn: (s: AppStateType) => s.card.name === "BUILD_INTERTIES",
         content: (
           <TutorialPrompt
             concepts={["supply", "demand"]}
-            text="Choose Build to add a connection to a neighboring grid."
+            text="Choose Build, then Interties to connect to a neighboring grid."
           />
         ),
       },
       {
-        card: "FACILITIES",
-        target: "#approve-intertie-california-north",
+        card: { name: "BUILD_INTERTIES", dontRemember: true },
+        target: "#review-intertie-california-north",
         advanceOn: (s: AppStateType) => !!tutorialNorthernIntertie(s),
         content: (
           <TutorialPrompt
             concepts={["money", "construction"]}
-            text="Approve the Pacific Northwest intertie with financing."
+            text="Review the Pacific Northwest intertie, then choose Take loan."
           />
         ),
       },
@@ -1021,8 +1021,7 @@ export const SCENARIOS = [
       fantasy: "Guide a small city grid through explosive growth.",
       objective:
         "Build enough dependable generation and storage before data-center demand arrives.",
-      threat:
-        "New demand will overwhelm the grid if you build too late. In January 2024, choose funded full connections in 2026 or phased connections in 2026 and 2028.",
+      threat: "New demand will overwhelm the grid if you build too late.",
     },
     ownership: "Public",
     startingYear: 2020,


### PR DESCRIPTION
Opening Build goes straight to one catalog with Generators selected and Storage and Interties tabs across the top. A shared header, consistent touch targets and card gutters simplify navigation on desktop and phones.

Intertie cards put a cart-icon Review button at the top right, with route details below the market name. Review opens cash and loan choices before construction starts. The redundant intertie introduction and section heading are removed, as is the storage catalog help-link row; contextual help remains inside purchase dialogs.

Removes the January 2024 connection-choice sentence from the Data Center Boom description. Tutorial copy and navigation follow the new flow, while existing build shortcuts remain available.

A design subagent proposed and reviewed the desktop/mobile layout and handed its recommendations to a coding subagent for implementation.

Validation passed: npm run check (types, lint, formatting, all Jest suites and every scenario invariant), npm run build, and 55 browser checks covering desktop, tablet, 390px and 320px layouts in both themes.

![Desktop intertie cards with top-right Review](https://github.com/user-attachments/assets/bbbf1cc1-ac8b-447f-87d4-e48bd69925f9)

![320px intertie cards in dark mode](https://github.com/user-attachments/assets/78c41982-c25d-49e1-bb20-96e382fc1cca)

![Storage catalog with help row removed](https://github.com/user-attachments/assets/47a45e4a-93c2-4afc-99bf-ce208d225509)
